### PR TITLE
feat(grpc): add error hierarchy and gRPC interceptors (#84)

### DIFF
--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/error.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/error.py
@@ -1,0 +1,83 @@
+"""gRPC error classes for Spakky framework.
+
+Provides base error classes and common gRPC error responses that map
+domain exceptions to appropriate gRPC status codes.
+"""
+
+from abc import ABC
+from typing import ClassVar
+
+import grpc
+
+from spakky.core.common.error import AbstractSpakkyFrameworkError
+
+
+class AbstractSpakkyGRPCError(AbstractSpakkyFrameworkError, ABC):
+    """Base error class for gRPC-related exceptions.
+
+    Subclasses must define ``status_code`` to specify which gRPC status
+    code the error maps to.
+
+    Attributes:
+        status_code: gRPC status code for this error type.
+        message: Human-readable error message.
+    """
+
+    status_code: ClassVar[grpc.StatusCode]
+    """gRPC status code returned for this error type."""
+
+
+class InvalidArgument(AbstractSpakkyGRPCError):
+    """gRPC INVALID_ARGUMENT error."""
+
+    message = "Invalid Argument"
+    status_code: ClassVar[grpc.StatusCode] = grpc.StatusCode.INVALID_ARGUMENT
+
+
+class NotFound(AbstractSpakkyGRPCError):
+    """gRPC NOT_FOUND error."""
+
+    message = "Not Found"
+    status_code: ClassVar[grpc.StatusCode] = grpc.StatusCode.NOT_FOUND
+
+
+class AlreadyExists(AbstractSpakkyGRPCError):
+    """gRPC ALREADY_EXISTS error."""
+
+    message = "Already Exists"
+    status_code: ClassVar[grpc.StatusCode] = grpc.StatusCode.ALREADY_EXISTS
+
+
+class PermissionDenied(AbstractSpakkyGRPCError):
+    """gRPC PERMISSION_DENIED error."""
+
+    message = "Permission Denied"
+    status_code: ClassVar[grpc.StatusCode] = grpc.StatusCode.PERMISSION_DENIED
+
+
+class Unauthenticated(AbstractSpakkyGRPCError):
+    """gRPC UNAUTHENTICATED error."""
+
+    message = "Unauthenticated"
+    status_code: ClassVar[grpc.StatusCode] = grpc.StatusCode.UNAUTHENTICATED
+
+
+class FailedPrecondition(AbstractSpakkyGRPCError):
+    """gRPC FAILED_PRECONDITION error."""
+
+    message = "Failed Precondition"
+    status_code: ClassVar[grpc.StatusCode] = grpc.StatusCode.FAILED_PRECONDITION
+
+
+class Unavailable(AbstractSpakkyGRPCError):
+    """gRPC UNAVAILABLE error."""
+
+    message = "Unavailable"
+    status_code: ClassVar[grpc.StatusCode] = grpc.StatusCode.UNAVAILABLE
+
+
+class InternalError(AbstractSpakkyGRPCError):
+    """gRPC INTERNAL error."""
+
+    message = "Internal Server Error"
+    status_code: ClassVar[grpc.StatusCode] = grpc.StatusCode.INTERNAL

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/interceptors/__init__.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/interceptors/__init__.py
@@ -1,0 +1,1 @@
+"""Interceptors for gRPC server integration."""

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/interceptors/error_handling.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/interceptors/error_handling.py
@@ -1,0 +1,149 @@
+"""Error handling interceptor for gRPC servers.
+
+Catches domain exceptions and maps them to appropriate gRPC status codes.
+Unexpected exceptions are logged and returned as ``INTERNAL`` status.
+"""
+
+import traceback
+from collections.abc import AsyncIterator, Awaitable, Callable
+from logging import getLogger
+from typing import Any
+
+import grpc
+import grpc.aio
+
+from spakky.plugins.grpc.error import AbstractSpakkyGRPCError, InternalError
+
+logger = getLogger(__name__)
+
+
+class ErrorHandlingInterceptor(grpc.aio.ServerInterceptor):
+    """Interceptor that converts exceptions to gRPC status codes.
+
+    ``AbstractSpakkyGRPCError`` subclasses are mapped to their declared
+    ``status_code``.  All other exceptions become ``INTERNAL``.
+
+    Attributes:
+        __debug: When True, include tracebacks in error details.
+    """
+
+    __debug: bool
+
+    def __init__(self, *, debug: bool = False) -> None:
+        """Initialize the error handling interceptor.
+
+        Args:
+            debug: Whether to include full tracebacks in error details.
+        """
+        self.__debug = debug
+
+    def _wrap_unary_behavior(
+        self,
+        behavior: Callable[..., Awaitable[object]],
+    ) -> Callable[..., Awaitable[object]]:
+        """Wrap a unary response handler with error handling."""
+
+        async def wrapper(
+            request_or_iterator: object,
+            context: grpc.aio.ServicerContext,
+        ) -> object:
+            try:
+                return await behavior(request_or_iterator, context)
+            except AbstractSpakkyGRPCError as error:
+                await context.abort(error.status_code, error.message)
+            except Exception as error:
+                if isinstance(error, grpc.aio.BaseError):
+                    raise
+                logger.exception(
+                    f"Unhandled exception during gRPC processing: {error!r}"
+                )
+                details = (
+                    traceback.format_exc() if self.__debug else InternalError.message
+                )
+                await context.abort(grpc.StatusCode.INTERNAL, details)
+
+        return wrapper
+
+    def _wrap_stream_behavior(
+        self,
+        behavior: Callable[..., AsyncIterator[object]],
+    ) -> Callable[..., AsyncIterator[object]]:
+        """Wrap a streaming response handler with error handling."""
+
+        async def wrapper(
+            request_or_iterator: object,
+            context: grpc.aio.ServicerContext,
+        ) -> AsyncIterator[object]:
+            try:
+                async for response in behavior(request_or_iterator, context):
+                    yield response
+            except AbstractSpakkyGRPCError as error:
+                await context.abort(error.status_code, error.message)
+            except Exception as error:
+                if isinstance(error, grpc.aio.BaseError):
+                    raise
+                logger.exception(
+                    f"Unhandled exception during gRPC processing: {error!r}"
+                )
+                details = (
+                    traceback.format_exc() if self.__debug else InternalError.message
+                )
+                await context.abort(grpc.StatusCode.INTERNAL, details)
+
+        return wrapper
+
+    async def intercept_service(
+        self,
+        continuation: Callable[
+            [grpc.HandlerCallDetails], Awaitable[grpc.RpcMethodHandler]
+        ],
+        handler_call_details: grpc.HandlerCallDetails,
+    ) -> grpc.RpcMethodHandler:
+        """Intercept an RPC and wrap the handler with error handling.
+
+        Args:
+            continuation: Calls the next interceptor or resolves the handler.
+            handler_call_details: Describes the incoming RPC.
+
+        Returns:
+            A handler with error-catching wrappers on its behavior methods.
+        """
+        handler = await continuation(handler_call_details)
+        if handler is None:
+            return handler  # type: ignore[return-value] — unimplemented method
+        return _WrappedHandler(
+            handler,
+            wrap_unary=self._wrap_unary_behavior,
+            wrap_stream=self._wrap_stream_behavior,
+        )
+
+
+class _WrappedHandler(grpc.RpcMethodHandler):
+    """Proxy that delegates to the original handler with wrapped behaviors."""
+
+    def __init__(
+        self,
+        handler: grpc.RpcMethodHandler,
+        wrap_unary: Callable[
+            ..., Any
+        ],  # Any: grpc stubs mix sync/async handler signatures
+        wrap_stream: Callable[
+            ..., Any
+        ],  # Any: grpc stubs mix sync/async handler signatures
+    ) -> None:
+        self.request_streaming = handler.request_streaming
+        self.response_streaming = handler.response_streaming
+        self.request_deserializer = handler.request_deserializer
+        self.response_serializer = handler.response_serializer
+        self.unary_unary = (
+            wrap_unary(handler.unary_unary) if handler.unary_unary else None
+        )  # type: ignore[arg-type] — grpc stubs define sync handler types but grpc.aio uses async
+        self.stream_unary = (
+            wrap_unary(handler.stream_unary) if handler.stream_unary else None
+        )  # type: ignore[arg-type] — grpc stubs define sync handler types but grpc.aio uses async
+        self.unary_stream = (
+            wrap_stream(handler.unary_stream) if handler.unary_stream else None
+        )  # type: ignore[arg-type] — grpc stubs define sync handler types but grpc.aio uses async
+        self.stream_stream = (
+            wrap_stream(handler.stream_stream) if handler.stream_stream else None
+        )  # type: ignore[arg-type] — grpc stubs define sync handler types but grpc.aio uses async

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/interceptors/tracing.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/interceptors/tracing.py
@@ -1,0 +1,166 @@
+"""Tracing interceptor for W3C Trace Context propagation over gRPC.
+
+Extracts trace context from incoming gRPC metadata, activates a child
+span for the RPC lifetime, and injects trace context into trailing
+metadata.
+"""
+
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any
+
+import grpc
+import grpc.aio
+
+from spakky.tracing.context import TraceContext
+from spakky.tracing.propagator import ITracePropagator
+
+
+class TracingInterceptor(grpc.aio.ServerInterceptor):
+    """Interceptor that propagates W3C Trace Context across gRPC boundaries.
+
+    Extracts ``traceparent`` / ``tracestate`` from incoming request
+    metadata, activates a child span for the RPC lifetime, and injects
+    the current trace context into trailing metadata.
+    """
+
+    __propagator: ITracePropagator
+
+    def __init__(self, *, propagator: ITracePropagator) -> None:
+        """Initialize the tracing interceptor.
+
+        Args:
+            propagator: Trace context propagator for extract/inject.
+        """
+        self.__propagator = propagator
+
+    @staticmethod
+    def _metadata_to_dict(
+        metadata: tuple[tuple[str, str | bytes], ...] | None,
+    ) -> dict[str, str]:
+        """Convert gRPC invocation metadata to a plain string dictionary."""
+        if metadata is None:
+            return {}
+        result: dict[str, str] = {}
+        for key, value in metadata:
+            result[key] = (
+                value
+                if isinstance(value, str)
+                else value.decode("utf-8", errors="replace")
+            )
+        return result
+
+    def _wrap_unary_behavior(
+        self,
+        behavior: Callable[..., Awaitable[object]],
+    ) -> Callable[..., Awaitable[object]]:
+        """Wrap a unary response handler with trace context lifecycle."""
+
+        async def wrapper(
+            request_or_iterator: object,
+            context: grpc.aio.ServicerContext,
+        ) -> object:
+            try:
+                result = await behavior(request_or_iterator, context)
+                trailing: dict[str, str] = {}
+                self.__propagator.inject(trailing)
+                if trailing:
+                    context.set_trailing_metadata(tuple(trailing.items()))
+                return result
+            finally:
+                TraceContext.clear()
+
+        return wrapper
+
+    def _wrap_stream_behavior(
+        self,
+        behavior: Callable[..., AsyncIterator[object]],
+    ) -> Callable[..., AsyncIterator[object]]:
+        """Wrap a streaming response handler with trace context lifecycle."""
+
+        async def wrapper(
+            request_or_iterator: object,
+            context: grpc.aio.ServicerContext,
+        ) -> AsyncIterator[object]:
+            try:
+                async for response in behavior(request_or_iterator, context):
+                    yield response
+                trailing: dict[str, str] = {}
+                self.__propagator.inject(trailing)
+                if trailing:
+                    context.set_trailing_metadata(tuple(trailing.items()))
+            finally:
+                TraceContext.clear()
+
+        return wrapper
+
+    async def intercept_service(
+        self,
+        continuation: Callable[
+            [grpc.HandlerCallDetails], Awaitable[grpc.RpcMethodHandler]
+        ],
+        handler_call_details: grpc.HandlerCallDetails,
+    ) -> grpc.RpcMethodHandler:
+        """Intercept an RPC and set up W3C Trace Context.
+
+        Extracts trace context from incoming metadata, creates a child span
+        (or a new root when no parent exists), and wraps the handler to inject
+        trace context into trailing metadata and clear it after completion.
+
+        Args:
+            continuation: Calls the next interceptor or resolves the handler.
+            handler_call_details: Describes the incoming RPC.
+
+        Returns:
+            A handler with trace-context lifecycle wrappers.
+        """
+        carrier = self._metadata_to_dict(handler_call_details.invocation_metadata)
+        parent = self.__propagator.extract(carrier)
+        ctx = parent.child() if parent is not None else TraceContext.new_root()
+        TraceContext.set(ctx)
+
+        try:
+            handler = await continuation(handler_call_details)
+        except Exception:
+            TraceContext.clear()
+            raise
+
+        if handler is None:
+            TraceContext.clear()
+            return handler  # type: ignore[return-value] — unimplemented method
+
+        return _WrappedHandler(
+            handler,
+            wrap_unary=self._wrap_unary_behavior,
+            wrap_stream=self._wrap_stream_behavior,
+        )
+
+
+class _WrappedHandler(grpc.RpcMethodHandler):
+    """Proxy that delegates to the original handler with wrapped behaviors."""
+
+    def __init__(
+        self,
+        handler: grpc.RpcMethodHandler,
+        wrap_unary: Callable[
+            ..., Any
+        ],  # Any: grpc stubs mix sync/async handler signatures
+        wrap_stream: Callable[
+            ..., Any
+        ],  # Any: grpc stubs mix sync/async handler signatures
+    ) -> None:
+        self.request_streaming = handler.request_streaming
+        self.response_streaming = handler.response_streaming
+        self.request_deserializer = handler.request_deserializer
+        self.response_serializer = handler.response_serializer
+        self.unary_unary = (
+            wrap_unary(handler.unary_unary) if handler.unary_unary else None
+        )  # type: ignore[arg-type] — grpc stubs define sync handler types but grpc.aio uses async
+        self.stream_unary = (
+            wrap_unary(handler.stream_unary) if handler.stream_unary else None
+        )  # type: ignore[arg-type] — grpc stubs define sync handler types but grpc.aio uses async
+        self.unary_stream = (
+            wrap_stream(handler.unary_stream) if handler.unary_stream else None
+        )  # type: ignore[arg-type] — grpc stubs define sync handler types but grpc.aio uses async
+        self.stream_stream = (
+            wrap_stream(handler.stream_stream) if handler.stream_stream else None
+        )  # type: ignore[arg-type] — grpc stubs define sync handler types but grpc.aio uses async

--- a/plugins/spakky-grpc/tests/unit/test_error_handling_interceptor.py
+++ b/plugins/spakky-grpc/tests/unit/test_error_handling_interceptor.py
@@ -1,0 +1,254 @@
+"""Unit tests for ErrorHandlingInterceptor."""
+
+import logging
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc
+import grpc.aio
+import pytest
+
+from spakky.plugins.grpc.error import InternalError, InvalidArgument, NotFound
+from spakky.plugins.grpc.interceptors.error_handling import ErrorHandlingInterceptor
+
+
+def _make_handler(
+    *,
+    unary_unary: AsyncMock | None = None,
+    unary_stream: AsyncMock | None = None,
+    stream_unary: AsyncMock | None = None,
+    stream_stream: AsyncMock | None = None,
+) -> MagicMock:
+    """Create a mock RpcMethodHandler with the given behavior methods."""
+    handler = MagicMock(spec=grpc.RpcMethodHandler)
+    handler.request_streaming = stream_unary is not None or stream_stream is not None
+    handler.response_streaming = unary_stream is not None or stream_stream is not None
+    handler.request_deserializer = None
+    handler.response_serializer = None
+    handler.unary_unary = unary_unary
+    handler.unary_stream = unary_stream
+    handler.stream_unary = stream_unary
+    handler.stream_stream = stream_stream
+    return handler
+
+
+def _make_call_details(method: str = "/test.Service/Method") -> MagicMock:
+    """Create a mock HandlerCallDetails."""
+    details = MagicMock(spec=grpc.HandlerCallDetails)
+    details.method = method
+    details.invocation_metadata = ()
+    return details
+
+
+@pytest.fixture
+def interceptor() -> ErrorHandlingInterceptor:
+    """Create an ErrorHandlingInterceptor with debug=False."""
+    return ErrorHandlingInterceptor()
+
+
+@pytest.fixture
+def debug_interceptor() -> ErrorHandlingInterceptor:
+    """Create an ErrorHandlingInterceptor with debug=True."""
+    return ErrorHandlingInterceptor(debug=True)
+
+
+@pytest.fixture
+def context() -> AsyncMock:
+    """Create a mock gRPC ServicerContext."""
+    ctx = AsyncMock(spec=grpc.aio.ServicerContext)
+    ctx.abort = AsyncMock(side_effect=grpc.aio.AbortError(grpc.StatusCode.INTERNAL, ""))
+    return ctx
+
+
+async def test_unary_handler_passes_through_on_success(
+    interceptor: ErrorHandlingInterceptor,
+    context: AsyncMock,
+) -> None:
+    """Successful unary handler should pass through unchanged."""
+    behavior = AsyncMock(return_value=b"response")
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    assert wrapped.unary_unary is not None
+    result = await wrapped.unary_unary(b"request", context)
+
+    assert result == b"response"
+    behavior.assert_awaited_once_with(b"request", context)
+
+
+async def test_unary_handler_catches_grpc_error_expect_abort_with_status(
+    interceptor: ErrorHandlingInterceptor,
+    context: AsyncMock,
+) -> None:
+    """AbstractSpakkyGRPCError should be converted to the declared gRPC status."""
+    behavior = AsyncMock(side_effect=NotFound())
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    assert wrapped.unary_unary is not None
+    with pytest.raises(grpc.aio.AbortError):
+        await wrapped.unary_unary(b"request", context)
+
+    context.abort.assert_awaited_once_with(grpc.StatusCode.NOT_FOUND, "Not Found")
+
+
+async def test_unary_handler_catches_unexpected_error_expect_internal(
+    interceptor: ErrorHandlingInterceptor,
+    context: AsyncMock,
+) -> None:
+    """Unhandled Exception should be mapped to INTERNAL status."""
+    behavior = AsyncMock(side_effect=RuntimeError("oops"))
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    assert wrapped.unary_unary is not None
+    with pytest.raises(grpc.aio.AbortError):
+        await wrapped.unary_unary(b"request", context)
+
+    context.abort.assert_awaited_once_with(
+        grpc.StatusCode.INTERNAL, InternalError.message
+    )
+
+
+async def test_unary_handler_reraises_grpc_rpc_error(
+    interceptor: ErrorHandlingInterceptor,
+) -> None:
+    """gRPC RpcError from the handler should be re-raised, not converted."""
+    rpc_error = grpc.aio.AbortError(grpc.StatusCode.CANCELLED, "cancelled")
+    behavior = AsyncMock(side_effect=rpc_error)
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    ctx = AsyncMock(spec=grpc.aio.ServicerContext)
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    assert wrapped.unary_unary is not None
+    with pytest.raises(grpc.aio.AbortError):
+        await wrapped.unary_unary(b"request", ctx)
+
+    ctx.abort.assert_not_awaited()
+
+
+async def test_unary_handler_debug_mode_includes_traceback(
+    debug_interceptor: ErrorHandlingInterceptor,
+    context: AsyncMock,
+) -> None:
+    """In debug mode, INTERNAL errors should include the traceback."""
+    behavior = AsyncMock(side_effect=RuntimeError("oops"))
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await debug_interceptor.intercept_service(
+        continuation, _make_call_details()
+    )
+    assert wrapped.unary_unary is not None
+    with pytest.raises(grpc.aio.AbortError):
+        await wrapped.unary_unary(b"request", context)
+
+    _code, details = context.abort.call_args.args
+    assert "RuntimeError" in details
+    assert "Traceback" in details
+
+
+async def test_unary_handler_logs_unexpected_error(
+    interceptor: ErrorHandlingInterceptor,
+    context: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unhandled exceptions should be logged at ERROR level."""
+    behavior = AsyncMock(side_effect=RuntimeError("oops"))
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    assert wrapped.unary_unary is not None
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(grpc.aio.AbortError),
+    ):
+        await wrapped.unary_unary(b"request", context)
+
+    assert "RuntimeError('oops')" in caplog.text
+
+
+async def test_intercept_service_returns_none_for_none_handler(
+    interceptor: ErrorHandlingInterceptor,
+) -> None:
+    """When continuation returns None, interceptor should return None."""
+    continuation = AsyncMock(return_value=None)
+    result = await interceptor.intercept_service(continuation, _make_call_details())
+    assert result is None
+
+
+async def test_stream_handler_passes_through_on_success(
+    interceptor: ErrorHandlingInterceptor,
+    context: AsyncMock,
+) -> None:
+    """Successful streaming handler should yield all responses."""
+
+    async def stream_behavior(
+        request: object, ctx: grpc.aio.ServicerContext
+    ) -> AsyncIterator[bytes]:
+        yield b"a"
+        yield b"b"
+
+    handler = _make_handler(unary_stream=stream_behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    assert wrapped.unary_stream is not None
+    results = [item async for item in wrapped.unary_stream(b"request", context)]  # type: ignore[arg-type] — grpc stubs declare sync Iterator but grpc.aio uses async
+
+    assert results == [b"a", b"b"]
+
+
+async def test_stream_handler_catches_grpc_error_expect_abort(
+    interceptor: ErrorHandlingInterceptor,
+    context: AsyncMock,
+) -> None:
+    """AbstractSpakkyGRPCError in a streaming handler should trigger abort."""
+
+    async def stream_behavior(
+        request: object, ctx: grpc.aio.ServicerContext
+    ) -> AsyncIterator[bytes]:
+        yield b"first"
+        raise InvalidArgument()
+
+    handler = _make_handler(unary_stream=stream_behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    assert wrapped.unary_stream is not None
+    with pytest.raises(grpc.aio.AbortError):
+        async for _ in wrapped.unary_stream(b"request", context):  # type: ignore[arg-type] — grpc stubs declare sync Iterator but grpc.aio uses async
+            pass
+
+    context.abort.assert_awaited_once_with(
+        grpc.StatusCode.INVALID_ARGUMENT, "Invalid Argument"
+    )
+
+
+async def test_multiple_error_types_map_to_correct_status(
+    interceptor: ErrorHandlingInterceptor,
+) -> None:
+    """Different error subclasses should map to their respective status codes."""
+    for error_class in [NotFound, InvalidArgument]:
+        behavior = AsyncMock(side_effect=error_class())
+        handler = _make_handler(unary_unary=behavior)
+        continuation = AsyncMock(return_value=handler)
+
+        ctx = AsyncMock(spec=grpc.aio.ServicerContext)
+        ctx.abort = AsyncMock(
+            side_effect=grpc.aio.AbortError(error_class.status_code, "")
+        )
+
+        wrapped = await interceptor.intercept_service(
+            continuation, _make_call_details()
+        )
+        assert wrapped.unary_unary is not None
+        with pytest.raises(grpc.aio.AbortError):
+            await wrapped.unary_unary(b"request", ctx)
+
+        ctx.abort.assert_awaited_once_with(error_class.status_code, error_class.message)

--- a/plugins/spakky-grpc/tests/unit/test_grpc_error.py
+++ b/plugins/spakky-grpc/tests/unit/test_grpc_error.py
@@ -1,0 +1,107 @@
+"""Unit tests for gRPC error hierarchy."""
+
+import grpc
+import pytest
+
+from spakky.core.common.error import AbstractSpakkyFrameworkError
+from spakky.plugins.grpc.error import (
+    AbstractSpakkyGRPCError,
+    AlreadyExists,
+    FailedPrecondition,
+    InternalError,
+    InvalidArgument,
+    NotFound,
+    PermissionDenied,
+    Unauthenticated,
+    Unavailable,
+)
+
+
+def test_abstract_spakky_grpc_error_inherits_from_framework_error() -> None:
+    """AbstractSpakkyGRPCError should be a subclass of AbstractSpakkyFrameworkError."""
+    assert issubclass(AbstractSpakkyGRPCError, AbstractSpakkyFrameworkError)
+
+
+def test_abstract_spakky_grpc_error_is_abstract() -> None:
+    """AbstractSpakkyGRPCError should be marked as ABC."""
+    assert AbstractSpakkyGRPCError.__abstractmethods__ is not None
+
+
+@pytest.mark.parametrize(
+    ("error_class", "expected_status", "expected_message"),
+    [
+        (InvalidArgument, grpc.StatusCode.INVALID_ARGUMENT, "Invalid Argument"),
+        (NotFound, grpc.StatusCode.NOT_FOUND, "Not Found"),
+        (AlreadyExists, grpc.StatusCode.ALREADY_EXISTS, "Already Exists"),
+        (PermissionDenied, grpc.StatusCode.PERMISSION_DENIED, "Permission Denied"),
+        (Unauthenticated, grpc.StatusCode.UNAUTHENTICATED, "Unauthenticated"),
+        (
+            FailedPrecondition,
+            grpc.StatusCode.FAILED_PRECONDITION,
+            "Failed Precondition",
+        ),
+        (Unavailable, grpc.StatusCode.UNAVAILABLE, "Unavailable"),
+        (InternalError, grpc.StatusCode.INTERNAL, "Internal Server Error"),
+    ],
+)
+def test_concrete_error_has_correct_status_code_and_message(
+    error_class: type[AbstractSpakkyGRPCError],
+    expected_status: grpc.StatusCode,
+    expected_message: str,
+) -> None:
+    """Each concrete error should map to the correct gRPC status code and message."""
+    assert error_class.status_code == expected_status
+    assert error_class.message == expected_message
+
+
+@pytest.mark.parametrize(
+    "error_class",
+    [
+        InvalidArgument,
+        NotFound,
+        AlreadyExists,
+        PermissionDenied,
+        Unauthenticated,
+        FailedPrecondition,
+        Unavailable,
+        InternalError,
+    ],
+)
+def test_concrete_error_is_subclass_of_abstract_grpc_error(
+    error_class: type[AbstractSpakkyGRPCError],
+) -> None:
+    """Each concrete error should be a subclass of AbstractSpakkyGRPCError."""
+    assert issubclass(error_class, AbstractSpakkyGRPCError)
+
+
+@pytest.mark.parametrize(
+    "error_class",
+    [
+        InvalidArgument,
+        NotFound,
+        AlreadyExists,
+        PermissionDenied,
+        Unauthenticated,
+        FailedPrecondition,
+        Unavailable,
+        InternalError,
+    ],
+)
+def test_concrete_error_is_raisable(
+    error_class: type[AbstractSpakkyGRPCError],
+) -> None:
+    """Each concrete error should be raisable and catchable."""
+    with pytest.raises(error_class):
+        raise error_class()
+
+
+def test_concrete_error_caught_as_abstract_grpc_error() -> None:
+    """A concrete error should be catchable as AbstractSpakkyGRPCError."""
+    with pytest.raises(AbstractSpakkyGRPCError):
+        raise NotFound()
+
+
+def test_concrete_error_caught_as_framework_error() -> None:
+    """A concrete error should be catchable as AbstractSpakkyFrameworkError."""
+    with pytest.raises(AbstractSpakkyFrameworkError):
+        raise InvalidArgument()

--- a/plugins/spakky-grpc/tests/unit/test_tracing_interceptor.py
+++ b/plugins/spakky-grpc/tests/unit/test_tracing_interceptor.py
@@ -1,0 +1,294 @@
+"""Unit tests for TracingInterceptor."""
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc
+import grpc.aio
+import pytest
+
+from spakky.tracing.context import TraceContext
+from spakky.tracing.propagator import ITracePropagator
+from spakky.plugins.grpc.interceptors.tracing import TracingInterceptor
+
+
+class FakePropagator(ITracePropagator):
+    """Minimal propagator for testing that stores extract/inject calls."""
+
+    def __init__(self, *, extract_result: TraceContext | None = None) -> None:
+        self._extract_result = extract_result
+        self.extract_calls: list[dict[str, str]] = []
+        self.inject_calls: list[dict[str, str]] = []
+
+    def inject(self, carrier: dict[str, str]) -> None:
+        """Copy the ambient trace context into the carrier."""
+        self.inject_calls.append(carrier)
+        ctx = TraceContext.get()
+        if ctx is not None:
+            carrier["traceparent"] = ctx.to_traceparent()
+
+    def extract(self, carrier: dict[str, str]) -> TraceContext | None:
+        """Return the configured extract result."""
+        self.extract_calls.append(carrier)
+        return self._extract_result
+
+    def fields(self) -> list[str]:
+        """Return W3C trace context field names."""
+        return ["traceparent", "tracestate"]
+
+
+def _make_handler(
+    *,
+    unary_unary: AsyncMock | None = None,
+    unary_stream: object | None = None,
+) -> MagicMock:
+    """Create a mock RpcMethodHandler."""
+    handler = MagicMock(spec=grpc.RpcMethodHandler)
+    handler.request_streaming = False
+    handler.response_streaming = unary_stream is not None
+    handler.request_deserializer = None
+    handler.response_serializer = None
+    handler.unary_unary = unary_unary
+    handler.unary_stream = unary_stream
+    handler.stream_unary = None
+    handler.stream_stream = None
+    return handler
+
+
+def _make_call_details(
+    method: str = "/test.Service/Method",
+    metadata: tuple[tuple[str, str | bytes], ...] | None = (),
+) -> MagicMock:
+    """Create a mock HandlerCallDetails with optional metadata."""
+    details = MagicMock(spec=grpc.HandlerCallDetails)
+    details.method = method
+    details.invocation_metadata = metadata
+    return details
+
+
+@pytest.fixture(autouse=True)
+def _clear_trace_context() -> None:
+    """Ensure trace context is clean before each test."""
+    TraceContext.clear()
+
+
+@pytest.fixture
+def context() -> AsyncMock:
+    """Create a mock gRPC ServicerContext."""
+    ctx = AsyncMock(spec=grpc.aio.ServicerContext)
+    return ctx
+
+
+async def test_tracing_interceptor_creates_new_root_when_no_parent(
+    context: AsyncMock,
+) -> None:
+    """When no traceparent exists, a new root trace should be created."""
+    propagator = FakePropagator(extract_result=None)
+    interceptor = TracingInterceptor(propagator=propagator)
+    behavior = AsyncMock(return_value=b"ok")
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    assert wrapped.unary_unary is not None
+    await wrapped.unary_unary(b"request", context)
+
+    assert len(propagator.extract_calls) == 1
+    assert len(propagator.inject_calls) == 1
+    assert "traceparent" in propagator.inject_calls[0]
+
+
+async def test_tracing_interceptor_creates_child_when_parent_exists(
+    context: AsyncMock,
+) -> None:
+    """When traceparent exists in metadata, a child span should be created."""
+    parent = TraceContext.new_root()
+    propagator = FakePropagator(extract_result=parent)
+    interceptor = TracingInterceptor(propagator=propagator)
+
+    captured_ctx: list[TraceContext | None] = []
+
+    async def capture_behavior(request: object, ctx: grpc.aio.ServicerContext) -> bytes:
+        captured_ctx.append(TraceContext.get())
+        return b"ok"
+
+    handler = _make_handler(unary_unary=AsyncMock(side_effect=capture_behavior))
+    continuation = AsyncMock(return_value=handler)
+
+    metadata = (("traceparent", parent.to_traceparent()),)
+    wrapped = await interceptor.intercept_service(
+        continuation, _make_call_details(metadata=metadata)
+    )
+    assert wrapped.unary_unary is not None
+    await wrapped.unary_unary(b"request", context)
+
+    assert len(captured_ctx) == 1
+    child = captured_ctx[0]
+    assert child is not None
+    assert child.trace_id == parent.trace_id
+    assert child.span_id != parent.span_id
+    assert child.parent_span_id == parent.span_id
+
+
+async def test_tracing_interceptor_extracts_metadata_as_dict(
+    context: AsyncMock,
+) -> None:
+    """Invocation metadata should be converted to a dict for the propagator."""
+    propagator = FakePropagator(extract_result=None)
+    interceptor = TracingInterceptor(propagator=propagator)
+    behavior = AsyncMock(return_value=b"ok")
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    metadata = (("traceparent", "00-abc-def-01"), ("custom-key", "custom-value"))
+    wrapped = await interceptor.intercept_service(
+        continuation, _make_call_details(metadata=metadata)
+    )
+    assert wrapped.unary_unary is not None
+    await wrapped.unary_unary(b"request", context)
+
+    assert propagator.extract_calls[0] == {
+        "traceparent": "00-abc-def-01",
+        "custom-key": "custom-value",
+    }
+
+
+async def test_tracing_interceptor_handles_binary_metadata_values(
+    context: AsyncMock,
+) -> None:
+    """Binary metadata values (bytes) should be decoded to str."""
+    propagator = FakePropagator(extract_result=None)
+    interceptor = TracingInterceptor(propagator=propagator)
+    behavior = AsyncMock(return_value=b"ok")
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    metadata = (("key", b"bytes-value"),)
+    wrapped = await interceptor.intercept_service(
+        continuation, _make_call_details(metadata=metadata)
+    )
+    assert wrapped.unary_unary is not None
+    await wrapped.unary_unary(b"request", context)
+
+    assert propagator.extract_calls[0] == {"key": "bytes-value"}
+
+
+async def test_tracing_interceptor_injects_trailing_metadata(
+    context: AsyncMock,
+) -> None:
+    """Trace context should be injected into trailing metadata."""
+    propagator = FakePropagator(extract_result=None)
+    interceptor = TracingInterceptor(propagator=propagator)
+    behavior = AsyncMock(return_value=b"ok")
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    assert wrapped.unary_unary is not None
+    await wrapped.unary_unary(b"request", context)
+
+    context.set_trailing_metadata.assert_called_once()
+    trailing = dict(context.set_trailing_metadata.call_args.args[0])
+    assert "traceparent" in trailing
+
+
+async def test_tracing_interceptor_clears_context_after_rpc(
+    context: AsyncMock,
+) -> None:
+    """Trace context should be cleared after the RPC completes."""
+    propagator = FakePropagator(extract_result=None)
+    interceptor = TracingInterceptor(propagator=propagator)
+    behavior = AsyncMock(return_value=b"ok")
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    assert wrapped.unary_unary is not None
+    await wrapped.unary_unary(b"request", context)
+
+    assert TraceContext.get() is None
+
+
+async def test_tracing_interceptor_clears_context_on_error(
+    context: AsyncMock,
+) -> None:
+    """Trace context should be cleared even if the handler raises."""
+    propagator = FakePropagator(extract_result=None)
+    interceptor = TracingInterceptor(propagator=propagator)
+    behavior = AsyncMock(side_effect=RuntimeError("boom"))
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    assert wrapped.unary_unary is not None
+    with pytest.raises(RuntimeError, match="boom"):
+        await wrapped.unary_unary(b"request", context)
+
+    assert TraceContext.get() is None
+
+
+async def test_tracing_interceptor_returns_none_for_none_handler() -> None:
+    """When continuation returns None, interceptor should return None."""
+    propagator = FakePropagator(extract_result=None)
+    interceptor = TracingInterceptor(propagator=propagator)
+    continuation = AsyncMock(return_value=None)
+
+    result = await interceptor.intercept_service(continuation, _make_call_details())
+    assert result is None
+    assert TraceContext.get() is None
+
+
+async def test_tracing_interceptor_handles_none_metadata(
+    context: AsyncMock,
+) -> None:
+    """None invocation_metadata should be handled gracefully."""
+    propagator = FakePropagator(extract_result=None)
+    interceptor = TracingInterceptor(propagator=propagator)
+    behavior = AsyncMock(return_value=b"ok")
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(
+        continuation, _make_call_details(metadata=None)
+    )
+    assert wrapped.unary_unary is not None
+    await wrapped.unary_unary(b"request", context)
+
+    assert propagator.extract_calls[0] == {}
+
+
+async def test_tracing_interceptor_stream_handler_injects_and_clears(
+    context: AsyncMock,
+) -> None:
+    """Streaming handler should inject trailing metadata and clear context."""
+    propagator = FakePropagator(extract_result=None)
+    interceptor = TracingInterceptor(propagator=propagator)
+
+    async def stream_behavior(
+        request: object, ctx: grpc.aio.ServicerContext
+    ) -> AsyncIterator[bytes]:
+        yield b"a"
+        yield b"b"
+
+    handler = _make_handler(unary_stream=stream_behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    assert wrapped.unary_stream is not None
+    results = [item async for item in wrapped.unary_stream(b"request", context)]  # type: ignore[arg-type] — grpc stubs declare sync Iterator but grpc.aio uses async
+
+    assert results == [b"a", b"b"]
+    context.set_trailing_metadata.assert_called_once()
+    assert TraceContext.get() is None
+
+
+async def test_tracing_interceptor_clears_context_on_continuation_failure() -> None:
+    """Trace context should be cleared if continuation raises an exception."""
+    propagator = FakePropagator(extract_result=None)
+    interceptor = TracingInterceptor(propagator=propagator)
+    continuation = AsyncMock(side_effect=RuntimeError("continuation failed"))
+
+    with pytest.raises(RuntimeError, match="continuation failed"):
+        await interceptor.intercept_service(continuation, _make_call_details())
+
+    assert TraceContext.get() is None


### PR DESCRIPTION
## 요약

gRPC 서버의 cross-cutting concern을 처리하는 에러 계층과 인터셉터를 구현합니다.

Closes #84

## 변경 사항

### 에러 계층 (`error.py`)
- `AbstractSpakkyGRPCError` — `grpc.StatusCode` 매핑을 강제하는 추상 기반 클래스
- 8개 구체 에러: `InvalidArgument`, `NotFound`, `AlreadyExists`, `PermissionDenied`, `Unauthenticated`, `FailedPrecondition`, `Unavailable`, `InternalError`

### 인터셉터
- `ErrorHandlingInterceptor` — 도메인 예외를 gRPC status code로 자동 변환. 미처리 예외는 `INTERNAL`로 매핑. debug 모드에서 traceback 포함 가능.
- `TracingInterceptor` — gRPC metadata에서 W3C Trace Context (`traceparent`) 추출 → `spakky-tracing`의 `TraceContext`에 전파. 응답 trailing metadata에 trace context 주입.

### 테스트
- 71개 단위 테스트, 100% 커버리지
- unary 및 streaming RPC 메서드 모두 테스트

## 수용 기준 확인
- [x] `AbstractSpakkyGRPCError`가 `grpc.StatusCode` 매핑을 강제
- [x] `ErrorHandlingInterceptor`가 도메인 에러를 올바른 gRPC status로 변환  
- [x] `ErrorHandlingInterceptor`가 미처리 예외를 `INTERNAL`로 변환
- [x] `TracingInterceptor`가 gRPC metadata에서 W3C Trace Context를 추출하여 `TraceContext`에 전파
- [x] 단위 테스트 작성 및 통과
- [x] lint + type check 통과