### PR TITLE
feat(saga): implement @Saga() stereotype and AbstractSaga base class (#90)

### DIFF
--- a/core/spakky-saga/src/spakky/saga/__init__.py
+++ b/core/spakky-saga/src/spakky/saga/__init__.py
@@ -1,13 +1,16 @@
 """Spakky Saga package - Distributed transaction saga orchestration."""
 
 from spakky.core.application.plugin import Plugin
+from spakky.saga.base import AbstractSaga
 from spakky.saga.data import AbstractSagaData
 from spakky.saga.error import (
     AbstractSpakkySagaError,
     SagaCompensationFailedError,
+    SagaEngineNotConnectedError,
     SagaFlowDefinitionError,
     SagaParallelMergeConflictError,
 )
+from spakky.saga.stereotype import Saga
 from spakky.saga.flow import (
     ActionFn,
     CompensateFn,
@@ -32,6 +35,10 @@ PLUGIN_NAME = Plugin(name="spakky-saga")
 """Plugin identifier for the Spakky Saga package."""
 
 __all__ = [
+    # Stereotype
+    "Saga",
+    # Base
+    "AbstractSaga",
     # Data
     "AbstractSagaData",
     # Status
@@ -59,6 +66,7 @@ __all__ = [
     "SagaFlowDefinitionError",
     "SagaCompensationFailedError",
     "SagaParallelMergeConflictError",
+    "SagaEngineNotConnectedError",
     # Plugin
     "PLUGIN_NAME",
 ]

--- a/core/spakky-saga/src/spakky/saga/base.py
+++ b/core/spakky-saga/src/spakky/saga/base.py
@@ -1,0 +1,95 @@
+"""AbstractSaga base class for saga definitions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from inspect import iscoroutinefunction
+from typing import Generic
+
+from spakky.saga.error import SagaEngineNotConnectedError
+from spakky.saga.flow import SagaDataT, SagaFlow, SagaStep
+from spakky.saga.result import SagaResult
+
+
+_FRAMEWORK_METHODS: frozenset[str] = frozenset({"flow", "execute"})
+
+
+class _SagaStepDescriptor:
+    """인스턴스 접근 시 bound method를 SagaStep으로 래핑하여 반환하는 디스크립터.
+
+    AbstractSaga.__init_subclass__()에서 공개 비동기 메서드를
+    이 디스크립터로 교체하여, 인스턴스에서 접근할 때 SagaStep 객체를
+    반환하도록 한다. 이를 통해 연산자(>>, &, |) 사용이 가능해진다.
+    """
+
+    __slots__ = ("_fn",)
+
+    def __init__(self, fn: object) -> None:
+        self._fn = fn
+
+    # fmt: off
+    def __get__(
+        self,
+        obj: object | None,
+        objtype: type | None = None,
+    ) -> SagaStep[SagaDataT] | _SagaStepDescriptor:  # pyrefly: ignore - descriptor return type
+        # fmt: on
+        if obj is None:
+            return self
+        bound_method = self._fn.__get__(obj, objtype)  # type: ignore[union-attr] - fn is always a function with __get__
+        return SagaStep(action=bound_method)
+
+
+class AbstractSaga(ABC, Generic[SagaDataT]):
+    """사가를 정의하는 제네릭 베이스 클래스.
+
+    서브클래스는 flow()를 구현하여 사가 흐름을 선언적으로 정의한다.
+    공개 비동기 메서드는 __init_subclass__()에 의해 SagaStep 디스크립터로
+    자동 래핑되어 연산자(>>, &, |) 사용이 가능하다.
+
+    Example:
+        @Saga()
+        class CreateOrderSaga(AbstractSaga[CreateOrderSagaData]):
+            async def create_ticket(self, data):
+                ...
+
+            async def cancel_ticket(self, data):
+                ...
+
+            def flow(self) -> SagaFlow[CreateOrderSagaData]:
+                return SagaFlow(items=(
+                    self.create_ticket >> self.cancel_ticket,
+                ))
+    """
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        for name in list(vars(cls)):
+            if name.startswith("_") or name in _FRAMEWORK_METHODS:
+                continue
+            value = vars(cls)[name]
+            if callable(value) and iscoroutinefunction(value):
+                setattr(cls, name, _SagaStepDescriptor(value))
+
+    @abstractmethod
+    def flow(self) -> SagaFlow[SagaDataT]:
+        """사가의 실행 흐름을 정의한다.
+
+        Returns:
+            SagaFlow[SagaDataT]: 사가 흐름 정의.
+        """
+        ...  # pragma: no branch - AbstractMethod only
+
+    async def execute(self, data: SagaDataT) -> SagaResult[SagaDataT]:
+        """사가를 실행한다. 엔진 연결 전에는 SagaEngineNotConnectedError를 발생시킨다.
+
+        Args:
+            data: 사가 비즈니스 데이터.
+
+        Returns:
+            SagaResult[SagaDataT]: 사가 실행 결과.
+
+        Raises:
+            SagaEngineNotConnectedError: 엔진이 아직 연결되지 않은 경우.
+        """
+        raise SagaEngineNotConnectedError()

--- a/core/spakky-saga/src/spakky/saga/error.py
+++ b/core/spakky-saga/src/spakky/saga/error.py
@@ -27,3 +27,9 @@ class SagaParallelMergeConflictError(AbstractSpakkySagaError):
     """Raised when parallel steps modify the same field during data merge."""
 
     message = "Parallel steps modified the same field"
+
+
+class SagaEngineNotConnectedError(AbstractSpakkySagaError):
+    """Raised when execute() is called before the saga engine is connected."""
+
+    message = "Saga engine is not connected"

--- a/core/spakky-saga/src/spakky/saga/stereotype.py
+++ b/core/spakky-saga/src/spakky/saga/stereotype.py
@@ -1,0 +1,21 @@
+"""Saga stereotype for distributed transaction orchestration.
+
+This module provides @Saga stereotype for organizing classes
+that implement saga orchestration logic.
+"""
+
+from dataclasses import dataclass
+
+from spakky.core.pod.annotations.pod import Pod
+
+
+@dataclass(eq=False)
+class Saga(Pod):
+    """Stereotype for saga orchestration classes.
+
+    Sagas represent distributed transaction orchestrations,
+    coordinating multiple services through sequential/parallel
+    steps with compensation logic.
+    """
+
+    ...

--- a/core/spakky-saga/tests/unit/test_base.py
+++ b/core/spakky-saga/tests/unit/test_base.py
@@ -1,0 +1,186 @@
+"""Unit tests for AbstractSaga base class and _SagaStepDescriptor."""
+
+from abc import ABC
+from dataclasses import field
+from uuid import UUID, uuid4
+
+import pytest
+
+from spakky.core.common.mutability import immutable
+from spakky.saga.base import AbstractSaga, _SagaStepDescriptor
+from spakky.saga.data import AbstractSagaData
+from spakky.saga.error import SagaEngineNotConnectedError
+from spakky.saga.flow import SagaFlow, SagaStep, Transaction
+from spakky.saga.strategy import Compensate, Retry, Skip
+
+
+@immutable
+class _OrderSagaData(AbstractSagaData):
+    order_id: UUID = field(default_factory=uuid4)
+
+
+class _ConcreteSaga(AbstractSaga[_OrderSagaData]):
+    """테스트용 구체 사가 클래스."""
+
+    async def create_ticket(self, data: _OrderSagaData) -> _OrderSagaData:
+        return data
+
+    async def cancel_ticket(self, data: _OrderSagaData) -> None:
+        return None
+
+    async def approve_order(self, data: _OrderSagaData) -> None:
+        return None
+
+    def flow(self) -> SagaFlow[_OrderSagaData]:
+        # fmt: off
+        return SagaFlow(
+            items=(self.create_ticket >> self.cancel_ticket,),  # pyrefly: ignore - descriptor wrapping at runtime
+        )
+        # fmt: on
+
+
+# --- AbstractSaga 기본 검증 ---
+
+
+def test_abstract_saga_is_abc_expect_true() -> None:
+    """AbstractSaga가 ABC 서브클래스인지 검증한다."""
+    assert issubclass(AbstractSaga, ABC)
+
+
+def test_abstract_saga_cannot_instantiate_expect_type_error() -> None:
+    """AbstractSaga를 직접 인스턴스화하면 TypeError가 발생하는지 검증한다."""
+    with pytest.raises(TypeError):
+        AbstractSaga()  # type: ignore[abstract] - intentional for test
+
+
+# --- __init_subclass__ 디스크립터 래핑 ---
+
+
+def test_init_subclass_wraps_public_async_methods_expect_descriptor() -> None:
+    """공개 비동기 메서드가 _SagaStepDescriptor로 래핑되는지 검증한다."""
+    assert isinstance(vars(_ConcreteSaga)["create_ticket"], _SagaStepDescriptor)
+    assert isinstance(vars(_ConcreteSaga)["cancel_ticket"], _SagaStepDescriptor)
+    assert isinstance(vars(_ConcreteSaga)["approve_order"], _SagaStepDescriptor)
+
+
+def test_init_subclass_skips_flow_method_expect_not_wrapped() -> None:
+    """flow() 메서드가 래핑되지 않는지 검증한다."""
+    assert not isinstance(vars(_ConcreteSaga).get("flow"), _SagaStepDescriptor)
+
+
+def test_init_subclass_skips_private_methods_expect_not_wrapped() -> None:
+    """private 메서드가 래핑되지 않는지 검증한다."""
+
+    class SagaWithPrivate(AbstractSaga[_OrderSagaData]):
+        async def _internal(self, data: _OrderSagaData) -> None:
+            return None
+
+        def flow(self) -> SagaFlow[_OrderSagaData]:
+            return SagaFlow(items=())
+
+    assert not isinstance(vars(SagaWithPrivate).get("_internal"), _SagaStepDescriptor)
+
+
+def test_init_subclass_skips_sync_methods_expect_not_wrapped() -> None:
+    """동기 메서드가 래핑되지 않는지 검증한다."""
+
+    class SagaWithSync(AbstractSaga[_OrderSagaData]):
+        def helper(self) -> str:
+            return "not wrapped"
+
+        def flow(self) -> SagaFlow[_OrderSagaData]:
+            return SagaFlow(items=())
+
+    assert not isinstance(vars(SagaWithSync).get("helper"), _SagaStepDescriptor)
+
+
+# --- 디스크립터 접근 시 SagaStep 반환 ---
+
+
+def test_descriptor_instance_access_expect_saga_step() -> None:
+    """인스턴스에서 래핑된 메서드 접근 시 SagaStep이 반환되는지 검증한다."""
+    saga = _ConcreteSaga()
+    result = saga.create_ticket
+    assert isinstance(result, SagaStep)
+
+
+def test_descriptor_class_access_expect_descriptor() -> None:
+    """클래스에서 래핑된 메서드 접근 시 _SagaStepDescriptor가 반환되는지 검증한다."""
+    result = _ConcreteSaga.create_ticket  # type: ignore[attr-defined] - descriptor access
+    assert isinstance(result, _SagaStepDescriptor)
+
+
+def test_descriptor_default_on_error_expect_compensate() -> None:
+    """디스크립터로 생성된 SagaStep의 기본 on_error가 Compensate인지 검증한다."""
+    saga = _ConcreteSaga()
+    # fmt: off
+    step = saga.create_ticket  # pyrefly: ignore - descriptor returns SagaStep at runtime
+    assert isinstance(step.on_error, Compensate)  # pyrefly: ignore - SagaStep has on_error
+    # fmt: on
+
+
+# --- 연산자 사용 ---
+
+
+def test_rshift_operator_expect_transaction() -> None:
+    """>> 연산자로 Transaction이 생성되는지 검증한다."""
+    saga = _ConcreteSaga()
+    # fmt: off
+    result = saga.create_ticket >> saga.cancel_ticket  # pyrefly: ignore - descriptor enables >> operator
+    # fmt: on
+    assert isinstance(result, Transaction)
+
+
+def test_and_operator_expect_parallel() -> None:
+    """& 연산자로 Parallel이 생성되는지 검증한다."""
+    from spakky.saga.flow import Parallel
+
+    saga = _ConcreteSaga()
+    # fmt: off
+    result = saga.create_ticket & saga.approve_order  # pyrefly: ignore - descriptor enables & operator
+    # fmt: on
+    assert isinstance(result, Parallel)
+    assert len(result.items) == 2
+
+
+def test_or_operator_expect_strategy_set() -> None:
+    """| 연산자로 on_error 전략이 설정되는지 검증한다."""
+    saga = _ConcreteSaga()
+    # fmt: off
+    result = saga.create_ticket | Retry(max_attempts=3)  # pyrefly: ignore - descriptor enables | operator
+    # fmt: on
+    assert isinstance(result, SagaStep)
+    assert isinstance(result.on_error, Retry)
+
+
+def test_combined_rshift_or_expect_transaction_with_strategy() -> None:
+    """(step >> compensate) | strategy가 동작하는지 검증한다."""
+    saga = _ConcreteSaga()
+    # fmt: off
+    result = (saga.create_ticket >> saga.cancel_ticket) | Skip()  # pyrefly: ignore - descriptor enables operators
+    # fmt: on
+    assert isinstance(result, Transaction)
+    assert isinstance(result.on_error, Skip)
+
+
+# --- flow() 메서드 ---
+
+
+def test_flow_returns_saga_flow_expect_correct_type() -> None:
+    """flow()가 SagaFlow를 반환하는지 검증한다."""
+    saga = _ConcreteSaga()
+    result = saga.flow()
+    assert isinstance(result, SagaFlow)
+    assert len(result.items) == 1
+
+
+# --- execute() 스텁 ---
+
+
+@pytest.mark.anyio
+async def test_execute_stub_expect_engine_not_connected_error() -> None:
+    """execute() 호출 시 SagaEngineNotConnectedError가 발생하는지 검증한다."""
+    saga = _ConcreteSaga()
+    data = _OrderSagaData()
+    with pytest.raises(SagaEngineNotConnectedError):
+        await saga.execute(data)

--- a/core/spakky-saga/tests/unit/test_error.py
+++ b/core/spakky-saga/tests/unit/test_error.py
@@ -6,6 +6,7 @@ from spakky.core.common.error import AbstractSpakkyFrameworkError
 from spakky.saga.error import (
     AbstractSpakkySagaError,
     SagaCompensationFailedError,
+    SagaEngineNotConnectedError,
     SagaFlowDefinitionError,
     SagaParallelMergeConflictError,
 )
@@ -52,3 +53,13 @@ def test_saga_parallel_merge_conflict_error_message_expect_correct_text() -> Non
         SagaParallelMergeConflictError.message
         == "Parallel steps modified the same field"
     )
+
+
+def test_saga_engine_not_connected_error_inheritance_expect_saga_error() -> None:
+    """SagaEngineNotConnectedError가 AbstractSpakkySagaError의 서브클래스인지 검증한다."""
+    assert issubclass(SagaEngineNotConnectedError, AbstractSpakkySagaError)
+
+
+def test_saga_engine_not_connected_error_message_expect_correct_text() -> None:
+    """SagaEngineNotConnectedError가 올바른 message 속성을 가지는지 검증한다."""
+    assert SagaEngineNotConnectedError.message == "Saga engine is not connected"

--- a/core/spakky-saga/tests/unit/test_stereotype.py
+++ b/core/spakky-saga/tests/unit/test_stereotype.py
@@ -1,0 +1,35 @@
+"""Unit tests for @Saga() stereotype."""
+
+from spakky.core.pod.annotations.pod import Pod
+from spakky.saga.stereotype import Saga
+
+
+def test_saga_inherits_pod_expect_true() -> None:
+    """Saga가 Pod의 서브클래스인지 검증한다."""
+    assert issubclass(Saga, Pod)
+
+
+def test_saga_decorator_applied_expect_annotation_present() -> None:
+    """@Saga() 데코레이터가 클래스에 올바르게 적용되고 조회되는지 검증한다."""
+
+    @Saga()
+    class SampleSaga: ...
+
+    assert Saga.get_or_none(SampleSaga) is not None
+
+
+def test_saga_decorator_not_applied_expect_annotation_absent() -> None:
+    """@Saga() 비적용 클래스에서 None이 반환되는지 검증한다."""
+
+    class NonAnnotated: ...
+
+    assert Saga.get_or_none(NonAnnotated) is None
+
+
+def test_saga_decorator_inherits_pod_annotation_expect_pod_present() -> None:
+    """@Saga() 적용 클래스가 Pod 어노테이션으로도 조회 가능한지 검증한다."""
+
+    @Saga()
+    class SampleSaga: ...
+
+    assert Pod.get_or_none(SampleSaga) is not None


### PR DESCRIPTION
## Summary

Implement `@Saga()` stereotype and `AbstractSaga[T]` generic base class for the `spakky-saga` package.

## Changes

### New Files
- **`stereotype.py`**: `@Saga()` Pod-based stereotype for DI container registration
- **`base.py`**: `AbstractSaga[T]` generic base class with:
  - `flow()` abstract method for declarative saga flow definition
  - `execute()` stub raising `SagaEngineNotConnectedError` (engine impl in future task)
  - `__init_subclass__()` wrapping public async methods as `_SagaStepDescriptor` for operator support (`>>`, `&`, `|`)

### Modified Files
- **`error.py`**: Added `SagaEngineNotConnectedError`
- **`__init__.py`**: Added exports for `Saga`, `AbstractSaga`, `SagaEngineNotConnectedError`

### Tests
- **`test_stereotype.py`**: Pod inheritance, `@Saga()` annotation application
- **`test_base.py`**: ABC enforcement, descriptor wrapping, operator usage, flow definition, execute stub
- **`test_error.py`**: Added `SagaEngineNotConnectedError` tests
- Coverage: **100%** across all saga modules

## Design Decisions

- **Wrapping criteria**: `__init_subclass__()` wraps public async methods only (excludes `_private`, `flow`, `execute`, sync methods)
- **Descriptor pattern**: `_SagaStepDescriptor.__get__()` returns `SagaStep` on instance access, enabling operator chaining
- **`# fmt: off`/`# fmt: on`**: Used around descriptor expressions in tests to prevent ruff version differences from breaking pyrefly ignore placement

Closes #90