### PR TITLE
refactor(fastapi): replace _HAS_TRACING with get_or_none() Optional DI

### DIFF
--- a/plugins/spakky-fastapi/pyproject.toml
+++ b/plugins/spakky-fastapi/pyproject.toml
@@ -10,15 +10,8 @@ dependencies = [
     "fastapi[standard]>=0.135.1",
     "orjson>=3.11.7",
     "spakky>=6.2.0",
-    "websockets>=16.0",
-]
-
-[project.optional-dependencies]
-tracing = ["spakky-tracing>=6.2.0"]
-
-[dependency-groups]
-dev = [
     "spakky-tracing>=6.2.0",
+    "websockets>=16.0",
 ]
 
 [project.entry-points."spakky.plugins"]

--- a/plugins/spakky-fastapi/src/spakky/plugins/fastapi/post_processors/add_builtin_middlewares.py
+++ b/plugins/spakky-fastapi/src/spakky/plugins/fastapi/post_processors/add_builtin_middlewares.py
@@ -1,8 +1,8 @@
 """Post-processor for adding built-in middleware to FastAPI applications.
 
 Automatically injects error handling and context management middleware
-into FastAPI instances registered in the container.  When ``spakky-tracing``
-is installed and its plugin is loaded, tracing middleware is also added.
+into FastAPI instances registered in the container.  When the tracing
+plugin is loaded, tracing middleware is also added.
 """
 
 from spakky.core.pod.annotations.order import Order
@@ -15,14 +15,8 @@ from spakky.core.pod.interfaces.post_processor import IPostProcessor
 
 from fastapi import FastAPI
 from spakky.plugins.fastapi.middlewares.error_handling import ErrorHandlingMiddleware
-
-try:
-    from spakky.tracing.propagator import ITracePropagator
-    from spakky.plugins.fastapi.middlewares.tracing import TracingMiddleware
-
-    _HAS_TRACING = True
-except ImportError:  # pragma: no cover - optional dependency (spakky-tracing)
-    _HAS_TRACING = False
+from spakky.plugins.fastapi.middlewares.tracing import TracingMiddleware
+from spakky.tracing.propagator import ITracePropagator
 
 
 @Order(0)
@@ -31,9 +25,8 @@ class AddBuiltInMiddlewaresPostProcessor(IPostProcessor, IApplicationContextAwar
     """Post-processor that adds built-in middleware to FastAPI instances.
 
     Injects error handling and tracing middleware into any FastAPI instance
-    created as a Pod.  Tracing middleware is only added when ``spakky-tracing``
-    is installed and its plugin is loaded.  Runs early in the post-processor
-    chain (Order 0).
+    created as a Pod.  Tracing middleware is only added when the tracing
+    plugin is loaded.  Runs early in the post-processor chain (Order 0).
     """
 
     __application_context: IApplicationContext
@@ -72,8 +65,8 @@ class AddBuiltInMiddlewaresPostProcessor(IPostProcessor, IApplicationContextAwar
             debug=pod.debug,
         )
 
-        if _HAS_TRACING and self.__application_context.contains(ITracePropagator):
-            propagator = self.__application_context.get(type_=ITracePropagator)
+        propagator = self.__application_context.get_or_none(ITracePropagator)
+        if propagator is not None:
             pod.add_middleware(
                 TracingMiddleware,
                 propagator=propagator,

--- a/plugins/spakky-fastapi/tests/test_tracing.py
+++ b/plugins/spakky-fastapi/tests/test_tracing.py
@@ -10,9 +10,6 @@ from spakky.tracing.context import TraceContext
 from spakky.tracing.w3c_propagator import W3CTracePropagator
 
 from spakky.plugins.fastapi.middlewares.tracing import TracingMiddleware
-from spakky.plugins.fastapi.post_processors import (
-    add_builtin_middlewares as middlewares_module,
-)
 
 TRACEPARENT_PATTERN = re.compile(r"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$")
 SAMPLE_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
@@ -196,8 +193,8 @@ def test_post_processor_with_tracing_plugin_expect_traceparent_in_response() -> 
     assert TRACEPARENT_PATTERN.match(response_traceparent)
 
 
-def test_post_processor_without_tracing_flag_expect_no_traceparent() -> None:
-    """_HAS_TRACING이 False일 때 응답에 traceparent 헤더가 포함되지 않음을 검증한다."""
+def test_post_processor_without_tracing_plugin_expect_no_traceparent() -> None:
+    """트레이싱 플러그인 미로드 시 응답에 traceparent 헤더가 포함되지 않음을 검증한다."""
     from spakky.core.application.application import SpakkyApplication
     from spakky.core.application.application_context import ApplicationContext
     from spakky.core.pod.annotations.pod import Pod
@@ -205,38 +202,30 @@ def test_post_processor_without_tracing_flag_expect_no_traceparent() -> None:
     import spakky.plugins.fastapi
     from tests import apps
 
-    original = (
-        middlewares_module._HAS_TRACING
-    )  # pyrefly: ignore - conditional module variable from try/except ImportError
-    middlewares_module._HAS_TRACING = False  # pyrefly: ignore - conditional module variable from try/except ImportError
-    try:
+    @Pod(name="key")
+    def get_name() -> str:
+        return "test"
 
-        @Pod(name="key")
-        def get_name() -> str:
-            return "test"
+    @Pod(name="api")
+    def get_api() -> FastAPI:
+        return FastAPI(debug=True)
 
-        @Pod(name="api")
-        def get_api() -> FastAPI:
-            return FastAPI(debug=True)
-
-        app = (
-            SpakkyApplication(ApplicationContext())
-            .load_plugins(
-                include={
-                    spakky.plugins.fastapi.PLUGIN_NAME,
-                }
-            )
-            .scan(apps)
-            .add(get_name)
-            .add(get_api)
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .load_plugins(
+            include={
+                spakky.plugins.fastapi.PLUGIN_NAME,
+            }
         )
-        app.start()
+        .scan(apps)
+        .add(get_name)
+        .add(get_api)
+    )
+    app.start()
 
-        api = app.container.get(type_=FastAPI)
-        with TestClient(api) as client:
-            response = client.get("/dummy")
+    api = app.container.get(type_=FastAPI)
+    with TestClient(api) as client:
+        response = client.get("/dummy")
 
-        assert response.status_code == 200
-        assert "traceparent" not in response.headers
-    finally:
-        middlewares_module._HAS_TRACING = original  # pyrefly: ignore - conditional module variable from try/except ImportError
+    assert response.status_code == 200
+    assert "traceparent" not in response.headers

--- a/uv.lock
+++ b/uv.lock
@@ -2829,17 +2829,8 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "orjson" },
     { name = "spakky" },
+    { name = "spakky-tracing" },
     { name = "websockets" },
-]
-
-[package.optional-dependencies]
-tracing = [
-    { name = "spakky-tracing" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "spakky-tracing" },
 ]
 
 [package.metadata]
@@ -2847,13 +2838,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.1" },
     { name = "orjson", specifier = ">=3.11.7" },
     { name = "spakky", editable = "core/spakky" },
-    { name = "spakky-tracing", marker = "extra == 'tracing'", editable = "core/spakky-tracing" },
+    { name = "spakky-tracing", editable = "core/spakky-tracing" },
     { name = "websockets", specifier = ">=16.0" },
 ]
-provides-extras = ["tracing"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "spakky-tracing", editable = "core/spakky-tracing" }]
 
 [[package]]
 name = "spakky-framework"


### PR DESCRIPTION
## Summary

- `spakky-tracing`을 optional에서 정식 의존성으로 전환
- `_HAS_TRACING` try/except import 패턴 제거, `get_or_none(ITracePropagator)` 기반 Optional DI로 전환
- `_HAS_TRACING` mock 테스트를 플러그인 미로드 시나리오로 단순화

## Test plan

- [x] `uv run ruff check .` — lint 통과
- [x] `uv run pyrefly check src/` — type check 통과
- [x] `uv run pytest` — 25 passed, 100% coverage

Closes #67