### PR TITLE
feat(core): add get_or_none() method to IContainer and ApplicationContext

### DIFF
--- a/core/spakky-event/tests/unit/post_processor/test_event_handler_registration.py
+++ b/core/spakky-event/tests/unit/post_processor/test_event_handler_registration.py
@@ -96,6 +96,14 @@ class InMemoryContainer(IContainer):
             return self._async_consumer  # type: ignore[return-value]
         raise ValueError(f"Unexpected type: {type_}")
 
+    def get_or_none(
+        self,
+        type_: type[ObjectT],
+        name: str | None = None,
+    ) -> ObjectT | None:
+        """Not implemented for testing."""
+        return None
+
     def contains(self, type_: type, name: str | None = None) -> bool:
         """Not implemented for testing."""
         return False

--- a/core/spakky/src/spakky/core/application/application_context.py
+++ b/core/spakky/src/spakky/core/application/application_context.py
@@ -556,6 +556,28 @@ class ApplicationContext(IApplicationContext):
         return instance
 
     @overload
+    def get_or_none(self, type_: type[ObjectT]) -> ObjectT | None: ...
+
+    @overload
+    def get_or_none(self, type_: type[ObjectT], name: str) -> ObjectT | None: ...
+
+    def get_or_none(
+        self,
+        type_: type[ObjectT],
+        name: str | None = None,
+    ) -> ObjectT | None:
+        """Get a Pod instance by type and optional name, or None if not found.
+
+        Args:
+            type_: The type to retrieve.
+            name: Optional name qualifier.
+
+        Returns:
+            The Pod instance, or None if no matching Pod found.
+        """
+        return self.__get_internal(type_=type_, name=name)
+
+    @overload
     def contains(self, type_: type) -> bool: ...
 
     @overload

--- a/core/spakky/src/spakky/core/pod/interfaces/container.py
+++ b/core/spakky/src/spakky/core/pod/interfaces/container.py
@@ -129,6 +129,31 @@ class IContainer(ABC):
 
     @overload
     @abstractmethod
+    def get_or_none(self, type_: type[ObjectT]) -> ObjectT | None: ...
+
+    @overload
+    @abstractmethod
+    def get_or_none(self, type_: type[ObjectT], name: str) -> ObjectT | None: ...
+
+    @abstractmethod
+    def get_or_none(
+        self,
+        type_: type[ObjectT],
+        name: str | None = None,
+    ) -> ObjectT | None:
+        """Get a Pod instance by type and optional name, or None if not found.
+
+        Args:
+            type_: The type to retrieve.
+            name: Optional name qualifier.
+
+        Returns:
+            The Pod instance, or None if no matching Pod found.
+        """
+        ...
+
+    @overload
+    @abstractmethod
     def contains(self, type_: type) -> bool: ...
 
     @overload

--- a/core/spakky/tests/application/test_application_context.py
+++ b/core/spakky/tests/application/test_application_context.py
@@ -1202,6 +1202,77 @@ def test_contains_with_name_existing() -> None:
     assert not context.contains(TestPod, name="nonexistent")
 
 
+def test_get_or_none_existing_pod_expect_instance() -> None:
+    """존재하는 Pod를 get_or_none으로 조회하면 인스턴스를 반환함을 검증한다."""
+
+    @Pod()
+    class SamplePod:
+        pass
+
+    context = ApplicationContext()
+    context.add(SamplePod)
+    context.start()
+
+    result = context.get_or_none(SamplePod)
+    assert result is not None
+    assert isinstance(result, SamplePod)
+
+    context.stop()
+
+
+def test_get_or_none_missing_pod_expect_none() -> None:
+    """존재하지 않는 Pod를 get_or_none으로 조회하면 None을 반환함을 검증한다."""
+
+    @Pod()
+    class RegisteredPod:
+        pass
+
+    class UnregisteredPod:
+        pass
+
+    context = ApplicationContext()
+    context.add(RegisteredPod)
+    context.start()
+
+    result = context.get_or_none(UnregisteredPod)
+    assert result is None
+
+    context.stop()
+
+
+def test_get_or_none_with_name_existing_expect_instance() -> None:
+    """이름으로 존재하는 Pod를 get_or_none으로 조회하면 인스턴스를 반환함을 검증한다."""
+
+    @Pod(name="named_pod")
+    class NamedPod:
+        pass
+
+    context = ApplicationContext()
+    context.add(NamedPod)
+    context.start()
+
+    result = context.get_or_none(NamedPod, name="named_pod")
+    assert result is not None
+    assert isinstance(result, NamedPod)
+
+    context.stop()
+
+
+def test_get_or_none_with_name_missing_expect_none() -> None:
+    """존재하지 않는 이름으로 get_or_none을 조회하면 None을 반환함을 검증한다."""
+
+    class UnregisteredPod:
+        pass
+
+    context = ApplicationContext()
+    context.start()
+
+    result = context.get_or_none(UnregisteredPod, name="nonexistent")
+    assert result is None
+
+    context.stop()
+
+
 def test_context_cache_multiple_pods() -> None:
     """여러 개의 CONTEXT 스코프 Pod가 컷텍스트 캐시에 정상적으로 저장됨을 검증한다."""
 


### PR DESCRIPTION
## Summary

- `IContainer` 인터페이스에 `get_or_none()` 추상 메서드 추가 (`get()`과 동일한 overload 패턴)
- `ApplicationContext`에 `get_or_none()` 구현 — `__get_internal()` 직접 위임
- Pod 존재 시 인스턴스 반환, 미존재 시 `None` 반환 (예외 없음)
- `spakky-event` 테스트의 `InMemoryContainer` 더블에 `get_or_none` 스텁 추가

Closes #62

## Test plan

- [x] `test_get_or_none_existing_pod_expect_instance` — Pod 존재 → 인스턴스 반환
- [x] `test_get_or_none_missing_pod_expect_none` — Pod 미존재 → None 반환
- [x] `test_get_or_none_with_name_existing_expect_instance` — 이름 지정 조회 → 인스턴스 반환
- [x] `test_get_or_none_with_name_missing_expect_none` — 미존재 이름 → None 반환
- [x] 커버리지 100%, lint/type check 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)