### PR TITLE
refactor(rabbitmq): replace _HAS_TRACING with static import and get_or_none()

### DIFF
--- a/plugins/spakky-rabbitmq/pyproject.toml
+++ b/plugins/spakky-rabbitmq/pyproject.toml
@@ -13,10 +13,8 @@ dependencies = [
   "pydantic>=2.12.5",
   "pydantic-settings>=2.13.1",
   "spakky-event>=6.2.0",
+  "spakky-tracing>=6.2.0",
 ]
-
-[project.optional-dependencies]
-tracing = ["spakky-tracing>=6.2.0"]
 
 [dependency-groups]
 dev = [

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/consumer.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/consumer.py
@@ -34,14 +34,8 @@ from spakky.event.event_consumer import (
 )
 
 from spakky.plugins.rabbitmq.common.config import RabbitMQConnectionConfig
-
-try:
-    from spakky.tracing.context import TraceContext
-    from spakky.tracing.propagator import ITracePropagator
-
-    _HAS_TRACING = True
-except ImportError:  # pragma: no cover - optional dependency (spakky-tracing)
-    _HAS_TRACING = False
+from spakky.tracing.context import TraceContext
+from spakky.tracing.propagator import ITracePropagator
 
 
 @Pod()
@@ -66,7 +60,7 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
     handlers: dict[type[AbstractEvent], list[EventHandlerCallback[Any]]]
     connection: BlockingConnection
     channel: BlockingChannel
-    _propagator: object | None
+    _propagator: ITracePropagator | None
 
     def __init__(self, config: RabbitMQConnectionConfig) -> None:
         """Initialize the synchronous RabbitMQ event consumer.
@@ -81,11 +75,11 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
         self.handlers = {}
         self._propagator = None
 
-    def set_propagator(self, propagator: object) -> None:
+    def set_propagator(self, propagator: ITracePropagator) -> None:
         """Set the trace propagator for extracting trace context from messages.
 
         Args:
-            propagator: An ITracePropagator instance.
+            propagator: The trace propagator instance.
         """
         self._propagator = propagator
 
@@ -127,10 +121,9 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
         """
         if method_frame.consumer_tag is None or method_frame.delivery_tag is None:
             raise InvalidMessageError("Missing consumer tag or delivery tag.")
-        if _HAS_TRACING and self._propagator is not None:
-            propagator: ITracePropagator = self._propagator  # type: ignore[assignment]  # guarded by _HAS_TRACING
+        if self._propagator is not None:
             carrier = self._to_string_headers(properties.headers)
-            parent = propagator.extract(carrier)
+            parent = self._propagator.extract(carrier)
             ctx = parent.child() if parent is not None else TraceContext.new_root()
             TraceContext.set(ctx)
         try:
@@ -142,7 +135,7 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
                 handler(event)
             channel.basic_ack(method_frame.delivery_tag)
         finally:
-            if _HAS_TRACING and self._propagator is not None:
+            if self._propagator is not None:
                 TraceContext.clear()
 
     def _check_if_event_set(self) -> None:
@@ -226,7 +219,7 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
     type_adapters: dict[type, TypeAdapter[AbstractEvent]]
     handlers: dict[type[AbstractEvent], list[AsyncEventHandlerCallback[Any]]]
     connection: AbstractRobustConnection
-    _propagator: object | None
+    _propagator: ITracePropagator | None
 
     def __init__(self, config: RabbitMQConnectionConfig) -> None:
         """Initialize the asynchronous RabbitMQ event consumer.
@@ -240,11 +233,11 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
         self.handlers = {}
         self._propagator = None
 
-    def set_propagator(self, propagator: object) -> None:
+    def set_propagator(self, propagator: ITracePropagator) -> None:
         """Set the trace propagator for extracting trace context from messages.
 
         Args:
-            propagator: An ITracePropagator instance.
+            propagator: The trace propagator instance.
         """
         self._propagator = propagator
 
@@ -280,10 +273,9 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
         """
         if message.consumer_tag is None or message.delivery_tag is None:
             raise InvalidMessageError("Missing consumer tag or delivery tag.")
-        if _HAS_TRACING and self._propagator is not None:
-            propagator: ITracePropagator = self._propagator  # type: ignore[assignment]  # guarded by _HAS_TRACING
+        if self._propagator is not None:
             carrier = self._to_string_headers(message.headers)
-            parent = propagator.extract(carrier)
+            parent = self._propagator.extract(carrier)
             ctx = parent.child() if parent is not None else TraceContext.new_root()
             TraceContext.set(ctx)
         try:
@@ -295,7 +287,7 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
                 await handler(event)
             await message.ack()
         finally:
-            if _HAS_TRACING and self._propagator is not None:
+            if self._propagator is not None:
                 TraceContext.clear()
 
     def register(

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/post_processor.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/post_processor.py
@@ -24,13 +24,7 @@ from spakky.event.event_consumer import (
     IEventConsumer,
 )
 from spakky.event.stereotype.event_handler import EventHandler, EventRoute
-
-try:
-    from spakky.tracing.propagator import ITracePropagator
-
-    _HAS_TRACING = True
-except ImportError:  # pragma: no cover - optional dependency (spakky-tracing)
-    _HAS_TRACING = False
+from spakky.tracing.propagator import ITracePropagator
 
 logger = getLogger(__name__)
 
@@ -82,8 +76,8 @@ class RabbitMQPostProcessor(IPostProcessor, IContainerAware, IApplicationContext
         handler: EventHandler = EventHandler.get(pod)
         consumer = self.__container.get(IEventConsumer)
         async_consumer = self.__container.get(IAsyncEventConsumer)
-        if _HAS_TRACING and self.__application_context.contains(ITracePropagator):
-            propagator = self.__application_context.get(type_=ITracePropagator)
+        propagator = self.__application_context.get_or_none(ITracePropagator)
+        if propagator is not None:
             if hasattr(consumer, "set_propagator"):
                 consumer.set_propagator(propagator)
             if hasattr(async_consumer, "set_propagator"):

--- a/plugins/spakky-rabbitmq/tests/unit/test_post_processor.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_post_processor.py
@@ -395,8 +395,7 @@ def test_rabbitmq_post_processor_with_tracing_available_expect_propagator_inject
     )
 
     mock_context = Mock(spec=ApplicationContext)
-    mock_context.contains.return_value = True
-    mock_context.get.return_value = mock_propagator
+    mock_context.get_or_none.return_value = mock_propagator
 
     post_processor = RabbitMQPostProcessor()
     post_processor.set_container(mock_container)
@@ -432,7 +431,7 @@ def test_rabbitmq_post_processor_without_tracing_expect_no_propagator_injected()
     )
 
     mock_context = Mock(spec=ApplicationContext)
-    mock_context.contains.return_value = False
+    mock_context.get_or_none.return_value = None
 
     post_processor = RabbitMQPostProcessor()
     post_processor.set_container(mock_container)
@@ -469,8 +468,7 @@ def test_rabbitmq_post_processor_with_tracing_but_no_set_propagator_expect_skipp
     )
 
     mock_context = Mock(spec=ApplicationContext)
-    mock_context.contains.return_value = True
-    mock_context.get.return_value = mock_propagator
+    mock_context.get_or_none.return_value = mock_propagator
 
     post_processor = RabbitMQPostProcessor()
     post_processor.set_container(mock_container)

--- a/uv.lock
+++ b/uv.lock
@@ -3029,10 +3029,6 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "spakky-event" },
-]
-
-[package.optional-dependencies]
-tracing = [
     { name = "spakky-tracing" },
 ]
 
@@ -3051,9 +3047,8 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "spakky-event", editable = "core/spakky-event" },
-    { name = "spakky-tracing", marker = "extra == 'tracing'", editable = "core/spakky-tracing" },
+    { name = "spakky-tracing", editable = "core/spakky-tracing" },
 ]
-provides-extras = ["tracing"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- `spakky-rabbitmq`에서 `try/except ImportError` + `_HAS_TRACING` 플래그 패턴을 제거
- `spakky-tracing`을 optional에서 정식 의존성으로 승격
- `ApplicationContext.get_or_none()`을 활용한 Optional DI로 전환
- Consumer의 `_propagator` 타입을 `object | None` → `ITracePropagator | None`으로 내로잉

## Changes

| 파일 | 변경 |
|------|------|
| `pyproject.toml` | `spakky-tracing` optional → dependencies 이동 |
| `post_processor.py` | try/except → 정적 import, `contains()` + `get()` → `get_or_none()` |
| `event/consumer.py` | try/except → 정적 import, 타입 내로잉, `_HAS_TRACING` 가드 제거 |
| `test_post_processor.py` | mock을 `get_or_none` 기반으로 전환 |

## Test plan

- [x] `uv run ruff check .` 통과
- [x] `uv run pyrefly check` 통과
- [x] `uv run pytest tests/unit/` 52 tests passed
- [x] 커버리지 100%

Closes #66