### PR TITLE
feat(celery): remove _HAS_TRACING pattern, use get_or_none() Optional DI

### DIFF
--- a/plugins/spakky-celery/pyproject.toml
+++ b/plugins/spakky-celery/pyproject.toml
@@ -10,10 +10,8 @@ dependencies = [
     "celery>=5.6.2",
     "pydantic-settings>=2.13.1",
     "spakky-task>=6.2.0",
+    "spakky-tracing>=6.2.0",
 ]
-
-[project.optional-dependencies]
-tracing = ["spakky-tracing>=6.2.0"]
 
 [project.entry-points."spakky.plugins"]
 spakky-celery = "spakky.plugins.celery.main:initialize"
@@ -24,7 +22,6 @@ dev = [
     "nest-asyncio>=1.6.0",
     "pytest-asyncio>=0.26.0",
     "pytest-integration-mark>=0.2.0",
-    "spakky-tracing>=6.2.0",
     "testcontainers[rabbitmq]>=4.14.1",
 ]
 

--- a/plugins/spakky-celery/src/spakky/plugins/celery/aspects/task_dispatch.py
+++ b/plugins/spakky-celery/src/spakky/plugins/celery/aspects/task_dispatch.py
@@ -20,12 +20,7 @@ from celery import Celery
 from spakky.plugins.celery.common.constants import CELERY_TASK_CONTEXT_KEY
 from spakky.plugins.celery.common.task_result import CeleryTaskResult
 
-try:
-    from spakky.tracing.propagator import ITracePropagator
-
-    _HAS_TRACING = True
-except ImportError:  # pragma: no cover - optional dependency (spakky-tracing)
-    _HAS_TRACING = False
+from spakky.tracing.propagator import ITracePropagator
 
 logger = getLogger(__name__)
 
@@ -41,7 +36,7 @@ class CeleryTaskDispatchAspect(IAspect, IApplicationContextAware):
 
     _celery: Celery
     _application_context: IApplicationContext
-    _propagator: object | None
+    _propagator: ITracePropagator | None
 
     def __init__(self, celery: Celery) -> None:
         """Initialize with the Celery application instance."""
@@ -52,7 +47,7 @@ class CeleryTaskDispatchAspect(IAspect, IApplicationContextAware):
         """Store the application context for checking worker context."""
         self._application_context = application_context
 
-    def set_propagator(self, propagator: object) -> None:
+    def set_propagator(self, propagator: ITracePropagator) -> None:
         """Set the trace propagator for injecting trace context into task headers."""
         self._propagator = propagator
 
@@ -63,9 +58,8 @@ class CeleryTaskDispatchAspect(IAspect, IApplicationContextAware):
 
         task_name: str = get_fully_qualified_name(joinpoint)
         task_headers: dict[str, str] = {}
-        if _HAS_TRACING and self._propagator is not None:
-            propagator: ITracePropagator = self._propagator  # type: ignore[assignment] - guarded by _HAS_TRACING
-            propagator.inject(task_headers)
+        if self._propagator is not None:
+            self._propagator.inject(task_headers)
         async_result = self._celery.send_task(
             task_name,
             args=args,
@@ -87,7 +81,7 @@ class AsyncCeleryTaskDispatchAspect(IAsyncAspect, IApplicationContextAware):
 
     _celery: Celery
     _application_context: IApplicationContext
-    _propagator: object | None
+    _propagator: ITracePropagator | None
 
     def __init__(self, celery: Celery) -> None:
         """Initialize with the Celery application instance."""
@@ -98,7 +92,7 @@ class AsyncCeleryTaskDispatchAspect(IAsyncAspect, IApplicationContextAware):
         """Store the application context for checking worker context."""
         self._application_context = application_context
 
-    def set_propagator(self, propagator: object) -> None:
+    def set_propagator(self, propagator: ITracePropagator) -> None:
         """Set the trace propagator for injecting trace context into task headers."""
         self._propagator = propagator
 
@@ -111,9 +105,8 @@ class AsyncCeleryTaskDispatchAspect(IAsyncAspect, IApplicationContextAware):
 
         task_name: str = get_fully_qualified_name(joinpoint)
         task_headers: dict[str, str] = {}
-        if _HAS_TRACING and self._propagator is not None:
-            propagator: ITracePropagator = self._propagator  # type: ignore[assignment] - guarded by _HAS_TRACING
-            propagator.inject(task_headers)
+        if self._propagator is not None:
+            self._propagator.inject(task_headers)
         async_result = self._celery.send_task(
             task_name,
             args=args,

--- a/plugins/spakky-celery/src/spakky/plugins/celery/post_processor.py
+++ b/plugins/spakky-celery/src/spakky/plugins/celery/post_processor.py
@@ -28,13 +28,8 @@ from spakky.plugins.celery.aspects.task_dispatch import (
 from spakky.plugins.celery.common.constants import CELERY_TASK_CONTEXT_KEY
 from spakky.plugins.celery.error import InvalidScheduleRouteError
 
-try:
-    from spakky.tracing.context import TraceContext
-    from spakky.tracing.propagator import ITracePropagator
-
-    _HAS_TRACING = True
-except ImportError:  # pragma: no cover - optional dependency (spakky-tracing)
-    _HAS_TRACING = False
+from spakky.tracing.context import TraceContext
+from spakky.tracing.propagator import ITracePropagator
 
 logger = getLogger(__name__)
 
@@ -54,7 +49,7 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
         self,
         handler_type: type[object],
         method: Callable[..., Any],
-        propagator: object | None,
+        propagator: ITracePropagator | None,
     ) -> Callable[..., Any]:
         """Create a sync endpoint that resolves handler from container."""
 
@@ -62,15 +57,14 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
         def endpoint(*args: Any, **kwargs: Any) -> Any:
             self.__application_context.clear_context()
             self.__application_context.set_context_value(CELERY_TASK_CONTEXT_KEY, True)
-            if _HAS_TRACING and propagator is not None:
-                typed_propagator: ITracePropagator = propagator  # type: ignore[assignment] - guarded by _HAS_TRACING
+            if propagator is not None:
                 raw_headers: dict[str, object] = (
                     current_task.request.get("headers") or {}
                 )
                 carrier: dict[str, str] = {
                     k: v for k, v in raw_headers.items() if isinstance(v, str)
                 }
-                parent = typed_propagator.extract(carrier)
+                parent = propagator.extract(carrier)
                 ctx = parent.child() if parent is not None else TraceContext.new_root()
                 TraceContext.set(ctx)
             try:
@@ -78,7 +72,7 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
                 bound_method = method.__get__(handler_instance, handler_type)
                 return bound_method(*args, **kwargs)
             finally:
-                if _HAS_TRACING and propagator is not None:
+                if propagator is not None:
                     TraceContext.clear()
 
         return endpoint
@@ -87,7 +81,7 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
         self,
         handler_type: type[object],
         method: Callable[..., Any],
-        propagator: object | None,
+        propagator: ITracePropagator | None,
     ) -> Callable[..., Any]:
         """Create an endpoint for async methods.
 
@@ -99,15 +93,14 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
             """Async wrapper that sets context and invokes handler method."""
             self.__application_context.clear_context()
             self.__application_context.set_context_value(CELERY_TASK_CONTEXT_KEY, True)
-            if _HAS_TRACING and propagator is not None:
-                typed_propagator: ITracePropagator = propagator  # type: ignore[assignment] - guarded by _HAS_TRACING
+            if propagator is not None:
                 raw_headers: dict[str, object] = (
                     current_task.request.get("headers") or {}
                 )
                 carrier: dict[str, str] = {
                     k: v for k, v in raw_headers.items() if isinstance(v, str)
                 }
-                parent = typed_propagator.extract(carrier)
+                parent = propagator.extract(carrier)
                 ctx = parent.child() if parent is not None else TraceContext.new_root()
                 TraceContext.set(ctx)
             try:
@@ -115,7 +108,7 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
                 bound_method = method.__get__(handler_instance, handler_type)
                 return await bound_method(*args, **kwargs)
             finally:
-                if _HAS_TRACING and propagator is not None:
+                if propagator is not None:
                     TraceContext.clear()
 
         @wraps(method)
@@ -160,7 +153,7 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
         celery: Celery,
         pod_type: type[object],
         method: Callable[..., Any],
-        propagator: object | None,
+        propagator: ITracePropagator | None,
     ) -> str:
         """Register a single method as a Celery task. Returns the task name."""
         if iscoroutinefunction(method):
@@ -180,9 +173,8 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
         celery: Celery = self.__application_context.get(Celery)
         pod_type = TaskHandler.get(pod).type_
 
-        propagator: object | None = None
-        if _HAS_TRACING and self.__application_context.contains(ITracePropagator):
-            propagator = self.__application_context.get(type_=ITracePropagator)
+        propagator = self.__application_context.get_or_none(type_=ITracePropagator)
+        if propagator is not None:
             for aspect_type in (
                 CeleryTaskDispatchAspect,
                 AsyncCeleryTaskDispatchAspect,

--- a/plugins/spakky-celery/tests/unit/test_post_processor.py
+++ b/plugins/spakky-celery/tests/unit/test_post_processor.py
@@ -42,7 +42,7 @@ def _create_post_processor(celery: Celery) -> CeleryPostProcessor:
     """CeleryPostProcessor를 생성하고 Aware 인터페이스를 설정한다."""
     context_mock = MagicMock()
     context_mock.get.return_value = celery
-    context_mock.contains.return_value = False
+    context_mock.get_or_none.return_value = None
 
     post_processor = CeleryPostProcessor()
     post_processor.set_application_context(context_mock)
@@ -136,7 +136,7 @@ def test_celery_post_processor_registers_wrapper_with_context_isolation() -> Non
         raise AssertionError(f"Unexpected dependency lookup: {type_}")
 
     application_context_mock.get.side_effect = get_from_context
-    application_context_mock.contains.return_value = False
+    application_context_mock.get_or_none.return_value = None
 
     post_processor = CeleryPostProcessor()
     post_processor.set_application_context(application_context_mock)
@@ -179,7 +179,7 @@ def test_celery_post_processor_registers_async_tasks() -> None:
         raise AssertionError(f"Unexpected dependency lookup: {type_}")
 
     application_context_mock.get.side_effect = get_from_context
-    application_context_mock.contains.return_value = False
+    application_context_mock.get_or_none.return_value = None
 
     post_processor = CeleryPostProcessor()
     post_processor.set_application_context(application_context_mock)
@@ -360,6 +360,9 @@ def _create_tracing_post_processor(
         raise AssertionError(f"Unexpected dependency lookup: {type_}")
 
     application_context_mock.get.side_effect = get_from_context
+    application_context_mock.get_or_none.return_value = (
+        propagator if with_propagator else None
+    )
     application_context_mock.contains.return_value = with_propagator
 
     post_processor = CeleryPostProcessor()
@@ -584,6 +587,7 @@ def test_post_processor_injects_propagator_into_dispatch_aspects_expect_set() ->
         raise AssertionError(f"Unexpected dependency lookup: {type_}")
 
     application_context_mock.get.side_effect = get_from_context
+    application_context_mock.get_or_none.return_value = propagator
     application_context_mock.contains.return_value = True
 
     post_processor = CeleryPostProcessor()
@@ -651,13 +655,8 @@ def test_post_processor_skips_aspect_injection_when_aspects_not_in_container() -
         raise AssertionError(f"Unexpected dependency lookup: {type_}")
 
     application_context_mock.get.side_effect = get_from_context
-
-    def contains_side_effect(type_: type[object]) -> bool:
-        if type_ is ITracePropagator:
-            return True
-        return False
-
-    application_context_mock.contains.side_effect = contains_side_effect
+    application_context_mock.get_or_none.return_value = propagator
+    application_context_mock.contains.return_value = False
 
     post_processor = CeleryPostProcessor()
     post_processor.set_application_context(application_context_mock)

--- a/uv.lock
+++ b/uv.lock
@@ -2744,10 +2744,6 @@ dependencies = [
     { name = "celery" },
     { name = "pydantic-settings" },
     { name = "spakky-task" },
-]
-
-[package.optional-dependencies]
-tracing = [
     { name = "spakky-tracing" },
 ]
 
@@ -2757,7 +2753,6 @@ dev = [
     { name = "nest-asyncio" },
     { name = "pytest-asyncio" },
     { name = "pytest-integration-mark" },
-    { name = "spakky-tracing" },
     { name = "testcontainers", extra = ["rabbitmq"] },
 ]
 
@@ -2766,9 +2761,8 @@ requires-dist = [
     { name = "celery", specifier = ">=5.6.2" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "spakky-task", editable = "core/spakky-task" },
-    { name = "spakky-tracing", marker = "extra == 'tracing'", editable = "core/spakky-tracing" },
+    { name = "spakky-tracing", editable = "core/spakky-tracing" },
 ]
-provides-extras = ["tracing"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2776,7 +2770,6 @@ dev = [
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-integration-mark", specifier = ">=0.2.0" },
-    { name = "spakky-tracing", editable = "core/spakky-tracing" },
     { name = "testcontainers", extras = ["rabbitmq"], specifier = ">=4.14.1" },
 ]
 


### PR DESCRIPTION
## Summary

- `spakky-tracing`을 optional에서 정식 의존성으로 승격
- `try/except ImportError` + `_HAS_TRACING` 플래그 패턴을 정적 import + `get_or_none()` 기반 Optional DI로 전환
- `object | None` 타입을 `ITracePropagator | None`으로 강화하여 `type: ignore` 캐스트 제거

## Changes

### `pyproject.toml`
- `spakky-tracing>=6.2.0`을 `dependencies`로 이동, `[project.optional-dependencies]` 섹션 제거

### `post_processor.py`
- `_HAS_TRACING` try/except 블록 → 정적 import
- `contains()` + `get()` → `get_or_none(type_=ITracePropagator)`
- `propagator: object | None` → `ITracePropagator | None` (시그니처 3곳)
- `typed_propagator` 캐스트 + `# type: ignore` 제거

### `aspects/task_dispatch.py`
- `_HAS_TRACING` try/except 블록 → 정적 import
- `_propagator: object | None` → `ITracePropagator | None`
- `set_propagator(propagator: object)` → `set_propagator(propagator: ITracePropagator)`
- `_HAS_TRACING and self._propagator is not None` → `self._propagator is not None`

### `tests/unit/test_post_processor.py`
- Mock 업데이트: `contains.return_value` → `get_or_none.return_value`

## Test plan

- [x] `uv run ruff check .` — lint 통과
- [x] `uv run pyrefly check` — 타입 체크 통과
- [x] `uv run pytest tests/unit/` — 48 tests passed, coverage 100%
- [x] 레이어 의존 방향 검증 통과

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)