### PR TITLE
feat(saga): define type system and domain models (#89)

### DIFF
--- a/core/spakky-saga/src/spakky/saga/__init__.py
+++ b/core/spakky-saga/src/spakky/saga/__init__.py
@@ -1,17 +1,59 @@
 """Spakky Saga package - Distributed transaction saga orchestration."""
 
 from spakky.core.application.plugin import Plugin
+from spakky.saga.data import AbstractSagaData
 from spakky.saga.error import (
     AbstractSpakkySagaError,
     SagaCompensationFailedError,
     SagaFlowDefinitionError,
     SagaParallelMergeConflictError,
 )
+from spakky.saga.flow import (
+    ActionFn,
+    CompensateFn,
+    FlowItem,
+    Parallel,
+    SagaDataT,
+    SagaFlow,
+    SagaStep,
+    Transaction,
+)
+from spakky.saga.result import SagaResult, StepRecord
+from spakky.saga.status import SagaStatus
+from spakky.saga.strategy import (
+    Compensate,
+    ErrorStrategy,
+    ExponentialBackoff,
+    Retry,
+    Skip,
+)
 
 PLUGIN_NAME = Plugin(name="spakky-saga")
 """Plugin identifier for the Spakky Saga package."""
 
 __all__ = [
+    # Data
+    "AbstractSagaData",
+    # Status
+    "SagaStatus",
+    # Result
+    "SagaResult",
+    "StepRecord",
+    # Strategy
+    "Compensate",
+    "Skip",
+    "ExponentialBackoff",
+    "Retry",
+    "ErrorStrategy",
+    # Flow
+    "SagaStep",
+    "Transaction",
+    "Parallel",
+    "SagaFlow",
+    "SagaDataT",
+    "ActionFn",
+    "CompensateFn",
+    "FlowItem",
     # Errors
     "AbstractSpakkySagaError",
     "SagaFlowDefinitionError",

--- a/core/spakky-saga/src/spakky/saga/data.py
+++ b/core/spakky-saga/src/spakky/saga/data.py
@@ -1,0 +1,15 @@
+"""Saga business data model."""
+
+from abc import ABC
+from dataclasses import field
+from uuid import UUID, uuid4
+
+from spakky.core.common.mutability import immutable
+from spakky.domain.models.base import AbstractDomainModel
+
+
+@immutable
+class AbstractSagaData(AbstractDomainModel, ABC):
+    """사가의 비즈니스 데이터. 엔진 상태를 포함하지 않는다."""
+
+    saga_id: UUID = field(default_factory=uuid4)

--- a/core/spakky-saga/src/spakky/saga/flow.py
+++ b/core/spakky-saga/src/spakky/saga/flow.py
@@ -1,0 +1,122 @@
+"""Saga flow composition types and type aliases."""
+
+from __future__ import annotations
+
+from dataclasses import field, replace
+from datetime import timedelta
+from typing import Awaitable, Callable, Generic, TypeAlias, TypeVar
+
+from spakky.core.common.mutability import immutable
+from spakky.saga.data import AbstractSagaData
+from spakky.saga.strategy import Compensate, ErrorStrategy
+
+SagaDataT = TypeVar("SagaDataT", bound=AbstractSagaData)
+"""사가 데이터 타입 변수."""
+
+ActionFn: TypeAlias = Callable[[SagaDataT], Awaitable[SagaDataT | None]]
+"""commit 액션 함수 시그니처. data를 변환하거나 None을 반환한다."""
+
+CompensateFn: TypeAlias = Callable[[SagaDataT], Awaitable[None]]
+"""보상 함수 시그니처. 부수효과만 수행한다."""
+
+
+@immutable
+class SagaStep(Generic[SagaDataT]):
+    """개별 saga step. 연산자로 Transaction, Parallel을 구성한다."""
+
+    action: Callable[[SagaDataT], Awaitable[SagaDataT | None]]
+    on_error: ErrorStrategy = field(default_factory=Compensate)
+
+    def __rshift__(
+        self,
+        compensate: Callable[[SagaDataT], Awaitable[None]],
+    ) -> Transaction[SagaDataT]:
+        return Transaction(
+            action=self.action,
+            compensate=compensate,
+            on_error=self.on_error,
+        )
+
+    def __and__(
+        self,
+        other: SagaStep[SagaDataT] | Transaction[SagaDataT] | Parallel[SagaDataT],
+    ) -> Parallel[SagaDataT]:
+        if isinstance(other, Parallel):
+            return Parallel(items=(self, *other.items))
+        return Parallel(items=(self, other))
+
+    def __or__(self, strategy: ErrorStrategy) -> SagaStep[SagaDataT]:
+        return replace(self, on_error=strategy)
+
+
+@immutable
+class Transaction(Generic[SagaDataT]):
+    """commit + compensate 쌍. >> 연산자의 결과."""
+
+    action: Callable[[SagaDataT], Awaitable[SagaDataT | None]]
+    compensate: Callable[[SagaDataT], Awaitable[None]]
+    on_error: ErrorStrategy = field(default_factory=Compensate)
+
+    def __and__(
+        self,
+        other: SagaStep[SagaDataT] | Transaction[SagaDataT] | Parallel[SagaDataT],
+    ) -> Parallel[SagaDataT]:
+        if isinstance(other, Parallel):
+            return Parallel(items=(self, *other.items))
+        return Parallel(items=(self, other))
+
+    def __or__(self, strategy: ErrorStrategy) -> Transaction[SagaDataT]:
+        return replace(self, on_error=strategy)
+
+
+@immutable
+class Parallel(Generic[SagaDataT]):
+    """동시 실행 그룹. & 연산자의 결과."""
+
+    items: tuple[
+        SagaStep[SagaDataT] | Transaction[SagaDataT],
+        ...,
+    ]
+
+    def __and__(
+        self,
+        other: SagaStep[SagaDataT] | Transaction[SagaDataT] | Parallel[SagaDataT],
+    ) -> Parallel[SagaDataT]:
+        if isinstance(other, Parallel):
+            return Parallel(items=(*self.items, *other.items))
+        return Parallel(items=(*self.items, other))
+
+
+FlowItem: TypeAlias = (
+    SagaStep[SagaDataT]
+    | Transaction[SagaDataT]
+    | Parallel[SagaDataT]
+    | Callable[[SagaDataT], Awaitable[SagaDataT | None]]
+)
+"""saga_flow에 넣을 수 있는 아이템 유니온 타입."""
+
+
+@immutable
+class SagaFlow(Generic[SagaDataT]):
+    """전체 사가 흐름 정의."""
+
+    items: tuple[
+        SagaStep[SagaDataT]
+        | Transaction[SagaDataT]
+        | Parallel[SagaDataT]
+        | Callable[[SagaDataT], Awaitable[SagaDataT | None]],
+        ...,
+    ]
+    saga_timeout: timedelta | None = None
+    compensation_failure_handler: Callable[[SagaDataT], Awaitable[None]] | None = None
+
+    def timeout(self, duration: timedelta) -> SagaFlow[SagaDataT]:
+        """사가 전체 타임아웃을 설정한다."""
+        return replace(self, saga_timeout=duration)
+
+    def on_compensation_failure(
+        self,
+        handler: Callable[[SagaDataT], Awaitable[None]],
+    ) -> SagaFlow[SagaDataT]:
+        """보상 실패 시 에스컬레이션 핸들러를 설정한다."""
+        return replace(self, compensation_failure_handler=handler)

--- a/core/spakky-saga/src/spakky/saga/result.py
+++ b/core/spakky-saga/src/spakky/saga/result.py
@@ -1,0 +1,31 @@
+"""Saga execution result."""
+
+from dataclasses import field
+from datetime import timedelta
+from typing import Generic, TypeVar
+
+from spakky.core.common.mutability import immutable
+from spakky.saga.data import AbstractSagaData
+from spakky.saga.status import SagaStatus
+
+SagaDataT_co = TypeVar("SagaDataT_co", bound=AbstractSagaData, covariant=True)
+
+
+@immutable
+class StepRecord:
+    """단일 step의 실행 기록."""
+
+    name: str
+    elapsed: timedelta
+
+
+@immutable
+class SagaResult(Generic[SagaDataT_co]):
+    """사가 실행 결과. 예외를 발생시키지 않고 결과를 전달한다."""
+
+    status: SagaStatus
+    data: SagaDataT_co
+    failed_step: str | None = None
+    error: Exception | None = None
+    history: tuple[StepRecord, ...] = field(default_factory=tuple)
+    elapsed: timedelta = field(default_factory=timedelta)

--- a/core/spakky-saga/src/spakky/saga/status.py
+++ b/core/spakky-saga/src/spakky/saga/status.py
@@ -1,0 +1,14 @@
+"""Saga execution status."""
+
+from enum import Enum
+
+
+class SagaStatus(Enum):
+    """Saga 실행 상태를 나타내는 열거형."""
+
+    STARTED = "STARTED"
+    RUNNING = "RUNNING"
+    COMPENSATING = "COMPENSATING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    TIMED_OUT = "TIMED_OUT"

--- a/core/spakky-saga/src/spakky/saga/strategy.py
+++ b/core/spakky-saga/src/spakky/saga/strategy.py
@@ -1,0 +1,36 @@
+"""Error strategy types for saga step failure handling."""
+
+from dataclasses import field
+from typing import TypeAlias, Union
+
+from spakky.core.common.mutability import immutable
+
+
+@immutable
+class Compensate:
+    """역순 보상을 트리거한다 (기본 전략)."""
+
+
+@immutable
+class Skip:
+    """실패를 무시하고 다음 step으로 진행한다."""
+
+
+@immutable
+class ExponentialBackoff:
+    """지수 백오프 전략."""
+
+    base: float = 1.0
+
+
+@immutable
+class Retry:
+    """지정 횟수만큼 재시도 후 then 전략을 적용한다."""
+
+    max_attempts: int = 3
+    backoff: ExponentialBackoff = field(default_factory=ExponentialBackoff)
+    then: Union["Compensate", "Skip"] = field(default_factory=Compensate)
+
+
+ErrorStrategy: TypeAlias = Compensate | Skip | Retry
+"""에러 전략 유니온 타입."""

--- a/core/spakky-saga/tests/unit/test_data.py
+++ b/core/spakky-saga/tests/unit/test_data.py
@@ -1,0 +1,63 @@
+"""Unit tests for AbstractSagaData."""
+
+from abc import ABC
+from dataclasses import FrozenInstanceError
+from uuid import UUID
+
+import pytest
+from spakky.core.common.mutability import immutable
+from spakky.domain.models.base import AbstractDomainModel
+from spakky.saga.data import AbstractSagaData
+
+
+@immutable
+class _ConcreteSagaData(AbstractSagaData):
+    order_id: UUID
+
+
+def test_abstract_saga_data_inheritance_expect_abstract_domain_model() -> None:
+    """AbstractSagaData가 AbstractDomainModel을 상속하는지 검증한다."""
+    assert issubclass(AbstractSagaData, AbstractDomainModel)
+
+
+def test_abstract_saga_data_is_abc_expect_true() -> None:
+    """AbstractSagaData가 ABC 서브클래스인지 검증한다."""
+    assert issubclass(AbstractSagaData, ABC)
+
+
+def test_concrete_saga_data_saga_id_default_expect_uuid() -> None:
+    """saga_id가 기본값으로 UUID를 생성하는지 검증한다."""
+    order_id = UUID("12345678-1234-5678-1234-567812345678")
+    data = _ConcreteSagaData(order_id=order_id)
+    assert isinstance(data.saga_id, UUID)
+
+
+def test_concrete_saga_data_saga_id_explicit_expect_preserved() -> None:
+    """명시적으로 지정한 saga_id가 유지되는지 검증한다."""
+    saga_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    order_id = UUID("12345678-1234-5678-1234-567812345678")
+    data = _ConcreteSagaData(saga_id=saga_id, order_id=order_id)
+    assert data.saga_id == saga_id
+
+
+def test_concrete_saga_data_frozen_expect_frozen_instance_error() -> None:
+    """AbstractSagaData가 frozen dataclass인지 검증한다."""
+    order_id = UUID("12345678-1234-5678-1234-567812345678")
+    data = _ConcreteSagaData(order_id=order_id)
+    with pytest.raises(FrozenInstanceError):
+        data.saga_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")  # type: ignore[misc]
+
+
+def test_concrete_saga_data_custom_fields_expect_accessible() -> None:
+    """서브클래스의 커스텀 필드에 접근 가능한지 검증한다."""
+    order_id = UUID("12345678-1234-5678-1234-567812345678")
+    data = _ConcreteSagaData(order_id=order_id)
+    assert data.order_id == order_id
+
+
+def test_concrete_saga_data_unique_saga_ids_expect_different() -> None:
+    """각 인스턴스가 고유한 saga_id를 가지는지 검증한다."""
+    order_id = UUID("12345678-1234-5678-1234-567812345678")
+    data1 = _ConcreteSagaData(order_id=order_id)
+    data2 = _ConcreteSagaData(order_id=order_id)
+    assert data1.saga_id != data2.saga_id

--- a/core/spakky-saga/tests/unit/test_flow.py
+++ b/core/spakky-saga/tests/unit/test_flow.py
@@ -1,0 +1,260 @@
+"""Unit tests for saga flow composition types."""
+
+from datetime import timedelta
+from uuid import UUID
+
+from spakky.core.common.mutability import immutable
+from spakky.saga.data import AbstractSagaData
+from spakky.saga.flow import Parallel, SagaFlow, SagaStep, Transaction
+from spakky.saga.strategy import Compensate, Retry, Skip
+
+
+@immutable
+class _TestData(AbstractSagaData):
+    order_id: UUID
+
+
+async def _action(data: _TestData) -> _TestData:
+    return data
+
+
+async def _compensate(data: _TestData) -> None:
+    pass
+
+
+async def _action2(data: _TestData) -> _TestData:
+    return data
+
+
+async def _compensate2(data: _TestData) -> None:
+    pass
+
+
+# --- SagaStep ---
+
+
+def test_saga_step_creation_expect_default_on_error() -> None:
+    """SagaStep 생성 시 기본 on_error가 Compensate인지 검증한다."""
+    step = SagaStep(action=_action)
+    assert step.action is _action
+    assert isinstance(step.on_error, Compensate)
+
+
+def test_saga_step_rshift_expect_transaction() -> None:
+    """SagaStep >> compensate가 Transaction을 반환하는지 검증한다."""
+    step = SagaStep(action=_action)
+    txn = step >> _compensate
+    assert isinstance(txn, Transaction)
+    assert txn.action is _action
+    assert txn.compensate is _compensate
+    assert isinstance(txn.on_error, Compensate)
+
+
+def test_saga_step_and_step_expect_parallel() -> None:
+    """SagaStep & SagaStep이 Parallel을 반환하는지 검증한다."""
+    step1 = SagaStep(action=_action)
+    step2 = SagaStep(action=_action2)
+    par = step1 & step2
+    assert isinstance(par, Parallel)
+    assert len(par.items) == 2
+    assert par.items[0] is step1
+    assert par.items[1] is step2
+
+
+def test_saga_step_or_strategy_expect_new_step_with_strategy() -> None:
+    """SagaStep | strategy가 on_error가 변경된 새 SagaStep을 반환하는지 검증한다."""
+    step = SagaStep(action=_action)
+    step_with_skip = step | Skip()
+    assert isinstance(step_with_skip, SagaStep)
+    assert isinstance(step_with_skip.on_error, Skip)
+    assert step_with_skip.action is _action
+
+
+def test_saga_step_or_retry_expect_retry_strategy() -> None:
+    """SagaStep | Retry가 Retry 전략을 설정하는지 검증한다."""
+    step = SagaStep(action=_action)
+    step_with_retry = step | Retry(max_attempts=5)
+    assert isinstance(step_with_retry.on_error, Retry)
+    assert step_with_retry.on_error.max_attempts == 5
+
+
+def test_saga_step_rshift_preserves_on_error_expect_strategy_in_transaction() -> None:
+    """SagaStep의 on_error가 >> 연산 시 Transaction에 전달되는지 검증한다."""
+    step = SagaStep(action=_action, on_error=Retry(max_attempts=3))
+    txn = step >> _compensate
+    assert isinstance(txn.on_error, Retry)
+
+
+# --- Transaction ---
+
+
+def test_transaction_creation_expect_correct_fields() -> None:
+    """Transaction 생성을 검증한다."""
+    txn = Transaction(action=_action, compensate=_compensate)
+    assert txn.action is _action
+    assert txn.compensate is _compensate
+    assert isinstance(txn.on_error, Compensate)
+
+
+def test_transaction_and_step_expect_parallel() -> None:
+    """Transaction & SagaStep이 Parallel을 반환하는지 검증한다."""
+    txn = Transaction(action=_action, compensate=_compensate)
+    step = SagaStep(action=_action2)
+    par = txn & step
+    assert isinstance(par, Parallel)
+    assert len(par.items) == 2
+    assert par.items[0] is txn
+    assert par.items[1] is step
+
+
+def test_transaction_and_transaction_expect_parallel() -> None:
+    """Transaction & Transaction이 Parallel을 반환하는지 검증한다."""
+    txn1 = Transaction(action=_action, compensate=_compensate)
+    txn2 = Transaction(action=_action2, compensate=_compensate2)
+    par = txn1 & txn2
+    assert isinstance(par, Parallel)
+    assert len(par.items) == 2
+
+
+def test_transaction_or_strategy_expect_new_transaction() -> None:
+    """Transaction | strategy가 on_error가 변경된 새 Transaction을 반환하는지 검증한다."""
+    txn = Transaction(action=_action, compensate=_compensate)
+    txn_with_retry = txn | Retry(max_attempts=2, then=Skip())
+    assert isinstance(txn_with_retry, Transaction)
+    assert isinstance(txn_with_retry.on_error, Retry)
+    assert txn_with_retry.on_error.max_attempts == 2
+    assert txn_with_retry.action is _action
+    assert txn_with_retry.compensate is _compensate
+
+
+# --- Parallel ---
+
+
+def test_parallel_creation_expect_items() -> None:
+    """Parallel 생성을 검증한다."""
+    step1 = SagaStep(action=_action)
+    step2 = SagaStep(action=_action2)
+    par = Parallel(items=(step1, step2))
+    assert len(par.items) == 2
+
+
+def test_parallel_and_step_expect_extended_parallel() -> None:
+    """Parallel & SagaStep이 확장된 Parallel을 반환하는지 검증한다."""
+    step1 = SagaStep(action=_action)
+    step2 = SagaStep(action=_action2)
+    par = Parallel(items=(step1,))
+    par_extended = par & step2
+    assert isinstance(par_extended, Parallel)
+    assert len(par_extended.items) == 2
+    assert par_extended.items[0] is step1
+    assert par_extended.items[1] is step2
+
+
+def test_parallel_and_parallel_expect_merged_parallel() -> None:
+    """Parallel & Parallel이 병합된 Parallel을 반환하는지 검증한다."""
+    step1 = SagaStep(action=_action)
+    step2 = SagaStep(action=_action2)
+    par1 = Parallel(items=(step1,))
+    par2 = Parallel(items=(step2,))
+    merged = par1 & par2
+    assert isinstance(merged, Parallel)
+    assert len(merged.items) == 2
+    assert merged.items[0] is step1
+    assert merged.items[1] is step2
+
+
+def test_step_and_parallel_expect_prepended() -> None:
+    """SagaStep & Parallel이 step을 앞에 추가하는지 검증한다."""
+    step1 = SagaStep(action=_action)
+    step2 = SagaStep(action=_action2)
+    par = Parallel(items=(step2,))
+    result = step1 & par
+    assert isinstance(result, Parallel)
+    assert len(result.items) == 2
+    assert result.items[0] is step1
+    assert result.items[1] is step2
+
+
+def test_transaction_and_parallel_expect_prepended() -> None:
+    """Transaction & Parallel이 transaction을 앞에 추가하는지 검증한다."""
+    txn = Transaction(action=_action, compensate=_compensate)
+    step = SagaStep(action=_action2)
+    par = Parallel(items=(step,))
+    result = txn & par
+    assert isinstance(result, Parallel)
+    assert len(result.items) == 2
+    assert result.items[0] is txn
+    assert result.items[1] is step
+
+
+# --- SagaFlow ---
+
+
+def test_saga_flow_creation_expect_items() -> None:
+    """SagaFlow 생성을 검증한다."""
+    step1 = SagaStep(action=_action)
+    step2 = SagaStep(action=_action2)
+    flow = SagaFlow(items=(step1, step2))
+    assert len(flow.items) == 2
+    assert flow.saga_timeout is None
+    assert flow.compensation_failure_handler is None
+
+
+def test_saga_flow_timeout_expect_new_flow_with_timeout() -> None:
+    """SagaFlow.timeout()이 새 SagaFlow를 반환하는지 검증한다."""
+    step = SagaStep(action=_action)
+    flow = SagaFlow(items=(step,))
+    flow_with_timeout = flow.timeout(timedelta(minutes=5))
+    assert isinstance(flow_with_timeout, SagaFlow)
+    assert flow_with_timeout.saga_timeout == timedelta(minutes=5)
+    assert flow.saga_timeout is None  # 원본 변경 없음
+
+
+def test_saga_flow_on_compensation_failure_expect_handler_set() -> None:
+    """SagaFlow.on_compensation_failure()가 핸들러를 설정하는지 검증한다."""
+    step = SagaStep(action=_action)
+    flow = SagaFlow(items=(step,))
+    flow_with_handler = flow.on_compensation_failure(_compensate)
+    assert flow_with_handler.compensation_failure_handler is _compensate
+    assert flow.compensation_failure_handler is None  # 원본 변경 없음
+
+
+def test_saga_flow_chained_config_expect_both_set() -> None:
+    """SagaFlow 설정 메서드를 체이닝할 수 있는지 검증한다."""
+    step = SagaStep(action=_action)
+    flow = (
+        SagaFlow(items=(step,))
+        .timeout(timedelta(minutes=5))
+        .on_compensation_failure(_compensate)
+    )
+    assert flow.saga_timeout == timedelta(minutes=5)
+    assert flow.compensation_failure_handler is _compensate
+
+
+# --- Operator composition ---
+
+
+def test_rshift_then_or_expect_transaction_with_strategy() -> None:
+    """(step >> compensate) | strategy 조합을 검증한다."""
+    step = SagaStep(action=_action)
+    txn = (step >> _compensate) | Retry(max_attempts=3)
+    assert isinstance(txn, Transaction)
+    assert isinstance(txn.on_error, Retry)
+
+
+def test_step_or_then_rshift_expect_transaction_preserves_strategy() -> None:
+    """(step | strategy) >> compensate 조합을 검증한다."""
+    step = SagaStep(action=_action)
+    txn = (step | Retry(max_attempts=3)) >> _compensate
+    assert isinstance(txn, Transaction)
+    assert isinstance(txn.on_error, Retry)
+
+
+def test_three_way_and_expect_parallel_with_three_items() -> None:
+    """a & b & c가 3개 아이템의 Parallel을 만드는지 검증한다."""
+    step1 = SagaStep(action=_action)
+    step2 = SagaStep(action=_action2)
+    step3 = SagaStep(action=_action)
+    par = step1 & step2 & step3
+    assert isinstance(par, Parallel)
+    assert len(par.items) == 3

--- a/core/spakky-saga/tests/unit/test_result.py
+++ b/core/spakky-saga/tests/unit/test_result.py
@@ -1,0 +1,87 @@
+"""Unit tests for SagaResult and StepRecord."""
+
+from datetime import timedelta
+from uuid import UUID
+
+from spakky.core.common.mutability import immutable
+from spakky.saga.data import AbstractSagaData
+from spakky.saga.result import SagaResult, StepRecord
+from spakky.saga.status import SagaStatus
+
+
+@immutable
+class _TestSagaData(AbstractSagaData):
+    order_id: UUID
+
+
+def test_step_record_fields_expect_accessible() -> None:
+    """StepRecord의 name과 elapsed 필드에 접근 가능한지 검증한다."""
+    record = StepRecord(name="validate", elapsed=timedelta(milliseconds=12))
+    assert record.name == "validate"
+    assert record.elapsed == timedelta(milliseconds=12)
+
+
+def test_saga_result_completed_expect_correct_fields() -> None:
+    """완료된 SagaResult의 필드를 검증한다."""
+    order_id = UUID("12345678-1234-5678-1234-567812345678")
+    data = _TestSagaData(order_id=order_id)
+    history = (
+        StepRecord(name="step1", elapsed=timedelta(milliseconds=10)),
+        StepRecord(name="step2", elapsed=timedelta(milliseconds=20)),
+    )
+    result: SagaResult[_TestSagaData] = SagaResult(
+        status=SagaStatus.COMPLETED,
+        data=data,
+        history=history,
+        elapsed=timedelta(milliseconds=30),
+    )
+    assert result.status is SagaStatus.COMPLETED
+    assert result.data is data
+    assert result.failed_step is None
+    assert result.error is None
+    assert len(result.history) == 2
+    assert result.elapsed == timedelta(milliseconds=30)
+
+
+def test_saga_result_failed_expect_error_and_step() -> None:
+    """실패한 SagaResult의 failed_step과 error를 검증한다."""
+    order_id = UUID("12345678-1234-5678-1234-567812345678")
+    data = _TestSagaData(order_id=order_id)
+    error = RuntimeError("connection timeout")
+    result: SagaResult[_TestSagaData] = SagaResult(
+        status=SagaStatus.FAILED,
+        data=data,
+        failed_step="create_ticket",
+        error=error,
+    )
+    assert result.status is SagaStatus.FAILED
+    assert result.failed_step == "create_ticket"
+    assert result.error is error
+
+
+def test_saga_result_defaults_expect_empty_history_and_zero_elapsed() -> None:
+    """SagaResult의 기본값이 올바른지 검증한다."""
+    order_id = UUID("12345678-1234-5678-1234-567812345678")
+    data = _TestSagaData(order_id=order_id)
+    result: SagaResult[_TestSagaData] = SagaResult(
+        status=SagaStatus.STARTED,
+        data=data,
+    )
+    assert result.history == ()
+    assert result.elapsed == timedelta()
+    assert result.failed_step is None
+    assert result.error is None
+
+
+def test_saga_result_timed_out_expect_status() -> None:
+    """타임아웃된 SagaResult의 상태를 검증한다."""
+    order_id = UUID("12345678-1234-5678-1234-567812345678")
+    data = _TestSagaData(order_id=order_id)
+    result: SagaResult[_TestSagaData] = SagaResult(
+        status=SagaStatus.TIMED_OUT,
+        data=data,
+        failed_step="authorize_payment",
+        elapsed=timedelta(minutes=5),
+    )
+    assert result.status is SagaStatus.TIMED_OUT
+    assert result.failed_step == "authorize_payment"

--- a/core/spakky-saga/tests/unit/test_status.py
+++ b/core/spakky-saga/tests/unit/test_status.py
@@ -1,0 +1,38 @@
+"""Unit tests for SagaStatus enum."""
+
+from spakky.saga.status import SagaStatus
+
+
+def test_saga_status_member_count_expect_six() -> None:
+    """SagaStatus가 정확히 6개의 멤버를 가지는지 검증한다."""
+    assert len(SagaStatus) == 6
+
+
+def test_saga_status_started_expect_correct_value() -> None:
+    """STARTED 상태의 값을 검증한다."""
+    assert SagaStatus.STARTED.value == "STARTED"
+
+
+def test_saga_status_running_expect_correct_value() -> None:
+    """RUNNING 상태의 값을 검증한다."""
+    assert SagaStatus.RUNNING.value == "RUNNING"
+
+
+def test_saga_status_compensating_expect_correct_value() -> None:
+    """COMPENSATING 상태의 값을 검증한다."""
+    assert SagaStatus.COMPENSATING.value == "COMPENSATING"
+
+
+def test_saga_status_completed_expect_correct_value() -> None:
+    """COMPLETED 상태의 값을 검증한다."""
+    assert SagaStatus.COMPLETED.value == "COMPLETED"
+
+
+def test_saga_status_failed_expect_correct_value() -> None:
+    """FAILED 상태의 값을 검증한다."""
+    assert SagaStatus.FAILED.value == "FAILED"
+
+
+def test_saga_status_timed_out_expect_correct_value() -> None:
+    """TIMED_OUT 상태의 값을 검증한다."""
+    assert SagaStatus.TIMED_OUT.value == "TIMED_OUT"

--- a/core/spakky-saga/tests/unit/test_strategy.py
+++ b/core/spakky-saga/tests/unit/test_strategy.py
@@ -1,0 +1,86 @@
+"""Unit tests for error strategy types."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from spakky.saga.strategy import (
+    Compensate,
+    ErrorStrategy,
+    ExponentialBackoff,
+    Retry,
+    Skip,
+)
+
+
+def test_compensate_instantiation_expect_success() -> None:
+    """Compensate를 인스턴스화할 수 있는지 검증한다."""
+    strategy = Compensate()
+    assert isinstance(strategy, Compensate)
+
+
+def test_skip_instantiation_expect_success() -> None:
+    """Skip을 인스턴스화할 수 있는지 검증한다."""
+    strategy = Skip()
+    assert isinstance(strategy, Skip)
+
+
+def test_exponential_backoff_default_expect_base_one() -> None:
+    """ExponentialBackoff의 기본 base가 1.0인지 검증한다."""
+    backoff = ExponentialBackoff()
+    assert backoff.base == 1.0
+
+
+def test_exponential_backoff_custom_base_expect_preserved() -> None:
+    """ExponentialBackoff에 커스텀 base를 지정할 수 있는지 검증한다."""
+    backoff = ExponentialBackoff(base=2.0)
+    assert backoff.base == 2.0
+
+
+def test_exponential_backoff_frozen_expect_frozen_instance_error() -> None:
+    """ExponentialBackoff가 frozen인지 검증한다."""
+    backoff = ExponentialBackoff()
+    with pytest.raises(FrozenInstanceError):
+        backoff.base = 2.0  # type: ignore[misc]
+
+
+def test_retry_defaults_expect_correct_values() -> None:
+    """Retry의 기본값을 검증한다."""
+    retry = Retry()
+    assert retry.max_attempts == 3
+    assert retry.backoff.base == 1.0
+    assert isinstance(retry.then, Compensate)
+
+
+def test_retry_custom_values_expect_preserved() -> None:
+    """Retry에 커스텀 값을 지정할 수 있는지 검증한다."""
+    retry = Retry(
+        max_attempts=5,
+        backoff=ExponentialBackoff(base=2.0),
+        then=Skip(),
+    )
+    assert retry.max_attempts == 5
+    assert retry.backoff.base == 2.0
+    assert isinstance(retry.then, Skip)
+
+
+def test_retry_then_skip_expect_skip_instance() -> None:
+    """Retry.then에 Skip을 지정할 수 있는지 검증한다."""
+    retry = Retry(max_attempts=2, then=Skip())
+    assert isinstance(retry.then, Skip)
+
+
+def test_retry_frozen_expect_frozen_instance_error() -> None:
+    """Retry가 frozen인지 검증한다."""
+    retry = Retry()
+    with pytest.raises(FrozenInstanceError):
+        retry.max_attempts = 10  # type: ignore[misc]
+
+
+def test_error_strategy_types_expect_union_members() -> None:
+    """ErrorStrategy 유니온에 Compensate, Skip, Retry가 포함되는지 검증한다."""
+    compensate: ErrorStrategy = Compensate()
+    skip: ErrorStrategy = Skip()
+    retry: ErrorStrategy = Retry()
+    assert isinstance(compensate, Compensate)
+    assert isinstance(skip, Skip)
+    assert isinstance(retry, Retry)


### PR DESCRIPTION
## 변경 사항

`spakky-saga` 패키지의 핵심 타입과 도메인 모델을 정의하여 후속 태스크(스테레오타입, flow builder, 엔진)가 의존할 타입 기반을 확립합니다.

### 추가된 타입

| 타입 | 파일 | 설명 |
|------|------|------|
| `AbstractSagaData` | `data.py` | `@immutable` + `AbstractDomainModel` 상속, `saga_id: UUID` |
| `SagaStatus` | `status.py` | 6-state enum (STARTED, RUNNING, COMPENSATING, COMPLETED, FAILED, TIMED_OUT) |
| `SagaResult[T]` | `result.py` | 실행 결과 (status, data, failed_step, error, history, elapsed) |
| `StepRecord` | `result.py` | step 실행 기록 (name, elapsed) |
| `SagaStep[T]` | `flow.py` | 개별 step + 연산자 (`>>`, `&`, `\|`) |
| `Transaction[T]` | `flow.py` | commit + compensate 쌍 (`>>` 결과) |
| `Parallel[T]` | `flow.py` | 동시 실행 그룹 (`&` 결과) |
| `SagaFlow[T]` | `flow.py` | 전체 흐름 정의 + timeout/on_compensation_failure |
| `Compensate`, `Skip`, `Retry` | `strategy.py` | 에러 전략 타입 |
| `ExponentialBackoff` | `strategy.py` | v1 백오프 전략 |
| `ActionFn`, `CompensateFn`, `FlowItem` | `flow.py` | 타입 별칭 |

### 검증

- ruff check/format ✅
- pyrefly type check ✅  
- pytest 59 passed, 100% coverage ✅

Closes #89