### PR TITLE
refactor(sqlalchemy): remove _HAS_OUTBOX pattern and make spakky-outbox a required dependency (#69)

### DIFF
--- a/plugins/spakky-sqlalchemy/pyproject.toml
+++ b/plugins/spakky-sqlalchemy/pyproject.toml
@@ -8,15 +8,12 @@ license = { text = "MIT" }
 authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
 dependencies = [
     "spakky-data>=6.2.0",
+    "spakky-outbox>=6.0.0",
     "sqlalchemy>=2.0.48",
 ]
 
-[project.optional-dependencies]
-outbox = ["spakky-outbox>=6.0.0"]
-
 [dependency-groups]
 dev = [
-    "spakky-outbox>=6.0.0",
     "testcontainers[postgres]>=4.14.1",
     "psycopg[binary]>=3.3.3",
     "greenlet>=3.3.2",
@@ -88,3 +85,4 @@ exclude_lines = [
 
 [tool.uv.sources]
 spakky-data = { workspace = true }
+spakky-outbox = { workspace = true }

--- a/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/main.py
+++ b/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/main.py
@@ -15,27 +15,19 @@ from spakky.plugins.sqlalchemy.persistency.transaction import (
     Transaction,
 )
 
-try:
-    from spakky.plugins.sqlalchemy.outbox.storage import (
-        AsyncSqlAlchemyOutboxStorage,
-        SqlAlchemyOutboxStorage,
-    )
-    from spakky.plugins.sqlalchemy.outbox.table import OutboxMessageTable
-
-    _HAS_OUTBOX = True
-except ImportError:  # pragma: no cover - optional dependency (spakky-outbox)
-    _HAS_OUTBOX = False
+from spakky.plugins.sqlalchemy.outbox.storage import (
+    AsyncSqlAlchemyOutboxStorage,
+    SqlAlchemyOutboxStorage,
+)
+from spakky.plugins.sqlalchemy.outbox.table import OutboxMessageTable
 
 
 def initialize(app: SpakkyApplication) -> None:
     """Initialize the SQLAlchemy plugin.
 
     Registers SQLAlchemy configuration, schema registry, session managers,
-    and transaction handlers. Async Pods (AsyncSessionManager, AsyncTransaction)
+    transaction handlers, and Outbox storage implementations. Async Pods
     are only registered when support_async_mode is True in the configuration.
-
-    When spakky-outbox is installed, Outbox storage implementations are
-    automatically registered (runtime detection).
 
     Args:
         app: The Spakky application instance.
@@ -49,13 +41,11 @@ def initialize(app: SpakkyApplication) -> None:
     app.add(SessionManager)
     app.add(Transaction)
 
+    app.add(OutboxMessageTable)
+    app.add(SqlAlchemyOutboxStorage)
+
     if config.support_async_mode:
         app.add(AsyncConnectionManager)
         app.add(AsyncSessionManager)
         app.add(AsyncTransaction)
-
-    if _HAS_OUTBOX:
-        app.add(OutboxMessageTable)
-        app.add(SqlAlchemyOutboxStorage)
-        if config.support_async_mode:
-            app.add(AsyncSqlAlchemyOutboxStorage)
+        app.add(AsyncSqlAlchemyOutboxStorage)

--- a/plugins/spakky-sqlalchemy/tests/unit/test_main.py
+++ b/plugins/spakky-sqlalchemy/tests/unit/test_main.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-import spakky.plugins.sqlalchemy.main as main_module
 from spakky.plugins.sqlalchemy.common.config import SQLAlchemyConnectionConfig
 from spakky.plugins.sqlalchemy.main import initialize
 from spakky.plugins.sqlalchemy.orm.schema_registry import SchemaRegistry
@@ -118,22 +117,3 @@ def test_initialize_default_async_mode_expect_async_pods_registered(
     assert AsyncConnectionManager in added_types
     assert AsyncSessionManager in added_types
     assert AsyncTransaction in added_types
-
-
-def test_initialize_without_outbox_expect_no_outbox_pods(
-    mock_app: MagicMock,
-) -> None:
-    """spakky-outbox 미설치 환경에서 Outbox Pod이 등록되지 않는지 검증한다."""
-    os.environ["SPAKKY_SQLALCHEMY__SUPPORT_ASYNC_MODE"] = "true"
-    original = main_module._HAS_OUTBOX
-    main_module._HAS_OUTBOX = False
-    try:
-        initialize(mock_app)
-    finally:
-        main_module._HAS_OUTBOX = original
-
-    added_types = [call.args[0] for call in mock_app.add.call_args_list]
-    assert OutboxMessageTable not in added_types
-    assert SqlAlchemyOutboxStorage not in added_types
-    assert AsyncSqlAlchemyOutboxStorage not in added_types
-    assert mock_app.add.call_count == 8

--- a/uv.lock
+++ b/uv.lock
@@ -2715,7 +2715,7 @@ sqlalchemy = [
     { name = "spakky-sqlalchemy" },
 ]
 sqlalchemy-outbox = [
-    { name = "spakky-sqlalchemy", extra = ["outbox"] },
+    { name = "spakky-sqlalchemy" },
 ]
 typer = [
     { name = "spakky-typer" },
@@ -3087,12 +3087,8 @@ version = "6.2.0"
 source = { editable = "plugins/spakky-sqlalchemy" }
 dependencies = [
     { name = "spakky-data" },
-    { name = "sqlalchemy" },
-]
-
-[package.optional-dependencies]
-outbox = [
     { name = "spakky-outbox" },
+    { name = "sqlalchemy" },
 ]
 
 [package.dev-dependencies]
@@ -3101,17 +3097,15 @@ dev = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest-asyncio" },
     { name = "pytest-integration-mark" },
-    { name = "spakky-outbox" },
     { name = "testcontainers" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "spakky-data", editable = "core/spakky-data" },
-    { name = "spakky-outbox", marker = "extra == 'outbox'", editable = "core/spakky-outbox" },
+    { name = "spakky-outbox", editable = "core/spakky-outbox" },
     { name = "sqlalchemy", specifier = ">=2.0.48" },
 ]
-provides-extras = ["outbox"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3119,7 +3113,6 @@ dev = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-integration-mark", specifier = ">=0.2.0" },
-    { name = "spakky-outbox", editable = "core/spakky-outbox" },
     { name = "testcontainers", extras = ["postgres"], specifier = ">=4.14.1" },
 ]
 


### PR DESCRIPTION
## Summary

- `spakky-outbox`를 optional에서 정식 의존성으로 전환 (`pyproject.toml`)
- `_HAS_OUTBOX` try/except import 패턴 제거, 정적 import + 무조건 등록으로 변경 (`main.py`)
- `AsyncSqlAlchemyOutboxStorage`를 기존 `support_async_mode` 블록에 합류
- 더 이상 유효하지 않은 `_HAS_OUTBOX` mock 테스트 삭제 (`test_main.py`)

## Test plan

- [x] `uv run ruff check .` — lint 통과
- [x] `uv run pyrefly check` — 타입 체크 통과
- [x] `uv run pytest tests/unit/ -x` — 100 tests passed, 커버리지 100%

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)