### PR TITLE
feat(saga): implement flow builder API (#91)

### DIFF
--- a/core/spakky-saga/src/spakky/saga/__init__.py
+++ b/core/spakky-saga/src/spakky/saga/__init__.py
@@ -17,6 +17,9 @@ from spakky.saga.flow import (
     SagaFlow,
     SagaStep,
     Transaction,
+    parallel,
+    saga_flow,
+    step,
 )
 from spakky.saga.result import SagaResult, StepRecord
 from spakky.saga.status import SagaStatus
@@ -54,6 +57,10 @@ __all__ = [
     "ActionFn",
     "CompensateFn",
     "FlowItem",
+    # Builder
+    "step",
+    "parallel",
+    "saga_flow",
     # Errors
     "AbstractSpakkySagaError",
     "SagaFlowDefinitionError",

--- a/core/spakky-saga/src/spakky/saga/flow.py
+++ b/core/spakky-saga/src/spakky/saga/flow.py
@@ -1,4 +1,4 @@
-"""Saga flow composition types and type aliases."""
+"""Saga flow composition types, type aliases, and builder functions."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from typing import Awaitable, Callable, Generic, TypeAlias, TypeVar
 
 from spakky.core.common.mutability import immutable
 from spakky.saga.data import AbstractSagaData
+from spakky.saga.error import SagaFlowDefinitionError
 from spakky.saga.strategy import Compensate, ErrorStrategy
 
 SagaDataT = TypeVar("SagaDataT", bound=AbstractSagaData)
@@ -26,6 +27,7 @@ class SagaStep(Generic[SagaDataT]):
 
     action: Callable[[SagaDataT], Awaitable[SagaDataT | None]]
     on_error: ErrorStrategy = field(default_factory=Compensate)
+    timeout: timedelta | None = None
 
     def __rshift__(
         self,
@@ -35,6 +37,7 @@ class SagaStep(Generic[SagaDataT]):
             action=self.action,
             compensate=compensate,
             on_error=self.on_error,
+            timeout=self.timeout,
         )
 
     def __and__(
@@ -56,6 +59,7 @@ class Transaction(Generic[SagaDataT]):
     action: Callable[[SagaDataT], Awaitable[SagaDataT | None]]
     compensate: Callable[[SagaDataT], Awaitable[None]]
     on_error: ErrorStrategy = field(default_factory=Compensate)
+    timeout: timedelta | None = None
 
     def __and__(
         self,
@@ -120,3 +124,104 @@ class SagaFlow(Generic[SagaDataT]):
     ) -> SagaFlow[SagaDataT]:
         """보상 실패 시 에스컬레이션 핸들러를 설정한다."""
         return replace(self, compensation_failure_handler=handler)
+
+
+_MIN_PARALLEL_ITEMS = 2
+"""parallel()에 필요한 최소 아이템 수."""
+
+
+def step(
+    action: Callable[[SagaDataT], Awaitable[SagaDataT | None]],
+    *,
+    compensate: Callable[[SagaDataT], Awaitable[None]] | None = None,
+    on_error: ErrorStrategy | None = None,
+    timeout: timedelta | None = None,
+) -> SagaStep[SagaDataT] | Transaction[SagaDataT]:
+    """commit-compensate 바인딩을 생성한다.
+
+    Args:
+        action: commit 액션 함수.
+        compensate: 보상 함수. 지정 시 Transaction을 반환한다.
+        on_error: 에러 전략. 미지정 시 Compensate.
+        timeout: step 타임아웃.
+
+    Returns:
+        compensate 미지정 시 SagaStep, 지정 시 Transaction.
+    """
+    resolved_on_error: ErrorStrategy = (
+        on_error if on_error is not None else Compensate()
+    )
+    if compensate is not None:
+        return Transaction(
+            action=action,
+            compensate=compensate,
+            on_error=resolved_on_error,
+            timeout=timeout,
+        )
+    return SagaStep(
+        action=action,
+        on_error=resolved_on_error,
+        timeout=timeout,
+    )
+
+
+def parallel(
+    *items: SagaStep[SagaDataT]
+    | Transaction[SagaDataT]
+    | Parallel[SagaDataT]
+    | Callable[[SagaDataT], Awaitable[SagaDataT | None]],
+) -> Parallel[SagaDataT]:
+    """동시 실행 그룹을 구성한다.
+
+    Callable은 SagaStep으로 자동 승격된다.
+
+    Args:
+        *items: 병렬 실행할 FlowItem들. 최소 2개 필요.
+
+    Raises:
+        SagaFlowDefinitionError: 아이템이 2개 미만일 때.
+    """
+    if len(items) < _MIN_PARALLEL_ITEMS:
+        raise SagaFlowDefinitionError
+    promoted: list[SagaStep[SagaDataT] | Transaction[SagaDataT]] = []
+    for item in items:
+        if isinstance(item, (SagaStep, Transaction)):
+            promoted.append(item)
+        elif isinstance(item, Parallel):
+            promoted.extend(item.items)
+        elif callable(item):
+            promoted.append(SagaStep(action=item))
+        else:
+            raise SagaFlowDefinitionError
+    return Parallel(items=tuple(promoted))
+
+
+def saga_flow(
+    *items: SagaStep[SagaDataT]
+    | Transaction[SagaDataT]
+    | Parallel[SagaDataT]
+    | Callable[[SagaDataT], Awaitable[SagaDataT | None]],
+) -> SagaFlow[SagaDataT]:
+    """사가 흐름을 정의한다.
+
+    Callable은 SagaStep으로 자동 승격된다.
+
+    Args:
+        *items: 순차 실행할 FlowItem들. 최소 1개 필요.
+
+    Raises:
+        SagaFlowDefinitionError: 아이템이 비어있을 때.
+    """
+    if len(items) == 0:
+        raise SagaFlowDefinitionError
+    promoted: list[
+        SagaStep[SagaDataT] | Transaction[SagaDataT] | Parallel[SagaDataT]
+    ] = []
+    for item in items:
+        if isinstance(item, (SagaStep, Transaction, Parallel)):
+            promoted.append(item)
+        elif callable(item):
+            promoted.append(SagaStep(action=item))
+        else:
+            raise SagaFlowDefinitionError
+    return SagaFlow(items=tuple(promoted))

--- a/core/spakky-saga/tests/unit/test_builder.py
+++ b/core/spakky-saga/tests/unit/test_builder.py
@@ -1,0 +1,339 @@
+"""Unit tests for saga flow builder functions."""
+
+from datetime import timedelta
+from uuid import UUID
+
+import pytest
+
+from spakky.core.common.mutability import immutable
+from spakky.saga.data import AbstractSagaData
+from spakky.saga.error import SagaFlowDefinitionError
+from spakky.saga.flow import (
+    Parallel,
+    SagaFlow,
+    SagaStep,
+    Transaction,
+    parallel,
+    saga_flow,
+    step,
+)
+from spakky.saga.strategy import Compensate, Retry, Skip
+
+
+@immutable
+class _TestData(AbstractSagaData):
+    order_id: UUID
+
+
+async def _action(data: _TestData) -> _TestData:
+    return data
+
+
+async def _compensate(data: _TestData) -> None:
+    pass
+
+
+async def _action2(data: _TestData) -> _TestData:
+    return data
+
+
+async def _compensate2(data: _TestData) -> None:
+    pass
+
+
+# --- step() ---
+
+
+def test_step_action_only_expect_saga_step() -> None:
+    """step(action)이 SagaStep을 반환하는지 검증한다."""
+    result = step(_action)
+    assert isinstance(result, SagaStep)
+    assert result.action is _action
+    assert isinstance(result.on_error, Compensate)
+    assert result.timeout is None
+
+
+def test_step_with_compensate_expect_transaction() -> None:
+    """step(action, compensate=)이 Transaction을 반환하는지 검증한다."""
+    result = step(_action, compensate=_compensate)
+    assert isinstance(result, Transaction)
+    assert result.action is _action
+    assert result.compensate is _compensate
+    assert isinstance(result.on_error, Compensate)
+
+
+def test_step_with_on_error_expect_strategy_applied() -> None:
+    """step(action, on_error=)이 에러 전략을 적용하는지 검증한다."""
+    result = step(_action, on_error=Skip())
+    assert isinstance(result, SagaStep)
+    assert isinstance(result.on_error, Skip)
+
+
+def test_step_with_compensate_and_on_error_expect_transaction_with_strategy() -> None:
+    """step(action, compensate=, on_error=)이 Transaction에 전략을 적용하는지 검증한다."""
+    result = step(_action, compensate=_compensate, on_error=Retry(max_attempts=3))
+    assert isinstance(result, Transaction)
+    assert isinstance(result.on_error, Retry)
+    assert result.on_error.max_attempts == 3
+
+
+def test_step_with_timeout_expect_timeout_set() -> None:
+    """step(action, timeout=)이 timeout을 설정하는지 검증한다."""
+    result = step(_action, timeout=timedelta(seconds=30))
+    assert isinstance(result, SagaStep)
+    assert result.timeout == timedelta(seconds=30)
+
+
+def test_step_with_compensate_and_timeout_expect_transaction_with_timeout() -> None:
+    """step(action, compensate=, timeout=)이 Transaction에 timeout을 설정하는지 검증한다."""
+    result = step(_action, compensate=_compensate, timeout=timedelta(seconds=10))
+    assert isinstance(result, Transaction)
+    assert result.timeout == timedelta(seconds=10)
+
+
+def test_step_all_params_expect_fully_configured() -> None:
+    """step()의 모든 파라미터를 지정하면 올바르게 구성되는지 검증한다."""
+    result = step(
+        _action,
+        compensate=_compensate,
+        on_error=Retry(max_attempts=5, then=Skip()),
+        timeout=timedelta(seconds=60),
+    )
+    assert isinstance(result, Transaction)
+    assert result.action is _action
+    assert result.compensate is _compensate
+    assert isinstance(result.on_error, Retry)
+    assert result.on_error.max_attempts == 5
+    assert result.timeout == timedelta(seconds=60)
+
+
+# --- parallel() ---
+
+
+def test_parallel_two_steps_expect_parallel_group() -> None:
+    """parallel(step1, step2)이 Parallel을 반환하는지 검증한다."""
+    s1 = SagaStep(action=_action)
+    s2 = SagaStep(action=_action2)
+    result = parallel(s1, s2)
+    assert isinstance(result, Parallel)
+    assert len(result.items) == 2
+    assert result.items[0] is s1
+    assert result.items[1] is s2
+
+
+def test_parallel_auto_promote_callable_expect_saga_step() -> None:
+    """parallel()에 callable을 넘기면 SagaStep으로 자동 승격되는지 검증한다."""
+    s1 = SagaStep(action=_action)
+    result = parallel(s1, _action2)
+    assert isinstance(result, Parallel)
+    assert len(result.items) == 2
+    assert result.items[0] is s1
+    assert isinstance(result.items[1], SagaStep)
+    assert result.items[1].action is _action2
+
+
+def test_parallel_all_callables_expect_all_promoted() -> None:
+    """parallel()에 모든 callable을 넘기면 전부 SagaStep으로 승격되는지 검증한다."""
+    result = parallel(_action, _action2)
+    assert isinstance(result, Parallel)
+    assert len(result.items) == 2
+    assert isinstance(result.items[0], SagaStep)
+    assert isinstance(result.items[1], SagaStep)
+    assert result.items[0].action is _action
+    assert result.items[1].action is _action2
+
+
+def test_parallel_with_transactions_expect_preserved() -> None:
+    """parallel()에 Transaction을 넘기면 보존되는지 검증한다."""
+    txn1 = Transaction(action=_action, compensate=_compensate)
+    txn2 = Transaction(action=_action2, compensate=_compensate2)
+    result = parallel(txn1, txn2)
+    assert isinstance(result, Parallel)
+    assert result.items[0] is txn1
+    assert result.items[1] is txn2
+
+
+def test_parallel_with_nested_parallel_expect_flattened() -> None:
+    """parallel()에 Parallel을 넘기면 items가 펼쳐지는지 검증한다."""
+    s1 = SagaStep(action=_action)
+    s2 = SagaStep(action=_action2)
+    inner = Parallel(items=(s1, s2))
+    s3 = SagaStep(action=_action)
+    result = parallel(inner, s3)
+    assert isinstance(result, Parallel)
+    assert len(result.items) == 3
+    assert result.items[0] is s1
+    assert result.items[1] is s2
+    assert result.items[2] is s3
+
+
+def test_parallel_empty_expect_error() -> None:
+    """parallel()에 아이템이 없으면 SagaFlowDefinitionError가 발생하는지 검증한다."""
+    with pytest.raises(SagaFlowDefinitionError):
+        parallel()
+
+
+def test_parallel_single_item_expect_error() -> None:
+    """parallel()에 아이템이 1개면 SagaFlowDefinitionError가 발생하는지 검증한다."""
+    with pytest.raises(SagaFlowDefinitionError):
+        parallel(SagaStep(action=_action))
+
+
+def test_parallel_invalid_item_type_expect_error() -> None:
+    """parallel()에 유효하지 않은 타입을 넘기면 SagaFlowDefinitionError가 발생하는지 검증한다."""
+    with pytest.raises(SagaFlowDefinitionError):
+        parallel("not_a_flow_item", SagaStep(action=_action))  # type: ignore[arg-type] - intentional invalid type for test
+
+
+# --- saga_flow() ---
+
+
+def test_saga_flow_single_step_expect_flow() -> None:
+    """saga_flow(step)이 SagaFlow를 반환하는지 검증한다."""
+    s = SagaStep(action=_action)
+    result = saga_flow(s)
+    assert isinstance(result, SagaFlow)
+    assert len(result.items) == 1
+    assert result.items[0] is s
+
+
+def test_saga_flow_multiple_steps_expect_flow() -> None:
+    """saga_flow(step1, step2)이 순서대로 SagaFlow를 구성하는지 검증한다."""
+    s1 = SagaStep(action=_action)
+    s2 = SagaStep(action=_action2)
+    result = saga_flow(s1, s2)
+    assert isinstance(result, SagaFlow)
+    assert len(result.items) == 2
+    assert result.items[0] is s1
+    assert result.items[1] is s2
+
+
+def test_saga_flow_auto_promote_callable_expect_saga_step() -> None:
+    """saga_flow()에 callable을 넘기면 SagaStep으로 자동 승격되는지 검증한다."""
+    result = saga_flow(_action, _action2)
+    assert isinstance(result, SagaFlow)
+    assert len(result.items) == 2
+    assert isinstance(result.items[0], SagaStep)
+    assert isinstance(result.items[1], SagaStep)
+    assert result.items[0].action is _action
+    assert result.items[1].action is _action2
+
+
+def test_saga_flow_mixed_items_expect_promoted_and_preserved() -> None:
+    """saga_flow()에 혼합 아이템을 넘기면 callable은 승격, 나머지는 보존되는지 검증한다."""
+    txn = Transaction(action=_action, compensate=_compensate)
+    par = Parallel(items=(SagaStep(action=_action), SagaStep(action=_action2)))
+    result = saga_flow(txn, _action2, par)
+    assert isinstance(result, SagaFlow)
+    assert len(result.items) == 3
+    assert result.items[0] is txn
+    assert isinstance(result.items[1], SagaStep)
+    assert result.items[1].action is _action2
+    assert result.items[2] is par
+
+
+def test_saga_flow_empty_expect_error() -> None:
+    """saga_flow()에 아이템이 없으면 SagaFlowDefinitionError가 발생하는지 검증한다."""
+    with pytest.raises(SagaFlowDefinitionError):
+        saga_flow()
+
+
+def test_saga_flow_invalid_item_type_expect_error() -> None:
+    """saga_flow()에 유효하지 않은 타입을 넘기면 SagaFlowDefinitionError가 발생하는지 검증한다."""
+    with pytest.raises(SagaFlowDefinitionError):
+        saga_flow(42)  # type: ignore[arg-type] - intentional invalid type for test
+
+
+def test_saga_flow_with_lambda_expect_auto_promoted() -> None:
+    """saga_flow()에 람다를 넘기면 SagaStep으로 자동 승격되는지 검증한다."""
+    result = saga_flow(
+        lambda d: _action(d),
+        lambda d: _action2(d),
+    )
+    assert isinstance(result, SagaFlow)
+    assert len(result.items) == 2
+    assert isinstance(result.items[0], SagaStep)
+    assert isinstance(result.items[1], SagaStep)
+
+
+def test_saga_flow_chaining_after_builder_expect_timeout_set() -> None:
+    """saga_flow() 결과에 .timeout()을 체이닝할 수 있는지 검증한다."""
+    result = saga_flow(_action).timeout(timedelta(minutes=5))
+    assert isinstance(result, SagaFlow)
+    assert result.saga_timeout == timedelta(minutes=5)
+
+
+def test_saga_flow_chaining_on_compensation_failure_expect_handler_set() -> None:
+    """saga_flow() 결과에 .on_compensation_failure()를 체이닝할 수 있는지 검증한다."""
+    result = saga_flow(_action).on_compensation_failure(_compensate)
+    assert isinstance(result, SagaFlow)
+    assert result.compensation_failure_handler is _compensate
+
+
+# --- Operator equivalence ---
+
+
+def test_step_with_compensate_equivalent_to_rshift_expect_same_result() -> None:
+    """step(a, compensate=b)이 SagaStep(a) >> b와 동일한 결과를 생성하는지 검증한다."""
+    via_func = step(_action, compensate=_compensate)
+    via_op = SagaStep(action=_action) >> _compensate
+    assert isinstance(via_func, Transaction)
+    assert isinstance(via_op, Transaction)
+    assert via_func.action is via_op.action
+    assert via_func.compensate is via_op.compensate
+    assert type(via_func.on_error) is type(via_op.on_error)
+
+
+def test_parallel_func_equivalent_to_and_operator_expect_same_items() -> None:
+    """parallel(a, b)이 a & b와 동일한 결과를 생성하는지 검증한다."""
+    s1 = SagaStep(action=_action)
+    s2 = SagaStep(action=_action2)
+    via_func = parallel(s1, s2)
+    via_op = s1 & s2
+    assert isinstance(via_func, Parallel)
+    assert isinstance(via_op, Parallel)
+    assert len(via_func.items) == len(via_op.items)
+    assert via_func.items[0] is via_op.items[0]
+    assert via_func.items[1] is via_op.items[1]
+
+
+def test_step_with_on_error_equivalent_to_or_operator_expect_same_strategy() -> None:
+    """step(a, on_error=Skip())이 SagaStep(a) | Skip()와 동일한 결과를 생성하는지 검증한다."""
+    via_func = step(_action, on_error=Skip())
+    via_op = SagaStep(action=_action) | Skip()
+    assert isinstance(via_func, SagaStep)
+    assert isinstance(via_op, SagaStep)
+    assert via_func.action is via_op.action
+    assert type(via_func.on_error) is type(via_op.on_error)
+
+
+def test_step_compensate_on_error_equivalent_to_rshift_or_expect_same() -> None:
+    """step(a, compensate=b, on_error=Retry(3))이 (SagaStep(a) >> b) | Retry(3)과 동일한지 검증한다."""
+    via_func = step(_action, compensate=_compensate, on_error=Retry(max_attempts=3))
+    via_op = (SagaStep(action=_action) >> _compensate) | Retry(max_attempts=3)
+    assert isinstance(via_func, Transaction)
+    assert isinstance(via_op, Transaction)
+    assert via_func.action is via_op.action
+    assert via_func.compensate is via_op.compensate
+    assert isinstance(via_func.on_error, Retry)
+    assert isinstance(via_op.on_error, Retry)
+    assert via_func.on_error.max_attempts == via_op.on_error.max_attempts
+
+
+def test_saga_flow_operator_mix_expect_valid_flow() -> None:
+    """saga_flow()에서 연산자와 함수 기반 API를 혼합하여 사용할 수 있는지 검증한다."""
+    flow = saga_flow(
+        step(_action, compensate=_compensate),
+        SagaStep(action=_action2) >> _compensate2,
+        _action,
+        parallel(
+            SagaStep(action=_action),
+            SagaStep(action=_action2),
+        ),
+    )
+    assert isinstance(flow, SagaFlow)
+    assert len(flow.items) == 4
+    assert isinstance(flow.items[0], Transaction)
+    assert isinstance(flow.items[1], Transaction)
+    assert isinstance(flow.items[2], SagaStep)
+    assert isinstance(flow.items[3], Parallel)

--- a/core/spakky-saga/tests/unit/test_flow.py
+++ b/core/spakky-saga/tests/unit/test_flow.py
@@ -85,6 +85,55 @@ def test_saga_step_rshift_preserves_on_error_expect_strategy_in_transaction() ->
     assert isinstance(txn.on_error, Retry)
 
 
+def test_saga_step_default_timeout_expect_none() -> None:
+    """SagaStep 생성 시 기본 timeout이 None인지 검증한다."""
+    step = SagaStep(action=_action)
+    assert step.timeout is None
+
+
+def test_saga_step_with_timeout_expect_preserved() -> None:
+    """SagaStep에 timeout을 설정하면 값이 보존되는지 검증한다."""
+    step = SagaStep(action=_action, timeout=timedelta(seconds=30))
+    assert step.timeout == timedelta(seconds=30)
+
+
+def test_saga_step_rshift_preserves_timeout_expect_timeout_in_transaction() -> None:
+    """SagaStep의 timeout이 >> 연산 시 Transaction에 전달되는지 검증한다."""
+    step = SagaStep(action=_action, timeout=timedelta(seconds=10))
+    txn = step >> _compensate
+    assert txn.timeout == timedelta(seconds=10)
+
+
+def test_saga_step_or_preserves_timeout_expect_timeout_kept() -> None:
+    """SagaStep | strategy가 timeout을 보존하는지 검증한다."""
+    step = SagaStep(action=_action, timeout=timedelta(seconds=5))
+    step_with_skip = step | Skip()
+    assert step_with_skip.timeout == timedelta(seconds=5)
+
+
+def test_transaction_default_timeout_expect_none() -> None:
+    """Transaction 생성 시 기본 timeout이 None인지 검증한다."""
+    txn = Transaction(action=_action, compensate=_compensate)
+    assert txn.timeout is None
+
+
+def test_transaction_with_timeout_expect_preserved() -> None:
+    """Transaction에 timeout을 설정하면 값이 보존되는지 검증한다."""
+    txn = Transaction(
+        action=_action, compensate=_compensate, timeout=timedelta(seconds=15)
+    )
+    assert txn.timeout == timedelta(seconds=15)
+
+
+def test_transaction_or_preserves_timeout_expect_timeout_kept() -> None:
+    """Transaction | strategy가 timeout을 보존하는지 검증한다."""
+    txn = Transaction(
+        action=_action, compensate=_compensate, timeout=timedelta(seconds=20)
+    )
+    txn_with_retry = txn | Retry(max_attempts=2)
+    assert txn_with_retry.timeout == timedelta(seconds=20)
+
+
 # --- Transaction ---
 
 


### PR DESCRIPTION
## Summary

Implement Flow Builder API for `spakky-saga` as specified in Issue #91 and ADR-0007.

### Changes

- **Builder functions**: `saga_flow()`, `step()`, `parallel()` — declarative saga flow construction
- **Lambda auto-promotion**: bare callables/lambdas are automatically wrapped as `SagaStep`
- **Static validation**: `SagaFlowDefinitionError` on invalid flow definitions (empty flow, parallel with < 2 items, invalid item types)
- **Timeout support**: `timeout` field added to `SagaStep` and `Transaction` for per-step timeout
- **Operator equivalence**: verified that `>>`, `&`, `|` operators produce identical results to function-based API

### Test Coverage

- 95 tests, 100% coverage
- Builder function tests in `test_builder.py`
- Timeout-related type tests in `test_flow.py`
- Operator equivalence verification

Closes #91