### PR TITLE
feat(rabbitmq): add trace context extraction to consumers

### DIFF
--- a/plugins/spakky-rabbitmq/pyproject.toml
+++ b/plugins/spakky-rabbitmq/pyproject.toml
@@ -15,9 +15,13 @@ dependencies = [
   "spakky-event>=6.2.0",
 ]
 
+[project.optional-dependencies]
+tracing = ["spakky-tracing>=6.2.0"]
+
 [dependency-groups]
 dev = [
     "pytest-integration-mark>=0.2.0",
+    "spakky-tracing>=6.2.0",
     "testcontainers>=4.14.1",
 ]
 
@@ -85,3 +89,4 @@ exclude_lines = [
 
 [tool.uv.sources]
 spakky-event = { workspace = true }
+spakky-tracing = { workspace = true }

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/consumer.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/consumer.py
@@ -5,6 +5,7 @@ services, consuming integration events from RabbitMQ queues and dispatching them
 to registered handlers.
 """
 
+from collections.abc import Mapping
 from typing import Any
 
 from aio_pika import (
@@ -34,6 +35,14 @@ from spakky.event.event_consumer import (
 
 from spakky.plugins.rabbitmq.common.config import RabbitMQConnectionConfig
 
+try:
+    from spakky.tracing.context import TraceContext
+    from spakky.tracing.propagator import ITracePropagator
+
+    _HAS_TRACING = True
+except ImportError:  # pragma: no cover - optional dependency (spakky-tracing)
+    _HAS_TRACING = False
+
 
 @Pod()
 class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
@@ -57,6 +66,7 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
     handlers: dict[type[AbstractEvent], list[EventHandlerCallback[Any]]]
     connection: BlockingConnection
     channel: BlockingChannel
+    _propagator: object | None
 
     def __init__(self, config: RabbitMQConnectionConfig) -> None:
         """Initialize the synchronous RabbitMQ event consumer.
@@ -69,23 +79,71 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
         self.type_lookup = {}
         self.type_adapters = {}
         self.handlers = {}
+        self._propagator = None
+
+    def set_propagator(self, propagator: object) -> None:
+        """Set the trace propagator for extracting trace context from messages.
+
+        Args:
+            propagator: An ITracePropagator instance.
+        """
+        self._propagator = propagator
+
+    @staticmethod
+    def _to_string_headers(raw: Mapping[str, object] | None) -> dict[str, str]:
+        """Convert AMQP headers to a string-valued carrier dict.
+
+        AMQP headers may contain bytes values (RabbitMQ encodes strings as
+        bytes). This method decodes bytes and keeps str values, skipping
+        other types.
+
+        Args:
+            raw: Raw AMQP headers dict, or None.
+
+        Returns:
+            A dict with string keys and string values.
+        """
+        if raw is None:
+            return {}
+        result: dict[str, str] = {}
+        for key, value in raw.items():
+            if isinstance(value, str):
+                result[key] = value
+            elif isinstance(value, bytes):
+                result[key] = value.decode()
+        return result
 
     def _route_event_handler(
         self,
         channel: BlockingChannel,
         method_frame: Basic.Deliver,
-        _: BasicProperties,
+        properties: BasicProperties,
         body: bytes,
     ) -> None:
+        """Route an incoming AMQP message to registered event handlers.
+
+        Extracts trace context from message headers when a propagator is
+        configured, dispatches to all handlers, and acknowledges the message.
+        """
         if method_frame.consumer_tag is None or method_frame.delivery_tag is None:
             raise InvalidMessageError("Missing consumer tag or delivery tag.")
-        event_type = self.type_lookup[method_frame.consumer_tag]
-        handlers = self.handlers[event_type]
-        type_adapter = self.type_adapters[event_type]
-        event = type_adapter.validate_json(body)
-        for handler in handlers:
-            handler(event)
-        channel.basic_ack(method_frame.delivery_tag)
+        if _HAS_TRACING and self._propagator is not None:
+            propagator: ITracePropagator = self._propagator  # type: ignore[assignment]  # guarded by _HAS_TRACING
+            carrier = self._to_string_headers(properties.headers)
+            parent = propagator.extract(carrier)
+            ctx = parent.child() if parent is not None else TraceContext.new_root()
+            TraceContext.set(ctx)
+        try:
+            event_type = self.type_lookup[method_frame.consumer_tag]
+            handlers = self.handlers[event_type]
+            type_adapter = self.type_adapters[event_type]
+            event = type_adapter.validate_json(body)
+            for handler in handlers:
+                handler(event)
+            channel.basic_ack(method_frame.delivery_tag)
+        finally:
+            if _HAS_TRACING and self._propagator is not None:
+                TraceContext.clear()
 
     def _check_if_event_set(self) -> None:
         if self._stop_event.is_set():
@@ -168,6 +226,7 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
     type_adapters: dict[type, TypeAdapter[AbstractEvent]]
     handlers: dict[type[AbstractEvent], list[AsyncEventHandlerCallback[Any]]]
     connection: AbstractRobustConnection
+    _propagator: object | None
 
     def __init__(self, config: RabbitMQConnectionConfig) -> None:
         """Initialize the asynchronous RabbitMQ event consumer.
@@ -179,17 +238,65 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
         self.type_lookup = {}
         self.type_adapters = {}
         self.handlers = {}
+        self._propagator = None
+
+    def set_propagator(self, propagator: object) -> None:
+        """Set the trace propagator for extracting trace context from messages.
+
+        Args:
+            propagator: An ITracePropagator instance.
+        """
+        self._propagator = propagator
+
+    @staticmethod
+    def _to_string_headers(raw: Mapping[str, object] | None) -> dict[str, str]:
+        """Convert AMQP headers to a string-valued carrier dict.
+
+        AMQP headers may contain bytes values (RabbitMQ encodes strings as
+        bytes). This method decodes bytes and keeps str values, skipping
+        other types.
+
+        Args:
+            raw: Raw AMQP headers dict, or None.
+
+        Returns:
+            A dict with string keys and string values.
+        """
+        if raw is None:
+            return {}
+        result: dict[str, str] = {}
+        for key, value in raw.items():
+            if isinstance(value, str):
+                result[key] = value
+            elif isinstance(value, bytes):
+                result[key] = value.decode()
+        return result
 
     async def _route_event_handler(self, message: AbstractIncomingMessage) -> None:
+        """Route an incoming AMQP message to registered async event handlers.
+
+        Extracts trace context from message headers when a propagator is
+        configured, dispatches to all handlers, and acknowledges the message.
+        """
         if message.consumer_tag is None or message.delivery_tag is None:
             raise InvalidMessageError("Missing consumer tag or delivery tag.")
-        event_type = self.type_lookup[message.consumer_tag]
-        handlers = self.handlers[event_type]
-        type_adapter = self.type_adapters[event_type]
-        event = type_adapter.validate_json(message.body)
-        for handler in handlers:
-            await handler(event)
-        await message.ack()
+        if _HAS_TRACING and self._propagator is not None:
+            propagator: ITracePropagator = self._propagator  # type: ignore[assignment]  # guarded by _HAS_TRACING
+            carrier = self._to_string_headers(message.headers)
+            parent = propagator.extract(carrier)
+            ctx = parent.child() if parent is not None else TraceContext.new_root()
+            TraceContext.set(ctx)
+        try:
+            event_type = self.type_lookup[message.consumer_tag]
+            handlers = self.handlers[event_type]
+            type_adapter = self.type_adapters[event_type]
+            event = type_adapter.validate_json(message.body)
+            for handler in handlers:
+                await handler(event)
+            await message.ack()
+        finally:
+            if _HAS_TRACING and self._propagator is not None:
+                TraceContext.clear()
 
     def register(
         self,

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/post_processor.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/post_processor.py
@@ -25,6 +25,13 @@ from spakky.event.event_consumer import (
 )
 from spakky.event.stereotype.event_handler import EventHandler, EventRoute
 
+try:
+    from spakky.tracing.propagator import ITracePropagator
+
+    _HAS_TRACING = True
+except ImportError:  # pragma: no cover - optional dependency (spakky-tracing)
+    _HAS_TRACING = False
+
 logger = getLogger(__name__)
 
 
@@ -75,6 +82,12 @@ class RabbitMQPostProcessor(IPostProcessor, IContainerAware, IApplicationContext
         handler: EventHandler = EventHandler.get(pod)
         consumer = self.__container.get(IEventConsumer)
         async_consumer = self.__container.get(IAsyncEventConsumer)
+        if _HAS_TRACING and self.__application_context.contains(ITracePropagator):
+            propagator = self.__application_context.get(type_=ITracePropagator)
+            if hasattr(consumer, "set_propagator"):
+                consumer.set_propagator(propagator)
+            if hasattr(async_consumer, "set_propagator"):
+                async_consumer.set_propagator(propagator)
         for name, method in getmembers(pod, ismethod):
             route: EventRoute[AbstractEvent] | None = EventRoute[
                 AbstractEvent

--- a/plugins/spakky-rabbitmq/tests/unit/test_consumer.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_consumer.py
@@ -18,6 +18,8 @@ from spakky.plugins.rabbitmq.event.consumer import (
     AsyncRabbitMQEventConsumer,
     RabbitMQEventConsumer,
 )
+from spakky.tracing.context import TraceContext
+from spakky.tracing.w3c_propagator import W3CTracePropagator
 
 
 class SampleIntegrationEvent(AbstractIntegrationEvent):
@@ -375,3 +377,301 @@ async def test_async_consumer_run_async_expect_wait_for_stop_event(
     await consumer.run_async()
 
     assert stop_event.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Trace context extraction tests
+# ---------------------------------------------------------------------------
+
+SAMPLE_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+SAMPLE_TRACE_ID = "0af7651916cd43dd8448eb211c80319c"
+SAMPLE_SPAN_ID = "b7ad6b7169203331"
+
+
+def test_sync_consumer_route_with_traceparent_expect_child_context_set(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """traceparent 헤더가 있으면 child TraceContext가 활성화됨을 검증한다."""
+    consumer = RabbitMQEventConsumer(config)
+    consumer.set_propagator(W3CTracePropagator())
+
+    captured_ctx: list[TraceContext | None] = []
+
+    def capturing_handler(event: SampleIntegrationEvent) -> None:
+        captured_ctx.append(TraceContext.get())
+
+    consumer.register(SampleIntegrationEvent, capturing_handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    channel = MagicMock()
+    method_frame = MagicMock()
+    method_frame.consumer_tag = "test_tag"
+    method_frame.delivery_tag = 123
+    properties = MagicMock()
+    properties.headers = {"traceparent": SAMPLE_TRACEPARENT}
+    body = b'{"data": "test"}'
+
+    consumer._route_event_handler(channel, method_frame, properties, body)
+
+    assert len(captured_ctx) == 1
+    ctx = captured_ctx[0]
+    assert ctx is not None
+    assert ctx.trace_id == SAMPLE_TRACE_ID
+    assert ctx.parent_span_id == SAMPLE_SPAN_ID
+    assert ctx.span_id != SAMPLE_SPAN_ID
+
+
+@pytest.mark.asyncio
+async def test_async_consumer_route_with_traceparent_expect_child_context_set(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """비동기 consumer에서 traceparent 헤더가 있으면 child TraceContext가 활성화됨을 검증한다."""
+    consumer = AsyncRabbitMQEventConsumer(config)
+    consumer.set_propagator(W3CTracePropagator())
+
+    captured_ctx: list[TraceContext | None] = []
+
+    async def capturing_handler(event: SampleIntegrationEvent) -> None:
+        captured_ctx.append(TraceContext.get())
+
+    consumer.register(SampleIntegrationEvent, capturing_handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    message = AsyncMock()
+    message.consumer_tag = "test_tag"
+    message.delivery_tag = 123
+    message.body = b'{"data": "test"}'
+    message.headers = {"traceparent": SAMPLE_TRACEPARENT}
+
+    await consumer._route_event_handler(message)
+
+    assert len(captured_ctx) == 1
+    ctx = captured_ctx[0]
+    assert ctx is not None
+    assert ctx.trace_id == SAMPLE_TRACE_ID
+    assert ctx.parent_span_id == SAMPLE_SPAN_ID
+    assert ctx.span_id != SAMPLE_SPAN_ID
+
+
+def test_sync_consumer_route_without_propagator_expect_no_trace_context(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """propagator 미설정 시 TraceContext가 설정되지 않음을 검증한다."""
+    consumer = RabbitMQEventConsumer(config)
+
+    captured_ctx: list[TraceContext | None] = []
+
+    def capturing_handler(event: SampleIntegrationEvent) -> None:
+        captured_ctx.append(TraceContext.get())
+
+    consumer.register(SampleIntegrationEvent, capturing_handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    channel = MagicMock()
+    method_frame = MagicMock()
+    method_frame.consumer_tag = "test_tag"
+    method_frame.delivery_tag = 123
+    properties = MagicMock()
+    properties.headers = {"traceparent": SAMPLE_TRACEPARENT}
+    body = b'{"data": "test"}'
+
+    TraceContext.clear()
+    consumer._route_event_handler(channel, method_frame, properties, body)
+
+    assert captured_ctx[0] is None
+
+
+@pytest.mark.asyncio
+async def test_async_consumer_route_without_propagator_expect_no_trace_context(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """비동기 consumer에서 propagator 미설정 시 TraceContext가 설정되지 않음을 검증한다."""
+    consumer = AsyncRabbitMQEventConsumer(config)
+
+    captured_ctx: list[TraceContext | None] = []
+
+    async def capturing_handler(event: SampleIntegrationEvent) -> None:
+        captured_ctx.append(TraceContext.get())
+
+    consumer.register(SampleIntegrationEvent, capturing_handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    message = AsyncMock()
+    message.consumer_tag = "test_tag"
+    message.delivery_tag = 123
+    message.body = b'{"data": "test"}'
+    message.headers = {"traceparent": SAMPLE_TRACEPARENT}
+
+    TraceContext.clear()
+    await consumer._route_event_handler(message)
+
+    assert captured_ctx[0] is None
+
+
+def test_sync_consumer_route_without_traceparent_expect_new_root_trace(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """traceparent 헤더 없을 때 새 root trace가 생성됨을 검증한다."""
+    consumer = RabbitMQEventConsumer(config)
+    consumer.set_propagator(W3CTracePropagator())
+
+    captured_ctx: list[TraceContext | None] = []
+
+    def capturing_handler(event: SampleIntegrationEvent) -> None:
+        captured_ctx.append(TraceContext.get())
+
+    consumer.register(SampleIntegrationEvent, capturing_handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    channel = MagicMock()
+    method_frame = MagicMock()
+    method_frame.consumer_tag = "test_tag"
+    method_frame.delivery_tag = 123
+    properties = MagicMock()
+    properties.headers = {}
+    body = b'{"data": "test"}'
+
+    consumer._route_event_handler(channel, method_frame, properties, body)
+
+    ctx = captured_ctx[0]
+    assert ctx is not None
+    assert ctx.parent_span_id is None
+
+
+@pytest.mark.asyncio
+async def test_async_consumer_route_without_traceparent_expect_new_root_trace(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """비동기 consumer에서 traceparent 헤더 없을 때 새 root trace가 생성됨을 검증한다."""
+    consumer = AsyncRabbitMQEventConsumer(config)
+    consumer.set_propagator(W3CTracePropagator())
+
+    captured_ctx: list[TraceContext | None] = []
+
+    async def capturing_handler(event: SampleIntegrationEvent) -> None:
+        captured_ctx.append(TraceContext.get())
+
+    consumer.register(SampleIntegrationEvent, capturing_handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    message = AsyncMock()
+    message.consumer_tag = "test_tag"
+    message.delivery_tag = 123
+    message.body = b'{"data": "test"}'
+    message.headers = {}
+
+    await consumer._route_event_handler(message)
+
+    ctx = captured_ctx[0]
+    assert ctx is not None
+    assert ctx.parent_span_id is None
+
+
+def test_sync_consumer_route_trace_context_cleared_after_handler(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """핸들러 완료 후 TraceContext가 정리됨을 검증한다."""
+    consumer = RabbitMQEventConsumer(config)
+    consumer.set_propagator(W3CTracePropagator())
+    consumer.register(SampleIntegrationEvent, MagicMock())
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    channel = MagicMock()
+    method_frame = MagicMock()
+    method_frame.consumer_tag = "test_tag"
+    method_frame.delivery_tag = 123
+    properties = MagicMock()
+    properties.headers = {"traceparent": SAMPLE_TRACEPARENT}
+    body = b'{"data": "test"}'
+
+    consumer._route_event_handler(channel, method_frame, properties, body)
+
+    assert TraceContext.get() is None
+
+
+@pytest.mark.asyncio
+async def test_async_consumer_route_trace_context_cleared_after_handler(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """비동기 consumer에서 핸들러 완료 후 TraceContext가 정리됨을 검증한다."""
+    consumer = AsyncRabbitMQEventConsumer(config)
+    consumer.set_propagator(W3CTracePropagator())
+    consumer.register(SampleIntegrationEvent, AsyncMock())
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    message = AsyncMock()
+    message.consumer_tag = "test_tag"
+    message.delivery_tag = 123
+    message.body = b'{"data": "test"}'
+    message.headers = {"traceparent": SAMPLE_TRACEPARENT}
+
+    await consumer._route_event_handler(message)
+
+    assert TraceContext.get() is None
+
+
+def test_sync_consumer_route_handler_exception_expect_trace_context_cleared(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """핸들러 예외 발생 시에도 TraceContext가 정리됨을 검증한다."""
+    consumer = RabbitMQEventConsumer(config)
+    consumer.set_propagator(W3CTracePropagator())
+
+    def failing_handler(event: SampleIntegrationEvent) -> None:
+        raise RuntimeError("handler failed")
+
+    consumer.register(SampleIntegrationEvent, failing_handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    channel = MagicMock()
+    method_frame = MagicMock()
+    method_frame.consumer_tag = "test_tag"
+    method_frame.delivery_tag = 123
+    properties = MagicMock()
+    properties.headers = {"traceparent": SAMPLE_TRACEPARENT}
+    body = b'{"data": "test"}'
+
+    with pytest.raises(RuntimeError):
+        consumer._route_event_handler(channel, method_frame, properties, body)
+
+    assert TraceContext.get() is None
+
+
+@pytest.mark.asyncio
+async def test_async_consumer_route_handler_exception_expect_trace_context_cleared(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """비동기 consumer에서 핸들러 예외 발생 시에도 TraceContext가 정리됨을 검증한다."""
+    consumer = AsyncRabbitMQEventConsumer(config)
+    consumer.set_propagator(W3CTracePropagator())
+
+    async def failing_handler(event: SampleIntegrationEvent) -> None:
+        raise RuntimeError("handler failed")
+
+    consumer.register(SampleIntegrationEvent, failing_handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    message = AsyncMock()
+    message.consumer_tag = "test_tag"
+    message.delivery_tag = 123
+    message.body = b'{"data": "test"}'
+    message.headers = {"traceparent": SAMPLE_TRACEPARENT}
+
+    with pytest.raises(RuntimeError):
+        await consumer._route_event_handler(message)
+
+    assert TraceContext.get() is None
+
+
+def test_sync_consumer_to_string_headers_with_bytes_expect_decoded() -> None:
+    """AMQP headers의 bytes 값이 str로 디코딩됨을 검증한다."""
+    result = RabbitMQEventConsumer._to_string_headers(
+        {"traceparent": b"00-abc-def-01", "key": "value", "num": 42}
+    )
+    assert result == {"traceparent": "00-abc-def-01", "key": "value"}
+
+
+def test_sync_consumer_to_string_headers_with_none_expect_empty() -> None:
+    """headers가 None이면 빈 dict를 반환함을 검증한다."""
+    result = RabbitMQEventConsumer._to_string_headers(None)
+    assert result == {}

--- a/plugins/spakky-rabbitmq/tests/unit/test_consumer.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_consumer.py
@@ -675,3 +675,17 @@ def test_sync_consumer_to_string_headers_with_none_expect_empty() -> None:
     """headers가 None이면 빈 dict를 반환함을 검증한다."""
     result = RabbitMQEventConsumer._to_string_headers(None)
     assert result == {}
+
+
+def test_async_consumer_to_string_headers_with_bytes_expect_decoded() -> None:
+    """비동기 consumer에서 AMQP headers의 bytes 값이 str로 디코딩됨을 검증한다."""
+    result = AsyncRabbitMQEventConsumer._to_string_headers(
+        {"traceparent": b"00-abc-def-01", "key": "value", "num": 42}
+    )
+    assert result == {"traceparent": "00-abc-def-01", "key": "value"}
+
+
+def test_async_consumer_to_string_headers_with_none_expect_empty() -> None:
+    """비동기 consumer에서 headers가 None이면 빈 dict를 반환함을 검증한다."""
+    result = AsyncRabbitMQEventConsumer._to_string_headers(None)
+    assert result == {}

--- a/plugins/spakky-rabbitmq/tests/unit/test_post_processor.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_post_processor.py
@@ -443,3 +443,42 @@ def test_rabbitmq_post_processor_without_tracing_expect_no_propagator_injected()
 
     mock_consumer.set_propagator.assert_not_called()
     mock_async_consumer.set_propagator.assert_not_called()
+
+
+def test_rabbitmq_post_processor_with_tracing_but_no_set_propagator_expect_skipped() -> (
+    None
+):
+    """consumer에 set_propagator가 없으면 주입을 건너뜀을 검증한다."""
+
+    @EventHandler()
+    class SampleEventHandler:
+        @on_event(SampleIntegrationEvent)
+        def handle_integration_event(self, event: SampleIntegrationEvent) -> None:
+            pass
+
+    mock_propagator = Mock(spec=ITracePropagator)
+    mock_consumer = Mock(spec=IEventConsumer)
+    mock_async_consumer = Mock(spec=IAsyncEventConsumer)
+    mock_container = Mock()
+    mock_container.get.side_effect = lambda t: (
+        mock_consumer
+        if t == IEventConsumer
+        else mock_async_consumer
+        if t == IAsyncEventConsumer
+        else None
+    )
+
+    mock_context = Mock(spec=ApplicationContext)
+    mock_context.contains.return_value = True
+    mock_context.get.return_value = mock_propagator
+
+    post_processor = RabbitMQPostProcessor()
+    post_processor.set_container(mock_container)
+    post_processor.set_application_context(mock_context)
+
+    handler_instance = SampleEventHandler()
+    # Should not raise even though consumer lacks set_propagator
+    post_processor.post_process(handler_instance)
+
+    assert not hasattr(mock_consumer, "set_propagator")
+    assert not hasattr(mock_async_consumer, "set_propagator")

--- a/plugins/spakky-rabbitmq/tests/unit/test_post_processor.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_post_processor.py
@@ -15,6 +15,7 @@ from spakky.event.event_consumer import (
     IEventConsumer,
 )
 from spakky.event.stereotype.event_handler import EventHandler, on_event
+from spakky.tracing.propagator import ITracePropagator
 
 from spakky.plugins.rabbitmq.post_processor import RabbitMQPostProcessor
 
@@ -55,6 +56,7 @@ def test_rabbitmq_post_processor_registers_integration_event_expect_success() ->
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.contains.return_value = False
 
     # Create post-processor
     post_processor = RabbitMQPostProcessor()
@@ -95,6 +97,7 @@ def test_rabbitmq_post_processor_registers_async_integration_event_expect_succes
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.contains.return_value = False
 
     # Create post-processor
     post_processor = RabbitMQPostProcessor()
@@ -138,6 +141,7 @@ def test_rabbitmq_post_processor_ignores_domain_event_expect_no_registration() -
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.contains.return_value = False
 
     # Create post-processor
     post_processor = RabbitMQPostProcessor()
@@ -181,6 +185,7 @@ def test_rabbitmq_post_processor_mixed_events_expect_only_integration_registered
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.contains.return_value = False
 
     # Create post-processor
     post_processor = RabbitMQPostProcessor()
@@ -240,6 +245,7 @@ def test_rabbitmq_post_processor_method_without_event_route_expect_skipped() -> 
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.contains.return_value = False
 
     post_processor = RabbitMQPostProcessor()
     post_processor.set_container(mock_container)
@@ -287,6 +293,7 @@ def test_rabbitmq_post_processor_sync_endpoint_invocation_expect_handler_called(
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.contains.return_value = False
 
     post_processor = RabbitMQPostProcessor()
     post_processor.set_container(mock_container)
@@ -341,6 +348,7 @@ async def test_rabbitmq_post_processor_async_endpoint_invocation_expect_handler_
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.contains.return_value = False
 
     post_processor = RabbitMQPostProcessor()
     post_processor.set_container(mock_container)
@@ -356,3 +364,82 @@ async def test_rabbitmq_post_processor_async_endpoint_invocation_expect_handler_
     assert handler_called["value"] is True
     assert handler_called["result"] == "handled: test"
     mock_context.clear_context.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Propagator injection tests
+# ---------------------------------------------------------------------------
+
+
+def test_rabbitmq_post_processor_with_tracing_available_expect_propagator_injected() -> (
+    None
+):
+    """tracing이 가용하면 consumer에 propagator가 주입됨을 검증한다."""
+
+    @EventHandler()
+    class SampleEventHandler:
+        @on_event(SampleIntegrationEvent)
+        def handle_integration_event(self, event: SampleIntegrationEvent) -> None:
+            pass
+
+    mock_propagator = Mock(spec=ITracePropagator)
+    mock_consumer = Mock()
+    mock_async_consumer = Mock()
+    mock_container = Mock()
+    mock_container.get.side_effect = lambda t: (
+        mock_consumer
+        if t == IEventConsumer
+        else mock_async_consumer
+        if t == IAsyncEventConsumer
+        else None
+    )
+
+    mock_context = Mock(spec=ApplicationContext)
+    mock_context.contains.return_value = True
+    mock_context.get.return_value = mock_propagator
+
+    post_processor = RabbitMQPostProcessor()
+    post_processor.set_container(mock_container)
+    post_processor.set_application_context(mock_context)
+
+    handler_instance = SampleEventHandler()
+    post_processor.post_process(handler_instance)
+
+    mock_consumer.set_propagator.assert_called_once_with(mock_propagator)
+    mock_async_consumer.set_propagator.assert_called_once_with(mock_propagator)
+
+
+def test_rabbitmq_post_processor_without_tracing_expect_no_propagator_injected() -> (
+    None
+):
+    """tracing��� 미가용하면 set_propagator가 호출되지 않음을 ���증한다."""
+
+    @EventHandler()
+    class SampleEventHandler:
+        @on_event(SampleIntegrationEvent)
+        def handle_integration_event(self, event: SampleIntegrationEvent) -> None:
+            pass
+
+    mock_consumer = Mock()
+    mock_async_consumer = Mock()
+    mock_container = Mock()
+    mock_container.get.side_effect = lambda t: (
+        mock_consumer
+        if t == IEventConsumer
+        else mock_async_consumer
+        if t == IAsyncEventConsumer
+        else None
+    )
+
+    mock_context = Mock(spec=ApplicationContext)
+    mock_context.contains.return_value = False
+
+    post_processor = RabbitMQPostProcessor()
+    post_processor.set_container(mock_container)
+    post_processor.set_application_context(mock_context)
+
+    handler_instance = SampleEventHandler()
+    post_processor.post_process(handler_instance)
+
+    mock_consumer.set_propagator.assert_not_called()
+    mock_async_consumer.set_propagator.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -2765,9 +2765,15 @@ dependencies = [
     { name = "spakky-event" },
 ]
 
+[package.optional-dependencies]
+tracing = [
+    { name = "spakky-tracing" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest-integration-mark" },
+    { name = "spakky-tracing" },
     { name = "testcontainers" },
 ]
 
@@ -2779,11 +2785,14 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "spakky-event", editable = "core/spakky-event" },
+    { name = "spakky-tracing", marker = "extra == 'tracing'", editable = "core/spakky-tracing" },
 ]
+provides-extras = ["tracing"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest-integration-mark", specifier = ">=0.2.0" },
+    { name = "spakky-tracing", editable = "core/spakky-tracing" },
     { name = "testcontainers", specifier = ">=4.14.1" },
 ]
 


### PR DESCRIPTION
## Summary

- RabbitMQ Consumer(동기/비동기)에서 AMQP 메시지 headers의 `traceparent`를 extract하여 `TraceContext` child span 복원
- `ITracePropagator` 선택적 DI 주입 — `spakky-tracing` 미설치 시 기존 동작 유지
- PostProcessor에서 `_HAS_TRACING + contains()` 패턴으로 propagator를 consumer에 주입
- `pyproject.toml`에 `[project.optional-dependencies] tracing` 추가

Closes #36

## Test plan

- [x] traceparent 헤더 → child span 활성화 (sync/async)
- [x] propagator 미설정 → 기존 동작 유지 (sync/async)
- [x] traceparent 없음 → new root trace 생성 (sync/async)
- [x] 핸들러 후 TraceContext cleared (sync/async)
- [x] 핸들러 예외 시에도 TraceContext cleared (sync/async)
- [x] `_to_string_headers` bytes 디코딩 + None 처리
- [x] PostProcessor propagator 주입/미주입 검증
- [x] 커버리지 97.93% (기준 90%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)