### PR TITLE
feat: Add TransactionalEventPublishingAspect for automatic domain event publishing

### DIFF
--- a/core/spakky-data/pyproject.toml
+++ b/core/spakky-data/pyproject.toml
@@ -60,6 +60,8 @@ exclude_lines = [
   "raise NotImplementedError",
   "@(abc\\.)?abstractmethod",
   "@(typing\\.)?overload",
+  "\\.\\.\\.\\.",
+  "pass",
 ]
 
 [tool.uv.sources]

--- a/core/spakky-data/src/spakky/data/__init__.py
+++ b/core/spakky-data/src/spakky/data/__init__.py
@@ -38,3 +38,8 @@ __all__ = [
     "AbstractSpakkyExternalError",
     "AbstractSpakkyPersistencyError",
 ]
+
+from spakky.core.application.plugin import Plugin
+
+PLUGIN_NAME = Plugin(name="spakky-data")
+"""Plugin identifier for the Spakky Data package."""

--- a/core/spakky-data/src/spakky/data/external/proxy.py
+++ b/core/spakky-data/src/spakky/data/external/proxy.py
@@ -1,9 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Sequence, TypeVar
+from typing import Generic, Sequence, TypeVar
 
 from spakky.core.common.interfaces.equatable import IEquatable
 from spakky.core.common.mutability import immutable
 
+ProxyIdT = TypeVar("ProxyIdT", bound=IEquatable)
+ProxyIdT_co = TypeVar("ProxyIdT_co", bound=IEquatable, covariant=True)
 ProxyIdT_contra = TypeVar("ProxyIdT_contra", bound=IEquatable, contravariant=True)
 
 
@@ -20,7 +22,11 @@ class ProxyModel(IEquatable, Generic[ProxyIdT_contra]):
         return hash(self.id)
 
 
-ProxyModelT_co = TypeVar("ProxyModelT_co", bound=ProxyModel[Any], covariant=True)
+ProxyModelT = TypeVar("ProxyModelT", bound=ProxyModel[IEquatable])
+ProxyModelT_co = TypeVar("ProxyModelT_co", bound=ProxyModel[IEquatable], covariant=True)
+ProxyModelT_contra = TypeVar(
+    "ProxyModelT_contra", bound=ProxyModel[IEquatable], contravariant=True
+)
 
 
 class IGenericProxy(ABC, Generic[ProxyModelT_co, ProxyIdT_contra]):

--- a/core/spakky-data/src/spakky/data/main.py
+++ b/core/spakky-data/src/spakky/data/main.py
@@ -4,8 +4,10 @@ from spakky.data.aspects.transactional import (
     AsyncTransactionalAspect,
     TransactionalAspect,
 )
+from spakky.data.persistency.aggregate_collector import AggregateCollector
 
 
 def initialize(app: SpakkyApplication) -> None:
     app.add(AsyncTransactionalAspect)
     app.add(TransactionalAspect)
+    app.add(AggregateCollector)

--- a/core/spakky-domain/pyproject.toml
+++ b/core/spakky-domain/pyproject.toml
@@ -7,6 +7,9 @@ authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
 requires-python = ">=3.11"
 dependencies = ["spakky>=5.0.1"]
 
+[project.entry-points."spakky.plugins"]
+spakky-domain = "spakky.domain.main:initialize"
+
 [build-system]
 requires = ["uv_build>=0.9.5,<0.10.0"]
 build-backend = "uv_build"

--- a/core/spakky-domain/pyproject.toml
+++ b/core/spakky-domain/pyproject.toml
@@ -60,4 +60,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
+    "\\.\\.\\.\\.",
+    "pass",
 ]

--- a/core/spakky-domain/src/spakky/domain/__init__.py
+++ b/core/spakky-domain/src/spakky/domain/__init__.py
@@ -47,3 +47,8 @@ __all__ = [
     "AbstractDomainValidationError",
     "AbstractSpakkyDomainError",
 ]
+
+from spakky.core.application.plugin import Plugin
+
+PLUGIN_NAME = Plugin(name="spakky-domain")
+"""Plugin identifier for the Spakky Domain package."""

--- a/core/spakky-domain/src/spakky/domain/application/command.py
+++ b/core/spakky-domain/src/spakky/domain/application/command.py
@@ -20,11 +20,23 @@ class AbstractCommand(ABC):
     ...
 
 
+CommandT = TypeVar("CommandT", bound=AbstractCommand)
+"""Invariant type variable for command types."""
+
+CommandT_co = TypeVar("CommandT_co", bound=AbstractCommand, covariant=True)
+"""Covariant type variable for command types."""
+
 CommandT_contra = TypeVar("CommandT_contra", bound=AbstractCommand, contravariant=True)
 """Contravariant type variable for command types."""
 
+ResultT = TypeVar("ResultT", bound=Any)
+"""Invariant type variable for result types."""
+
 ResultT_co = TypeVar("ResultT_co", bound=Any, covariant=True)
 """Covariant type variable for result types."""
+
+ResultT_contra = TypeVar("ResultT_contra", bound=Any, contravariant=True)
+"""Contravariant type variable for result types."""
 
 
 class ICommandUseCase(ABC, Generic[CommandT_contra, ResultT_co]):

--- a/core/spakky-domain/src/spakky/domain/application/query.py
+++ b/core/spakky-domain/src/spakky/domain/application/query.py
@@ -20,11 +20,23 @@ class AbstractQuery(ABC):
     ...
 
 
+QueryT = TypeVar("QueryT", bound=AbstractQuery)
+"""Invariant type variable for query types."""
+
+QueryT_co = TypeVar("QueryT_co", bound=AbstractQuery, covariant=True)
+"""Covariant type variable for query types."""
+
 QueryT_contra = TypeVar("QueryT_contra", bound=AbstractQuery, contravariant=True)
 """Contravariant type variable for query types."""
 
+ResultT = TypeVar("ResultT", bound=Any)
+"""Invariant type variable for result types."""
+
 ResultT_co = TypeVar("ResultT_co", bound=Any, covariant=True)
 """Covariant type variable for result types."""
+
+ResultT_contra = TypeVar("ResultT_contra", bound=Any, contravariant=True)
+"""Contravariant type variable for result types."""
 
 
 class IQueryUseCase(ABC, Generic[QueryT_contra, ResultT_co]):

--- a/core/spakky-domain/src/spakky/domain/main.py
+++ b/core/spakky-domain/src/spakky/domain/main.py
@@ -1,0 +1,5 @@
+from spakky.core.application.application import SpakkyApplication
+
+
+def initialize(app: SpakkyApplication) -> None:
+    return

--- a/core/spakky-domain/src/spakky/domain/models/aggregate_root.py
+++ b/core/spakky-domain/src/spakky/domain/models/aggregate_root.py
@@ -6,9 +6,9 @@ that manage domain events and maintain consistency boundaries.
 
 from abc import ABC
 from dataclasses import field
-from typing import Any, Generic, Sequence, TypeVar
+from typing import Generic, Sequence, TypeVar
 
-from spakky.core.common.interfaces.equatable import EquatableT
+from spakky.core.common.interfaces.equatable import EquatableT_co, IEquatable
 from spakky.core.common.mutability import mutable
 
 from spakky.domain.models.entity import AbstractEntity
@@ -16,7 +16,7 @@ from spakky.domain.models.event import AbstractDomainEvent
 
 
 @mutable
-class AbstractAggregateRoot(AbstractEntity[EquatableT], Generic[EquatableT], ABC):
+class AbstractAggregateRoot(AbstractEntity[EquatableT_co], Generic[EquatableT_co], ABC):
     """Base class for DDD aggregate roots.
 
     Aggregate roots are entities that serve as entry points to aggregates,
@@ -59,5 +59,15 @@ class AbstractAggregateRoot(AbstractEntity[EquatableT], Generic[EquatableT], ABC
         self.__events.clear()
 
 
-AggregateRootT = TypeVar("AggregateRootT", bound=AbstractAggregateRoot[Any])
-"""Type variable for aggregate root types."""
+AggregateRootT = TypeVar("AggregateRootT", bound=AbstractAggregateRoot[IEquatable])
+"""Type variable for aggregate root types (invariant for repositories)."""
+
+AggregateRootT_co = TypeVar(
+    "AggregateRootT_co", bound=AbstractAggregateRoot[IEquatable], covariant=True
+)
+"""Type variable for aggregate root types (covariant for read-only operations)."""
+
+AggregateRootT_contra = TypeVar(
+    "AggregateRootT_contra", bound=AbstractAggregateRoot[IEquatable], contravariant=True
+)
+"""Type variable for aggregate root types (contravariant for input parameters)."""

--- a/core/spakky-domain/src/spakky/domain/models/entity.py
+++ b/core/spakky-domain/src/spakky/domain/models/entity.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from typing import Any, ClassVar, Generic
 from uuid import UUID, uuid4
 
-from spakky.core.common.interfaces.equatable import EquatableT, IEquatable
+from spakky.core.common.interfaces.equatable import EquatableT_co, IEquatable
 from spakky.core.common.mutability import mutable
 
 from spakky.domain.error import AbstractSpakkyDomainError
@@ -23,7 +23,7 @@ class CannotMonkeyPatchEntityError(AbstractSpakkyDomainError):
 
 
 @mutable
-class AbstractEntity(IEquatable, Generic[EquatableT], ABC):
+class AbstractEntity(IEquatable, Generic[EquatableT_co], ABC):
     """Base class for DDD entities with identity and validation.
 
     Entities are objects with unique identity that maintain consistency
@@ -41,7 +41,7 @@ class AbstractEntity(IEquatable, Generic[EquatableT], ABC):
 
     __initialized: bool = field(init=False, repr=False, default=False)
 
-    uid: EquatableT
+    uid: EquatableT_co
     """Unique identifier for this entity."""
 
     version: UUID = field(default_factory=uuid4)
@@ -55,7 +55,7 @@ class AbstractEntity(IEquatable, Generic[EquatableT], ABC):
 
     @classmethod
     @abstractmethod
-    def next_id(cls) -> EquatableT:
+    def next_id(cls) -> EquatableT_co:
         """Generate next unique identifier for this entity type.
 
         Returns:

--- a/core/spakky-event/pyproject.toml
+++ b/core/spakky-event/pyproject.toml
@@ -60,6 +60,8 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
+    "\\.\\.\\.\\.",
+    "pass",
 ]
 
 [tool.uv.sources]

--- a/core/spakky-event/pyproject.toml
+++ b/core/spakky-event/pyproject.toml
@@ -7,6 +7,9 @@ authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
 requires-python = ">=3.11"
 dependencies = ["spakky-domain>=5.0.1", "spakky-data>=5.0.1"]
 
+[project.entry-points."spakky.plugins"]
+spakky-event = "spakky.event.main:initialize"
+
 [build-system]
 requires = ["uv_build>=0.9.5,<0.10.0"]
 build-backend = "uv_build"

--- a/core/spakky-event/src/spakky/event/__init__.py
+++ b/core/spakky-event/src/spakky/event/__init__.py
@@ -4,12 +4,18 @@ This package provides:
 - Event publishers and consumers
 - Event handler stereotype
 - Event-related errors
+- Transactional event publishing aspects
 
 Usage:
     from spakky.event import IIntegrationEventPublisher, IAsyncIntegrationEventPublisher
     from spakky.event import IIntegrationEventConsumer, IAsyncIntegrationEventConsumer
+    from spakky.event import AsyncTransactionalEventPublishingAspect
 """
 
+from spakky.event.aspects import (
+    AsyncTransactionalEventPublishingAspect,
+    TransactionalEventPublishingAspect,
+)
 from spakky.event.error import (
     AbstractSpakkyEventError,
     DuplicateEventHandlerError,
@@ -39,6 +45,9 @@ __all__ = [
     "IDomainEventConsumer",
     "IAsyncIntegrationEventConsumer",
     "IIntegrationEventConsumer",
+    # Aspects
+    "AsyncTransactionalEventPublishingAspect",
+    "TransactionalEventPublishingAspect",
     # Errors
     "AbstractSpakkyEventError",
     "DuplicateEventHandlerError",

--- a/core/spakky-event/src/spakky/event/__init__.py
+++ b/core/spakky-event/src/spakky/event/__init__.py
@@ -53,3 +53,8 @@ __all__ = [
     "DuplicateEventHandlerError",
     "InvalidMessageError",
 ]
+
+from spakky.core.application.plugin import Plugin
+
+PLUGIN_NAME = Plugin(name="spakky-event")
+"""Plugin identifier for the Spakky Event package."""

--- a/core/spakky-event/src/spakky/event/aspects/__init__.py
+++ b/core/spakky-event/src/spakky/event/aspects/__init__.py
@@ -1,0 +1,15 @@
+"""Spakky Event Aspects package.
+
+This package provides aspects for event-driven architecture:
+- TransactionalEventPublishingAspect: Automatic domain event publishing after transactions
+"""
+
+from spakky.event.aspects.transactional_event_publishing import (
+    AsyncTransactionalEventPublishingAspect,
+    TransactionalEventPublishingAspect,
+)
+
+__all__ = [
+    "AsyncTransactionalEventPublishingAspect",
+    "TransactionalEventPublishingAspect",
+]

--- a/core/spakky-event/src/spakky/event/aspects/transactional_event_publishing.py
+++ b/core/spakky-event/src/spakky/event/aspects/transactional_event_publishing.py
@@ -1,0 +1,167 @@
+"""Transactional event publishing aspect for automatic domain event publishing.
+
+This module provides aspects that automatically publish domain events after
+successful transaction completion. The aspect collects aggregates from the
+AggregateCollector, extracts their domain events, and publishes them.
+
+Example:
+    @Order(100)  # Executes inside TransactionalAspect(@Order(0))
+    @AsyncAspect()
+    class AsyncTransactionalEventPublishingAspect(IAsyncAspect):
+        async def after_returning_async(self, result: Any) -> None:
+            # Publish events from collected aggregates
+            ...
+"""
+
+from inspect import iscoroutinefunction
+from typing import Any
+
+from spakky.core.aop.aspect import Aspect, AsyncAspect
+from spakky.core.aop.interfaces.aspect import IAspect, IAsyncAspect
+from spakky.core.aop.pointcut import AfterRaising, AfterReturning
+from spakky.core.pod.annotations.order import Order
+from spakky.data.aspects.transactional import Transactional
+from spakky.data.persistency.aggregate_collector import AggregateCollector
+
+from spakky.event.event_publisher import (
+    IAsyncDomainEventPublisher,
+    IDomainEventPublisher,
+)
+
+
+@Order(1)  # Executes inside AsyncTransactionalAspect(@Order(0))
+@AsyncAspect()
+class AsyncTransactionalEventPublishingAspect(IAsyncAspect):
+    """Aspect for automatic domain event publishing in async transactional methods.
+
+    This aspect intercepts async methods decorated with @Transactional and
+    automatically publishes domain events after successful transaction completion.
+    The aspect executes inside the TransactionalAspect (@Order(0)), ensuring
+    events are published within the same transaction.
+
+    Execution flow:
+        1. TransactionalAspect (@Order(0)) begins transaction
+        2. UseCase logic executes -> repository.save(aggregate) -> collector.collect()
+        3. AsyncTransactionalEventPublishingAspect (@Order(100)) publishes events
+        4. TransactionalAspect commits or rolls back
+
+    Args:
+        collector: Context-scoped collector tracking saved aggregates
+        publisher: Publisher for domain events
+    """
+
+    _collector: AggregateCollector
+    _publisher: IAsyncDomainEventPublisher
+
+    def __init__(
+        self,
+        collector: AggregateCollector,
+        publisher: IAsyncDomainEventPublisher,
+    ) -> None:
+        """Initialize async transactional event publishing aspect.
+
+        Args:
+            collector: Aggregate collector for tracking saved aggregates.
+            publisher: Domain event publisher for publishing events.
+        """
+        self._collector = collector
+        self._publisher = publisher
+
+    @AfterReturning(lambda x: Transactional.exists(x) and iscoroutinefunction(x))
+    async def after_returning_async(self, result: Any) -> None:
+        """Publish domain events after successful UseCase execution.
+
+        This method is called after a @Transactional method successfully completes.
+        It extracts all domain events from collected aggregates and publishes them.
+        After publishing, it clears the events from aggregates and clears the collector.
+
+        Args:
+            result: The return value of the method.
+        """
+        for aggregate in self._collector.all():
+            for event in aggregate.events:
+                await self._publisher.publish(event)
+            aggregate.clear_events()
+        self._collector.clear()
+
+    @AfterRaising(lambda x: Transactional.exists(x) and iscoroutinefunction(x))
+    async def after_raising_async(self, error: Exception) -> None:
+        """Clean up collector after UseCase failure.
+
+        This method is called when a @Transactional method raises an exception.
+        It only clears the collector without publishing events, as the transaction
+        will be rolled back.
+
+        Args:
+            error: The exception that was raised.
+        """
+        self._collector.clear()
+
+
+@Order(1)  # Executes inside TransactionalAspect(@Order(0))
+@Aspect()
+class TransactionalEventPublishingAspect(IAspect):
+    """Aspect for automatic domain event publishing in sync transactional methods.
+
+    This aspect intercepts sync methods decorated with @Transactional and
+    automatically publishes domain events after successful transaction completion.
+    The aspect executes inside the TransactionalAspect (@Order(0)), ensuring
+    events are published within the same transaction.
+
+    Execution flow:
+        1. TransactionalAspect (@Order(0)) begins transaction
+        2. UseCase logic executes -> repository.save(aggregate) -> collector.collect()
+        3. TransactionalEventPublishingAspect (@Order(100)) publishes events
+        4. TransactionalAspect commits or rolls back
+
+    Args:
+        collector: Context-scoped collector tracking saved aggregates
+        publisher: Publisher for domain events
+    """
+
+    _collector: AggregateCollector
+    _publisher: IDomainEventPublisher
+
+    def __init__(
+        self,
+        collector: AggregateCollector,
+        publisher: IDomainEventPublisher,
+    ) -> None:
+        """Initialize sync transactional event publishing aspect.
+
+        Args:
+            collector: Aggregate collector for tracking saved aggregates.
+            publisher: Domain event publisher for publishing events.
+        """
+        self._collector = collector
+        self._publisher = publisher
+
+    @AfterReturning(lambda x: Transactional.exists(x) and not iscoroutinefunction(x))
+    def after_returning(self, result: Any) -> None:
+        """Publish domain events after successful UseCase execution.
+
+        This method is called after a @Transactional method successfully completes.
+        It extracts all domain events from collected aggregates and publishes them.
+        After publishing, it clears the events from aggregates and clears the collector.
+
+        Args:
+            result: The return value of the method.
+        """
+        for aggregate in self._collector.all():
+            for event in aggregate.events:
+                self._publisher.publish(event)
+            aggregate.clear_events()
+        self._collector.clear()
+
+    @AfterRaising(lambda x: Transactional.exists(x) and not iscoroutinefunction(x))
+    def after_raising(self, error: Exception) -> None:
+        """Clean up collector after UseCase failure.
+
+        This method is called when a @Transactional method raises an exception.
+        It only clears the collector without publishing events, as the transaction
+        will be rolled back.
+
+        Args:
+            error: The exception that was raised.
+        """
+        self._collector.clear()

--- a/core/spakky-event/src/spakky/event/event_consumer.py
+++ b/core/spakky-event/src/spakky/event/event_consumer.py
@@ -4,13 +4,25 @@ from typing import Awaitable, Callable, TypeAlias, TypeVar
 from spakky.domain.models.event import AbstractDomainEvent, AbstractIntegrationEvent
 
 DomainEventT = TypeVar("DomainEventT", bound=AbstractDomainEvent)
-DomainEventHandlerCallback: TypeAlias = Callable[[DomainEventT], None]
-AsyncDomainEventHandlerCallback: TypeAlias = Callable[[DomainEventT], Awaitable[None]]
+DomainEventT_co = TypeVar("DomainEventT_co", bound=AbstractDomainEvent, covariant=True)
+DomainEventT_contra = TypeVar(
+    "DomainEventT_contra", bound=AbstractDomainEvent, contravariant=True
+)
+DomainEventHandlerCallback: TypeAlias = Callable[[DomainEventT_contra], None]
+AsyncDomainEventHandlerCallback: TypeAlias = Callable[
+    [DomainEventT_contra], Awaitable[None]
+]
 
 IntegrationEventT = TypeVar("IntegrationEventT", bound=AbstractIntegrationEvent)
-IntegrationEventHandlerCallback: TypeAlias = Callable[[IntegrationEventT], None]
+IntegrationEventT_co = TypeVar(
+    "IntegrationEventT_co", bound=AbstractIntegrationEvent, covariant=True
+)
+IntegrationEventT_contra = TypeVar(
+    "IntegrationEventT_contra", bound=AbstractIntegrationEvent, contravariant=True
+)
+IntegrationEventHandlerCallback: TypeAlias = Callable[[IntegrationEventT_contra], None]
 AsyncIntegrationEventHandlerCallback: TypeAlias = Callable[
-    [IntegrationEventT], Awaitable[None]
+    [IntegrationEventT_contra], Awaitable[None]
 ]
 
 
@@ -18,8 +30,8 @@ class IDomainEventConsumer(ABC):
     @abstractmethod
     def register(
         self,
-        event: type[DomainEventT],
-        handler: DomainEventHandlerCallback[DomainEventT],
+        event: type[DomainEventT_contra],
+        handler: DomainEventHandlerCallback[DomainEventT_contra],
     ) -> None: ...
 
 
@@ -27,8 +39,8 @@ class IAsyncDomainEventConsumer(ABC):
     @abstractmethod
     def register(
         self,
-        event: type[DomainEventT],
-        handler: AsyncDomainEventHandlerCallback[DomainEventT],
+        event: type[DomainEventT_contra],
+        handler: AsyncDomainEventHandlerCallback[DomainEventT_contra],
     ) -> None: ...
 
 
@@ -36,8 +48,8 @@ class IIntegrationEventConsumer(ABC):
     @abstractmethod
     def register(
         self,
-        event: type[IntegrationEventT],
-        handler: IntegrationEventHandlerCallback[IntegrationEventT],
+        event: type[IntegrationEventT_contra],
+        handler: IntegrationEventHandlerCallback[IntegrationEventT_contra],
     ) -> None: ...
 
 
@@ -45,6 +57,6 @@ class IAsyncIntegrationEventConsumer(ABC):
     @abstractmethod
     def register(
         self,
-        event: type[IntegrationEventT],
-        handler: AsyncIntegrationEventHandlerCallback[IntegrationEventT],
+        event: type[IntegrationEventT_contra],
+        handler: AsyncIntegrationEventHandlerCallback[IntegrationEventT_contra],
     ) -> None: ...

--- a/core/spakky-event/src/spakky/event/main.py
+++ b/core/spakky-event/src/spakky/event/main.py
@@ -1,0 +1,11 @@
+from spakky.core.application.application import SpakkyApplication
+
+from spakky.event.aspects.transactional_event_publishing import (
+    AsyncTransactionalEventPublishingAspect,
+    TransactionalEventPublishingAspect,
+)
+
+
+def initialize(app: SpakkyApplication) -> None:
+    app.add(AsyncTransactionalEventPublishingAspect)
+    app.add(TransactionalEventPublishingAspect)

--- a/core/spakky-event/src/spakky/event/stereotype/event_handler.py
+++ b/core/spakky-event/src/spakky/event/stereotype/event_handler.py
@@ -12,23 +12,31 @@ from spakky.core.pod.annotations.pod import Pod
 from spakky.domain.models.event import AbstractEvent
 
 EventT = TypeVar("EventT", bound=AbstractEvent)
-"""Type variable for domain event types."""
+"""Type variable for domain event types (invariant)."""
 
-EventHandlerMethod: TypeAlias = Callable[[Any, EventT], None | Awaitable[None]]
+EventT_co = TypeVar("EventT_co", bound=AbstractEvent, covariant=True)
+"""Type variable for domain event types (covariant for return types)."""
+
+EventT_contra = TypeVar("EventT_contra", bound=AbstractEvent, contravariant=True)
+"""Type variable for domain event types (contravariant for handler parameters)."""
+
+EventHandlerMethod: TypeAlias = Callable[[Any, EventT_contra], None | Awaitable[None]]
 """Type alias for event handler callback functions."""
 
 
 @dataclass
-class EventRoute(FunctionAnnotation, Generic[EventT]):
+class EventRoute(FunctionAnnotation, Generic[EventT_contra]):
     """Annotation for marking methods as event handlers.
 
     Associates a method with a specific domain event type.
     """
 
-    event_type: type[EventT]
+    event_type: type[EventT_contra]
     """The domain event type this handler processes."""
 
-    def __call__(self, obj: EventHandlerMethod[EventT]) -> EventHandlerMethod[EventT]:
+    def __call__(
+        self, obj: EventHandlerMethod[EventT_contra]
+    ) -> EventHandlerMethod[EventT_contra]:
         """Apply event route annotation to method.
 
         Args:
@@ -41,10 +49,10 @@ class EventRoute(FunctionAnnotation, Generic[EventT]):
 
 
 def on_event(
-    event_type: type[EventT],
+    event_type: type[EventT_contra],
 ) -> Callable[
-    [EventHandlerMethod[EventT]],
-    EventHandlerMethod[EventT],
+    [EventHandlerMethod[EventT_contra]],
+    EventHandlerMethod[EventT_contra],
 ]:
     """Decorator for marking methods as event handlers.
 
@@ -64,8 +72,8 @@ def on_event(
     """
 
     def wrapper(
-        method: EventHandlerMethod[EventT],
-    ) -> EventHandlerMethod[EventT]:
+        method: EventHandlerMethod[EventT_contra],
+    ) -> EventHandlerMethod[EventT_contra]:
         return EventRoute(event_type)(method)
 
     return wrapper

--- a/core/spakky-event/tests/aspects/test_transactional_event_publishing.py
+++ b/core/spakky-event/tests/aspects/test_transactional_event_publishing.py
@@ -1,0 +1,330 @@
+from typing import Self
+from uuid import UUID, uuid4
+
+import pytest
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.common.mutability import immutable, mutable
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.stereotype.usecase import UseCase
+from spakky.data.aspects.transactional import (
+    AsyncTransactionalAspect,
+    Transactional,
+    TransactionalAspect,
+)
+from spakky.data.persistency.aggregate_collector import AggregateCollector
+from spakky.data.persistency.transaction import (
+    AbstractAsyncTransaction,
+    AbstractTransaction,
+)
+from spakky.domain.models.aggregate_root import AbstractAggregateRoot
+from spakky.domain.models.event import AbstractDomainEvent
+
+from spakky.event.aspects.transactional_event_publishing import (
+    AsyncTransactionalEventPublishingAspect,
+    TransactionalEventPublishingAspect,
+)
+from spakky.event.event_publisher import (
+    IAsyncDomainEventPublisher,
+    IDomainEventPublisher,
+)
+
+
+@mutable
+class User(AbstractAggregateRoot[UUID]):
+    """User aggregate root."""
+
+    username: str
+
+    def validate(self) -> None:
+        """Validate user."""
+        pass
+
+    @immutable
+    class Created(AbstractDomainEvent):
+        """Domain event raised when a user is created."""
+
+        user_id: str
+        username: str
+
+    @classmethod
+    def next_id(cls) -> UUID:
+        """Generate next user ID."""
+        return uuid4()
+
+    @classmethod
+    def create(cls: type[Self], username: str) -> Self:
+        """Create a new user and raise Created event."""
+        user: Self = cls(uid=cls.next_id(), username=username)
+        user.add_event(cls.Created(user_id=str(user.uid), username=username))
+        return user
+
+
+def test_sync_aspect_publishes_events_on_success() -> None:
+    """Test that TransactionalEventPublishingAspect publishes events after successful execution."""
+
+    @Pod()
+    class InMemoryTransaction(AbstractTransaction):
+        def initialize(self) -> None: ...
+        def dispose(self) -> None: ...
+        def commit(self) -> None: ...
+        def rollback(self) -> None: ...
+
+    @Pod()
+    class InMemoryDomainEventPublisher(IDomainEventPublisher):
+        published_events: list[AbstractDomainEvent] = []
+
+        def publish(self, event: AbstractDomainEvent) -> None:
+            self.published_events.append(event)
+
+    @UseCase()
+    class CreateUserUseCase:
+        def __init__(self, collector: AggregateCollector) -> None:
+            self.collector = collector
+
+        @Transactional()
+        def execute(self, username: str) -> User:
+            user = User.create(username)
+            self.collector.collect(user)
+            return user
+
+    context = ApplicationContext()
+    context.add(InMemoryTransaction)
+    context.add(InMemoryDomainEventPublisher)
+    context.add(AggregateCollector)
+    context.add(CreateUserUseCase)
+    context.add(TransactionalAspect)
+    context.add(TransactionalEventPublishingAspect)
+    context.start()
+
+    use_case: CreateUserUseCase = context.get(type_=CreateUserUseCase)
+    publisher: InMemoryDomainEventPublisher = context.get(
+        type_=InMemoryDomainEventPublisher
+    )
+    collector: AggregateCollector = context.get(type_=AggregateCollector)
+
+    result = use_case.execute("alice")
+
+    assert result.username == "alice"
+    assert len(publisher.published_events) == 1
+    assert isinstance(publisher.published_events[0], User.Created)
+    assert publisher.published_events[0].username == "alice"
+    assert len(result.events) == 0  # Events should be cleared
+    assert len(collector.all()) == 0  # Collector should be cleared
+
+
+def test_sync_aspect_does_not_publish_on_error() -> None:
+    """Test that TransactionalEventPublishingAspect does not publish events when method fails."""
+
+    @Pod()
+    class InMemoryTransaction(AbstractTransaction):
+        def initialize(self) -> None: ...
+        def dispose(self) -> None: ...
+        def commit(self) -> None: ...
+        def rollback(self) -> None: ...
+
+    @Pod()
+    class InMemoryDomainEventPublisher(IDomainEventPublisher):
+        published_events: list[AbstractDomainEvent] = []
+
+        def publish(self, event: AbstractDomainEvent) -> None:
+            self.published_events.append(event)
+
+    @UseCase()
+    class CreateUserUseCase:
+        def __init__(self, collector: AggregateCollector) -> None:
+            self.collector = collector
+
+        @Transactional()
+        def execute(self, username: str) -> User:
+            user = User.create(username)
+            self.collector.collect(user)
+            raise RuntimeError("Something went wrong")
+
+    context = ApplicationContext()
+    context.add(InMemoryTransaction)
+    context.add(InMemoryDomainEventPublisher)
+    context.add(AggregateCollector)
+    context.add(CreateUserUseCase)
+    context.add(TransactionalAspect)
+    context.add(TransactionalEventPublishingAspect)
+    context.start()
+
+    use_case: CreateUserUseCase = context.get(type_=CreateUserUseCase)
+    publisher: InMemoryDomainEventPublisher = context.get(
+        type_=InMemoryDomainEventPublisher
+    )
+    collector: AggregateCollector = context.get(type_=AggregateCollector)
+
+    with pytest.raises(RuntimeError, match="Something went wrong"):
+        use_case.execute("alice")
+
+    assert len(publisher.published_events) == 0  # No events should be published
+    assert len(collector.all()) == 0  # Collector should be cleared
+
+
+@pytest.mark.asyncio
+async def test_async_aspect_publishes_events_on_success() -> None:
+    """Test that AsyncTransactionalEventPublishingAspect publishes events after successful execution."""
+
+    @Pod()
+    class AsyncInMemoryTransaction(AbstractAsyncTransaction):
+        async def initialize(self) -> None: ...
+        async def dispose(self) -> None: ...
+        async def commit(self) -> None: ...
+        async def rollback(self) -> None: ...
+
+    @Pod()
+    class AsyncInMemoryDomainEventPublisher(IAsyncDomainEventPublisher):
+        published_events: list[AbstractDomainEvent] = []
+
+        async def publish(self, event: AbstractDomainEvent) -> None:
+            self.published_events.append(event)
+
+    @UseCase()
+    class CreateUserUseCase:
+        def __init__(self, collector: AggregateCollector) -> None:
+            self.collector = collector
+
+        @Transactional()
+        async def execute(self, username: str) -> User:
+            user = User.create(username)
+            self.collector.collect(user)
+            return user
+
+    context = ApplicationContext()
+    context.add(AsyncInMemoryTransaction)
+    context.add(AsyncInMemoryDomainEventPublisher)
+    context.add(AggregateCollector)
+    context.add(CreateUserUseCase)
+    context.add(AsyncTransactionalAspect)
+    context.add(AsyncTransactionalEventPublishingAspect)
+    context.start()
+
+    use_case: CreateUserUseCase = context.get(type_=CreateUserUseCase)
+    publisher: AsyncInMemoryDomainEventPublisher = context.get(
+        type_=AsyncInMemoryDomainEventPublisher
+    )
+    collector: AggregateCollector = context.get(type_=AggregateCollector)
+
+    result = await use_case.execute("alice")
+
+    assert result.username == "alice"
+    assert len(publisher.published_events) == 1
+    assert isinstance(publisher.published_events[0], User.Created)
+    assert publisher.published_events[0].username == "alice"
+    assert len(result.events) == 0  # Events should be cleared
+    assert len(collector.all()) == 0  # Collector should be cleared
+
+
+@pytest.mark.asyncio
+async def test_async_aspect_does_not_publish_on_error() -> None:
+    """Test that AsyncTransactionalEventPublishingAspect does not publish events when method fails."""
+
+    @Pod()
+    class AsyncInMemoryTransaction(AbstractAsyncTransaction):
+        async def initialize(self) -> None: ...
+        async def dispose(self) -> None: ...
+        async def commit(self) -> None: ...
+        async def rollback(self) -> None: ...
+
+    @Pod()
+    class AsyncInMemoryDomainEventPublisher(IAsyncDomainEventPublisher):
+        published_events: list[AbstractDomainEvent] = []
+
+        async def publish(self, event: AbstractDomainEvent) -> None:
+            self.published_events.append(event)
+
+    @UseCase()
+    class CreateUserUseCase:
+        def __init__(self, collector: AggregateCollector) -> None:
+            self.collector = collector
+
+        @Transactional()
+        async def execute(self, username: str) -> User:
+            user = User.create(username)
+            self.collector.collect(user)
+            raise RuntimeError("Something went wrong")
+
+    context = ApplicationContext()
+    context.add(AsyncInMemoryTransaction)
+    context.add(AsyncInMemoryDomainEventPublisher)
+    context.add(AggregateCollector)
+    context.add(CreateUserUseCase)
+    context.add(AsyncTransactionalAspect)
+    context.add(AsyncTransactionalEventPublishingAspect)
+    context.start()
+
+    use_case: CreateUserUseCase = context.get(type_=CreateUserUseCase)
+    publisher: AsyncInMemoryDomainEventPublisher = context.get(
+        type_=AsyncInMemoryDomainEventPublisher
+    )
+    collector: AggregateCollector = context.get(type_=AggregateCollector)
+
+    with pytest.raises(RuntimeError, match="Something went wrong"):
+        await use_case.execute("alice")
+
+    assert len(publisher.published_events) == 0  # No events should be published
+    assert len(collector.all()) == 0  # Collector should be cleared
+
+
+@pytest.mark.asyncio
+async def test_async_aspect_publishes_multiple_events_from_multiple_aggregates() -> (
+    None
+):
+    """Test that aspect publishes all events from multiple aggregates."""
+
+    @Pod()
+    class AsyncInMemoryTransaction(AbstractAsyncTransaction):
+        async def initialize(self) -> None: ...
+        async def dispose(self) -> None: ...
+        async def commit(self) -> None: ...
+        async def rollback(self) -> None: ...
+
+    @Pod()
+    class AsyncInMemoryDomainEventPublisher(IAsyncDomainEventPublisher):
+        published_events: list[AbstractDomainEvent] = []
+
+        async def publish(self, event: AbstractDomainEvent) -> None:
+            self.published_events.append(event)
+
+    @UseCase()
+    class CreateMultipleUsersUseCase:
+        def __init__(self, collector: AggregateCollector) -> None:
+            self.collector = collector
+
+        @Transactional()
+        async def execute(self) -> list[User]:
+            user1 = User.create("alice")
+            user2 = User.create("bob")
+            self.collector.collect(user1)
+            self.collector.collect(user2)
+            return [user1, user2]
+
+    context = ApplicationContext()
+    context.add(AsyncInMemoryTransaction)
+    context.add(AsyncInMemoryDomainEventPublisher)
+    context.add(AggregateCollector)
+    context.add(CreateMultipleUsersUseCase)
+    context.add(AsyncTransactionalAspect)
+    context.add(AsyncTransactionalEventPublishingAspect)
+    context.start()
+
+    use_case: CreateMultipleUsersUseCase = context.get(type_=CreateMultipleUsersUseCase)
+    publisher: AsyncInMemoryDomainEventPublisher = context.get(
+        type_=AsyncInMemoryDomainEventPublisher
+    )
+    collector: AggregateCollector = context.get(type_=AggregateCollector)
+
+    results = await use_case.execute()
+
+    assert len(results) == 2
+    assert len(publisher.published_events) == 2
+    assert all(isinstance(e, User.Created) for e in publisher.published_events)
+    event1 = publisher.published_events[0]
+    event2 = publisher.published_events[1]
+    assert isinstance(event1, User.Created)
+    assert isinstance(event2, User.Created)
+    assert event1.username == "alice"
+    assert event2.username == "bob"
+    assert all(len(user.events) == 0 for user in results)  # All events cleared
+    assert len(collector.all()) == 0  # Collector cleared

--- a/core/spakky/pyproject.toml
+++ b/core/spakky/pyproject.toml
@@ -65,4 +65,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
+    "\\.\\.\\.",
+    "pass",
 ]

--- a/core/spakky/src/spakky/core/aop/interfaces/aspect.py
+++ b/core/spakky/src/spakky/core/aop/interfaces/aspect.py
@@ -4,10 +4,10 @@ This module defines the protocols that aspect classes must implement to intercep
 method calls in the AOP system.
 """
 
+from abc import ABC
 from typing import Any, TypeVar
 
 from spakky.core.common.types import AsyncFunc, Func
-from abc import ABC
 
 
 class IAspect(ABC):
@@ -113,4 +113,11 @@ class IAsyncAspect(ABC):
 
 
 AspectT = TypeVar("AspectT", bound=type[IAspect])
+AspectT_co = TypeVar("AspectT_co", bound=type[IAspect], covariant=True)
+AspectT_contra = TypeVar("AspectT_contra", bound=type[IAspect], contravariant=True)
+
 AsyncAspectT = TypeVar("AsyncAspectT", bound=type[IAsyncAspect])
+AsyncAspectT_co = TypeVar("AsyncAspectT_co", bound=type[IAsyncAspect], covariant=True)
+AsyncAspectT_contra = TypeVar(
+    "AsyncAspectT_contra", bound=type[IAsyncAspect], contravariant=True
+)

--- a/core/spakky/src/spakky/core/common/interfaces/cloneable.py
+++ b/core/spakky/src/spakky/core/common/interfaces/cloneable.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 from typing import Protocol, Self, TypeVar, runtime_checkable
 
 
@@ -6,14 +5,15 @@ from typing import Protocol, Self, TypeVar, runtime_checkable
 class ICloneable(Protocol):
     """Interface for cloneable objects."""
 
-    @abstractmethod
     def clone(self) -> Self:
         """Creates a clone of the current object.
 
         Returns:
             Self: A new instance that is a clone of the current object.
         """
-        raise NotImplementedError
+        ...
 
 
 CloneableT = TypeVar("CloneableT", bound=ICloneable)
+CloneableT_co = TypeVar("CloneableT_co", bound=ICloneable, covariant=True)
+CloneableT_contra = TypeVar("CloneableT_contra", bound=ICloneable, contravariant=True)

--- a/core/spakky/src/spakky/core/common/interfaces/comparable.py
+++ b/core/spakky/src/spakky/core/common/interfaces/comparable.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 from typing import Protocol, Self, TypeVar, runtime_checkable
 
 
@@ -6,7 +5,6 @@ from typing import Protocol, Self, TypeVar, runtime_checkable
 class IComparable(Protocol):
     """Interface for comparable objects."""
 
-    @abstractmethod
     def __lt__(self, __value: Self) -> bool:
         """Less than comparison.
 
@@ -16,9 +14,8 @@ class IComparable(Protocol):
         Returns:
             bool: True if self is less than __value, False otherwise.
         """
-        raise NotImplementedError
+        ...
 
-    @abstractmethod
     def __le__(self, __value: Self) -> bool:
         """Less than or equal comparison.
 
@@ -27,9 +24,8 @@ class IComparable(Protocol):
         Returns:
             bool: True if self is less than or equal to __value, False otherwise.
         """
-        raise NotImplementedError
+        ...
 
-    @abstractmethod
     def __gt__(self, __value: Self) -> bool:
         """Greater than comparison.
 
@@ -39,9 +35,8 @@ class IComparable(Protocol):
         Returns:
             bool: True if self is greater than __value, False otherwise.
         """
-        raise NotImplementedError
+        ...
 
-    @abstractmethod
     def __ge__(self, __value: Self) -> bool:
         """Greater than or equal comparison.
 
@@ -50,7 +45,11 @@ class IComparable(Protocol):
         Returns:
             bool: True if self is greater than or equal to __value, False otherwise.
         """
-        raise NotImplementedError
+        ...
 
 
 ComparableT = TypeVar("ComparableT", bound=IComparable)
+ComparableT_co = TypeVar("ComparableT_co", bound=IComparable, covariant=True)
+ComparableT_contra = TypeVar(
+    "ComparableT_contra", bound=IComparable, contravariant=True
+)

--- a/core/spakky/src/spakky/core/common/interfaces/disposable.py
+++ b/core/spakky/src/spakky/core/common/interfaces/disposable.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 from types import TracebackType
 from typing import Protocol, Self, TypeVar, runtime_checkable
 
@@ -7,16 +6,14 @@ from typing import Protocol, Self, TypeVar, runtime_checkable
 class IDisposable(Protocol):
     """Interface for disposable objects."""
 
-    @abstractmethod
     def __enter__(self) -> Self:
         """Enters the runtime context related to this object.
 
         Returns:
             Self: The object itself.
         """
-        raise NotImplementedError
+        ...
 
-    @abstractmethod
     def __exit__(
         self,
         __exc_type: type[BaseException] | None,
@@ -33,23 +30,21 @@ class IDisposable(Protocol):
         Returns:
             bool | None: True if the exception was handled, False otherwise.
         """
-        raise NotImplementedError
+        ...
 
 
 @runtime_checkable
 class IAsyncDisposable(Protocol):
     """Interface for asynchronously disposable objects."""
 
-    @abstractmethod
     async def __aenter__(self) -> Self:
         """Asynchronously enters the runtime context related to this object.
 
         Returns:
             Self: The object itself.
         """
-        raise NotImplementedError
+        ...
 
-    @abstractmethod
     async def __aexit__(
         self,
         __exc_type: type[BaseException] | None,
@@ -66,8 +61,19 @@ class IAsyncDisposable(Protocol):
         Returns:
             bool | None: True if the exception was handled, False otherwise.
         """
-        raise NotImplementedError
+        ...
 
 
 DisposableT = TypeVar("DisposableT", bound=IDisposable)
+DisposableT_co = TypeVar("DisposableT_co", bound=IDisposable, covariant=True)
+DisposableT_contra = TypeVar(
+    "DisposableT_contra", bound=IDisposable, contravariant=True
+)
+
 AsyncDisposableT = TypeVar("AsyncDisposableT", bound=IAsyncDisposable)
+AsyncDisposableT_co = TypeVar(
+    "AsyncDisposableT_co", bound=IAsyncDisposable, covariant=True
+)
+AsyncDisposableT_contra = TypeVar(
+    "AsyncDisposableT_contra", bound=IAsyncDisposable, contravariant=True
+)

--- a/core/spakky/src/spakky/core/common/interfaces/equatable.py
+++ b/core/spakky/src/spakky/core/common/interfaces/equatable.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 from typing import Protocol, TypeVar, runtime_checkable
 
 
@@ -6,7 +5,6 @@ from typing import Protocol, TypeVar, runtime_checkable
 class IEquatable(Protocol):
     """Interface for equatable objects."""
 
-    @abstractmethod
     def __eq__(self, __value: object) -> bool:
         """Checks equality with another object.
 
@@ -16,16 +14,17 @@ class IEquatable(Protocol):
         Returns:
             bool: True if equal, False otherwise.
         """
-        raise NotImplementedError
+        ...
 
-    @abstractmethod
     def __hash__(self) -> int:
         """Returns the hash of the object.
 
         Returns:
             int: The hash value.
         """
-        raise NotImplementedError
+        ...
 
 
 EquatableT = TypeVar("EquatableT", bound=IEquatable)
+EquatableT_co = TypeVar("EquatableT_co", bound=IEquatable, covariant=True)
+EquatableT_contra = TypeVar("EquatableT_contra", bound=IEquatable, contravariant=True)

--- a/core/spakky/src/spakky/core/common/interfaces/representable.py
+++ b/core/spakky/src/spakky/core/common/interfaces/representable.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 from typing import Protocol, TypeVar, runtime_checkable
 
 
@@ -6,23 +5,25 @@ from typing import Protocol, TypeVar, runtime_checkable
 class IRepresentable(Protocol):
     """Interface for representable objects."""
 
-    @abstractmethod
     def __str__(self) -> str:
         """Returns the string representation of the object.
 
         Returns:
             str: The string representation.
         """
-        raise NotImplementedError
+        ...
 
-    @abstractmethod
     def __repr__(self) -> str:
         """Returns the official string representation of the object.
 
         Returns:
             str: The official string representation.
         """
-        raise NotImplementedError
+        ...
 
 
 RepresentableT = TypeVar("RepresentableT", bound=IRepresentable)
+RepresentableT_co = TypeVar("RepresentableT_co", bound=IRepresentable, covariant=True)
+RepresentableT_contra = TypeVar(
+    "RepresentableT_contra", bound=IRepresentable, contravariant=True
+)

--- a/core/spakky/src/spakky/core/pod/annotations/pod.py
+++ b/core/spakky/src/spakky/core/pod/annotations/pod.py
@@ -46,6 +46,8 @@ class DependencyInfo:
 DependencyMap: TypeAlias = dict[str, DependencyInfo]
 PodType: TypeAlias = Func | Class
 PodT = TypeVar("PodT", bound=PodType)
+PodT_co = TypeVar("PodT_co", bound=PodType, covariant=True)
+PodT_contra = TypeVar("PodT_contra", bound=PodType, contravariant=True)
 
 
 class CannotDeterminePodTypeError(PodAnnotationFailedError):

--- a/plugins/spakky-fastapi/pyproject.toml
+++ b/plugins/spakky-fastapi/pyproject.toml
@@ -66,4 +66,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
+    "\\.\\.\\.\\.",
+    "pass",
 ]

--- a/plugins/spakky-kafka/pyproject.toml
+++ b/plugins/spakky-kafka/pyproject.toml
@@ -71,6 +71,8 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
+    "\\.\\.\\.\\.",
+    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/event/consumer.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/event/consumer.py
@@ -19,7 +19,7 @@ from spakky.event.event_consumer import (
     IAsyncIntegrationEventConsumer,
     IIntegrationEventConsumer,
     IntegrationEventHandlerCallback,
-    IntegrationEventT,
+    IntegrationEventT_contra,
 )
 
 from spakky.plugins.kafka.common.config import KafkaConnectionConfig
@@ -93,8 +93,8 @@ class KafkaEventConsumer(IIntegrationEventConsumer, AbstractBackgroundService):
 
     def register(
         self,
-        event: type[IntegrationEventT],
-        handler: IntegrationEventHandlerCallback[IntegrationEventT],
+        event: type[IntegrationEventT_contra],
+        handler: IntegrationEventHandlerCallback[IntegrationEventT_contra],
     ) -> None:
         if event in self.handlers:
             raise DuplicateEventHandlerError(event)
@@ -184,8 +184,8 @@ class AsyncKafkaEventConsumer(
 
     def register(
         self,
-        event: type[IntegrationEventT],
-        handler: AsyncIntegrationEventHandlerCallback[IntegrationEventT],
+        event: type[IntegrationEventT_contra],
+        handler: AsyncIntegrationEventHandlerCallback[IntegrationEventT_contra],
     ) -> None:
         if event in self.handlers:
             raise DuplicateEventHandlerError(event)

--- a/plugins/spakky-rabbitmq/pyproject.toml
+++ b/plugins/spakky-rabbitmq/pyproject.toml
@@ -71,6 +71,8 @@ exclude_lines = [
   "raise NotImplementedError",
   "@(abc\\.)?abstractmethod",
   "@(typing\\.)?overload",
+  "\\.\\.\\.\\.",
+  "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/consumer.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/consumer.py
@@ -28,7 +28,7 @@ from spakky.event.event_consumer import (
     IAsyncIntegrationEventConsumer,
     IIntegrationEventConsumer,
     IntegrationEventHandlerCallback,
-    IntegrationEventT,
+    IntegrationEventT_contra,
 )
 
 from spakky.plugins.rabbitmq.common.config import RabbitMQConnectionConfig
@@ -92,8 +92,8 @@ class RabbitMQEventConsumer(IIntegrationEventConsumer, AbstractBackgroundService
 
     def register(
         self,
-        event: type[IntegrationEventT],
-        handler: IntegrationEventHandlerCallback[IntegrationEventT],
+        event: type[IntegrationEventT_contra],
+        handler: IntegrationEventHandlerCallback[IntegrationEventT_contra],
     ) -> None:
         """Register an event handler for a specific event type.
 
@@ -198,8 +198,8 @@ class AsyncRabbitMQEventConsumer(
 
     def register(
         self,
-        event: type[IntegrationEventT],
-        handler: AsyncIntegrationEventHandlerCallback[IntegrationEventT],
+        event: type[IntegrationEventT_contra],
+        handler: AsyncIntegrationEventHandlerCallback[IntegrationEventT_contra],
     ) -> None:
         """Register an async event handler for a specific event type.
 

--- a/plugins/spakky-security/pyproject.toml
+++ b/plugins/spakky-security/pyproject.toml
@@ -66,4 +66,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
+    "\\.\\.\\.\\.",
+    "pass",
 ]

--- a/plugins/spakky-typer/pyproject.toml
+++ b/plugins/spakky-typer/pyproject.toml
@@ -61,4 +61,6 @@ exclude_lines = [
   "raise NotImplementedError",
   "@(abc\\.)?abstractmethod",
   "@(typing\\.)?overload",
+  "\\.\\.\\.\\.",
+  "pass",
 ]


### PR DESCRIPTION
## Summary
Implements Issue #2: Automatic domain event publishing after transaction completion.

## Changes

### New Features
- **TransactionalEventPublishingAspect**: Synchronous aspect for publishing domain events after `@Transactional` methods succeed
- **AsyncTransactionalEventPublishingAspect**: Asynchronous aspect for publishing domain events after `@Transactional` async methods succeed
- Auto-registration via `spakky-event` plugin initialization

### Type System Improvements
- Added complete variance coverage for all TypeVars (invariant, covariant, contravariant)
- Fixed `AggregateCollector` to use `IEquatable` instead of incorrect TypeVar usage
- Removed `Any` from TypeVar bounds, replaced with concrete types (`IEquatable`)
- Added variance variants for:
  - `AggregateRootT`, `ProxyIdT`, `ProxyModelT`
  - `DomainEventT`, `IntegrationEventT`, `EventT`
  - `AspectT`, `AsyncAspectT`, `PodT`
  - `CommandT`, `QueryT`, `ResultT`

### Implementation Details
- Aspects use `@Order(1)` to run after `@Transactional` aspects (`@Order(0)`)
- Events are published via `IDomainEventPublisher` / `IAsyncDomainEventPublisher`
- Events are cleared from aggregates after successful publishing
- On transaction failure (`@AfterRaising`), collector is cleared without publishing
- Uses `AggregateCollector` (context-scoped) to track saved aggregates

## Testing
- ✅ 5 new tests for TransactionalEventPublishingAspect
- ✅ All 434 existing tests pass
- ✅ Type checking passes (Pyrefly)
- ✅ Linting passes (Ruff)
- ✅ Pre-push hooks validated 7 affected packages

## Affected Packages
- `core/spakky` - TypeVar improvements
- `core/spakky-domain` - TypeVar improvements, AggregateRoot variants
- `core/spakky-data` - AggregateCollector fix
- `core/spakky-event` - New aspects, TypeVar improvements
- `plugins/spakky-rabbitmq` - Updated to use new contravariant TypeVars
- `plugins/spakky-kafka` - Updated to use new contravariant TypeVars

## Related Issue
Closes #2