### PR TITLE
docs: 문서화 오류 수정

### DIFF
--- a/docs/di-container.md
+++ b/docs/di-container.md
@@ -51,21 +51,19 @@ def create_connection_pool() -> ConnectionPool:
 
 ### Configuration 패턴
 
-관련 팩토리 메서드를 `@Configuration` 클래스로 그룹화합니다.
+`@Configuration`은 `@Pod`의 특화 스테레오타입으로, 설정 값을 그룹화하는 클래스에 사용합니다.
 
 ```python
 from spakky.core.stereotype.configuration import Configuration
+from pydantic_settings import BaseSettings
 
 @Configuration()
-class DatabaseConfig:
-    @Pod()
-    def connection_pool(self) -> ConnectionPool:
-        return ConnectionPool(size=10)
-
-    @Pod()
-    def session_factory(self, pool: ConnectionPool) -> SessionFactory:
-        return SessionFactory(pool)
+class DatabaseConfig(BaseSettings):
+    pool_size: int = 10
+    connection_url: str = "postgresql://localhost/mydb"
 ```
+
+> **주의**: `@Configuration` 클래스 내부 메서드에 `@Pod()`를 붙여도 자동으로 Pod이 등록되지 않습니다. 팩토리 메서드는 모듈 수준 함수로 정의하세요.
 
 ---
 
@@ -287,56 +285,83 @@ class ExpensiveService:
 
 ## 순서 지정
 
-`@Order`로 Pod 처리 순서를 지정합니다 (숫자가 낮을수록 우선).
+`@Order`로 PostProcessor와 Aspect의 실행 순서를 지정합니다. 숫자가 낮을수록 먼저 실행됩니다. 기본값은 `sys.maxsize`(마지막)입니다.
 
 ```python
 from spakky.core.pod.annotations.order import Order
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.post_processor import IPostProcessor
 
-@Pod()
 @Order(1)
-class FirstProcessor:
-    ...
-
 @Pod()
+class FirstPostProcessor(IPostProcessor):
+    def post_process(self, pod: object) -> object:
+        # 가장 먼저 실행됨
+        return pod
+
 @Order(2)
-class SecondProcessor:
-    ...
+@Pod()
+class SecondPostProcessor(IPostProcessor):
+    def post_process(self, pod: object) -> object:
+        # 그 다음 실행됨
+        return pod
 ```
+
+> **참고**: `@Order`는 PostProcessor, Aspect 등 프레임워크 확장 포인트의 실행 순서를 제어합니다. 일반 Pod의 초기화 순서를 지정하는 데는 사용되지 않습니다.
 
 ---
 
 ## Tag로 그룹화
 
-`@Tag`로 Pod를 그룹화하여 일괄 조회합니다.
+`Tag`를 서브클래싱하여 커스텀 메타데이터 태그를 정의합니다. 태그는 Pod와 독립적으로 등록할 수도 있습니다.
 
 ```python
+from dataclasses import dataclass
 from spakky.core.pod.annotations.tag import Tag
+from spakky.core.pod.annotations.pod import Pod
 
-VALIDATOR_TAG = Tag("validator")
+@dataclass(eq=False)
+class ValidatorTag(Tag):
+    """검증기 태그"""
+    category: str = ""
 
+@ValidatorTag(category="input")
 @Pod()
-@VALIDATOR_TAG
 class EmailValidator:
     ...
 
+@ValidatorTag(category="input")
 @Pod()
-@VALIDATOR_TAG
 class PhoneValidator:
     ...
+```
 
-# 태그로 모든 validator 조회
-validators = context.find(lambda pod: VALIDATOR_TAG in pod.tags)
+태그는 `ApplicationContext`의 태그 레지스트리에서 조회합니다:
+
+```python
+# 등록된 모든 태그 조회
+all_tags = context.list_tags()
+
+# 조건으로 필터링
+input_tags = context.list_tags(
+    lambda t: isinstance(t, ValidatorTag) and t.category == "input"
+)
+
+# 특정 태그 존재 여부 확인
+assert context.contains_tag(ValidatorTag(category="input"))
 ```
 
 ---
 
 ## PostProcessor
 
-Pod 인스턴스가 생성된 후 추가 처리를 수행하는 확장 포인트입니다.
+Pod 인스턴스가 생성된 후 추가 처리를 수행하는 확장 포인트입니다. PostProcessor도 `@Pod()`로 등록해야 합니다.
 
 ```python
+from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.interfaces.post_processor import IPostProcessor
 
+@Pod()
 class LoggingPostProcessor(IPostProcessor):
     def post_process(self, pod: object) -> object:
         print(f"Pod created: {type(pod).__name__}")

--- a/docs/event-system.md
+++ b/docs/event-system.md
@@ -114,18 +114,37 @@ class Order(AbstractAggregateRoot[UUID]):
 
 ### 아키텍처
 
-```
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│  Publisher  │────▶│  Dispatcher │────▶│  Handler    │
-└─────────────┘     └─────────────┘     └─────────────┘
-                           │
-                           │ (Consumer 역할)
-                           ▼
-                    ┌─────────────┐
-                    │  Mediator   │
-                    │ (Consumer + │
-                    │  Dispatcher)│
-                    └─────────────┘
+Publisher는 이벤트 타입에 따라 라우팅합니다:
+
+```mermaid
+graph LR
+    subgraph "📤 발행"
+        P["Publisher<br/>(IEventPublisher)"]
+    end
+
+    subgraph "🔀 라우팅"
+        M["Mediator<br/>(Consumer + Dispatcher)"]
+        B["EventBus<br/>(IEventBus)"]
+    end
+
+    subgraph "📥 처리"
+        H1["@EventHandler<br/>핸들러 A"]
+        H2["@EventHandler<br/>핸들러 B"]
+        T["EventTransport<br/>(IEventTransport)"]
+    end
+
+    P -->|"DomainEvent"| M
+    P -->|"IntegrationEvent"| B
+    M -->|"dispatch"| H1
+    M -->|"dispatch"| H2
+    B -->|"send"| T
+
+    style P fill:#4A90D9,stroke:#2C5F8A,color:#fff
+    style M fill:#7B68EE,stroke:#5A4FCF,color:#fff
+    style B fill:#7B68EE,stroke:#5A4FCF,color:#fff
+    style H1 fill:#50C878,stroke:#3A9D5C,color:#fff
+    style H2 fill:#50C878,stroke:#3A9D5C,color:#fff
+    style T fill:#FF8C42,stroke:#CC6F35,color:#fff
 ```
 
 ### Mediator
@@ -307,93 +326,33 @@ class PlaceOrderUseCase:
 
 ### RabbitMQ (spakky-rabbitmq)
 
-> `RabbitMQEventTransport` (implements `IEventTransport`) / `RabbitMQEventConsumer`
-
-```python
-@Pod()
-class OrderService:
-    def __init__(self, publisher: IAsyncEventPublisher) -> None:
-        self.publisher = publisher
-
-    async def place_order(self, command: PlaceOrderCommand) -> Order:
-        order = await self.create_order(command)
-        await self.publisher.publish(OrderPlacedEvent(...))
-        return order
-```
+> `RabbitMQEventTransport` / `AsyncRabbitMQEventTransport` (implements `IEventTransport` / `IAsyncEventTransport`)
+>
+> `RabbitMQEventConsumer` / `AsyncRabbitMQEventConsumer` (implements `IEventConsumer` / `IAsyncEventConsumer`)
 
 ### Kafka (spakky-kafka)
 
-> `KafkaEventTransport` (implements `IEventTransport`) / `KafkaEventConsumer`
+> `KafkaEventTransport` / `AsyncKafkaEventTransport` (implements `IEventTransport` / `IAsyncEventTransport`)
+>
+> `KafkaEventConsumer` / `AsyncKafkaEventConsumer` (implements `IEventConsumer` / `IAsyncEventConsumer`)
+
+Publisher 코드는 브로커에 의존하지 않습니다. `IAsyncEventPublisher.publish()`를 통해 IntegrationEvent를 발행하면, DI로 주입된 `IAsyncEventBus` → `IAsyncEventTransport` 경로로 브로커에 전송됩니다.
 
 ---
 
 ## 오류 처리
 
-### Mediator의 탄력적 디스패치
+### Mediator의 핸들러 격리
 
 인프로세스 Mediator는 핸들러 실패 시에도 나머지 핸들러를 계속 실행합니다:
 
 ```python
 # 핸들러 A 실행 → 성공
-# 핸들러 B 실행 → 실패 (로그 기록)
+# 핸들러 B 실행 → 실패 (로그 기록, 예외 전파하지 않음)
 # 핸들러 C 실행 → 계속 실행됨
 ```
 
 ### 재시도 전략
 
-분산 환경에서는 재시도 로직이 필요합니다:
+분산 환경에서의 재시도는 메시지 브로커 수준에서 처리됩니다. RabbitMQ의 nack/requeue, Kafka의 offset 관리 등 트랜스포트 구현체가 재시도 로직을 담당합니다. 개별 핸들러에 재시도 로직을 직접 구현할 필요는 없습니다.
 
-```python
-@EventHandler()
-class ResilientHandler:
-    @on_event(OrderPlacedEvent)
-    async def handle_with_retry(self, event: OrderPlacedEvent) -> None:
-        for attempt in range(3):
-            try:
-                await self.process(event)
-                return
-            except RetryableError:
-                if attempt == 2:
-                    raise
-                await asyncio.sleep(2 ** attempt)
-```
-
----
-
-## 테스트
-
-```python
-import pytest
-from unittest.mock import AsyncMock
-
-@pytest.mark.asyncio
-async def test_event_handler():
-    # 목 의존성
-    mailer = AsyncMock()
-
-    # 핸들러 생성
-    handler = UserEventHandler(mailer=mailer, analytics=AsyncMock())
-
-    # 이벤트 발생
-    event = UserCreatedEvent(user_id=uuid4(), email="test@example.com")
-    await handler.send_welcome_email(event)
-
-    # 검증
-    mailer.send_welcome.assert_called_once_with("test@example.com")
-```
-
-### Mediator 테스트
-
-```python
-@pytest.mark.asyncio
-async def test_mediator_dispatches_to_handlers():
-    mediator = AsyncEventMediator()
-    handler = AsyncMock()
-
-    mediator.register(UserCreatedEvent, handler)
-
-    event = UserCreatedEvent(user_id=uuid4(), email="test@example.com")
-    await mediator.dispatch(event)
-
-    handler.assert_called_once_with(event)
-```

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -31,12 +31,13 @@ app.start()
 ### 선택적 플러그인 로드
 
 ```python
-from spakky.core.application.plugin import Plugin
+import spakky.plugins.fastapi
+import spakky.plugins.sqlalchemy
 
-# 특정 플러그인만 로드
+# 각 플러그인의 PLUGIN_NAME을 사용하여 특정 플러그인만 로드
 app.load_plugins(include={
-    Plugin(name="spakky-fastapi"),
-    Plugin(name="spakky-sqlalchemy"),
+    spakky.plugins.fastapi.PLUGIN_NAME,
+    spakky.plugins.sqlalchemy.PLUGIN_NAME,
 })
 ```
 
@@ -44,7 +45,9 @@ app.load_plugins(include={
 
 ## 공식 플러그인
 
-### Core 플러그인 (자동 로드)
+### Core 플러그인
+
+Core 플러그인은 자동 로드되지 않습니다. 구현체 플러그인의 `dependencies`로 선언되어, 구현체 플러그인 설치 시 함께 설치됩니다.
 
 | 플러그인        | 설명                           |
 | --------------- | ------------------------------ |
@@ -227,27 +230,25 @@ class MyFeatureHandler(Pod):
 
 ```python
 from spakky.core.pod.annotations.pod import Pod
-from spakky.core.service.interfaces.service import IAsyncService
-import asyncio
+from spakky.core.service.background import AbstractBackgroundService
 
 @Pod()
-class MyFeatureBackgroundService(IAsyncService):
+class MyFeatureBackgroundService(AbstractBackgroundService):
     """백그라운드에서 실행되는 서비스"""
 
-    _stop_event: asyncio.Event
+    def initialize(self) -> None:
+        """서비스 초기화"""
+        ...
 
-    def set_stop_event(self, stop_event: asyncio.Event) -> None:
-        self._stop_event = stop_event
-
-    async def start_async(self) -> None:
-        """서비스 시작"""
+    def run(self) -> None:
+        """메인 루프 (백그라운드 스레드)"""
         while not self._stop_event.is_set():
-            await self.do_work()
-            await asyncio.sleep(1)
+            self.do_work()
+            self._stop_event.wait(timeout=1)
 
-    async def stop_async(self) -> None:
-        """서비스 정지"""
-        await self.cleanup()
+    def dispose(self) -> None:
+        """리소스 정리"""
+        ...
 ```
 
 ---


### PR DESCRIPTION
## 변경 사항

### di-container.md
- **Configuration**: 팩토리 메서드 그룹화 패턴(실제로 동작하지 않음)을 설정 값 그룹화 패턴으로 수정
- **Order**: 일반 Pod 순서가 아닌 PostProcessor/Aspect 실행 순서 제어임을 명확화
- **Tag**: `Tag("name")` 직접 사용을 서브클래싱 패턴으로 수정, `list_tags()` API 반영
- **PostProcessor**: 예제에 누락된 `@Pod()` 데코레이터 추가

### event-system.md
- **아키텍처 다이어그램**: ASCII art를 mermaid로 전환, 실제 Publisher 라우팅 흐름(DomainEvent→Mediator, IntegrationEvent→Bus) 반영
- **분산 이벤트 브로커**: RabbitMQ 섹션의 불필요한(브로커 비특정적) 코드 블럭 제거, Async 클래스명 보완
- **핸들러 격리**: "탄력적 디스패치" → "핸들러 격리"로 리네이밍 (코드에서 구현 확인됨)
- **재시도 전략**: 핸들러 내 수동 재시도 예시를 트랜스포트 수준 설명으로 변경
- **테스트 섹션**: 문서에 불필요한 테스트 코드 제거

### plugin-api.md
- **선택적 플러그인 로드**: `Plugin(name="...")` 문자열 기반에서 `PLUGIN_NAME` import 사용으로 변경
- **Core 플러그인**: "자동 로드" → 구현체 플러그인의 의존성으로 함께 설치됨을 명시
- **백그라운드 서비스**: `IAsyncService` 직접 사용을 `AbstractBackgroundService` 기반으로 수정 (네이밍 컨벤션 준수)