### PR TITLE
refactor(kafka): remove _HAS_TRACING pattern, use Optional DI with get_or_none()

### DIFF
--- a/plugins/spakky-kafka/pyproject.toml
+++ b/plugins/spakky-kafka/pyproject.toml
@@ -12,15 +12,12 @@ dependencies = [
     "pydantic>=2.12.5",
     "pydantic-settings>=2.13.1",
     "spakky-event>=6.2.0",
+    "spakky-tracing>=6.2.0",
 ]
-
-[project.optional-dependencies]
-tracing = ["spakky-tracing>=6.2.0"]
 
 [dependency-groups]
 dev = [
     "pytest-integration-mark>=0.2.0",
-    "spakky-tracing>=6.2.0",
     "testcontainers>=4.14.1",
 ]
 

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/event/consumer.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/event/consumer.py
@@ -21,13 +21,8 @@ from spakky.event.event_consumer import (
 
 from spakky.plugins.kafka.common.config import KafkaConnectionConfig
 
-try:
-    from spakky.tracing.context import TraceContext
-    from spakky.tracing.propagator import ITracePropagator
-
-    _HAS_TRACING = True
-except ImportError:  # pragma: no cover - optional dependency (spakky-tracing)
-    _HAS_TRACING = False
+from spakky.tracing.context import TraceContext
+from spakky.tracing.propagator import ITracePropagator
 
 logger = getLogger(__name__)
 
@@ -42,7 +37,7 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
     handlers: dict[type[AbstractEvent], list[EventHandlerCallback[Any]]]
     admin: AdminClient
     consumer: Consumer
-    _propagator: object | None
+    _propagator: ITracePropagator | None
 
     def __init__(self, config: KafkaConnectionConfig) -> None:
         """Initialize the Kafka consumer with connection config."""
@@ -58,7 +53,7 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
             logger=logger,
         )
 
-    def set_propagator(self, propagator: object) -> None:
+    def set_propagator(self, propagator: ITracePropagator) -> None:
         """Set the trace propagator for extracting trace context from messages.
 
         Args:
@@ -125,10 +120,9 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
         if event_type is None:  # pragma: no cover
             logger.warning(f"Received message for unknown event type: {topic}")
             return
-        if _HAS_TRACING and self._propagator is not None:
-            propagator: ITracePropagator = self._propagator  # type: ignore[assignment]  # guarded by _HAS_TRACING
+        if self._propagator is not None:
             carrier = self._to_string_headers(message.headers())
-            parent = propagator.extract(carrier)
+            parent = self._propagator.extract(carrier)
             ctx = parent.child() if parent is not None else TraceContext.new_root()
             TraceContext.set(ctx)
         try:
@@ -143,7 +137,7 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
         except Exception as e:  # pragma: no cover
             logger.error(f"Error processing message for event type {topic}: {e}")
         finally:
-            if _HAS_TRACING and self._propagator is not None:
+            if self._propagator is not None:
                 TraceContext.clear()
 
     def register(
@@ -189,7 +183,7 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
     handlers: dict[type[AbstractEvent], list[AsyncEventHandlerCallback[Any]]]
     admin: AdminClient
     consumer: AIOConsumer
-    _propagator: object | None
+    _propagator: ITracePropagator | None
 
     def __init__(self, config: KafkaConnectionConfig) -> None:
         """Initialize the async Kafka consumer with connection config."""
@@ -201,7 +195,7 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
         self._propagator = None
         self.admin = AdminClient(self.config.configuration_dict)
 
-    def set_propagator(self, propagator: object) -> None:
+    def set_propagator(self, propagator: ITracePropagator) -> None:
         """Set the trace propagator for extracting trace context from messages.
 
         Args:
@@ -270,10 +264,9 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
         if event_type is None:  # pragma: no cover
             logger.warning(f"Received message for unknown event type: {topic}")
             return
-        if _HAS_TRACING and self._propagator is not None:
-            propagator: ITracePropagator = self._propagator  # type: ignore[assignment]  # guarded by _HAS_TRACING
+        if self._propagator is not None:
             carrier = self._to_string_headers(message.headers())
-            parent = propagator.extract(carrier)
+            parent = self._propagator.extract(carrier)
             ctx = parent.child() if parent is not None else TraceContext.new_root()
             TraceContext.set(ctx)
         try:
@@ -288,7 +281,7 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
         except Exception as e:  # pragma: no cover
             logger.error(f"Error processing message for event type {topic}: {e}")
         finally:
-            if _HAS_TRACING and self._propagator is not None:
+            if self._propagator is not None:
                 TraceContext.clear()
 
     def register(

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/post_processor.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/post_processor.py
@@ -19,12 +19,7 @@ from spakky.event.event_consumer import (
 )
 from spakky.event.stereotype.event_handler import EventHandler, EventRoute
 
-try:
-    from spakky.tracing.propagator import ITracePropagator
-
-    _HAS_TRACING = True
-except ImportError:  # pragma: no cover - optional dependency (spakky-tracing)
-    _HAS_TRACING = False
+from spakky.tracing.propagator import ITracePropagator
 
 logger = getLogger(__name__)
 
@@ -76,8 +71,8 @@ class KafkaPostProcessor(IPostProcessor, IContainerAware, IApplicationContextAwa
         handler: EventHandler = EventHandler.get(pod)
         consumer = self.__container.get(IEventConsumer)
         async_consumer = self.__container.get(IAsyncEventConsumer)
-        if _HAS_TRACING and self.__application_context.contains(ITracePropagator):
-            propagator = self.__application_context.get(type_=ITracePropagator)
+        propagator = self.__application_context.get_or_none(ITracePropagator)
+        if propagator is not None:
             if hasattr(consumer, "set_propagator"):
                 consumer.set_propagator(propagator)
             if hasattr(async_consumer, "set_propagator"):

--- a/plugins/spakky-kafka/tests/unit/test_post_processor.py
+++ b/plugins/spakky-kafka/tests/unit/test_post_processor.py
@@ -57,6 +57,7 @@ def test_kafka_post_processor_registers_integration_event_expect_success() -> No
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.get_or_none.return_value = None
 
     # Create post-processor
     post_processor = KafkaPostProcessor()
@@ -97,6 +98,7 @@ def test_kafka_post_processor_registers_async_integration_event_expect_success()
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.get_or_none.return_value = None
 
     # Create post-processor
     post_processor = KafkaPostProcessor()
@@ -140,6 +142,7 @@ def test_kafka_post_processor_ignores_domain_event_expect_no_registration() -> N
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.get_or_none.return_value = None
 
     # Create post-processor
     post_processor = KafkaPostProcessor()
@@ -181,6 +184,7 @@ def test_kafka_post_processor_mixed_events_expect_only_integration_registered() 
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.get_or_none.return_value = None
 
     # Create post-processor
     post_processor = KafkaPostProcessor()
@@ -232,6 +236,7 @@ def test_kafka_post_processor_sync_endpoint_invocation_expect_handler_called() -
     mock_container.get.side_effect = get_mock
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.get_or_none.return_value = None
 
     # Create post-processor
     post_processor = KafkaPostProcessor()
@@ -294,6 +299,7 @@ async def test_kafka_post_processor_async_endpoint_invocation_expect_handler_cal
     mock_container.get.side_effect = get_mock
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.get_or_none.return_value = None
 
     # Create post-processor
     post_processor = KafkaPostProcessor()
@@ -343,6 +349,7 @@ def test_kafka_post_processor_non_event_handler_class_expect_early_return() -> N
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.get_or_none.return_value = None
 
     # Create post-processor
     post_processor = KafkaPostProcessor()
@@ -385,6 +392,7 @@ def test_kafka_post_processor_handler_with_non_decorated_method_expect_skip() ->
     )
 
     mock_context = Mock(spec=ApplicationContext)
+    mock_context.get_or_none.return_value = None
 
     # Create post-processor
     post_processor = KafkaPostProcessor()
@@ -430,8 +438,7 @@ def test_kafka_post_processor_with_tracing_available_expect_propagator_injected(
     )
 
     mock_context = Mock(spec=ApplicationContext)
-    mock_context.contains.return_value = True
-    mock_context.get.return_value = mock_propagator
+    mock_context.get_or_none.return_value = mock_propagator
 
     post_processor = KafkaPostProcessor()
     post_processor.set_container(mock_container)
@@ -465,7 +472,7 @@ def test_kafka_post_processor_without_tracing_expect_no_propagator_injected() ->
     )
 
     mock_context = Mock(spec=ApplicationContext)
-    mock_context.contains.return_value = False
+    mock_context.get_or_none.return_value = None
 
     post_processor = KafkaPostProcessor()
     post_processor.set_container(mock_container)
@@ -502,8 +509,7 @@ def test_kafka_post_processor_with_tracing_but_no_set_propagator_expect_skipped(
     )
 
     mock_context = Mock(spec=ApplicationContext)
-    mock_context.contains.return_value = True
-    mock_context.get.return_value = mock_propagator
+    mock_context.get_or_none.return_value = mock_propagator
 
     post_processor = KafkaPostProcessor()
     post_processor.set_container(mock_container)

--- a/uv.lock
+++ b/uv.lock
@@ -2908,17 +2908,12 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "spakky-event" },
-]
-
-[package.optional-dependencies]
-tracing = [
     { name = "spakky-tracing" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "pytest-integration-mark" },
-    { name = "spakky-tracing" },
     { name = "testcontainers" },
 ]
 
@@ -2929,14 +2924,12 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "spakky-event", editable = "core/spakky-event" },
-    { name = "spakky-tracing", marker = "extra == 'tracing'", editable = "core/spakky-tracing" },
+    { name = "spakky-tracing", editable = "core/spakky-tracing" },
 ]
-provides-extras = ["tracing"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest-integration-mark", specifier = ">=0.2.0" },
-    { name = "spakky-tracing", editable = "core/spakky-tracing" },
     { name = "testcontainers", specifier = ">=4.14.1" },
 ]
 


### PR DESCRIPTION
## Summary

- `spakky-kafka` 플러그인에서 `try/except ImportError` + `_HAS_TRACING` 플래그 패턴을 제거하고, `spakky-tracing`을 정식 의존성으로 승격
- `post_processor.py`: `contains()` + `get()` 3단계 호출을 `get_or_none()` 1단계로 교체
- `consumer.py`: `_propagator` 타입을 `object | None` → `ITracePropagator | None`으로 명시, `# type: ignore` 주석 제거

Closes #65