### PR TITLE
refactor(opentelemetry): replace _HAS_LOGGING with ILogContextBinder Optional DI (#68)

### DIFF
--- a/plugins/spakky-opentelemetry/src/spakky/plugins/opentelemetry/bridge.py
+++ b/plugins/spakky-opentelemetry/src/spakky/plugins/opentelemetry/bridge.py
@@ -1,33 +1,35 @@
 """LogContextBridge — optional trace-to-logging context synchronization."""
 
+from spakky.core.logging.interfaces.log_context_binder import ILogContextBinder
+from spakky.core.pod.annotations.pod import Pod
 from spakky.tracing.context import TraceContext
 
-try:
-    from spakky.plugins.logging.context import LogContext
 
-    _HAS_LOGGING = True
-except ImportError:  # pragma: no cover - optional dependency (spakky-logging)
-    _HAS_LOGGING = False
-
-
+@Pod()
 class LogContextBridge:
     """Synchronizes TraceContext fields into LogContext.
 
-    When spakky-logging is installed, ``sync()`` binds the current
-    trace_id and span_id into the structured logging context.
-    When spakky-logging is not installed, all operations are no-ops.
+    When an ``ILogContextBinder`` is available (i.e., spakky-logging is
+    installed and registered), ``sync()`` binds the current trace_id
+    and span_id into the structured logging context.
+    When no binder is available, all operations are no-ops.
     """
 
-    @staticmethod
-    def sync() -> None:
+    __binder: ILogContextBinder | None
+
+    def __init__(self, binder: ILogContextBinder | None = None) -> None:
+        self.__binder = binder
+
+    def sync(self) -> None:
         """Bind current TraceContext's trace_id/span_id into LogContext.
 
-        If no TraceContext is active, unbinds trace fields from LogContext.
+        If no ``ILogContextBinder`` was injected, this is a no-op.
+        If no TraceContext is active, unbinds trace fields.
         """
-        if not _HAS_LOGGING:
-            return  # pragma: no cover - optional dependency (spakky-logging)
+        if self.__binder is None:
+            return
         ctx = TraceContext.get()
         if ctx is not None:
-            LogContext.bind(trace_id=ctx.trace_id, span_id=ctx.span_id)
+            self.__binder.bind(trace_id=ctx.trace_id, span_id=ctx.span_id)
         else:
-            LogContext.unbind("trace_id", "span_id")
+            self.__binder.unbind("trace_id", "span_id")

--- a/plugins/spakky-opentelemetry/src/spakky/plugins/opentelemetry/main.py
+++ b/plugins/spakky-opentelemetry/src/spakky/plugins/opentelemetry/main.py
@@ -2,6 +2,7 @@
 
 from spakky.core.application.application import SpakkyApplication
 
+from spakky.plugins.opentelemetry.bridge import LogContextBridge
 from spakky.plugins.opentelemetry.config import OpenTelemetryConfig
 from spakky.plugins.opentelemetry.post_processor import OTelSetupPostProcessor
 
@@ -9,11 +10,13 @@ from spakky.plugins.opentelemetry.post_processor import OTelSetupPostProcessor
 def initialize(app: SpakkyApplication) -> None:
     """Initialize the spakky-opentelemetry plugin.
 
-    Registers the OpenTelemetry configuration and the post-processor
-    that sets up TracerProvider and replaces W3CTracePropagator.
+    Registers the OpenTelemetry configuration, the post-processor
+    that sets up TracerProvider and replaces W3CTracePropagator,
+    and the LogContextBridge for optional trace-to-logging sync.
 
     Args:
         app: The SpakkyApplication instance.
     """
     app.add(OpenTelemetryConfig)
     app.add(OTelSetupPostProcessor)
+    app.add(LogContextBridge)

--- a/plugins/spakky-opentelemetry/tests/unit/test_bridge.py
+++ b/plugins/spakky-opentelemetry/tests/unit/test_bridge.py
@@ -1,46 +1,48 @@
 """Tests for LogContextBridge."""
 
-from spakky.plugins.logging.context import LogContext
+from unittest.mock import MagicMock
+
+from spakky.core.logging.interfaces.log_context_binder import ILogContextBinder
 from spakky.tracing.context import TraceContext
 
 from spakky.plugins.opentelemetry.bridge import LogContextBridge
 
 
 def test_sync_with_active_trace_expect_log_context_bound() -> None:
-    """활성 TraceContext가 있으면 LogContext에 trace_id/span_id를 바인딩한다."""
+    """활성 TraceContext가 있으면 binder.bind()로 trace_id/span_id를 바인딩한다."""
+    binder = MagicMock(spec=ILogContextBinder)
+    bridge = LogContextBridge(binder=binder)
     ctx = TraceContext(
         trace_id="0af7651916cd43dd8448eb211c80319c",
         span_id="b7ad6b7169203331",
     )
     TraceContext.set(ctx)
-    LogContext.clear()
     try:
-        LogContextBridge.sync()
+        bridge.sync()
 
-        log_ctx = LogContext.get()
-        assert log_ctx["trace_id"] == "0af7651916cd43dd8448eb211c80319c"
-        assert log_ctx["span_id"] == "b7ad6b7169203331"
+        binder.bind.assert_called_once_with(
+            trace_id="0af7651916cd43dd8448eb211c80319c",
+            span_id="b7ad6b7169203331",
+        )
     finally:
         TraceContext.clear()
-        LogContext.clear()
 
 
 def test_sync_without_trace_expect_log_context_unbound() -> None:
-    """TraceContext가 없으면 LogContext에서 trace_id/span_id를 제거한다."""
-    LogContext.bind(trace_id="old-trace", span_id="old-span")
+    """TraceContext가 없으면 binder.unbind()로 trace_id/span_id를 제거한다."""
+    binder = MagicMock(spec=ILogContextBinder)
+    bridge = LogContextBridge(binder=binder)
     TraceContext.clear()
-    try:
-        LogContextBridge.sync()
 
-        log_ctx = LogContext.get()
-        assert "trace_id" not in log_ctx
-        assert "span_id" not in log_ctx
-    finally:
-        LogContext.clear()
+    bridge.sync()
+
+    binder.unbind.assert_called_once_with("trace_id", "span_id")
 
 
-def test_sync_updates_on_context_change() -> None:
-    """TraceContext 변경 후 sync()를 호출하면 LogContext가 갱신된다."""
+def test_sync_on_context_change_expect_log_context_updated() -> None:
+    """TraceContext 변경 후 sync()를 호출하면 binder.bind()가 새 값으로 호출된다."""
+    binder = MagicMock(spec=ILogContextBinder)
+    bridge = LogContextBridge(binder=binder)
     ctx1 = TraceContext(
         trace_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
         span_id="bbbbbbbbbbbbbb01",
@@ -49,15 +51,33 @@ def test_sync_updates_on_context_change() -> None:
         trace_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2",
         span_id="bbbbbbbbbbbbbb02",
     )
-    LogContext.clear()
     try:
         TraceContext.set(ctx1)
-        LogContextBridge.sync()
-        assert LogContext.get()["trace_id"] == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"
+        bridge.sync()
+        binder.bind.assert_called_with(
+            trace_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+            span_id="bbbbbbbbbbbbbb01",
+        )
 
         TraceContext.set(ctx2)
-        LogContextBridge.sync()
-        assert LogContext.get()["trace_id"] == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2"
+        bridge.sync()
+        binder.bind.assert_called_with(
+            trace_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2",
+            span_id="bbbbbbbbbbbbbb02",
+        )
     finally:
         TraceContext.clear()
-        LogContext.clear()
+
+
+def test_sync_without_binder_expect_noop() -> None:
+    """binder가 None이면 sync()는 아무 동작도 하지 않는다."""
+    bridge = LogContextBridge()
+    ctx = TraceContext(
+        trace_id="0af7651916cd43dd8448eb211c80319c",
+        span_id="b7ad6b7169203331",
+    )
+    TraceContext.set(ctx)
+    try:
+        bridge.sync()  # Should not raise
+    finally:
+        TraceContext.clear()

--- a/plugins/spakky-opentelemetry/tests/unit/test_main.py
+++ b/plugins/spakky-opentelemetry/tests/unit/test_main.py
@@ -4,18 +4,23 @@ from unittest.mock import MagicMock, call
 
 from spakky.core.application.application import SpakkyApplication
 
+from spakky.plugins.opentelemetry.bridge import LogContextBridge
 from spakky.plugins.opentelemetry.config import OpenTelemetryConfig
 from spakky.plugins.opentelemetry.main import initialize
 from spakky.plugins.opentelemetry.post_processor import OTelSetupPostProcessor
 
 
-def test_initialize_registers_config_and_post_processor() -> None:
-    """initialize()가 OpenTelemetryConfig과 OTelSetupPostProcessor를 등록한다."""
+def test_initialize_registers_all_pods() -> None:
+    """initialize()가 Config, PostProcessor, LogContextBridge를 등록한다."""
     app = MagicMock(spec=SpakkyApplication)
 
     initialize(app)
 
     app.add.assert_has_calls(
-        [call(OpenTelemetryConfig), call(OTelSetupPostProcessor)],
+        [
+            call(OpenTelemetryConfig),
+            call(OTelSetupPostProcessor),
+            call(LogContextBridge),
+        ],
     )
-    assert app.add.call_count == 2
+    assert app.add.call_count == 3


### PR DESCRIPTION
## Summary

- `LogContextBridge`를 `@Pod()`로 전환하고, 생성자에서 `ILogContextBinder | None = None` Optional DI를 적용
- `try/except ImportError` + `_HAS_LOGGING` 플래그 패턴을 완전히 제거
- `spakky-logging` 플러그인 직접 import 의존을 core `ILogContextBinder` 인터페이스로 대체
- 플러그인 `initialize()`에 `LogContextBridge` Pod 등록 추가

## Test plan

- [x] `LogContextBridge.sync()` — 활성 TraceContext 시 binder.bind() 호출 확인
- [x] `LogContextBridge.sync()` — TraceContext 없을 때 binder.unbind() 호출 확인
- [x] `LogContextBridge.sync()` — context 변경 시 새 값으로 bind 확인
- [x] `LogContextBridge.sync()` — binder=None 시 no-op 확인
- [x] `initialize()` — LogContextBridge 포함 3개 Pod 등록 확인
- [x] 커버리지 100%
- [x] ruff lint + pyrefly type check 통과

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)