### PR TITLE
feat(fastapi): add TracingMiddleware for W3C Trace Context propagation

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -10,5 +10,12 @@ disable-model-invocation: true
 1. `git diff main...HEAD`로 변경 파일 확인
 2. Conventional Commits 형식 타이틀 (scope는 `/commit` 스킬 참조)
 3. PR 내용을 마크다운으로 출력 → **사용자 승인 후** `gh pr create` 실행
+4. PR 생성 후 메타데이터 설정:
+   - **Assignee**: `gh pr edit {PR_NUMBER} --add-assignee @me`
+   - **Label**: 변경 내용의 성격에 맞는 label을 선택하여 적용
+     ```bash
+     gh label list --limit 50  # 사용 가능한 label 확인
+     gh pr edit {PR_NUMBER} --add-label "{LABELS}"
+     ```
 
 PR 대상: $ARGUMENTS

--- a/.claude/skills/update-project-status/SKILL.md
+++ b/.claude/skills/update-project-status/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: update-project-status
+description: GitHub Issue에 연결된 프로젝트의 Status 필드를 갱신합니다.
+argument-hint: "<issue-number> <status>"
+user-invocable: false
+---
+
+# Update Project Status — 프로젝트 상태 자동 갱신
+
+GitHub Issue에 연결된 프로젝트(ProjectV2)의 Status 필드를 갱신한다.
+연결된 프로젝트가 없거나 Status 필드가 없으면 조용히 건너뛴다.
+
+## 인자
+
+`$ARGUMENTS`를 파싱한다:
+
+- 첫 번째: Issue 번호 (예: `42`, `#42`)
+- 두 번째: 목표 Status 값 (예: `In Progress`, `In Review`, `Done`)
+
+## 절차
+
+### 1. 프로젝트 항목 조회
+
+이슈에 연결된 프로젝트 항목과 Status 필드 정보를 조회한다.
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $issueNumber: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $issueNumber) {
+        projectItems(first: 10) {
+          nodes {
+            id
+            project {
+              id
+              title
+              field(name: "Status") {
+                ... on ProjectV2SingleSelectField {
+                  id
+                  options { id name }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -F owner={OWNER} -F repo={REPO} -F issueNumber=$ISSUE_NUMBER
+```
+
+- `owner`와 `repo`는 현재 리포지토리에서 `gh repo view --json owner,name`으로 얻는다.
+- `projectItems.nodes`가 비어있으면 "연결된 프로젝트 없음"을 출력하고 종료한다.
+
+### 2. 옵션 매칭
+
+각 프로젝트 항목에 대해:
+
+1. `project.field`가 null이면 (Status 필드 없음) 해당 프로젝트를 건너뛴다.
+2. `field.options`에서 목표 Status와 이름이 일치하는 옵션 ID를 찾는다.
+3. 일치하는 옵션이 없으면 해당 프로젝트를 건너뛴다.
+
+### 3. 상태 갱신
+
+매칭된 각 프로젝트에 대해 mutation을 실행한다:
+
+```bash
+gh api graphql -f query='
+  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+    updateProjectV2ItemFieldValue(
+      input: {
+        projectId: $projectId
+        itemId: $itemId
+        fieldId: $fieldId
+        value: { singleSelectOptionId: $optionId }
+      }
+    ) {
+      projectV2Item { id }
+    }
+  }
+' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" -f fieldId="$FIELD_ID" -f optionId="$OPTION_ID"
+```
+
+### 4. 결과 보고
+
+- 갱신 성공: `프로젝트 "{프로젝트명}" 상태 -> {STATUS}` 출력
+- 갱신 실패: 경고만 출력하고 호출자의 흐름을 중단하지 않는다.
+- 스킵된 프로젝트가 있으면 사유를 간결히 출력한다.
+
+## 규칙
+
+- 이 스킬은 실패해도 호출자의 Phase 진행을 차단하지 않는다.
+- GraphQL 호출 실패 시 1회 재시도 후 포기한다.
+- `gh auth status`에 `project` scope가 없으면 경고를 출력하고 종료한다.
+
+$ARGUMENTS

--- a/core/spakky-data/.pre-commit-config.yaml
+++ b/core/spakky-data/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-data" ]; then cd core/spakky-data; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "core/spakky-data" ]; then cd core/spakky-data; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky-domain/.pre-commit-config.yaml
+++ b/core/spakky-domain/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-domain" ]; then cd core/spakky-domain; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "core/spakky-domain" ]; then cd core/spakky-domain; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky-event/.pre-commit-config.yaml
+++ b/core/spakky-event/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-event" ]; then cd core/spakky-event; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "core/spakky-event" ]; then cd core/spakky-event; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky-outbox/.pre-commit-config.yaml
+++ b/core/spakky-outbox/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-outbox" ]; then cd core/spakky-outbox; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "core/spakky-outbox" ]; then cd core/spakky-outbox; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky-task/.pre-commit-config.yaml
+++ b/core/spakky-task/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-task" ]; then cd core/spakky-task; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "core/spakky-task" ]; then cd core/spakky-task; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky-tracing/.pre-commit-config.yaml
+++ b/core/spakky-tracing/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-tracing" ]; then cd core/spakky-tracing; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "core/spakky-tracing" ]; then cd core/spakky-tracing; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky/.pre-commit-config.yaml
+++ b/core/spakky/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky" ]; then cd core/spakky; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "core/spakky" ]; then cd core/spakky; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-celery/.pre-commit-config.yaml
+++ b/plugins/spakky-celery/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-celery" ]; then cd plugins/spakky-celery; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "plugins/spakky-celery" ]; then cd plugins/spakky-celery; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-fastapi/.pre-commit-config.yaml
+++ b/plugins/spakky-fastapi/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-fastapi" ]; then cd plugins/spakky-fastapi; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "plugins/spakky-fastapi" ]; then cd plugins/spakky-fastapi; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-fastapi/pyproject.toml
+++ b/plugins/spakky-fastapi/pyproject.toml
@@ -13,6 +13,14 @@ dependencies = [
     "websockets>=16.0",
 ]
 
+[project.optional-dependencies]
+tracing = ["spakky-tracing>=6.2.0"]
+
+[dependency-groups]
+dev = [
+    "spakky-tracing>=6.2.0",
+]
+
 [project.entry-points."spakky.plugins"]
 spakky-fastapi = "spakky.plugins.fastapi.main:initialize"
 

--- a/plugins/spakky-fastapi/src/spakky/plugins/fastapi/middlewares/tracing.py
+++ b/plugins/spakky-fastapi/src/spakky/plugins/fastapi/middlewares/tracing.py
@@ -1,0 +1,71 @@
+"""Tracing middleware for W3C Trace Context propagation.
+
+Extracts trace context from incoming HTTP request headers, activates a
+child span for the request lifetime, and injects trace context into
+response headers.
+"""
+
+from typing import Awaitable, Callable, TypeAlias
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, DispatchFunction
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from spakky.tracing.context import TraceContext
+from spakky.tracing.propagator import ITracePropagator
+
+Next: TypeAlias = Callable[[Request], Awaitable[Response]]
+
+
+class TracingMiddleware(BaseHTTPMiddleware):
+    """Middleware that propagates W3C Trace Context across HTTP boundaries.
+
+    Extracts ``traceparent`` from request headers, activates a child span
+    for the request lifetime, and injects ``traceparent`` into response
+    headers.  When no incoming trace context is present, a new root trace
+    is started.
+    """
+
+    __propagator: ITracePropagator
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        dispatch: DispatchFunction | None = None,
+        *,
+        propagator: ITracePropagator,
+    ) -> None:
+        """Initialize the tracing middleware.
+
+        Args:
+            app: The ASGI application.
+            dispatch: Optional custom dispatch function.
+            propagator: Trace context propagator for extract/inject.
+        """
+        super().__init__(app, dispatch)
+        self.__propagator = propagator
+
+    async def dispatch(self, request: Request, call_next: Next) -> Response:
+        """Extract trace context, process request, and inject into response.
+
+        Args:
+            request: The incoming HTTP request.
+            call_next: Function to call the next middleware or route handler.
+
+        Returns:
+            The HTTP response with trace context headers injected.
+        """
+        carrier: dict[str, str] = dict(request.headers)
+        parent = self.__propagator.extract(carrier)
+        ctx = parent.child() if parent is not None else TraceContext.new_root()
+        TraceContext.set(ctx)
+        try:
+            response = await call_next(request)
+            response_carrier: dict[str, str] = {}
+            self.__propagator.inject(response_carrier)
+            for key, value in response_carrier.items():
+                response.headers[key] = value
+            return response
+        finally:
+            TraceContext.clear()

--- a/plugins/spakky-fastapi/src/spakky/plugins/fastapi/post_processors/add_builtin_middlewares.py
+++ b/plugins/spakky-fastapi/src/spakky/plugins/fastapi/post_processors/add_builtin_middlewares.py
@@ -1,7 +1,8 @@
 """Post-processor for adding built-in middleware to FastAPI applications.
 
 Automatically injects error handling and context management middleware
-into FastAPI instances registered in the container.
+into FastAPI instances registered in the container.  When ``spakky-tracing``
+is installed and its plugin is loaded, tracing middleware is also added.
 """
 
 from spakky.core.pod.annotations.order import Order
@@ -15,14 +16,24 @@ from spakky.core.pod.interfaces.post_processor import IPostProcessor
 from fastapi import FastAPI
 from spakky.plugins.fastapi.middlewares.error_handling import ErrorHandlingMiddleware
 
+try:
+    from spakky.tracing.propagator import ITracePropagator
+    from spakky.plugins.fastapi.middlewares.tracing import TracingMiddleware
+
+    _HAS_TRACING = True
+except ImportError:  # pragma: no cover - optional dependency (spakky-tracing)
+    _HAS_TRACING = False
+
 
 @Order(0)
 @Pod()
 class AddBuiltInMiddlewaresPostProcessor(IPostProcessor, IApplicationContextAware):
     """Post-processor that adds built-in middleware to FastAPI instances.
 
-    Injects error handling and context management middleware into any FastAPI
-    instance created as a Pod. Runs early in the post-processor chain (Order 0).
+    Injects error handling and tracing middleware into any FastAPI instance
+    created as a Pod.  Tracing middleware is only added when ``spakky-tracing``
+    is installed and its plugin is loaded.  Runs early in the post-processor
+    chain (Order 0).
     """
 
     __application_context: IApplicationContext
@@ -38,8 +49,14 @@ class AddBuiltInMiddlewaresPostProcessor(IPostProcessor, IApplicationContextAwar
     def post_process(self, pod: object) -> object:
         """Add built-in middleware to FastAPI instances.
 
-        If the Pod is a FastAPI instance, adds error handling and context
-        management middleware. Non-FastAPI Pods are returned unchanged.
+        If the Pod is a FastAPI instance, adds error handling middleware and
+        optionally tracing middleware.  Non-FastAPI Pods are returned unchanged.
+
+        Middleware execution order (outermost first):
+        1. ``TracingMiddleware`` — extract/inject W3C Trace Context
+        2. ``ErrorHandlingMiddleware`` — catch exceptions → JSON responses
+
+        ``add_middleware`` prepends, so the last added middleware executes first.
 
         Args:
             pod: The Pod to process.
@@ -54,4 +71,12 @@ class AddBuiltInMiddlewaresPostProcessor(IPostProcessor, IApplicationContextAwar
             ErrorHandlingMiddleware,
             debug=pod.debug,
         )
+
+        if _HAS_TRACING and self.__application_context.contains(ITracePropagator):
+            propagator = self.__application_context.get(type_=ITracePropagator)
+            pod.add_middleware(
+                TracingMiddleware,
+                propagator=propagator,
+            )
+
         return pod

--- a/plugins/spakky-fastapi/tests/test_tracing.py
+++ b/plugins/spakky-fastapi/tests/test_tracing.py
@@ -1,0 +1,239 @@
+"""TracingMiddleware 단위 및 통합 테스트."""
+
+import re
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from spakky.tracing.context import TraceContext
+from spakky.tracing.w3c_propagator import W3CTracePropagator
+
+from spakky.plugins.fastapi.middlewares.tracing import TracingMiddleware
+from spakky.plugins.fastapi.post_processors import (
+    add_builtin_middlewares as middlewares_module,
+)
+
+TRACEPARENT_PATTERN = re.compile(
+    r"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$"
+)
+SAMPLE_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+SAMPLE_TRACE_ID = "0af7651916cd43dd8448eb211c80319c"
+SAMPLE_SPAN_ID = "b7ad6b7169203331"
+
+
+def _create_app_with_tracing() -> FastAPI:
+    """TracingMiddleware가 설정된 FastAPI 앱을 생성한다."""
+    api = FastAPI()
+    propagator = W3CTracePropagator()
+    api.add_middleware(TracingMiddleware, propagator=propagator)
+    return api
+
+
+# --- 단위 테스트 ---
+
+
+def test_tracing_middleware_with_traceparent_expect_child_span() -> None:
+    """traceparent 헤더가 있는 요청 시 같은 trace_id의 child span이 응답에 포함됨을 검증한다."""
+    api = _create_app_with_tracing()
+
+    @api.get("/test")
+    async def endpoint() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    with TestClient(api) as client:
+        response = client.get(
+            "/test",
+            headers={"traceparent": SAMPLE_TRACEPARENT},
+        )
+
+    assert response.status_code == 200
+    response_traceparent = response.headers.get("traceparent")
+    assert response_traceparent is not None
+    assert TRACEPARENT_PATTERN.match(response_traceparent)
+
+    parts = response_traceparent.split("-")
+    assert parts[1] == SAMPLE_TRACE_ID
+    assert parts[2] != SAMPLE_SPAN_ID
+
+
+def test_tracing_middleware_without_traceparent_expect_new_root() -> None:
+    """traceparent 헤더가 없는 요청 시 새로운 root trace가 생성됨을 검증한다."""
+    api = _create_app_with_tracing()
+
+    @api.get("/test")
+    async def endpoint() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    with TestClient(api) as client:
+        response = client.get("/test")
+
+    assert response.status_code == 200
+    response_traceparent = response.headers.get("traceparent")
+    assert response_traceparent is not None
+    assert TRACEPARENT_PATTERN.match(response_traceparent)
+
+
+def test_tracing_middleware_with_invalid_traceparent_expect_new_root() -> None:
+    """잘못된 traceparent 헤더 시 새로운 root trace가 생성됨을 검증한다."""
+    api = _create_app_with_tracing()
+
+    @api.get("/test")
+    async def endpoint() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    with TestClient(api) as client:
+        response = client.get(
+            "/test",
+            headers={"traceparent": "invalid-header"},
+        )
+
+    assert response.status_code == 200
+    response_traceparent = response.headers.get("traceparent")
+    assert response_traceparent is not None
+    assert TRACEPARENT_PATTERN.match(response_traceparent)
+
+    parts = response_traceparent.split("-")
+    assert parts[1] != SAMPLE_TRACE_ID
+
+
+def test_tracing_middleware_handler_access_context_expect_trace_context_available() -> None:
+    """핸들러 내부에서 TraceContext.get()으로 현재 trace context에 접근 가능함을 검증한다."""
+    api = _create_app_with_tracing()
+    captured_trace_id: str | None = None
+    captured_parent_span_id: str | None = None
+
+    @api.get("/test")
+    async def endpoint() -> JSONResponse:
+        nonlocal captured_trace_id, captured_parent_span_id
+        ctx = TraceContext.get()
+        assert ctx is not None
+        captured_trace_id = ctx.trace_id
+        captured_parent_span_id = ctx.parent_span_id
+        return JSONResponse({"ok": True})
+
+    with TestClient(api) as client:
+        response = client.get(
+            "/test",
+            headers={"traceparent": SAMPLE_TRACEPARENT},
+        )
+
+    assert response.status_code == 200
+    assert captured_trace_id == SAMPLE_TRACE_ID
+    assert captured_parent_span_id == SAMPLE_SPAN_ID
+
+
+def test_tracing_middleware_clears_context_after_request_expect_none() -> None:
+    """요청 완료 후 TraceContext가 정리됨을 검증한다."""
+    api = _create_app_with_tracing()
+
+    @api.get("/test")
+    async def endpoint() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    with TestClient(api) as client:
+        client.get("/test", headers={"traceparent": SAMPLE_TRACEPARENT})
+
+    assert TraceContext.get() is None
+
+
+def test_tracing_middleware_clears_context_on_error_expect_none() -> None:
+    """핸들러 예외 시에도 TraceContext가 정리됨을 검증한다."""
+    api = _create_app_with_tracing()
+
+    @api.get("/test")
+    async def endpoint() -> JSONResponse:
+        raise RuntimeError("test error")
+
+    with TestClient(api, raise_server_exceptions=False) as client:
+        client.get("/test", headers={"traceparent": SAMPLE_TRACEPARENT})
+
+    assert TraceContext.get() is None
+
+
+# --- PostProcessor 통합 테스트 ---
+
+
+def test_post_processor_with_tracing_plugin_expect_traceparent_in_response() -> None:
+    """spakky-tracing 플러그인 로드 시 응답에 traceparent 헤더가 포함됨을 검증한다."""
+    from spakky.core.application.application import SpakkyApplication
+    from spakky.core.application.application_context import ApplicationContext
+    from spakky.core.pod.annotations.pod import Pod
+
+    import spakky.plugins.fastapi
+    import spakky.tracing
+    from tests import apps
+
+    @Pod(name="key")
+    def get_name() -> str:
+        return "test"
+
+    @Pod(name="api")
+    def get_api() -> FastAPI:
+        return FastAPI(debug=True)
+
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .load_plugins(
+            include={
+                spakky.plugins.fastapi.PLUGIN_NAME,
+                spakky.tracing.PLUGIN_NAME,
+            }
+        )
+        .scan(apps)
+        .add(get_name)
+        .add(get_api)
+    )
+    app.start()
+
+    api = app.container.get(type_=FastAPI)
+    with TestClient(api) as client:
+        response = client.get("/dummy")
+
+    assert response.status_code == 200
+    response_traceparent = response.headers.get("traceparent")
+    assert response_traceparent is not None
+    assert TRACEPARENT_PATTERN.match(response_traceparent)
+
+
+def test_post_processor_without_tracing_flag_expect_no_traceparent() -> None:
+    """_HAS_TRACING이 False일 때 응답에 traceparent 헤더가 포함되지 않음을 검증한다."""
+    from spakky.core.application.application import SpakkyApplication
+    from spakky.core.application.application_context import ApplicationContext
+    from spakky.core.pod.annotations.pod import Pod
+
+    import spakky.plugins.fastapi
+    from tests import apps
+
+    original = middlewares_module._HAS_TRACING  # pyrefly: ignore - conditional module variable from try/except ImportError
+    middlewares_module._HAS_TRACING = False  # pyrefly: ignore - conditional module variable from try/except ImportError
+    try:
+        @Pod(name="key")
+        def get_name() -> str:
+            return "test"
+
+        @Pod(name="api")
+        def get_api() -> FastAPI:
+            return FastAPI(debug=True)
+
+        app = (
+            SpakkyApplication(ApplicationContext())
+            .load_plugins(
+                include={
+                    spakky.plugins.fastapi.PLUGIN_NAME,
+                }
+            )
+            .scan(apps)
+            .add(get_name)
+            .add(get_api)
+        )
+        app.start()
+
+        api = app.container.get(type_=FastAPI)
+        with TestClient(api) as client:
+            response = client.get("/dummy")
+
+        assert response.status_code == 200
+        assert "traceparent" not in response.headers
+    finally:
+        middlewares_module._HAS_TRACING = original  # pyrefly: ignore - conditional module variable from try/except ImportError

--- a/plugins/spakky-fastapi/tests/test_tracing.py
+++ b/plugins/spakky-fastapi/tests/test_tracing.py
@@ -14,9 +14,7 @@ from spakky.plugins.fastapi.post_processors import (
     add_builtin_middlewares as middlewares_module,
 )
 
-TRACEPARENT_PATTERN = re.compile(
-    r"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$"
-)
+TRACEPARENT_PATTERN = re.compile(r"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$")
 SAMPLE_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
 SAMPLE_TRACE_ID = "0af7651916cd43dd8448eb211c80319c"
 SAMPLE_SPAN_ID = "b7ad6b7169203331"
@@ -97,7 +95,9 @@ def test_tracing_middleware_with_invalid_traceparent_expect_new_root() -> None:
     assert parts[1] != SAMPLE_TRACE_ID
 
 
-def test_tracing_middleware_handler_access_context_expect_trace_context_available() -> None:
+def test_tracing_middleware_handler_access_context_expect_trace_context_available() -> (
+    None
+):
     """핸들러 내부에서 TraceContext.get()으로 현재 trace context에 접근 가능함을 검증한다."""
     api = _create_app_with_tracing()
     captured_trace_id: str | None = None
@@ -205,9 +205,12 @@ def test_post_processor_without_tracing_flag_expect_no_traceparent() -> None:
     import spakky.plugins.fastapi
     from tests import apps
 
-    original = middlewares_module._HAS_TRACING  # pyrefly: ignore - conditional module variable from try/except ImportError
+    original = (
+        middlewares_module._HAS_TRACING
+    )  # pyrefly: ignore - conditional module variable from try/except ImportError
     middlewares_module._HAS_TRACING = False  # pyrefly: ignore - conditional module variable from try/except ImportError
     try:
+
         @Pod(name="key")
         def get_name() -> str:
             return "test"

--- a/plugins/spakky-kafka/.pre-commit-config.yaml
+++ b/plugins/spakky-kafka/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-kafka" ]; then cd plugins/spakky-kafka; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "plugins/spakky-kafka" ]; then cd plugins/spakky-kafka; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-logging/.pre-commit-config.yaml
+++ b/plugins/spakky-logging/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-logging" ]; then cd plugins/spakky-logging; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "plugins/spakky-logging" ]; then cd plugins/spakky-logging; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-rabbitmq/.pre-commit-config.yaml
+++ b/plugins/spakky-rabbitmq/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-rabbitmq" ]; then cd plugins/spakky-rabbitmq; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "plugins/spakky-rabbitmq" ]; then cd plugins/spakky-rabbitmq; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-security/.pre-commit-config.yaml
+++ b/plugins/spakky-security/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-security" ]; then cd plugins/spakky-security; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "plugins/spakky-security" ]; then cd plugins/spakky-security; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-sqlalchemy/.pre-commit-config.yaml
+++ b/plugins/spakky-sqlalchemy/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-sqlalchemy" ]; then cd plugins/spakky-sqlalchemy; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "plugins/spakky-sqlalchemy" ]; then cd plugins/spakky-sqlalchemy; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-typer/.pre-commit-config.yaml
+++ b/plugins/spakky-typer/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-typer" ]; then cd plugins/spakky-typer; fi && uv run pyrefly check'
+        entry: bash -c 'if [ -d "plugins/spakky-typer" ]; then cd plugins/spakky-typer; fi && uv run pyrefly check --disable-project-excludes-heuristics'
         language: system
         types: [python]
         pass_filenames: false

--- a/uv.lock
+++ b/uv.lock
@@ -2619,13 +2619,28 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.optional-dependencies]
+tracing = [
+    { name = "spakky-tracing" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "spakky-tracing" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.1" },
     { name = "orjson", specifier = ">=3.11.7" },
     { name = "spakky", editable = "core/spakky" },
+    { name = "spakky-tracing", marker = "extra == 'tracing'", editable = "core/spakky-tracing" },
     { name = "websockets", specifier = ">=16.0" },
 ]
+provides-extras = ["tracing"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "spakky-tracing", editable = "core/spakky-tracing" }]
 
 [[package]]
 name = "spakky-framework"


### PR DESCRIPTION
## Summary

- `TracingMiddleware` 추가: HTTP 요청의 `traceparent` 헤더에서 trace context를 extract하고, child span을 생성하여 응답 헤더에 inject
- `AddBuiltInMiddlewaresPostProcessor` 수정: `spakky-tracing` 설치 + 플러그인 로드 시 조건부로 `TracingMiddleware` 등록 (`_HAS_TRACING` + `contains(ITracePropagator)` 이중 가드)
- pyrefly pre-commit hook 워크트리 호환성 수정: `--disable-project-excludes-heuristics` 플래그 추가

Closes #35

## Test plan

- [x] traceparent 헤더 있는 요청 → 같은 trace_id, 다른 span_id 응답
- [x] traceparent 없는 요청 → 새 root trace 생성
- [x] 잘못된 traceparent → 새 root trace 생성
- [x] 핸들러 내부 TraceContext.get() 접근 가능
- [x] 요청 완료/에러 후 TraceContext.clear() 확인
- [x] spakky-tracing 플러그인 로드 시 통합 테스트
- [x] _HAS_TRACING=False 시 미등록 확인
- [x] 전체 테스트 25/25 통과, 커버리지 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)