### PR TITLE
feat(celery): add trace context propagation (#38)

### DIFF
--- a/plugins/spakky-celery/pyproject.toml
+++ b/plugins/spakky-celery/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "spakky-task>=6.2.0",
 ]
 
+[project.optional-dependencies]
+tracing = ["spakky-tracing>=6.2.0"]
+
 [project.entry-points."spakky.plugins"]
 spakky-celery = "spakky.plugins.celery.main:initialize"
 
@@ -21,6 +24,7 @@ dev = [
     "nest-asyncio>=1.6.0",
     "pytest-asyncio>=0.26.0",
     "pytest-integration-mark>=0.2.0",
+    "spakky-tracing>=6.2.0",
     "testcontainers[rabbitmq]>=4.14.1",
 ]
 
@@ -94,3 +98,4 @@ exclude_lines = [
 [tool.uv.sources]
 spakky = { workspace = true }
 spakky-task = { workspace = true }
+spakky-tracing = { workspace = true }

--- a/plugins/spakky-celery/src/spakky/plugins/celery/aspects/task_dispatch.py
+++ b/plugins/spakky-celery/src/spakky/plugins/celery/aspects/task_dispatch.py
@@ -20,6 +20,13 @@ from celery import Celery
 from spakky.plugins.celery.common.constants import CELERY_TASK_CONTEXT_KEY
 from spakky.plugins.celery.common.task_result import CeleryTaskResult
 
+try:
+    from spakky.tracing.propagator import ITracePropagator
+
+    _HAS_TRACING = True
+except ImportError:  # pragma: no cover - optional dependency (spakky-tracing)
+    _HAS_TRACING = False
+
 logger = getLogger(__name__)
 
 
@@ -34,14 +41,20 @@ class CeleryTaskDispatchAspect(IAspect, IApplicationContextAware):
 
     _celery: Celery
     _application_context: IApplicationContext
+    _propagator: object | None
 
     def __init__(self, celery: Celery) -> None:
         """Initialize with the Celery application instance."""
         self._celery = celery
+        self._propagator = None
 
     def set_application_context(self, application_context: IApplicationContext) -> None:
         """Store the application context for checking worker context."""
         self._application_context = application_context
+
+    def set_propagator(self, propagator: object) -> None:
+        """Set the trace propagator for injecting trace context into task headers."""
+        self._propagator = propagator
 
     @Around(lambda x: TaskRoute.exists(x) and not iscoroutinefunction(x))
     def around(self, joinpoint: Func, *args: Any, **kwargs: Any) -> Any:
@@ -49,7 +62,16 @@ class CeleryTaskDispatchAspect(IAspect, IApplicationContextAware):
             return joinpoint(*args, **kwargs)
 
         task_name: str = get_fully_qualified_name(joinpoint)
-        async_result = self._celery.send_task(task_name, args=args, kwargs=kwargs)
+        task_headers: dict[str, str] = {}
+        if _HAS_TRACING and self._propagator is not None:
+            propagator: ITracePropagator = self._propagator  # type: ignore[assignment] - guarded by _HAS_TRACING
+            propagator.inject(task_headers)
+        async_result = self._celery.send_task(
+            task_name,
+            args=args,
+            kwargs=kwargs,
+            headers=task_headers,
+        )
         logger.debug("Dispatched task %s", task_name)
         return CeleryTaskResult(async_result)
 
@@ -65,14 +87,20 @@ class AsyncCeleryTaskDispatchAspect(IAsyncAspect, IApplicationContextAware):
 
     _celery: Celery
     _application_context: IApplicationContext
+    _propagator: object | None
 
     def __init__(self, celery: Celery) -> None:
         """Initialize with the Celery application instance."""
         self._celery = celery
+        self._propagator = None
 
     def set_application_context(self, application_context: IApplicationContext) -> None:
         """Store the application context for checking worker context."""
         self._application_context = application_context
+
+    def set_propagator(self, propagator: object) -> None:
+        """Set the trace propagator for injecting trace context into task headers."""
+        self._propagator = propagator
 
     @Around(lambda x: TaskRoute.exists(x) and iscoroutinefunction(x))
     async def around_async(
@@ -82,6 +110,15 @@ class AsyncCeleryTaskDispatchAspect(IAsyncAspect, IApplicationContextAware):
             return await joinpoint(*args, **kwargs)
 
         task_name: str = get_fully_qualified_name(joinpoint)
-        async_result = self._celery.send_task(task_name, args=args, kwargs=kwargs)
+        task_headers: dict[str, str] = {}
+        if _HAS_TRACING and self._propagator is not None:
+            propagator: ITracePropagator = self._propagator  # type: ignore[assignment] - guarded by _HAS_TRACING
+            propagator.inject(task_headers)
+        async_result = self._celery.send_task(
+            task_name,
+            args=args,
+            kwargs=kwargs,
+            headers=task_headers,
+        )
         logger.debug("Dispatched task %s (async)", task_name)
         return CeleryTaskResult(async_result)

--- a/plugins/spakky-celery/src/spakky/plugins/celery/post_processor.py
+++ b/plugins/spakky-celery/src/spakky/plugins/celery/post_processor.py
@@ -18,11 +18,23 @@ from spakky.task.stereotype.crontab import Crontab, Month, Weekday
 from spakky.task.stereotype.schedule import ScheduleRoute
 from spakky.task.stereotype.task_handler import TaskHandler, TaskRoute
 
-from celery import Celery
+from celery import Celery, current_task
 from celery.schedules import crontab as celery_crontab
 from celery.schedules import schedule as celery_schedule
+from spakky.plugins.celery.aspects.task_dispatch import (
+    AsyncCeleryTaskDispatchAspect,
+    CeleryTaskDispatchAspect,
+)
 from spakky.plugins.celery.common.constants import CELERY_TASK_CONTEXT_KEY
 from spakky.plugins.celery.error import InvalidScheduleRouteError
+
+try:
+    from spakky.tracing.context import TraceContext
+    from spakky.tracing.propagator import ITracePropagator
+
+    _HAS_TRACING = True
+except ImportError:  # pragma: no cover - optional dependency (spakky-tracing)
+    _HAS_TRACING = False
 
 logger = getLogger(__name__)
 
@@ -42,6 +54,7 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
         self,
         handler_type: type[object],
         method: Callable[..., Any],
+        propagator: object | None,
     ) -> Callable[..., Any]:
         """Create a sync endpoint that resolves handler from container."""
 
@@ -49,9 +62,24 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
         def endpoint(*args: Any, **kwargs: Any) -> Any:
             self.__application_context.clear_context()
             self.__application_context.set_context_value(CELERY_TASK_CONTEXT_KEY, True)
-            handler_instance = self.__application_context.get(handler_type)
-            bound_method = method.__get__(handler_instance, handler_type)
-            return bound_method(*args, **kwargs)
+            if _HAS_TRACING and propagator is not None:
+                typed_propagator: ITracePropagator = propagator  # type: ignore[assignment] - guarded by _HAS_TRACING
+                raw_headers: dict[str, object] = (
+                    current_task.request.get("headers") or {}
+                )
+                carrier: dict[str, str] = {
+                    k: v for k, v in raw_headers.items() if isinstance(v, str)
+                }
+                parent = typed_propagator.extract(carrier)
+                ctx = parent.child() if parent is not None else TraceContext.new_root()
+                TraceContext.set(ctx)
+            try:
+                handler_instance = self.__application_context.get(handler_type)
+                bound_method = method.__get__(handler_instance, handler_type)
+                return bound_method(*args, **kwargs)
+            finally:
+                if _HAS_TRACING and propagator is not None:
+                    TraceContext.clear()
 
         return endpoint
 
@@ -59,6 +87,7 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
         self,
         handler_type: type[object],
         method: Callable[..., Any],
+        propagator: object | None,
     ) -> Callable[..., Any]:
         """Create an endpoint for async methods.
 
@@ -70,9 +99,24 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
             """Async wrapper that sets context and invokes handler method."""
             self.__application_context.clear_context()
             self.__application_context.set_context_value(CELERY_TASK_CONTEXT_KEY, True)
-            handler_instance = self.__application_context.get(handler_type)
-            bound_method = method.__get__(handler_instance, handler_type)
-            return await bound_method(*args, **kwargs)
+            if _HAS_TRACING and propagator is not None:
+                typed_propagator: ITracePropagator = propagator  # type: ignore[assignment] - guarded by _HAS_TRACING
+                raw_headers: dict[str, object] = (
+                    current_task.request.get("headers") or {}
+                )
+                carrier: dict[str, str] = {
+                    k: v for k, v in raw_headers.items() if isinstance(v, str)
+                }
+                parent = typed_propagator.extract(carrier)
+                ctx = parent.child() if parent is not None else TraceContext.new_root()
+                TraceContext.set(ctx)
+            try:
+                handler_instance = self.__application_context.get(handler_type)
+                bound_method = method.__get__(handler_instance, handler_type)
+                return await bound_method(*args, **kwargs)
+            finally:
+                if _HAS_TRACING and propagator is not None:
+                    TraceContext.clear()
 
         @wraps(method)
         def endpoint(*args: Any, **kwargs: Any) -> Any:
@@ -116,12 +160,13 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
         celery: Celery,
         pod_type: type[object],
         method: Callable[..., Any],
+        propagator: object | None,
     ) -> str:
         """Register a single method as a Celery task. Returns the task name."""
         if iscoroutinefunction(method):
-            endpoint = self._create_async_endpoint(pod_type, method)
+            endpoint = self._create_async_endpoint(pod_type, method, propagator)
         else:
-            endpoint = self._create_sync_endpoint(pod_type, method)
+            endpoint = self._create_sync_endpoint(pod_type, method, propagator)
 
         task_name = get_fully_qualified_name(method)
         celery.task(name=task_name)(endpoint)
@@ -135,6 +180,17 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
         celery: Celery = self.__application_context.get(Celery)
         pod_type = TaskHandler.get(pod).type_
 
+        propagator: object | None = None
+        if _HAS_TRACING and self.__application_context.contains(ITracePropagator):
+            propagator = self.__application_context.get(type_=ITracePropagator)
+            for aspect_type in (
+                CeleryTaskDispatchAspect,
+                AsyncCeleryTaskDispatchAspect,
+            ):
+                if self.__application_context.contains(aspect_type):
+                    aspect = self.__application_context.get(type_=aspect_type)
+                    aspect.set_propagator(propagator)
+
         for _, method in getmembers(pod_type, isfunction):
             has_task = TaskRoute.get_or_none(method) is not None
             schedule_route = ScheduleRoute.get_or_none(method)
@@ -143,7 +199,7 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
             if not has_task and not has_schedule:
                 continue
 
-            task_name = self._register_method(celery, pod_type, method)
+            task_name = self._register_method(celery, pod_type, method, propagator)
 
             if has_schedule:
                 assert schedule_route is not None

--- a/plugins/spakky-celery/tests/unit/test_dispatcher.py
+++ b/plugins/spakky-celery/tests/unit/test_dispatcher.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock
 
 import pytest
 from spakky.task.stereotype.task_handler import TaskRoute
+from spakky.tracing.context import TraceContext
+from spakky.tracing.w3c_propagator import W3CTracePropagator
 
 from spakky.plugins.celery.aspects.task_dispatch import (
     CELERY_TASK_CONTEXT_KEY,
@@ -17,6 +19,10 @@ from spakky.plugins.celery.common.task_result import CeleryTaskResult
 # Test constants for task naming
 TEST_MODULE = "test_module"
 TEST_HANDLER_CLASS = "TestHandler"
+
+SAMPLE_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+SAMPLE_TRACE_ID = "0af7651916cd43dd8448eb211c80319c"
+SAMPLE_SPAN_ID = "b7ad6b7169203331"
 
 
 def _make_task_name(method_name: str) -> str:
@@ -78,6 +84,7 @@ def test_around_dispatches_task_via_send_task() -> None:
         _make_task_name("send_email"),
         args=(),
         kwargs={"to": "test@example.com", "subject": "Hi"},
+        headers={},
     )
     assert isinstance(result, CeleryTaskResult)
     assert result.task_id == "task-abc-123"
@@ -96,6 +103,7 @@ def test_around_dispatches_task_with_positional_args() -> None:
         _make_task_name("send_email"),
         args=("test@example.com", "Hi"),
         kwargs={},
+        headers={},
     )
 
 
@@ -122,6 +130,42 @@ def test_around_in_celery_task_context_calls_joinpoint() -> None:
     assert calls == [((), {"to": "test@example.com"})]
     celery.send_task.assert_not_called()
     assert result == "direct"
+
+
+def test_around_injects_traceparent_expect_headers_contain_traceparent() -> None:
+    """propagator가 설정된 경우 send_task()에 traceparent 헤더가 포함되는지 검증한다."""
+    celery = _create_mock_celery()
+    aspect = CeleryTaskDispatchAspect(celery)
+    aspect.set_application_context(_create_mock_application_context())
+    aspect.set_propagator(W3CTracePropagator())
+    joinpoint = _create_joinpoint("send_email")
+
+    ctx = TraceContext.from_traceparent(SAMPLE_TRACEPARENT)
+    TraceContext.set(ctx)
+    try:
+        aspect.around(joinpoint)
+    finally:
+        TraceContext.clear()
+
+    call_kwargs = celery.send_task.call_args
+    headers = call_kwargs.kwargs["headers"]
+    assert "traceparent" in headers
+    assert headers["traceparent"] == SAMPLE_TRACEPARENT
+
+
+def test_around_sends_empty_headers_when_propagator_none_expect_no_traceparent() -> (
+    None
+):
+    """propagator가 None인 경우 send_task()에 빈 headers가 전달되는지 검증한다."""
+    celery = _create_mock_celery()
+    aspect = CeleryTaskDispatchAspect(celery)
+    aspect.set_application_context(_create_mock_application_context())
+    joinpoint = _create_joinpoint("send_email")
+
+    aspect.around(joinpoint)
+
+    call_kwargs = celery.send_task.call_args
+    assert call_kwargs.kwargs["headers"] == {}
 
 
 # ── Async AsyncCeleryTaskDispatchAspect ──
@@ -162,6 +206,7 @@ async def test_async_around_dispatches_task_via_send_task() -> None:
         _make_task_name("async_send_email"),
         args=(),
         kwargs={"to": "test@example.com", "subject": "Hi"},
+        headers={},
     )
     assert isinstance(result, CeleryTaskResult)
     assert result.task_id == "task-async-456"
@@ -191,3 +236,43 @@ async def test_async_around_in_celery_task_context_calls_joinpoint() -> None:
     assert calls == [((), {"to": "test@example.com"})]
     celery.send_task.assert_not_called()
     assert result == "direct"
+
+
+@pytest.mark.asyncio
+async def test_async_around_injects_traceparent_expect_headers_contain_traceparent() -> (
+    None
+):
+    """async propagator가 설정된 경우 send_task()에 traceparent 헤더가 포함되는지 검증한다."""
+    celery = _create_mock_celery()
+    aspect = AsyncCeleryTaskDispatchAspect(celery)
+    aspect.set_application_context(_create_mock_application_context())
+    aspect.set_propagator(W3CTracePropagator())
+    joinpoint = _create_async_joinpoint("async_send_email")
+
+    ctx = TraceContext.from_traceparent(SAMPLE_TRACEPARENT)
+    TraceContext.set(ctx)
+    try:
+        await aspect.around_async(joinpoint)
+    finally:
+        TraceContext.clear()
+
+    call_kwargs = celery.send_task.call_args
+    headers = call_kwargs.kwargs["headers"]
+    assert "traceparent" in headers
+    assert headers["traceparent"] == SAMPLE_TRACEPARENT
+
+
+@pytest.mark.asyncio
+async def test_async_around_sends_empty_headers_when_propagator_none_expect_no_traceparent() -> (
+    None
+):
+    """async propagator가 None인 경우 send_task()에 빈 headers가 전달되는지 검증한다."""
+    celery = _create_mock_celery()
+    aspect = AsyncCeleryTaskDispatchAspect(celery)
+    aspect.set_application_context(_create_mock_application_context())
+    joinpoint = _create_async_joinpoint("async_send_email")
+
+    await aspect.around_async(joinpoint)
+
+    call_kwargs = celery.send_task.call_args
+    assert call_kwargs.kwargs["headers"] == {}

--- a/plugins/spakky-celery/tests/unit/test_post_processor.py
+++ b/plugins/spakky-celery/tests/unit/test_post_processor.py
@@ -1,8 +1,9 @@
 """Tests for CeleryPostProcessor."""
 
 from datetime import time, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import pytest
 from celery import Celery
 from celery.schedules import crontab as celery_crontab
 from celery.schedules import schedule as celery_schedule
@@ -10,7 +11,14 @@ from spakky.core.utils.inspection import get_fully_qualified_name
 from spakky.task.stereotype.crontab import Crontab, Weekday
 from spakky.task.stereotype.schedule import schedule
 from spakky.task.stereotype.task_handler import TaskHandler, task
+from spakky.tracing.context import TraceContext
+from spakky.tracing.propagator import ITracePropagator
+from spakky.tracing.w3c_propagator import W3CTracePropagator
 
+from spakky.plugins.celery.aspects.task_dispatch import (
+    AsyncCeleryTaskDispatchAspect,
+    CeleryTaskDispatchAspect,
+)
 from spakky.plugins.celery.post_processor import CeleryPostProcessor
 
 
@@ -34,6 +42,7 @@ def _create_post_processor(celery: Celery) -> CeleryPostProcessor:
     """CeleryPostProcessor를 생성하고 Aware 인터페이스를 설정한다."""
     context_mock = MagicMock()
     context_mock.get.return_value = celery
+    context_mock.contains.return_value = False
 
     post_processor = CeleryPostProcessor()
     post_processor.set_application_context(context_mock)
@@ -127,6 +136,7 @@ def test_celery_post_processor_registers_wrapper_with_context_isolation() -> Non
         raise AssertionError(f"Unexpected dependency lookup: {type_}")
 
     application_context_mock.get.side_effect = get_from_context
+    application_context_mock.contains.return_value = False
 
     post_processor = CeleryPostProcessor()
     post_processor.set_application_context(application_context_mock)
@@ -169,6 +179,7 @@ def test_celery_post_processor_registers_async_tasks() -> None:
         raise AssertionError(f"Unexpected dependency lookup: {type_}")
 
     application_context_mock.get.side_effect = get_from_context
+    application_context_mock.contains.return_value = False
 
     post_processor = CeleryPostProcessor()
     post_processor.set_application_context(application_context_mock)
@@ -309,3 +320,347 @@ def test_crontab_to_celery_converts_tuple_of_intenum_to_numeric_string() -> None
     assert cron_dict["_orig_month_of_year"] == "1,7"
     # Weekday.MONDAY=0, Weekday.FRIDAY=4
     assert cron_dict["_orig_day_of_week"] == "0,4"
+
+
+# =============================================================================
+# Scenario: Trace context propagation
+# =============================================================================
+
+SAMPLE_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+SAMPLE_TRACE_ID = "0af7651916cd43dd8448eb211c80319c"
+SAMPLE_SPAN_ID = "b7ad6b7169203331"
+
+
+def _create_tracing_post_processor(
+    celery_mock: MagicMock,
+    handler_type: type[object],
+    handler_instance: object,
+    *,
+    with_propagator: bool = True,
+) -> CeleryPostProcessor:
+    """트레이싱 테스트용 CeleryPostProcessor를 생성한다."""
+
+    propagator = W3CTracePropagator()
+    sync_aspect = CeleryTaskDispatchAspect(celery_mock)
+    async_aspect = AsyncCeleryTaskDispatchAspect(celery_mock)
+
+    application_context_mock = MagicMock()
+
+    def get_from_context(type_: type[object]) -> object:
+        if type_ is Celery:
+            return celery_mock
+        if type_ is handler_type:
+            return handler_instance
+        if type_ is ITracePropagator:
+            return propagator
+        if type_ is CeleryTaskDispatchAspect:
+            return sync_aspect
+        if type_ is AsyncCeleryTaskDispatchAspect:
+            return async_aspect
+        raise AssertionError(f"Unexpected dependency lookup: {type_}")
+
+    application_context_mock.get.side_effect = get_from_context
+    application_context_mock.contains.return_value = with_propagator
+
+    post_processor = CeleryPostProcessor()
+    post_processor.set_application_context(application_context_mock)
+    return post_processor
+
+
+def test_sync_endpoint_extracts_trace_context_expect_child_span() -> None:
+    """sync 엔드포인트가 traceparent 헤더에서 trace context를 추출하여 child span을 생성하는지 검증한다."""
+
+    @TaskHandler()
+    class TracingHandler:
+        def __init__(self) -> None:
+            self.captured_ctx: TraceContext | None = None
+
+        @task
+        def traced_task(self) -> None:
+            self.captured_ctx = TraceContext.get()
+
+    handler = TracingHandler()
+    celery_mock = MagicMock()
+    post_processor = _create_tracing_post_processor(
+        celery_mock, TracingHandler, handler
+    )
+    post_processor.post_process(handler)
+
+    endpoint = celery_mock.task.return_value.call_args_list[0].args[0]
+
+    mock_request = MagicMock()
+    mock_request.get.return_value = {"traceparent": SAMPLE_TRACEPARENT}
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        endpoint()
+
+    assert handler.captured_ctx is not None
+    assert handler.captured_ctx.trace_id == SAMPLE_TRACE_ID
+    assert handler.captured_ctx.parent_span_id == SAMPLE_SPAN_ID
+    assert handler.captured_ctx.span_id != SAMPLE_SPAN_ID
+    assert TraceContext.get() is None
+
+
+def test_sync_endpoint_creates_root_when_no_traceparent_expect_new_root() -> None:
+    """sync 엔드포인트에서 traceparent 헤더가 없을 때 새 root trace를 생성하는지 검증한다."""
+
+    @TaskHandler()
+    class RootTraceHandler:
+        def __init__(self) -> None:
+            self.captured_ctx: TraceContext | None = None
+
+        @task
+        def traced_task(self) -> None:
+            self.captured_ctx = TraceContext.get()
+
+    handler = RootTraceHandler()
+    celery_mock = MagicMock()
+    post_processor = _create_tracing_post_processor(
+        celery_mock, RootTraceHandler, handler
+    )
+    post_processor.post_process(handler)
+
+    endpoint = celery_mock.task.return_value.call_args_list[0].args[0]
+
+    mock_request = MagicMock()
+    mock_request.get.return_value = {}
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        endpoint()
+
+    assert handler.captured_ctx is not None
+    assert handler.captured_ctx.parent_span_id is None
+    assert TraceContext.get() is None
+
+
+def test_sync_endpoint_clears_trace_context_on_exception_expect_none() -> None:
+    """sync 엔드포인트에서 핸들러가 예외를 발생시켜도 TraceContext가 정리되는지 검증한다."""
+
+    @TaskHandler()
+    class FailingHandler:
+        @task
+        def failing_task(self) -> None:
+            raise RuntimeError("boom")
+
+    handler = FailingHandler()
+    celery_mock = MagicMock()
+    post_processor = _create_tracing_post_processor(
+        celery_mock, FailingHandler, handler
+    )
+    post_processor.post_process(handler)
+
+    endpoint = celery_mock.task.return_value.call_args_list[0].args[0]
+
+    mock_request = MagicMock()
+    mock_request.get.return_value = {"traceparent": SAMPLE_TRACEPARENT}
+
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        with pytest.raises(RuntimeError, match="boom"):
+            endpoint()
+
+    assert TraceContext.get() is None
+
+
+def test_sync_endpoint_no_trace_when_propagator_none_expect_context_unset() -> None:
+    """propagator가 없을 때 sync 엔드포인트에서 TraceContext가 설정되지 않는지 검증한다."""
+
+    @TaskHandler()
+    class NoTraceHandler:
+        def __init__(self) -> None:
+            self.captured_ctx: TraceContext | None = None
+
+        @task
+        def simple_task(self) -> None:
+            self.captured_ctx = TraceContext.get()
+
+    handler = NoTraceHandler()
+    celery_mock = MagicMock()
+    post_processor = _create_tracing_post_processor(
+        celery_mock, NoTraceHandler, handler, with_propagator=False
+    )
+    post_processor.post_process(handler)
+
+    endpoint = celery_mock.task.return_value.call_args_list[0].args[0]
+    endpoint()
+
+    assert handler.captured_ctx is None
+
+
+def test_async_endpoint_extracts_trace_context_expect_child_span() -> None:
+    """async 엔드포인트가 traceparent 헤더에서 trace context를 추출하여 child span을 생성하는지 검증한다."""
+
+    @TaskHandler()
+    class AsyncTracingHandler:
+        def __init__(self) -> None:
+            self.captured_ctx: TraceContext | None = None
+
+        @task
+        async def async_traced_task(self) -> None:
+            self.captured_ctx = TraceContext.get()
+
+    handler = AsyncTracingHandler()
+    celery_mock = MagicMock()
+    post_processor = _create_tracing_post_processor(
+        celery_mock, AsyncTracingHandler, handler
+    )
+    post_processor.post_process(handler)
+
+    endpoint = celery_mock.task.return_value.call_args_list[0].args[0]
+
+    mock_request = MagicMock()
+    mock_request.get.return_value = {"traceparent": SAMPLE_TRACEPARENT}
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        endpoint()
+
+    assert handler.captured_ctx is not None
+    assert handler.captured_ctx.trace_id == SAMPLE_TRACE_ID
+    assert handler.captured_ctx.parent_span_id == SAMPLE_SPAN_ID
+    assert handler.captured_ctx.span_id != SAMPLE_SPAN_ID
+    assert TraceContext.get() is None
+
+
+def test_async_endpoint_clears_trace_context_on_exception_expect_none() -> None:
+    """async 엔드포인트에서 핸들러가 예외를 발생시켜도 TraceContext가 정리되는지 검증한다."""
+
+    @TaskHandler()
+    class AsyncFailingHandler:
+        @task
+        async def async_failing_task(self) -> None:
+            raise RuntimeError("async boom")
+
+    handler = AsyncFailingHandler()
+    celery_mock = MagicMock()
+    post_processor = _create_tracing_post_processor(
+        celery_mock, AsyncFailingHandler, handler
+    )
+    post_processor.post_process(handler)
+
+    endpoint = celery_mock.task.return_value.call_args_list[0].args[0]
+
+    mock_request = MagicMock()
+    mock_request.get.return_value = {"traceparent": SAMPLE_TRACEPARENT}
+
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        with pytest.raises(RuntimeError, match="async boom"):
+            endpoint()
+
+    assert TraceContext.get() is None
+
+
+def test_post_processor_injects_propagator_into_dispatch_aspects_expect_set() -> None:
+    """post_process()가 dispatch aspect에 propagator를 주입하는지 검증한다."""
+
+    celery_mock = MagicMock()
+    propagator = W3CTracePropagator()
+    sync_aspect = CeleryTaskDispatchAspect(celery_mock)
+    async_aspect = AsyncCeleryTaskDispatchAspect(celery_mock)
+
+    application_context_mock = MagicMock()
+
+    def get_from_context(type_: type[object]) -> object:
+        if type_ is Celery:
+            return celery_mock
+        if type_ is ITracePropagator:
+            return propagator
+        if type_ is CeleryTaskDispatchAspect:
+            return sync_aspect
+        if type_ is AsyncCeleryTaskDispatchAspect:
+            return async_aspect
+        if type_ is _SampleTaskHandler:
+            return _SampleTaskHandler()
+        raise AssertionError(f"Unexpected dependency lookup: {type_}")
+
+    application_context_mock.get.side_effect = get_from_context
+    application_context_mock.contains.return_value = True
+
+    post_processor = CeleryPostProcessor()
+    post_processor.set_application_context(application_context_mock)
+    post_processor.post_process(_SampleTaskHandler())
+
+    assert sync_aspect._propagator is propagator
+    assert async_aspect._propagator is propagator
+
+
+def test_sync_endpoint_filters_non_string_headers_expect_only_strings() -> None:
+    """sync 엔드포인트가 non-string 헤더 값을 필터링하는지 검증한다."""
+
+    @TaskHandler()
+    class MixedHeaderHandler:
+        def __init__(self) -> None:
+            self.captured_ctx: TraceContext | None = None
+
+        @task
+        def traced_task(self) -> None:
+            self.captured_ctx = TraceContext.get()
+
+    handler = MixedHeaderHandler()
+    celery_mock = MagicMock()
+    post_processor = _create_tracing_post_processor(
+        celery_mock, MixedHeaderHandler, handler
+    )
+    post_processor.post_process(handler)
+
+    endpoint = celery_mock.task.return_value.call_args_list[0].args[0]
+
+    mock_request = MagicMock()
+    # non-string 값(int, bytes 등)은 필터링되어야 함
+    mock_request.get.return_value = {
+        "traceparent": SAMPLE_TRACEPARENT,
+        "x-numeric": 42,
+        "x-bytes": b"raw",
+    }
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        endpoint()
+
+    assert handler.captured_ctx is not None
+    assert handler.captured_ctx.trace_id == SAMPLE_TRACE_ID
+    assert TraceContext.get() is None
+
+
+def test_post_processor_skips_aspect_injection_when_aspects_not_in_container() -> None:
+    """dispatch aspect가 컨테이너에 없을 때 propagator 주입을 건너뛰는지 검증한다."""
+
+    celery_mock = MagicMock()
+    propagator = W3CTracePropagator()
+
+    application_context_mock = MagicMock()
+
+    def get_from_context(type_: type[object]) -> object:
+        if type_ is Celery:
+            return celery_mock
+        if type_ is ITracePropagator:
+            return propagator
+        if type_ is _SampleTaskHandler:
+            return _SampleTaskHandler()
+        raise AssertionError(f"Unexpected dependency lookup: {type_}")
+
+    application_context_mock.get.side_effect = get_from_context
+
+    def contains_side_effect(type_: type[object]) -> bool:
+        if type_ is ITracePropagator:
+            return True
+        return False
+
+    application_context_mock.contains.side_effect = contains_side_effect
+
+    post_processor = CeleryPostProcessor()
+    post_processor.set_application_context(application_context_mock)
+
+    # aspect가 컨테이너에 없어도 예외 없이 정상 처리되어야 함
+    post_processor.post_process(_SampleTaskHandler())

--- a/uv.lock
+++ b/uv.lock
@@ -2542,12 +2542,18 @@ dependencies = [
     { name = "spakky-task" },
 ]
 
+[package.optional-dependencies]
+tracing = [
+    { name = "spakky-tracing" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "celery-types" },
     { name = "nest-asyncio" },
     { name = "pytest-asyncio" },
     { name = "pytest-integration-mark" },
+    { name = "spakky-tracing" },
     { name = "testcontainers", extra = ["rabbitmq"] },
 ]
 
@@ -2556,7 +2562,9 @@ requires-dist = [
     { name = "celery", specifier = ">=5.6.2" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "spakky-task", editable = "core/spakky-task" },
+    { name = "spakky-tracing", marker = "extra == 'tracing'", editable = "core/spakky-tracing" },
 ]
+provides-extras = ["tracing"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2564,6 +2572,7 @@ dev = [
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-integration-mark", specifier = ">=0.2.0" },
+    { name = "spakky-tracing", editable = "core/spakky-tracing" },
     { name = "testcontainers", extras = ["rabbitmq"], specifier = ">=4.14.1" },
 ]
 


### PR DESCRIPTION
## Summary

- `CeleryTaskDispatchAspect` / `AsyncCeleryTaskDispatchAspect`에서 `send_task()` 호출 시 `traceparent` 헤더를 inject
- `CeleryPostProcessor`의 워커 엔드포인트 래퍼에서 `task.request.headers`로부터 trace context를 extract하여 `TraceContext` 복원
- `spakky-tracing`을 optional dependency로 추가 — 미설치 시 기존 동작 유지
- Kafka/RabbitMQ 플러그인의 확립된 패턴(`_HAS_TRACING` 가드, `set_propagator()`, `object | None` 타입) 적용

## Test plan

- [x] dispatch aspect: propagator 설정 시 `send_task(headers={"traceparent": "..."})` 호출 확인
- [x] dispatch aspect: propagator 미설정 시 `headers={}` 전달 확인
- [x] worker endpoint: traceparent 포함 → child span 생성 확인
- [x] worker endpoint: traceparent 미포함 → new root 생성 확인
- [x] worker endpoint: 핸들러 예외 시 `TraceContext.clear()` 호출 확인
- [x] worker endpoint: propagator 미설정 시 `TraceContext` 미설정 확인
- [x] post-processor: dispatch aspect에 propagator 주입 확인
- [x] non-string 헤더 필터링 확인
- [x] 48 unit tests passed, coverage 100%

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)