### PR TITLE
feat(grpc): implement PostProcessors for dynamic service registration (#86)

### DIFF
--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/handler.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/handler.py
@@ -1,0 +1,400 @@
+"""Generic RPC handler for code-first gRPC service dispatch.
+
+Routes incoming gRPC calls to ``@GrpcController`` methods by matching
+the fully-qualified method name, performing protobuf ↔ dataclass
+conversion transparently.
+"""
+
+from collections.abc import AsyncIterator
+from dataclasses import fields, is_dataclass
+from inspect import getmembers, isfunction
+from logging import getLogger
+from typing import Callable
+
+import grpc
+import grpc.aio
+from google.protobuf.message import Message
+from google.protobuf.message_factory import GetMessageClass
+
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.plugins.grpc.decorators.rpc import Rpc, RpcMethodType
+from spakky.plugins.grpc.schema.registry import DescriptorRegistry
+
+logger = getLogger(__name__)
+
+
+class GrpcServiceHandler(grpc.GenericRpcHandler):
+    """Generic handler dispatching gRPC calls to ``@GrpcController`` methods.
+
+    For each ``@rpc``-decorated method, builds a ``grpc.RpcMethodHandler``
+    with serialiser/deserialiser that convert between protobuf wire format
+    and Python dataclasses.
+
+    Attributes:
+        _full_service_name: Fully-qualified ``<package>.<service>`` name.
+        _controller_type: The ``@GrpcController`` class.
+        _container: IoC container for obtaining fresh controller instances.
+        _application_context: Application context for request-scoped isolation.
+        _registry: Descriptor registry for message class lookup.
+        _handlers: Pre-built map of ``/<package>.<service>/<method>`` →
+            ``RpcMethodHandler``.
+    """
+
+    _full_service_name: str
+    _controller_type: type
+    _container: IContainer
+    _application_context: IApplicationContext
+    _registry: DescriptorRegistry
+    _handlers: dict[str, grpc.RpcMethodHandler]
+
+    def __init__(
+        self,
+        *,
+        controller_type: type,
+        package: str,
+        service_name: str,
+        container: IContainer,
+        application_context: IApplicationContext,
+        registry: DescriptorRegistry,
+    ) -> None:
+        """Initialise the handler and pre-build per-method dispatchers.
+
+        Args:
+            controller_type: The ``@GrpcController``-decorated class.
+            package: Protobuf package name.
+            service_name: gRPC service name.
+            container: IoC container for obtaining controller instances.
+            application_context: Application context for request isolation.
+            registry: Descriptor registry for message class lookup.
+        """
+        self._full_service_name = f"{package}.{service_name}"
+        self._controller_type = controller_type
+        self._container = container
+        self._application_context = application_context
+        self._registry = registry
+        self._handlers = {}
+        self._build_handlers()
+
+    def service(
+        self,
+        handler_call_details: grpc.HandlerCallDetails,
+    ) -> grpc.RpcMethodHandler | None:
+        """Resolve an RPC method handler for the incoming call.
+
+        Args:
+            handler_call_details: Describes the incoming RPC.
+
+        Returns:
+            The matched handler, or ``None`` if not handled.
+        """
+        return self._handlers.get(handler_call_details.method)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_handlers(self) -> None:
+        """Pre-build ``RpcMethodHandler`` for every ``@rpc`` method."""
+        for method_name, method in getmembers(
+            self._controller_type, predicate=isfunction
+        ):
+            rpc_annotation = Rpc.get_or_none(method)
+            if rpc_annotation is None:
+                continue
+
+            full_method = f"/{self._full_service_name}/{method_name}"
+            request_deserializer = self._make_deserializer(rpc_annotation.request_type)
+            response_serializer = self._make_serializer(rpc_annotation.response_type)
+            handler = self._make_rpc_method_handler(
+                method_name=method_name,
+                rpc_annotation=rpc_annotation,
+                request_deserializer=request_deserializer,
+                response_serializer=response_serializer,
+            )
+            self._handlers[full_method] = handler
+            logger.debug(
+                f"Registered gRPC method {full_method} "
+                f"({rpc_annotation.method_type.value})"
+            )
+
+    def _make_rpc_method_handler(
+        self,
+        *,
+        method_name: str,
+        rpc_annotation: Rpc,
+        request_deserializer: Callable[[bytes], object] | None,
+        response_serializer: Callable[[object], bytes] | None,
+    ) -> grpc.RpcMethodHandler:
+        """Create a ``grpc.RpcMethodHandler`` for a single ``@rpc`` method.
+
+        Args:
+            method_name: Controller method name.
+            rpc_annotation: The ``@rpc`` annotation.
+            request_deserializer: Bytes → domain object.
+            response_serializer: Domain object → bytes.
+
+        Returns:
+            A configured ``grpc.RpcMethodHandler``.
+        """
+        method_type = rpc_annotation.method_type
+
+        if method_type is RpcMethodType.UNARY:
+            return grpc.unary_unary_rpc_method_handler(
+                self._make_unary_behavior(method_name, rpc_annotation),
+                request_deserializer=request_deserializer,
+                response_serializer=response_serializer,
+            )
+        if method_type is RpcMethodType.SERVER_STREAMING:
+            return grpc.unary_stream_rpc_method_handler(
+                self._make_server_streaming_behavior(method_name, rpc_annotation),
+                request_deserializer=request_deserializer,
+                response_serializer=response_serializer,
+            )
+        if method_type is RpcMethodType.CLIENT_STREAMING:
+            return grpc.stream_unary_rpc_method_handler(
+                self._make_client_streaming_behavior(method_name, rpc_annotation),
+                request_deserializer=request_deserializer,
+                response_serializer=response_serializer,
+            )
+        # BIDI_STREAMING
+        return grpc.stream_stream_rpc_method_handler(
+            self._make_bidi_streaming_behavior(method_name, rpc_annotation),
+            request_deserializer=request_deserializer,
+            response_serializer=response_serializer,
+        )
+
+    # ------ Behaviour factories ------
+
+    def _make_unary_behavior(
+        self,
+        method_name: str,
+        rpc_annotation: Rpc,
+    ) -> Callable[..., object]:
+        """Build an async unary-unary handler."""
+        request_type = rpc_annotation.request_type
+
+        async def _behavior(
+            request: object,
+            context: grpc.aio.ServicerContext,
+        ) -> object:
+            self._application_context.clear_context()
+            instance = self._container.get(self._controller_type)
+            handler_method = getattr(instance, method_name)
+            domain_request = (
+                _protobuf_to_dataclass(request, request_type)
+                if request_type is not None and isinstance(request, Message)
+                else request
+            )
+            return await handler_method(domain_request)
+
+        return _behavior
+
+    def _make_server_streaming_behavior(
+        self,
+        method_name: str,
+        rpc_annotation: Rpc,
+    ) -> Callable[..., AsyncIterator[object]]:
+        """Build an async unary-stream (server streaming) handler."""
+        request_type = rpc_annotation.request_type
+
+        async def _behavior(
+            request: object,
+            context: grpc.aio.ServicerContext,
+        ) -> AsyncIterator[object]:
+            self._application_context.clear_context()
+            instance = self._container.get(self._controller_type)
+            handler_method = getattr(instance, method_name)
+            domain_request = (
+                _protobuf_to_dataclass(request, request_type)
+                if request_type is not None and isinstance(request, Message)
+                else request
+            )
+            async for item in handler_method(domain_request):
+                yield item
+
+        return _behavior
+
+    def _make_client_streaming_behavior(
+        self,
+        method_name: str,
+        rpc_annotation: Rpc,
+    ) -> Callable[..., object]:
+        """Build an async stream-unary (client streaming) handler."""
+        request_type = rpc_annotation.request_type
+
+        async def _behavior(
+            request_iterator: AsyncIterator[object],
+            context: grpc.aio.ServicerContext,
+        ) -> object:
+            self._application_context.clear_context()
+            instance = self._container.get(self._controller_type)
+            handler_method = getattr(instance, method_name)
+
+            async def _convert_stream() -> AsyncIterator[object]:
+                async for request in request_iterator:
+                    if request_type is not None and isinstance(request, Message):
+                        yield _protobuf_to_dataclass(request, request_type)
+                    else:
+                        yield request
+
+            return await handler_method(_convert_stream())
+
+        return _behavior
+
+    def _make_bidi_streaming_behavior(
+        self,
+        method_name: str,
+        rpc_annotation: Rpc,
+    ) -> Callable[..., AsyncIterator[object]]:
+        """Build an async stream-stream (bidirectional streaming) handler."""
+        request_type = rpc_annotation.request_type
+
+        async def _behavior(
+            request_iterator: AsyncIterator[object],
+            context: grpc.aio.ServicerContext,
+        ) -> AsyncIterator[object]:
+            self._application_context.clear_context()
+            instance = self._container.get(self._controller_type)
+            handler_method = getattr(instance, method_name)
+
+            async def _convert_stream() -> AsyncIterator[object]:
+                async for request in request_iterator:
+                    if request_type is not None and isinstance(request, Message):
+                        yield _protobuf_to_dataclass(request, request_type)
+                    else:
+                        yield request
+
+            async for item in handler_method(_convert_stream()):
+                yield item
+
+        return _behavior
+
+    # ------ Serialisation helpers ------
+
+    def _make_deserializer(
+        self,
+        request_type: type | None,
+    ) -> Callable[[bytes], object] | None:
+        """Build a bytes → protobuf Message deserializer.
+
+        Args:
+            request_type: The Python dataclass type for the request.
+
+        Returns:
+            A callable that parses raw bytes into a protobuf Message,
+            or ``None`` when there is no request type.
+        """
+        if request_type is None:
+            return None
+
+        full_name = (
+            f"{self._full_service_name.rsplit('.', 1)[0]}.{request_type.__name__}"
+        )
+        message_class = self._registry.get_message_class(full_name)
+
+        def _deserialize(data: bytes) -> Message:
+            msg = message_class()
+            msg.ParseFromString(data)
+            return msg
+
+        return _deserialize
+
+    def _make_serializer(
+        self,
+        response_type: type | None,
+    ) -> Callable[[object], bytes] | None:
+        """Build a domain object → bytes serializer.
+
+        Args:
+            response_type: The Python dataclass type for the response.
+
+        Returns:
+            A callable that serialises domain objects to protobuf bytes,
+            or ``None`` when there is no response type.
+        """
+        if response_type is None:
+            return None
+
+        full_name = (
+            f"{self._full_service_name.rsplit('.', 1)[0]}.{response_type.__name__}"
+        )
+        message_class = self._registry.get_message_class(full_name)
+
+        def _serialize(obj: object) -> bytes:
+            if isinstance(obj, Message):
+                return obj.SerializeToString()
+            msg = _dataclass_to_protobuf(obj, message_class)
+            return msg.SerializeToString()
+
+        return _serialize
+
+
+# ------------------------------------------------------------------
+# Module-level conversion helpers
+# ------------------------------------------------------------------
+
+
+def _protobuf_to_dataclass(message: Message, dataclass_type: type) -> object:
+    """Convert a protobuf ``Message`` to a Python dataclass instance.
+
+    Handles nested messages, repeated fields and optional (None) values.
+
+    Args:
+        message: The protobuf message.
+        dataclass_type: The target dataclass type.
+
+    Returns:
+        An instance of *dataclass_type* populated from *message*.
+    """
+    kwargs: dict[str, object] = {}
+    for field in fields(dataclass_type):
+        raw = getattr(message, field.name)
+        kwargs[field.name] = _convert_proto_value(raw, field.type)
+    return dataclass_type(**kwargs)
+
+
+def _convert_proto_value(value: object, target_type: object) -> object:
+    """Recursively convert a protobuf field value to its Python equivalent.
+
+    Args:
+        value: The raw protobuf field value.
+        target_type: The expected Python type annotation.
+
+    Returns:
+        The converted value.
+    """
+    if isinstance(value, Message):
+        if is_dataclass(target_type) and isinstance(target_type, type):
+            return _protobuf_to_dataclass(value, target_type)
+    return value
+
+
+def _dataclass_to_protobuf(obj: object, message_class: type[Message]) -> Message:
+    """Convert a Python dataclass to a protobuf ``Message``.
+
+    Handles nested dataclasses and repeated fields.
+
+    Args:
+        obj: The dataclass instance.
+        message_class: The target protobuf message class.
+
+    Returns:
+        A populated protobuf ``Message``.
+    """
+    msg = message_class()
+    descriptor = msg.DESCRIPTOR
+    for field_desc in descriptor.fields:
+        value = getattr(obj, field_desc.name, None)
+        if value is None:
+            continue
+        if field_desc.message_type is not None and is_dataclass(type(value)):
+            nested_class = msg.DESCRIPTOR.fields_by_name[field_desc.name].message_type
+            nested_msg_class = GetMessageClass(nested_class)
+            nested_msg = _dataclass_to_protobuf(value, nested_msg_class)
+            getattr(msg, field_desc.name).CopyFrom(nested_msg)
+        elif field_desc.label == field_desc.LABEL_REPEATED:
+            getattr(msg, field_desc.name).extend(value)  # type: ignore[arg-type] — protobuf repeated field .extend() accepts iterables
+        else:
+            setattr(msg, field_desc.name, value)
+    return msg

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/handler.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/handler.py
@@ -5,11 +5,12 @@ the fully-qualified method name, performing protobuf ↔ dataclass
 conversion transparently.
 """
 
-from collections.abc import AsyncIterator
+import types
+from collections.abc import AsyncIterator, Sequence
 from dataclasses import fields, is_dataclass
 from inspect import getmembers, isfunction
 from logging import getLogger
-from typing import Annotated, Callable, get_args, get_origin
+from typing import Annotated, Callable, Union, get_args, get_origin
 
 from google.protobuf.message import Message
 from google.protobuf.message_factory import GetMessageClass
@@ -341,10 +342,20 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
 # ------------------------------------------------------------------
 
 
+def _is_optional(tp: object) -> bool:
+    """Return ``True`` if *tp* is ``Optional[T]`` (i.e. ``T | None``)."""
+    origin = get_origin(tp)
+    if origin is Union or isinstance(tp, types.UnionType):
+        return type(None) in get_args(tp)
+    return False
+
+
 def _protobuf_to_dataclass(message: Message, dataclass_type: type) -> object:
     """Convert a protobuf ``Message`` to a Python dataclass instance.
 
     Handles nested messages, repeated fields and optional (None) values.
+    For proto3 optional fields, uses ``HasField`` to distinguish between
+    an unset field (mapped to ``None``) and a field set to the default value.
 
     Args:
         message: The protobuf message.
@@ -355,9 +366,16 @@ def _protobuf_to_dataclass(message: Message, dataclass_type: type) -> object:
     """
     kwargs: dict[str, object] = {}
     for field in fields(dataclass_type):
-        raw = getattr(message, field.name)
         resolved_type = _unwrap_annotated(field.type)
-        kwargs[field.name] = _convert_proto_value(raw, resolved_type)
+        if _is_optional(resolved_type) and message.HasField(field.name):
+            raw = getattr(message, field.name)
+            inner_type = next(a for a in get_args(resolved_type) if a is not type(None))
+            kwargs[field.name] = _convert_proto_value(raw, inner_type)
+        elif _is_optional(resolved_type):
+            kwargs[field.name] = None
+        else:
+            raw = getattr(message, field.name)
+            kwargs[field.name] = _convert_proto_value(raw, resolved_type)
     return dataclass_type(**kwargs)
 
 
@@ -382,7 +400,11 @@ def _convert_proto_value(value: object, target_type: object) -> object:
         if is_dataclass(target_type) and isinstance(target_type, type):
             return _protobuf_to_dataclass(value, target_type)
     origin = get_origin(target_type)
-    if origin is list and isinstance(value, (list, tuple)):
+    if (
+        origin is list
+        and isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes))
+    ):
         inner_args = get_args(target_type)
         if (
             inner_args
@@ -395,6 +417,7 @@ def _convert_proto_value(value: object, target_type: object) -> object:
                 else v
                 for v in value
             ]
+        return list(value)
     return value
 
 
@@ -416,7 +439,21 @@ def _dataclass_to_protobuf(obj: object, message_class: type[Message]) -> Message
         value = getattr(obj, field_desc.name, None)
         if value is None:
             continue
-        if field_desc.message_type is not None and is_dataclass(type(value)):
+        if (
+            field_desc.label == field_desc.LABEL_REPEATED
+            and field_desc.message_type is not None
+            and isinstance(value, Sequence)
+            and not isinstance(value, (str, bytes))
+        ):
+            nested_class = msg.DESCRIPTOR.fields_by_name[field_desc.name].message_type
+            nested_msg_class = GetMessageClass(nested_class)
+            for item in value:
+                if is_dataclass(type(item)):
+                    nested_msg = _dataclass_to_protobuf(item, nested_msg_class)
+                    getattr(msg, field_desc.name).append(nested_msg)
+                else:
+                    getattr(msg, field_desc.name).append(item)
+        elif field_desc.message_type is not None and is_dataclass(type(value)):
             nested_class = msg.DESCRIPTOR.fields_by_name[field_desc.name].message_type
             nested_msg_class = GetMessageClass(nested_class)
             nested_msg = _dataclass_to_protobuf(value, nested_msg_class)

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/handler.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/handler.py
@@ -9,17 +9,17 @@ from collections.abc import AsyncIterator
 from dataclasses import fields, is_dataclass
 from inspect import getmembers, isfunction
 from logging import getLogger
-from typing import Callable
+from typing import Annotated, Callable, get_args, get_origin
 
-import grpc
-import grpc.aio
 from google.protobuf.message import Message
 from google.protobuf.message_factory import GetMessageClass
-
 from spakky.core.pod.interfaces.application_context import IApplicationContext
 from spakky.core.pod.interfaces.container import IContainer
 from spakky.plugins.grpc.decorators.rpc import Rpc, RpcMethodType
 from spakky.plugins.grpc.schema.registry import DescriptorRegistry
+
+import grpc
+import grpc.aio
 
 logger = getLogger(__name__)
 
@@ -181,9 +181,11 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
             self._application_context.clear_context()
             instance = self._container.get(self._controller_type)
             handler_method = getattr(instance, method_name)
+            if request_type is None:
+                return await handler_method()
             domain_request = (
                 _protobuf_to_dataclass(request, request_type)
-                if request_type is not None and isinstance(request, Message)
+                if isinstance(request, Message)
                 else request
             )
             return await handler_method(domain_request)
@@ -205,9 +207,13 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
             self._application_context.clear_context()
             instance = self._container.get(self._controller_type)
             handler_method = getattr(instance, method_name)
+            if request_type is None:
+                async for item in handler_method():
+                    yield item
+                return
             domain_request = (
                 _protobuf_to_dataclass(request, request_type)
-                if request_type is not None and isinstance(request, Message)
+                if isinstance(request, Message)
                 else request
             )
             async for item in handler_method(domain_request):
@@ -350,8 +356,16 @@ def _protobuf_to_dataclass(message: Message, dataclass_type: type) -> object:
     kwargs: dict[str, object] = {}
     for field in fields(dataclass_type):
         raw = getattr(message, field.name)
-        kwargs[field.name] = _convert_proto_value(raw, field.type)
+        resolved_type = _unwrap_annotated(field.type)
+        kwargs[field.name] = _convert_proto_value(raw, resolved_type)
     return dataclass_type(**kwargs)
+
+
+def _unwrap_annotated(tp: object) -> object:
+    """Unwrap ``Annotated[T, ...]`` to its inner type ``T``."""
+    if get_origin(tp) is Annotated:
+        return get_args(tp)[0]
+    return tp
 
 
 def _convert_proto_value(value: object, target_type: object) -> object:
@@ -367,6 +381,20 @@ def _convert_proto_value(value: object, target_type: object) -> object:
     if isinstance(value, Message):
         if is_dataclass(target_type) and isinstance(target_type, type):
             return _protobuf_to_dataclass(value, target_type)
+    origin = get_origin(target_type)
+    if origin is list and isinstance(value, (list, tuple)):
+        inner_args = get_args(target_type)
+        if (
+            inner_args
+            and is_dataclass(inner_args[0])
+            and isinstance(inner_args[0], type)
+        ):
+            return [
+                _protobuf_to_dataclass(v, inner_args[0])
+                if isinstance(v, Message)
+                else v
+                for v in value
+            ]
     return value
 
 

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/main.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/main.py
@@ -5,7 +5,6 @@ interceptor injection, and server lifecycle management.
 """
 
 from spakky.core.application.application import SpakkyApplication
-
 from spakky.plugins.grpc.post_processors.add_interceptors import (
     AddInterceptorsPostProcessor,
 )

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/main.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/main.py
@@ -1,18 +1,33 @@
 """Plugin initialization for gRPC integration.
 
-Registers post-processors that enable automatic gRPC service registration
-and server lifecycle management.
+Registers post-processors that enable automatic gRPC service registration,
+interceptor injection, and server lifecycle management.
 """
 
 from spakky.core.application.application import SpakkyApplication
+
+from spakky.plugins.grpc.post_processors.add_interceptors import (
+    AddInterceptorsPostProcessor,
+)
+from spakky.plugins.grpc.post_processors.bind_server import (
+    BindServerPostProcessor,
+)
+from spakky.plugins.grpc.post_processors.register_services import (
+    RegisterServicesPostProcessor,
+)
 
 
 def initialize(app: SpakkyApplication) -> None:
     """Initialize the gRPC plugin.
 
-    Post-processors for gRPC service registration will be added
-    in subsequent tasks.
+    Registers post-processors for automatic gRPC service registration,
+    interceptor injection, and server lifecycle management.  This
+    function is called automatically by the Spakky framework during
+    plugin loading.
 
     Args:
         app: The Spakky application instance.
     """
+    app.add(RegisterServicesPostProcessor)
+    app.add(AddInterceptorsPostProcessor)
+    app.add(BindServerPostProcessor)

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/__init__.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/__init__.py
@@ -1,0 +1,1 @@
+"""Post-processor package for gRPC plugin."""

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/add_interceptors.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/add_interceptors.py
@@ -7,8 +7,6 @@ that has ``ErrorHandlingInterceptor`` and (optionally)
 
 from logging import getLogger
 
-import grpc
-import grpc.aio
 from spakky.core.pod.annotations.order import Order
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.interfaces.application_context import IApplicationContext
@@ -18,10 +16,12 @@ from spakky.core.pod.interfaces.aware.application_context_aware import (
 from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
 from spakky.core.pod.interfaces.container import IContainer
 from spakky.core.pod.interfaces.post_processor import IPostProcessor
-
 from spakky.plugins.grpc.interceptors.error_handling import ErrorHandlingInterceptor
 from spakky.plugins.grpc.interceptors.tracing import TracingInterceptor
 from spakky.tracing.propagator import ITracePropagator
+
+import grpc
+import grpc.aio
 
 logger = getLogger(__name__)
 

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/add_interceptors.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/add_interceptors.py
@@ -1,0 +1,93 @@
+"""Post-processor for injecting interceptors into the gRPC server.
+
+Replaces a bare ``grpc.aio.Server`` Pod with a new server instance
+that has ``ErrorHandlingInterceptor`` and (optionally)
+``TracingInterceptor`` configured.
+"""
+
+from logging import getLogger
+
+import grpc
+import grpc.aio
+from spakky.core.pod.annotations.order import Order
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.aware.application_context_aware import (
+    IApplicationContextAware,
+)
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.core.pod.interfaces.post_processor import IPostProcessor
+
+from spakky.plugins.grpc.interceptors.error_handling import ErrorHandlingInterceptor
+from spakky.plugins.grpc.interceptors.tracing import TracingInterceptor
+from spakky.tracing.propagator import ITracePropagator
+
+logger = getLogger(__name__)
+
+
+@Order(1)
+@Pod()
+class AddInterceptorsPostProcessor(
+    IPostProcessor, IContainerAware, IApplicationContextAware
+):
+    """Post-processor that injects interceptors into the gRPC server.
+
+    Because ``grpc.aio.Server`` requires interceptors at creation time,
+    this processor creates a **new** server with the appropriate
+    interceptors and returns it as a replacement for the original Pod.
+
+    Interceptors added (in order):
+
+    1. ``ErrorHandlingInterceptor`` — always.
+    2. ``TracingInterceptor`` — only when an ``ITracePropagator`` is
+       available in the application context.
+
+    Runs at ``@Order(1)`` — after service registration.
+    """
+
+    __container: IContainer
+    __application_context: IApplicationContext
+
+    def set_container(self, container: IContainer) -> None:
+        """Inject the IoC container.
+
+        Args:
+            container: The IoC container.
+        """
+        self.__container = container
+
+    def set_application_context(self, application_context: IApplicationContext) -> None:
+        """Inject the application context.
+
+        Args:
+            application_context: The application context.
+        """
+        self.__application_context = application_context
+
+    def post_process(self, pod: object) -> object:
+        """Replace a bare ``grpc.aio.Server`` with an interceptor-equipped one.
+
+        Non-server Pods are returned unchanged.
+
+        Args:
+            pod: The Pod instance to process.
+
+        Returns:
+            A new ``grpc.aio.Server`` with interceptors if *pod* is a
+            server, otherwise the original *pod*.
+        """
+        if not isinstance(pod, grpc.aio.Server):
+            return pod
+
+        interceptors: list[grpc.aio.ServerInterceptor] = []
+        interceptors.append(ErrorHandlingInterceptor())
+
+        propagator = self.__application_context.get_or_none(ITracePropagator)
+        if propagator is not None:
+            interceptors.append(TracingInterceptor(propagator=propagator))
+
+        new_server = grpc.aio.server(interceptors=interceptors)
+
+        logger.info(f"Injected {len(interceptors)} interceptor(s) into gRPC server")
+        return new_server

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/bind_server.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/bind_server.py
@@ -1,0 +1,119 @@
+"""Post-processor for binding gRPC server lifecycle.
+
+Wraps the ``grpc.aio.Server`` lifecycle so that it starts and stops
+together with the Spakky ``ApplicationContext``.
+"""
+
+from asyncio import locks
+from logging import getLogger
+
+import grpc.aio
+from spakky.core.pod.annotations.order import Order
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.aware.application_context_aware import (
+    IApplicationContextAware,
+)
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.core.pod.interfaces.post_processor import IPostProcessor
+from spakky.core.service.interfaces.service import IAsyncService
+
+logger = getLogger(__name__)
+
+GRACEFUL_SHUTDOWN_SECONDS: float = 5.0
+"""Default grace period (seconds) for server shutdown."""
+
+
+class GrpcServerService(IAsyncService):
+    """Async service wrapper for ``grpc.aio.Server`` lifecycle.
+
+    Registers with the ``ApplicationContext`` so that the gRPC server
+    starts and stops together with the application.
+
+    Attributes:
+        _server: The gRPC async server to manage.
+        _stop_event: Async event signalled when the application stops.
+    """
+
+    _server: grpc.aio.Server
+    _stop_event: locks.Event
+
+    def __init__(self, server: grpc.aio.Server) -> None:
+        """Initialise with the target server.
+
+        Args:
+            server: The gRPC async server to manage.
+        """
+        self._server = server
+
+    def set_stop_event(self, stop_event: locks.Event) -> None:
+        """Set the async stop event.
+
+        Args:
+            stop_event: Async event to signal service shutdown.
+        """
+        self._stop_event = stop_event
+
+    async def start_async(self) -> None:
+        """Start the gRPC server."""
+        await self._server.start()
+        logger.info("gRPC server started")
+
+    async def stop_async(self) -> None:
+        """Gracefully stop the gRPC server."""
+        await self._server.stop(grace=GRACEFUL_SHUTDOWN_SECONDS)
+        logger.info("gRPC server stopped")
+
+
+@Order(2)
+@Pod()
+class BindServerPostProcessor(
+    IPostProcessor, IContainerAware, IApplicationContextAware
+):
+    """Post-processor that binds gRPC server lifecycle to ApplicationContext.
+
+    Wraps the ``grpc.aio.Server`` in a ``GrpcServerService`` and
+    registers it with the ``ApplicationContext`` for automatic
+    start/stop management.
+
+    Runs at ``@Order(2)`` — last in the gRPC post-processor chain.
+    """
+
+    __container: IContainer
+    __application_context: IApplicationContext
+
+    def set_container(self, container: IContainer) -> None:
+        """Inject the IoC container.
+
+        Args:
+            container: The IoC container.
+        """
+        self.__container = container
+
+    def set_application_context(self, application_context: IApplicationContext) -> None:
+        """Inject the application context.
+
+        Args:
+            application_context: The application context.
+        """
+        self.__application_context = application_context
+
+    def post_process(self, pod: object) -> object:
+        """Bind server lifecycle if *pod* is a ``grpc.aio.Server``.
+
+        Non-server Pods are returned unchanged.
+
+        Args:
+            pod: The Pod instance to process.
+
+        Returns:
+            The unmodified Pod.
+        """
+        if not isinstance(pod, grpc.aio.Server):
+            return pod
+
+        service = GrpcServerService(pod)
+        self.__application_context.add_service(service)
+        logger.info("Bound gRPC server lifecycle to ApplicationContext")
+        return pod

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/bind_server.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/bind_server.py
@@ -7,7 +7,6 @@ together with the Spakky ``ApplicationContext``.
 from asyncio import locks
 from logging import getLogger
 
-import grpc.aio
 from spakky.core.pod.annotations.order import Order
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.interfaces.application_context import IApplicationContext
@@ -18,6 +17,8 @@ from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
 from spakky.core.pod.interfaces.container import IContainer
 from spakky.core.pod.interfaces.post_processor import IPostProcessor
 from spakky.core.service.interfaces.service import IAsyncService
+
+import grpc.aio
 
 logger = getLogger(__name__)
 
@@ -114,6 +115,7 @@ class BindServerPostProcessor(
             return pod
 
         service = GrpcServerService(pod)
+        service.set_stop_event(self.__application_context.task_stop_event)
         self.__application_context.add_service(service)
         logger.info("Bound gRPC server lifecycle to ApplicationContext")
         return pod

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/register_services.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/register_services.py
@@ -6,7 +6,6 @@ at runtime, and registers generic RPC handlers on the ``grpc.aio.Server``.
 
 from logging import getLogger
 
-import grpc.aio
 from spakky.core.pod.annotations.order import Order
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.interfaces.application_context import IApplicationContext
@@ -16,11 +15,12 @@ from spakky.core.pod.interfaces.aware.application_context_aware import (
 from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
 from spakky.core.pod.interfaces.container import IContainer
 from spakky.core.pod.interfaces.post_processor import IPostProcessor
-
 from spakky.plugins.grpc.handler import GrpcServiceHandler
 from spakky.plugins.grpc.schema.descriptor_builder import build_file_descriptor
 from spakky.plugins.grpc.schema.registry import DescriptorRegistry
 from spakky.plugins.grpc.stereotypes.grpc_controller import GrpcController
+
+import grpc.aio
 
 logger = getLogger(__name__)
 

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/register_services.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/register_services.py
@@ -6,6 +6,7 @@ at runtime, and registers generic RPC handlers on the ``grpc.aio.Server``.
 
 from logging import getLogger
 
+from spakky.core.common.constants import DYNAMIC_PROXY_CLASS_NAME_SUFFIX
 from spakky.core.pod.annotations.order import Order
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.interfaces.application_context import IApplicationContext
@@ -62,6 +63,25 @@ class RegisterServicesPostProcessor(
         """
         self.__application_context = application_context
 
+    @staticmethod
+    def _unwrap_proxy_type(pod_type: type) -> type:
+        """Return the original class if *pod_type* is an AOP dynamic proxy.
+
+        ``AspectPostProcessor`` runs before user-defined post-processors and
+        may replace a Pod with a dynamic subclass whose name ends with
+        ``@DynamicProxy``.  The proxy inherits from the original class, so
+        ``__bases__[0]`` recovers the registered controller type.
+
+        Args:
+            pod_type: The runtime type of the Pod instance.
+
+        Returns:
+            The original (non-proxy) controller class.
+        """
+        if pod_type.__name__.endswith(DYNAMIC_PROXY_CLASS_NAME_SUFFIX):
+            return pod_type.__bases__[0]
+        return pod_type
+
     def post_process(self, pod: object) -> object:
         """Register a gRPC service if *pod* is a ``@GrpcController``.
 
@@ -76,7 +96,7 @@ class RegisterServicesPostProcessor(
         if not GrpcController.exists(type(pod)):
             return pod
 
-        controller_type = type(pod)
+        controller_type = self._unwrap_proxy_type(type(pod))
         annotation = GrpcController.get(controller_type)
         package = annotation.package
         service_name = annotation.service_name or controller_type.__name__

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/register_services.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/post_processors/register_services.py
@@ -1,0 +1,106 @@
+"""Post-processor for registering gRPC services from controllers.
+
+Scans ``@GrpcController``-decorated Pods, builds protobuf descriptors
+at runtime, and registers generic RPC handlers on the ``grpc.aio.Server``.
+"""
+
+from logging import getLogger
+
+import grpc.aio
+from spakky.core.pod.annotations.order import Order
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.aware.application_context_aware import (
+    IApplicationContextAware,
+)
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.core.pod.interfaces.post_processor import IPostProcessor
+
+from spakky.plugins.grpc.handler import GrpcServiceHandler
+from spakky.plugins.grpc.schema.descriptor_builder import build_file_descriptor
+from spakky.plugins.grpc.schema.registry import DescriptorRegistry
+from spakky.plugins.grpc.stereotypes.grpc_controller import GrpcController
+
+logger = getLogger(__name__)
+
+
+@Order(0)
+@Pod()
+class RegisterServicesPostProcessor(
+    IPostProcessor, IContainerAware, IApplicationContextAware
+):
+    """Post-processor that registers gRPC services from controllers.
+
+    When a ``@GrpcController`` Pod is created, this processor:
+
+    1. Builds a ``FileDescriptorProto`` from the controller's ``@rpc``
+       methods and dataclass message types.
+    2. Registers the descriptor in the shared ``DescriptorRegistry``.
+    3. Creates a ``GrpcServiceHandler`` (generic handler) and adds it
+       to the ``grpc.aio.Server``.
+
+    Runs at ``@Order(0)`` — first in the gRPC post-processor chain.
+    """
+
+    __container: IContainer
+    __application_context: IApplicationContext
+
+    def set_container(self, container: IContainer) -> None:
+        """Inject the IoC container.
+
+        Args:
+            container: The IoC container.
+        """
+        self.__container = container
+
+    def set_application_context(self, application_context: IApplicationContext) -> None:
+        """Inject the application context.
+
+        Args:
+            application_context: The application context.
+        """
+        self.__application_context = application_context
+
+    def post_process(self, pod: object) -> object:
+        """Register a gRPC service if *pod* is a ``@GrpcController``.
+
+        Non-controller Pods are returned unchanged.
+
+        Args:
+            pod: The Pod instance to process.
+
+        Returns:
+            The unmodified Pod.
+        """
+        if not GrpcController.exists(type(pod)):
+            return pod
+
+        controller_type = type(pod)
+        annotation = GrpcController.get(controller_type)
+        package = annotation.package
+        service_name = annotation.service_name or controller_type.__name__
+
+        file_desc = build_file_descriptor(controller_type)
+
+        registry = self.__container.get(DescriptorRegistry)
+        if not registry.is_registered(file_desc.name):
+            registry.register(file_desc)
+
+        handler = GrpcServiceHandler(
+            controller_type=controller_type,
+            package=package,
+            service_name=service_name,
+            container=self.__container,
+            application_context=self.__application_context,
+            registry=registry,
+        )
+
+        server = self.__container.get(grpc.aio.Server)
+        server.add_generic_rpc_handlers([handler])
+
+        logger.info(
+            f"Registered gRPC service {package}.{service_name} "
+            f"from {controller_type.__qualname__}"
+        )
+        return pod

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/schema/descriptor_builder.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/schema/descriptor_builder.py
@@ -13,6 +13,7 @@ from google.protobuf.descriptor_pb2 import (
     FieldDescriptorProto,
     FileDescriptorProto,
     MethodDescriptorProto,
+    OneofDescriptorProto,
     ServiceDescriptorProto,
 )
 from spakky.plugins.grpc.decorators.rpc import Rpc
@@ -69,6 +70,9 @@ def build_message_descriptor(
         elif resolved.is_optional:
             field_desc.label = FieldDescriptorProto.LABEL_OPTIONAL
             field_desc.proto3_optional = True
+            oneof_index = len(descriptor.oneof_decl)
+            descriptor.oneof_decl.append(OneofDescriptorProto(name=f"__{field.name}"))
+            field_desc.oneof_index = oneof_index
         else:
             field_desc.label = FieldDescriptorProto.LABEL_OPTIONAL
 

--- a/plugins/spakky-grpc/tests/unit/conftest.py
+++ b/plugins/spakky-grpc/tests/unit/conftest.py
@@ -8,7 +8,6 @@ import grpc.aio
 import pytest
 from spakky.core.pod.interfaces.application_context import IApplicationContext
 from spakky.core.pod.interfaces.container import IContainer
-
 from spakky.plugins.grpc.annotations.field import ProtoField
 from spakky.plugins.grpc.decorators.rpc import rpc
 from spakky.plugins.grpc.schema.registry import DescriptorRegistry

--- a/plugins/spakky-grpc/tests/unit/conftest.py
+++ b/plugins/spakky-grpc/tests/unit/conftest.py
@@ -1,0 +1,67 @@
+"""Shared fixtures for gRPC PostProcessor and handler tests."""
+
+from dataclasses import dataclass
+from typing import Annotated
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc.aio
+import pytest
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.container import IContainer
+
+from spakky.plugins.grpc.annotations.field import ProtoField
+from spakky.plugins.grpc.decorators.rpc import rpc
+from spakky.plugins.grpc.schema.registry import DescriptorRegistry
+from spakky.plugins.grpc.stereotypes.grpc_controller import GrpcController
+
+
+@dataclass
+class HelloRequest:
+    """Test request message."""
+
+    name: Annotated[str, ProtoField(number=1)]
+
+
+@dataclass
+class HelloReply:
+    """Test response message."""
+
+    message: Annotated[str, ProtoField(number=1)]
+
+
+@GrpcController(package="test.v1")
+class GreeterController:
+    """Test gRPC controller."""
+
+    @rpc()
+    async def say_hello(self, request: HelloRequest) -> HelloReply:
+        """Simple unary RPC."""
+        return HelloReply(message=f"Hello {request.name}")
+
+
+@pytest.fixture
+def container() -> MagicMock:
+    """Create a mock IContainer."""
+    return MagicMock(spec=IContainer)
+
+
+@pytest.fixture
+def application_context() -> MagicMock:
+    """Create a mock IApplicationContext."""
+    ctx = MagicMock(spec=IApplicationContext)
+    ctx.get_or_none = MagicMock(return_value=None)
+    return ctx
+
+
+@pytest.fixture
+def registry() -> DescriptorRegistry:
+    """Create a fresh DescriptorRegistry."""
+    return DescriptorRegistry()
+
+
+@pytest.fixture
+def server() -> AsyncMock:
+    """Create a mock grpc.aio.Server."""
+    mock = AsyncMock(spec=grpc.aio.Server)
+    mock.add_generic_rpc_handlers = MagicMock()
+    return mock

--- a/plugins/spakky-grpc/tests/unit/test_add_interceptors.py
+++ b/plugins/spakky-grpc/tests/unit/test_add_interceptors.py
@@ -1,0 +1,94 @@
+"""Unit tests for AddInterceptorsPostProcessor."""
+
+from unittest.mock import MagicMock, patch
+
+import grpc.aio
+import pytest
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.container import IContainer
+
+from spakky.plugins.grpc.interceptors.error_handling import ErrorHandlingInterceptor
+from spakky.plugins.grpc.interceptors.tracing import TracingInterceptor
+from spakky.plugins.grpc.post_processors.add_interceptors import (
+    AddInterceptorsPostProcessor,
+)
+from spakky.tracing.propagator import ITracePropagator
+
+
+@pytest.fixture
+def processor() -> AddInterceptorsPostProcessor:
+    """Create a configured AddInterceptorsPostProcessor (no tracing)."""
+    proc = AddInterceptorsPostProcessor.__new__(AddInterceptorsPostProcessor)
+    container = MagicMock(spec=IContainer)
+    application_context = MagicMock(spec=IApplicationContext)
+    application_context.get_or_none = MagicMock(return_value=None)
+    proc.set_container(container)
+    proc.set_application_context(application_context)
+    return proc
+
+
+@pytest.fixture
+def processor_with_tracing() -> AddInterceptorsPostProcessor:
+    """Create AddInterceptorsPostProcessor with a trace propagator available."""
+    proc = AddInterceptorsPostProcessor.__new__(AddInterceptorsPostProcessor)
+    container = MagicMock(spec=IContainer)
+    propagator = MagicMock(spec=ITracePropagator)
+    application_context = MagicMock(spec=IApplicationContext)
+    application_context.get_or_none = MagicMock(return_value=propagator)
+    proc.set_container(container)
+    proc.set_application_context(application_context)
+    return proc
+
+
+def test_add_interceptors_skips_non_server(
+    processor: AddInterceptorsPostProcessor,
+) -> None:
+    """Non-server Pods should be returned unchanged."""
+    plain_pod = object()
+    result = processor.post_process(plain_pod)
+    assert result is plain_pod
+
+
+def test_add_interceptors_replaces_server_with_interceptor_equipped_server(
+    processor: AddInterceptorsPostProcessor,
+) -> None:
+    """Server Pod should be replaced with a new server that has interceptors."""
+    original_server = grpc.aio.server()
+
+    with patch(
+        "spakky.plugins.grpc.post_processors.add_interceptors.grpc.aio.server"
+    ) as mock_server_factory:
+        new_server = MagicMock(spec=grpc.aio.Server)
+        mock_server_factory.return_value = new_server
+
+        result = processor.post_process(original_server)
+
+        mock_server_factory.assert_called_once()
+        call_kwargs = mock_server_factory.call_args
+        interceptors = call_kwargs.kwargs.get(
+            "interceptors", call_kwargs.args[0] if call_kwargs.args else []
+        )
+        assert len(interceptors) == 1
+        assert isinstance(interceptors[0], ErrorHandlingInterceptor)
+        assert result is new_server
+
+
+def test_add_interceptors_includes_tracing_when_propagator_available(
+    processor_with_tracing: AddInterceptorsPostProcessor,
+) -> None:
+    """Server should have both error handling and tracing interceptors when propagator exists."""
+    original_server = grpc.aio.server()
+
+    with patch(
+        "spakky.plugins.grpc.post_processors.add_interceptors.grpc.aio.server"
+    ) as mock_server_factory:
+        new_server = MagicMock(spec=grpc.aio.Server)
+        mock_server_factory.return_value = new_server
+
+        processor_with_tracing.post_process(original_server)
+
+        call_kwargs = mock_server_factory.call_args
+        interceptors = call_kwargs.kwargs.get("interceptors", [])
+        assert len(interceptors) == 2
+        assert isinstance(interceptors[0], ErrorHandlingInterceptor)
+        assert isinstance(interceptors[1], TracingInterceptor)

--- a/plugins/spakky-grpc/tests/unit/test_add_interceptors.py
+++ b/plugins/spakky-grpc/tests/unit/test_add_interceptors.py
@@ -6,7 +6,6 @@ import grpc.aio
 import pytest
 from spakky.core.pod.interfaces.application_context import IApplicationContext
 from spakky.core.pod.interfaces.container import IContainer
-
 from spakky.plugins.grpc.interceptors.error_handling import ErrorHandlingInterceptor
 from spakky.plugins.grpc.interceptors.tracing import TracingInterceptor
 from spakky.plugins.grpc.post_processors.add_interceptors import (

--- a/plugins/spakky-grpc/tests/unit/test_bind_server.py
+++ b/plugins/spakky-grpc/tests/unit/test_bind_server.py
@@ -1,12 +1,12 @@
 """Unit tests for BindServerPostProcessor."""
 
+from asyncio import Event as AsyncEvent
 from unittest.mock import MagicMock
 
 import grpc.aio
 import pytest
 from spakky.core.pod.interfaces.application_context import IApplicationContext
 from spakky.core.pod.interfaces.container import IContainer
-
 from spakky.plugins.grpc.post_processors.bind_server import (
     BindServerPostProcessor,
     GrpcServerService,
@@ -19,6 +19,7 @@ def processor() -> BindServerPostProcessor:
     proc = BindServerPostProcessor.__new__(BindServerPostProcessor)
     container = MagicMock(spec=IContainer)
     application_context = MagicMock(spec=IApplicationContext)
+    application_context.task_stop_event = AsyncEvent()
     proc.set_container(container)
     proc.set_application_context(application_context)
     return proc

--- a/plugins/spakky-grpc/tests/unit/test_bind_server.py
+++ b/plugins/spakky-grpc/tests/unit/test_bind_server.py
@@ -1,0 +1,90 @@
+"""Unit tests for BindServerPostProcessor."""
+
+from unittest.mock import MagicMock
+
+import grpc.aio
+import pytest
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.container import IContainer
+
+from spakky.plugins.grpc.post_processors.bind_server import (
+    BindServerPostProcessor,
+    GrpcServerService,
+)
+
+
+@pytest.fixture
+def processor() -> BindServerPostProcessor:
+    """Create a configured BindServerPostProcessor."""
+    proc = BindServerPostProcessor.__new__(BindServerPostProcessor)
+    container = MagicMock(spec=IContainer)
+    application_context = MagicMock(spec=IApplicationContext)
+    proc.set_container(container)
+    proc.set_application_context(application_context)
+    return proc
+
+
+def test_bind_server_skips_non_server(
+    processor: BindServerPostProcessor,
+) -> None:
+    """Non-server Pods should be returned unchanged."""
+    plain_pod = object()
+    result = processor.post_process(plain_pod)
+    assert result is plain_pod
+
+
+def test_bind_server_registers_service_for_server_pod(
+    processor: BindServerPostProcessor,
+) -> None:
+    """Server Pod should be registered as a service in the application context."""
+    server = MagicMock(spec=grpc.aio.Server)
+
+    result = processor.post_process(server)
+
+    assert result is server
+    app_ctx = (
+        processor._BindServerPostProcessor__application_context  # pyrefly: ignore - name-mangled private attr access
+    )
+    app_ctx.add_service.assert_called_once()
+    service_arg = app_ctx.add_service.call_args[0][0]
+    assert isinstance(service_arg, GrpcServerService)
+
+
+async def test_grpc_server_service_start_calls_server_start() -> None:
+    """GrpcServerService.start_async() should start the underlying server."""
+    server = MagicMock(spec=grpc.aio.Server)
+    server.start = MagicMock(return_value=_coro(None))
+    service = GrpcServerService(server)
+
+    await service.start_async()
+
+    server.start.assert_called_once()
+
+
+async def test_grpc_server_service_stop_calls_server_stop() -> None:
+    """GrpcServerService.stop_async() should stop the underlying server with grace."""
+    server = MagicMock(spec=grpc.aio.Server)
+    server.stop = MagicMock(return_value=_coro(None))
+    service = GrpcServerService(server)
+
+    await service.stop_async()
+
+    server.stop.assert_called_once_with(grace=5.0)
+
+
+def test_grpc_server_service_set_stop_event() -> None:
+    """GrpcServerService should accept a stop event."""
+    import asyncio
+
+    server = MagicMock(spec=grpc.aio.Server)
+    service = GrpcServerService(server)
+    event = asyncio.Event()
+
+    service.set_stop_event(event)
+
+    assert service._stop_event is event
+
+
+async def _coro(value: object) -> object:
+    """Helper to create a simple coroutine returning a value."""
+    return value

--- a/plugins/spakky-grpc/tests/unit/test_handler.py
+++ b/plugins/spakky-grpc/tests/unit/test_handler.py
@@ -16,6 +16,7 @@ from spakky.plugins.grpc.handler import (
     GrpcServiceHandler,
     _convert_proto_value,
     _dataclass_to_protobuf,
+    _is_optional,
     _protobuf_to_dataclass,
     _unwrap_annotated,
 )
@@ -500,3 +501,187 @@ def test_convert_proto_value_converts_list_of_messages() -> None:
     assert len(result) == 1
     assert isinstance(result[0], PingRequest)
     assert result[0].value == "item"
+
+
+# ------------------------------------------------------------------
+# _is_optional detection
+# ------------------------------------------------------------------
+
+
+def test_is_optional_detects_optional_type() -> None:
+    """_is_optional should return True for Optional[T] and T | None."""
+    from typing import Optional
+
+    assert _is_optional(Optional[str]) is True
+    assert _is_optional(str | None) is True
+    assert _is_optional(str) is False
+    assert _is_optional(int) is False
+    assert _is_optional(list[str]) is False
+
+
+# ------------------------------------------------------------------
+# _protobuf_to_dataclass: Optional field with HasField
+# ------------------------------------------------------------------
+
+
+@dataclass
+class OptionalMsg:
+    """Message with optional fields for HasField testing."""
+
+    name: Annotated[str, ProtoField(number=1)]
+    nickname: Annotated[str | None, ProtoField(number=2)]
+
+
+@GrpcController(package="optional.v1", service_name="OptionalSvc")
+class OptionalController:
+    """Controller using optional fields."""
+
+    @rpc()
+    async def echo(self, request: OptionalMsg) -> OptionalMsg:
+        """Echo optional message."""
+        return request
+
+
+def test_protobuf_to_dataclass_optional_field_unset_expect_none() -> None:
+    """_protobuf_to_dataclass should map unset proto3 optional fields to None."""
+    registry = _build_registry_for(OptionalController)
+    msg_class = registry.get_message_class("optional.v1.OptionalMsg")
+
+    proto = msg_class()
+    proto.name = "test"  # pyrefly: ignore - dynamic protobuf attr
+    # nickname is NOT set — should decode as None
+
+    result = _protobuf_to_dataclass(proto, OptionalMsg)
+    assert isinstance(result, OptionalMsg)
+    assert result.name == "test"
+    assert result.nickname is None
+
+
+def test_protobuf_to_dataclass_optional_field_set_expect_value() -> None:
+    """_protobuf_to_dataclass should decode set proto3 optional fields."""
+    registry = _build_registry_for(OptionalController)
+    msg_class = registry.get_message_class("optional.v1.OptionalMsg")
+
+    proto = msg_class()
+    proto.name = "test"  # pyrefly: ignore - dynamic protobuf attr
+    proto.nickname = "nick"  # pyrefly: ignore - dynamic protobuf attr
+
+    result = _protobuf_to_dataclass(proto, OptionalMsg)
+    assert isinstance(result, OptionalMsg)
+    assert result.name == "test"
+    assert result.nickname == "nick"
+
+
+def test_protobuf_to_dataclass_optional_field_set_to_default_expect_default() -> None:
+    """_protobuf_to_dataclass should preserve explicitly set default values."""
+    registry = _build_registry_for(OptionalController)
+    msg_class = registry.get_message_class("optional.v1.OptionalMsg")
+
+    proto = msg_class()
+    proto.name = "test"  # pyrefly: ignore - dynamic protobuf attr
+    proto.nickname = ""  # pyrefly: ignore - explicitly set to empty string
+
+    result = _protobuf_to_dataclass(proto, OptionalMsg)
+    assert isinstance(result, OptionalMsg)
+    assert result.nickname == ""
+
+
+# ------------------------------------------------------------------
+# _convert_proto_value: repeated field from protobuf container
+# ------------------------------------------------------------------
+
+
+def test_convert_proto_value_repeated_scalar_from_protobuf_expect_list() -> None:
+    """_convert_proto_value should convert repeated protobuf container to list."""
+    registry = _build_registry_for(NestedController)
+    msg_class = registry.get_message_class("nested.v1.OuterMsg")
+
+    proto = msg_class()
+    proto.tags.append("a")  # pyrefly: ignore - dynamic protobuf attr
+    proto.tags.append("b")  # pyrefly: ignore - dynamic protobuf attr
+
+    # proto.tags is a RepeatedScalarFieldContainer, not list
+    result = _convert_proto_value(
+        proto.tags,  # pyrefly: ignore - dynamic protobuf attr
+        list[str],
+    )
+    assert isinstance(result, list)
+    assert result == ["a", "b"]
+
+
+# ------------------------------------------------------------------
+# _dataclass_to_protobuf: repeated message fields (list[dataclass])
+# ------------------------------------------------------------------
+
+
+@dataclass
+class ItemMsg:
+    """Repeated element message."""
+
+    label: Annotated[str, ProtoField(number=1)]
+
+
+@dataclass
+class ContainerMsg:
+    """Message with a repeated message field."""
+
+    items: Annotated[list[ItemMsg], ProtoField(number=1)]
+
+
+@GrpcController(package="repeated.v1", service_name="RepeatedSvc")
+class RepeatedMsgController:
+    """Controller using repeated message fields."""
+
+    @rpc()
+    async def echo(self, request: ContainerMsg) -> ContainerMsg:
+        """Echo container message."""
+        return request
+
+
+def test_dataclass_to_protobuf_repeated_message_expect_converted() -> None:
+    """_dataclass_to_protobuf should convert list[dataclass] to repeated message."""
+    registry = _build_registry_for(RepeatedMsgController)
+    msg_class = registry.get_message_class("repeated.v1.ContainerMsg")
+
+    src = ContainerMsg(items=[ItemMsg(label="a"), ItemMsg(label="b")])
+    proto = _dataclass_to_protobuf(src, msg_class)
+
+    assert len(proto.items) == 2  # pyrefly: ignore - dynamic protobuf attr
+    assert proto.items[0].label == "a"  # pyrefly: ignore - dynamic protobuf attr
+    assert proto.items[1].label == "b"  # pyrefly: ignore - dynamic protobuf attr
+
+
+def test_protobuf_to_dataclass_repeated_message_expect_converted() -> None:
+    """_protobuf_to_dataclass should convert repeated message to list[dataclass]."""
+    registry = _build_registry_for(RepeatedMsgController)
+    msg_class = registry.get_message_class("repeated.v1.ContainerMsg")
+
+    proto = msg_class()
+    item1 = proto.items.add()  # pyrefly: ignore - dynamic protobuf attr
+    item1.label = "x"  # pyrefly: ignore - dynamic protobuf attr
+    item2 = proto.items.add()  # pyrefly: ignore - dynamic protobuf attr
+    item2.label = "y"  # pyrefly: ignore - dynamic protobuf attr
+
+    result = _protobuf_to_dataclass(proto, ContainerMsg)
+    assert isinstance(result, ContainerMsg)
+    assert len(result.items) == 2
+    assert result.items[0].label == "x"
+    assert result.items[1].label == "y"
+
+
+def test_roundtrip_repeated_message_field() -> None:
+    """Round-trip: list[dataclass] → protobuf repeated message → list[dataclass]."""
+    registry = _build_registry_for(RepeatedMsgController)
+    msg_class = registry.get_message_class("repeated.v1.ContainerMsg")
+
+    original = ContainerMsg(items=[ItemMsg(label="one"), ItemMsg(label="two")])
+    proto = _dataclass_to_protobuf(original, msg_class)
+    raw = proto.SerializeToString()
+
+    restored_proto = msg_class()
+    restored_proto.ParseFromString(raw)
+    result = _protobuf_to_dataclass(restored_proto, ContainerMsg)
+    assert isinstance(result, ContainerMsg)
+    assert len(result.items) == 2
+    assert result.items[0].label == "one"
+    assert result.items[1].label == "two"

--- a/plugins/spakky-grpc/tests/unit/test_handler.py
+++ b/plugins/spakky-grpc/tests/unit/test_handler.py
@@ -1,0 +1,467 @@
+"""Unit tests for GrpcServiceHandler."""
+
+from collections.abc import AsyncGenerator, AsyncIterator
+from dataclasses import dataclass
+from typing import Annotated
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc
+import grpc.aio
+import pytest
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.container import IContainer
+
+from spakky.plugins.grpc.annotations.field import ProtoField
+from spakky.plugins.grpc.decorators.rpc import RpcMethodType, rpc
+from spakky.plugins.grpc.handler import (
+    GrpcServiceHandler,
+    _convert_proto_value,
+    _dataclass_to_protobuf,
+    _protobuf_to_dataclass,
+)
+from spakky.plugins.grpc.schema.descriptor_builder import build_file_descriptor
+from spakky.plugins.grpc.schema.registry import DescriptorRegistry
+from spakky.plugins.grpc.stereotypes.grpc_controller import GrpcController
+
+
+@dataclass
+class PingRequest:
+    """Test request."""
+
+    value: Annotated[str, ProtoField(number=1)]
+
+
+@dataclass
+class PingReply:
+    """Test response."""
+
+    value: Annotated[str, ProtoField(number=1)]
+
+
+@GrpcController(package="handler.v1")
+class PingController:
+    """Controller with a unary method for handler tests."""
+
+    @rpc()
+    async def ping(self, request: PingRequest) -> PingReply:
+        """Echo the value back."""
+        return PingReply(value=request.value)
+
+
+@GrpcController(package="handler.v1", service_name="MultiRpc")
+class MultiRpcController:
+    """Controller with multiple RPC method types."""
+
+    @rpc(method_type=RpcMethodType.UNARY)
+    async def unary_method(self, request: PingRequest) -> PingReply:
+        """Unary RPC."""
+        return PingReply(value=request.value)
+
+    @rpc(method_type=RpcMethodType.SERVER_STREAMING, response_type=PingReply)
+    async def server_stream_method(
+        self, request: PingRequest
+    ) -> AsyncGenerator[PingReply, None]:
+        """Server streaming RPC."""
+        yield PingReply(value=request.value)  # type: ignore[misc] — async generator for test
+
+    def not_an_rpc(self) -> None:
+        """Regular method, not decorated with @rpc."""
+
+
+def _build_registry_for(controller_type: type) -> DescriptorRegistry:
+    """Build and register descriptors for a controller type."""
+    registry = DescriptorRegistry()
+    file_desc = build_file_descriptor(controller_type)
+    registry.register(file_desc)
+    return registry
+
+
+def _make_call_details(method: str) -> MagicMock:
+    """Create mock HandlerCallDetails."""
+    details = MagicMock(spec=grpc.HandlerCallDetails)
+    details.method = method
+    return details
+
+
+@pytest.fixture
+def ping_handler() -> GrpcServiceHandler:
+    """Create a handler for PingController."""
+    registry = _build_registry_for(PingController)
+    container = MagicMock(spec=IContainer)
+    application_context = MagicMock(spec=IApplicationContext)
+    return GrpcServiceHandler(
+        controller_type=PingController,
+        package="handler.v1",
+        service_name="PingController",
+        container=container,
+        application_context=application_context,
+        registry=registry,
+    )
+
+
+@pytest.fixture
+def multi_handler() -> GrpcServiceHandler:
+    """Create a handler for MultiRpcController."""
+    registry = _build_registry_for(MultiRpcController)
+    container = MagicMock(spec=IContainer)
+    application_context = MagicMock(spec=IApplicationContext)
+    return GrpcServiceHandler(
+        controller_type=MultiRpcController,
+        package="handler.v1",
+        service_name="MultiRpc",
+        container=container,
+        application_context=application_context,
+        registry=registry,
+    )
+
+
+def test_handler_resolves_known_method(
+    ping_handler: GrpcServiceHandler,
+) -> None:
+    """Handler should return an RpcMethodHandler for a registered method."""
+    details = _make_call_details("/handler.v1.PingController/ping")
+    result = ping_handler.service(details)
+    assert result is not None
+
+
+def test_handler_returns_none_for_unknown_method(
+    ping_handler: GrpcServiceHandler,
+) -> None:
+    """Handler should return None for an unregistered method."""
+    details = _make_call_details("/handler.v1.PingController/nonexistent")
+    result = ping_handler.service(details)
+    assert result is None
+
+
+def test_handler_registers_only_rpc_methods(
+    multi_handler: GrpcServiceHandler,
+) -> None:
+    """Handler should register only @rpc-decorated methods."""
+    unary_details = _make_call_details("/handler.v1.MultiRpc/unary_method")
+    stream_details = _make_call_details("/handler.v1.MultiRpc/server_stream_method")
+    plain_details = _make_call_details("/handler.v1.MultiRpc/not_an_rpc")
+
+    assert multi_handler.service(unary_details) is not None
+    assert multi_handler.service(stream_details) is not None
+    assert multi_handler.service(plain_details) is None
+
+
+def test_handler_unary_method_has_correct_streaming_flags(
+    multi_handler: GrpcServiceHandler,
+) -> None:
+    """Unary method handler should have both streaming flags as False."""
+    details = _make_call_details("/handler.v1.MultiRpc/unary_method")
+    handler = multi_handler.service(details)
+    assert handler is not None
+    assert handler.request_streaming is False
+    assert handler.response_streaming is False
+
+
+def test_handler_server_streaming_method_has_correct_flags(
+    multi_handler: GrpcServiceHandler,
+) -> None:
+    """Server streaming handler should have response_streaming=True."""
+    details = _make_call_details("/handler.v1.MultiRpc/server_stream_method")
+    handler = multi_handler.service(details)
+    assert handler is not None
+    assert handler.request_streaming is False
+    assert handler.response_streaming is True
+
+
+async def test_handler_unary_behavior_calls_controller(
+    ping_handler: GrpcServiceHandler,
+) -> None:
+    """Unary handler should invoke the controller method and return result."""
+    reply = PingReply(value="pong")
+    mock_instance = MagicMock()
+    mock_instance.ping = AsyncMock(return_value=reply)
+    ping_handler._container.get.return_value = mock_instance
+
+    details = _make_call_details("/handler.v1.PingController/ping")
+    handler = ping_handler.service(details)
+    assert handler is not None
+
+    request_class = ping_handler._registry.get_message_class("handler.v1.PingRequest")
+    request_msg = request_class()
+    request_msg.value = "pong"  # pyrefly: ignore - dynamic protobuf attr
+    raw_bytes = request_msg.SerializeToString()
+
+    deserialized = handler.request_deserializer(  # pyrefly: ignore - callable at runtime after service() lookup
+        raw_bytes
+    )
+    context = AsyncMock(spec=grpc.aio.ServicerContext)
+    result = await handler.unary_unary(  # pyrefly: ignore - callable at runtime after service() lookup
+        deserialized, context
+    )
+    assert result is not None
+
+
+async def test_handler_serializer_produces_bytes(
+    ping_handler: GrpcServiceHandler,
+) -> None:
+    """Response serializer should produce bytes from a dataclass."""
+    details = _make_call_details("/handler.v1.PingController/ping")
+    handler = ping_handler.service(details)
+    assert handler is not None
+
+    reply = PingReply(value="hello")
+    serialized = handler.response_serializer(  # pyrefly: ignore - callable at runtime after service() lookup
+        reply
+    )
+    assert isinstance(serialized, bytes)
+    assert len(serialized) > 0
+
+
+async def test_handler_deserializer_produces_message(
+    ping_handler: GrpcServiceHandler,
+) -> None:
+    """Request deserializer should produce a protobuf Message from bytes."""
+    details = _make_call_details("/handler.v1.PingController/ping")
+    handler = ping_handler.service(details)
+    assert handler is not None
+
+    request_class = ping_handler._registry.get_message_class("handler.v1.PingRequest")
+    msg = request_class()
+    msg.value = "test"  # pyrefly: ignore - dynamic protobuf attr
+    raw = msg.SerializeToString()
+
+    result = handler.request_deserializer(  # pyrefly: ignore - callable at runtime after service() lookup
+        raw
+    )
+    assert hasattr(result, "value")
+    assert result.value == "test"
+
+
+# ------------------------------------------------------------------
+# Streaming handler tests (cover CLIENT_STREAMING and BIDI_STREAMING)
+# ------------------------------------------------------------------
+
+
+@GrpcController(package="stream.v1", service_name="StreamSvc")
+class StreamController:
+    """Controller with all four streaming patterns."""
+
+    @rpc(method_type=RpcMethodType.CLIENT_STREAMING, request_type=PingRequest)
+    async def client_stream(
+        self, request_iter: AsyncIterator[PingRequest]
+    ) -> PingReply:
+        """Client streaming RPC."""
+        last = PingReply(value="")
+        async for req in request_iter:
+            last = PingReply(value=req.value)
+        return last
+
+    @rpc(
+        method_type=RpcMethodType.BIDI_STREAMING,
+        request_type=PingRequest,
+        response_type=PingReply,
+    )
+    async def bidi_stream(
+        self, request_iter: AsyncIterator[PingRequest]
+    ) -> AsyncGenerator[PingReply, None]:
+        """Bidirectional streaming RPC."""
+        async for req in request_iter:
+            yield PingReply(value=req.value)
+
+
+@pytest.fixture
+def stream_handler() -> GrpcServiceHandler:
+    """Create a handler for StreamController."""
+    registry = _build_registry_for(StreamController)
+    container = MagicMock(spec=IContainer)
+    application_context = MagicMock(spec=IApplicationContext)
+    return GrpcServiceHandler(
+        controller_type=StreamController,
+        package="stream.v1",
+        service_name="StreamSvc",
+        container=container,
+        application_context=application_context,
+        registry=registry,
+    )
+
+
+def test_client_streaming_handler_has_correct_flags(
+    stream_handler: GrpcServiceHandler,
+) -> None:
+    """Client streaming handler should have request_streaming=True."""
+    details = _make_call_details("/stream.v1.StreamSvc/client_stream")
+    handler = stream_handler.service(details)
+    assert handler is not None
+    assert handler.request_streaming is True
+    assert handler.response_streaming is False
+
+
+def test_bidi_streaming_handler_has_correct_flags(
+    stream_handler: GrpcServiceHandler,
+) -> None:
+    """Bidi streaming handler should have both streaming flags True."""
+    details = _make_call_details("/stream.v1.StreamSvc/bidi_stream")
+    handler = stream_handler.service(details)
+    assert handler is not None
+    assert handler.request_streaming is True
+    assert handler.response_streaming is True
+
+
+# ------------------------------------------------------------------
+# Serializer / deserializer edge cases
+# ------------------------------------------------------------------
+
+
+async def test_serializer_handles_protobuf_message_directly(
+    ping_handler: GrpcServiceHandler,
+) -> None:
+    """Serializer should pass through if value is already a protobuf Message."""
+    details = _make_call_details("/handler.v1.PingController/ping")
+    handler = ping_handler.service(details)
+    assert handler is not None
+
+    msg_class = ping_handler._registry.get_message_class("handler.v1.PingReply")
+    proto_msg = msg_class()
+    proto_msg.value = "direct"  # pyrefly: ignore - dynamic protobuf attr
+    serialized = handler.response_serializer(  # pyrefly: ignore - callable at runtime after service() lookup
+        proto_msg
+    )
+    assert isinstance(serialized, bytes)
+
+
+def test_make_deserializer_returns_none_when_no_request_type() -> None:
+    """_make_deserializer should return None when request_type is None."""
+    registry = _build_registry_for(PingController)
+    container = MagicMock(spec=IContainer)
+    application_context = MagicMock(spec=IApplicationContext)
+    handler = GrpcServiceHandler(
+        controller_type=PingController,
+        package="handler.v1",
+        service_name="PingController",
+        container=container,
+        application_context=application_context,
+        registry=registry,
+    )
+    result = handler._make_deserializer(None)
+    assert result is None
+
+
+def test_make_serializer_returns_none_when_no_response_type() -> None:
+    """_make_serializer should return None when response_type is None."""
+    registry = _build_registry_for(PingController)
+    container = MagicMock(spec=IContainer)
+    application_context = MagicMock(spec=IApplicationContext)
+    handler = GrpcServiceHandler(
+        controller_type=PingController,
+        package="handler.v1",
+        service_name="PingController",
+        container=container,
+        application_context=application_context,
+        registry=registry,
+    )
+    result = handler._make_serializer(None)
+    assert result is None
+
+
+# ------------------------------------------------------------------
+# Conversion helpers: _dataclass_to_protobuf / _protobuf_to_dataclass
+# ------------------------------------------------------------------
+
+
+@dataclass
+class InnerMsg:
+    """Nested message type."""
+
+    text: Annotated[str, ProtoField(number=1)]
+
+
+@dataclass
+class OuterMsg:
+    """Message with a nested dataclass and a repeated field."""
+
+    inner: Annotated[InnerMsg, ProtoField(number=1)]
+    tags: Annotated[list[str], ProtoField(number=2)]
+
+
+@GrpcController(package="nested.v1", service_name="NestedSvc")
+class NestedController:
+    """Controller using nested/repeated messages."""
+
+    @rpc()
+    async def echo(self, request: OuterMsg) -> OuterMsg:
+        """Echo nested message."""
+        return request
+
+
+def test_dataclass_to_protobuf_with_nested_and_repeated() -> None:
+    """_dataclass_to_protobuf should handle nested dataclass and repeated fields."""
+    registry = _build_registry_for(NestedController)
+    msg_class = registry.get_message_class("nested.v1.OuterMsg")
+
+    src = OuterMsg(inner=InnerMsg(text="hi"), tags=["a", "b"])
+    proto = _dataclass_to_protobuf(src, msg_class)
+
+    assert proto.inner.text == "hi"  # pyrefly: ignore - dynamic protobuf attr
+    assert list(proto.tags) == ["a", "b"]  # pyrefly: ignore - dynamic protobuf attr
+
+
+def test_protobuf_to_dataclass_with_nested() -> None:
+    """_protobuf_to_dataclass should convert nested messages back to dataclasses."""
+    registry = _build_registry_for(NestedController)
+    msg_class = registry.get_message_class("nested.v1.OuterMsg")
+
+    proto = msg_class()
+    proto.inner.text = "world"  # pyrefly: ignore - dynamic protobuf attr
+    proto.tags.append("x")  # pyrefly: ignore - dynamic protobuf attr
+
+    result = _protobuf_to_dataclass(proto, OuterMsg)
+    assert isinstance(result, OuterMsg)
+
+
+def test_dataclass_to_protobuf_roundtrip_simple() -> None:
+    """Round-trip: dataclass → protobuf → bytes → protobuf → dataclass."""
+    registry = _build_registry_for(PingController)
+    msg_class = registry.get_message_class("handler.v1.PingReply")
+
+    original = PingReply(value="roundtrip")
+    proto = _dataclass_to_protobuf(original, msg_class)
+    raw = proto.SerializeToString()
+
+    restored_proto = msg_class()
+    restored_proto.ParseFromString(raw)
+    result = _protobuf_to_dataclass(restored_proto, PingReply)
+    assert isinstance(result, PingReply)
+    assert result.value == "roundtrip"
+
+
+# ------------------------------------------------------------------
+# Edge case: _convert_proto_value with nested Message + dataclass type
+# ------------------------------------------------------------------
+
+
+def test_convert_proto_value_nested_message_to_dataclass() -> None:
+    """_convert_proto_value should convert nested Message to dataclass."""
+    registry = _build_registry_for(NestedController)
+    outer_class = registry.get_message_class("nested.v1.OuterMsg")
+
+    proto = outer_class()
+    proto.inner.text = "nested"  # pyrefly: ignore - dynamic protobuf attr
+
+    inner_message = proto.inner  # pyrefly: ignore - dynamic protobuf attr
+    result = _convert_proto_value(inner_message, InnerMsg)
+    assert isinstance(result, InnerMsg)
+    assert result.text == "nested"
+
+
+# ------------------------------------------------------------------
+# Edge case: _dataclass_to_protobuf with None fields
+# ------------------------------------------------------------------
+
+
+def test_dataclass_to_protobuf_skips_none_fields() -> None:
+    """_dataclass_to_protobuf should skip fields when getattr returns None."""
+    registry = _build_registry_for(PingController)
+    msg_class = registry.get_message_class("handler.v1.PingReply")
+
+    # Create an object whose 'value' field returns None
+    mock_obj = MagicMock()
+    mock_obj.value = None
+
+    proto = _dataclass_to_protobuf(mock_obj, msg_class)
+    # Default proto3 value for string is ""
+    assert proto.value == ""  # pyrefly: ignore - dynamic protobuf attr

--- a/plugins/spakky-grpc/tests/unit/test_handler.py
+++ b/plugins/spakky-grpc/tests/unit/test_handler.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import grpc
 import grpc.aio
 import pytest
+from google.protobuf.message_factory import GetMessageClass
 from spakky.core.pod.interfaces.application_context import IApplicationContext
 from spakky.core.pod.interfaces.container import IContainer
 from spakky.plugins.grpc.annotations.field import ProtoField
@@ -685,3 +686,43 @@ def test_roundtrip_repeated_message_field() -> None:
     assert len(result.items) == 2
     assert result.items[0].label == "one"
     assert result.items[1].label == "two"
+
+
+def test_convert_proto_value_list_type_non_sequence_value_expect_passthrough() -> None:
+    """_convert_proto_value should return non-Sequence value unchanged even if target is list."""
+    result = _convert_proto_value(42, list[int])
+    assert result == 42
+
+
+def test_convert_proto_value_list_type_string_value_expect_passthrough() -> None:
+    """_convert_proto_value should return string unchanged even when target is list[str]."""
+    result = _convert_proto_value("hello", list[str])
+    assert result == "hello"
+
+
+def test_convert_proto_value_message_non_dataclass_target_expect_passthrough() -> None:
+    """_convert_proto_value should return Message unchanged when target is not a dataclass."""
+    registry = _build_registry_for(RepeatedMsgController)
+    msg_class = registry.get_message_class("repeated.v1.ItemMsg")
+    proto = msg_class()
+    proto.label = "test"  # pyrefly: ignore - dynamic protobuf attr
+
+    result = _convert_proto_value(proto, str)
+    assert result is proto
+
+
+def test_dataclass_to_protobuf_repeated_message_non_dataclass_expect_appended() -> None:
+    """_dataclass_to_protobuf should append non-dataclass items to repeated message field."""
+    registry = _build_registry_for(RepeatedMsgController)
+    msg_class = registry.get_message_class("repeated.v1.ContainerMsg")
+    nested_class = msg_class.DESCRIPTOR.fields_by_name["items"].message_type
+    nested_msg_class = GetMessageClass(nested_class)
+
+    raw_msg = nested_msg_class()
+    raw_msg.label = "raw"  # pyrefly: ignore - dynamic protobuf attr
+
+    src = ContainerMsg(items=[raw_msg])  # type: ignore[list-item] - intentional: testing non-dataclass Message in repeated field
+    proto = _dataclass_to_protobuf(src, msg_class)
+
+    assert len(proto.items) == 1  # pyrefly: ignore - dynamic protobuf attr
+    assert proto.items[0].label == "raw"  # pyrefly: ignore - dynamic protobuf attr

--- a/plugins/spakky-grpc/tests/unit/test_handler.py
+++ b/plugins/spakky-grpc/tests/unit/test_handler.py
@@ -10,7 +10,6 @@ import grpc.aio
 import pytest
 from spakky.core.pod.interfaces.application_context import IApplicationContext
 from spakky.core.pod.interfaces.container import IContainer
-
 from spakky.plugins.grpc.annotations.field import ProtoField
 from spakky.plugins.grpc.decorators.rpc import RpcMethodType, rpc
 from spakky.plugins.grpc.handler import (
@@ -18,6 +17,7 @@ from spakky.plugins.grpc.handler import (
     _convert_proto_value,
     _dataclass_to_protobuf,
     _protobuf_to_dataclass,
+    _unwrap_annotated,
 )
 from spakky.plugins.grpc.schema.descriptor_builder import build_file_descriptor
 from spakky.plugins.grpc.schema.registry import DescriptorRegistry
@@ -465,3 +465,38 @@ def test_dataclass_to_protobuf_skips_none_fields() -> None:
     proto = _dataclass_to_protobuf(mock_obj, msg_class)
     # Default proto3 value for string is ""
     assert proto.value == ""  # pyrefly: ignore - dynamic protobuf attr
+
+
+# ------------------------------------------------------------------
+# Annotated type unwrapping
+# ------------------------------------------------------------------
+
+
+def test_unwrap_annotated_extracts_inner_type() -> None:
+    """_unwrap_annotated should extract T from Annotated[T, ...]."""
+    annotated_type = Annotated[str, ProtoField(number=1)]
+    assert _unwrap_annotated(annotated_type) is str
+
+
+def test_unwrap_annotated_returns_plain_type_unchanged() -> None:
+    """_unwrap_annotated should return non-Annotated types as-is."""
+    assert _unwrap_annotated(int) is int
+
+
+# ------------------------------------------------------------------
+# _convert_proto_value: list branch
+# ------------------------------------------------------------------
+
+
+def test_convert_proto_value_converts_list_of_messages() -> None:
+    """_convert_proto_value should convert list[Message] to list[dataclass]."""
+    registry = _build_registry_for(PingController)
+    msg_class = registry.get_message_class("handler.v1.PingRequest")
+    msg = msg_class()
+    msg.value = "item"  # pyrefly: ignore - dynamic protobuf attr
+
+    result = _convert_proto_value([msg], list[PingRequest])
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], PingRequest)
+    assert result[0].value == "item"

--- a/plugins/spakky-grpc/tests/unit/test_main.py
+++ b/plugins/spakky-grpc/tests/unit/test_main.py
@@ -1,0 +1,42 @@
+"""Unit tests for gRPC plugin main.py initialize function."""
+
+from unittest.mock import MagicMock, call
+
+from spakky.core.application.application import SpakkyApplication
+
+from spakky.plugins.grpc.main import initialize
+from spakky.plugins.grpc.post_processors.add_interceptors import (
+    AddInterceptorsPostProcessor,
+)
+from spakky.plugins.grpc.post_processors.bind_server import (
+    BindServerPostProcessor,
+)
+from spakky.plugins.grpc.post_processors.register_services import (
+    RegisterServicesPostProcessor,
+)
+
+
+def test_initialize_registers_all_post_processors() -> None:
+    """initialize() should register all three PostProcessors."""
+    app = MagicMock(spec=SpakkyApplication)
+
+    initialize(app)
+
+    app.add.assert_any_call(RegisterServicesPostProcessor)
+    app.add.assert_any_call(AddInterceptorsPostProcessor)
+    app.add.assert_any_call(BindServerPostProcessor)
+    assert app.add.call_count == 3
+
+
+def test_initialize_registration_order() -> None:
+    """PostProcessors should be registered in the expected order."""
+    app = MagicMock(spec=SpakkyApplication)
+
+    initialize(app)
+
+    expected_calls = [
+        call(RegisterServicesPostProcessor),
+        call(AddInterceptorsPostProcessor),
+        call(BindServerPostProcessor),
+    ]
+    app.add.assert_has_calls(expected_calls, any_order=False)

--- a/plugins/spakky-grpc/tests/unit/test_main.py
+++ b/plugins/spakky-grpc/tests/unit/test_main.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock, call
 
 from spakky.core.application.application import SpakkyApplication
-
 from spakky.plugins.grpc.main import initialize
 from spakky.plugins.grpc.post_processors.add_interceptors import (
     AddInterceptorsPostProcessor,

--- a/plugins/spakky-grpc/tests/unit/test_register_services.py
+++ b/plugins/spakky-grpc/tests/unit/test_register_services.py
@@ -1,0 +1,90 @@
+"""Unit tests for RegisterServicesPostProcessor."""
+
+from unittest.mock import MagicMock
+
+import grpc.aio
+import pytest
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.container import IContainer
+
+from spakky.plugins.grpc.post_processors.register_services import (
+    RegisterServicesPostProcessor,
+)
+from spakky.plugins.grpc.schema.registry import DescriptorRegistry
+
+from tests.unit.conftest import GreeterController
+
+
+@pytest.fixture
+def processor() -> RegisterServicesPostProcessor:
+    """Create a configured RegisterServicesPostProcessor."""
+    proc = RegisterServicesPostProcessor.__new__(RegisterServicesPostProcessor)
+
+    container = MagicMock(spec=IContainer)
+    application_context = MagicMock(spec=IApplicationContext)
+    registry = DescriptorRegistry()
+    server = MagicMock(spec=grpc.aio.Server)
+    server.add_generic_rpc_handlers = MagicMock()
+
+    def get_side_effect(type_: type, name: str | None = None) -> object:
+        if type_ is DescriptorRegistry:
+            return registry
+        if type_ is grpc.aio.Server:
+            return server
+        return MagicMock()
+
+    container.get = MagicMock(side_effect=get_side_effect)
+
+    proc.set_container(container)
+    proc.set_application_context(application_context)
+    return proc
+
+
+def test_register_services_skips_non_controller(
+    processor: RegisterServicesPostProcessor,
+) -> None:
+    """Non-controller Pods should be returned unchanged."""
+    plain_pod = object()
+    result = processor.post_process(plain_pod)
+    assert result is plain_pod
+
+
+def test_register_services_processes_grpc_controller(
+    processor: RegisterServicesPostProcessor,
+) -> None:
+    """@GrpcController Pod should trigger service registration."""
+    controller_instance = GreeterController()
+    result = processor.post_process(controller_instance)
+
+    assert result is controller_instance
+    container = (
+        processor._RegisterServicesPostProcessor__container  # pyrefly: ignore - name-mangled private attr access
+    )
+    server = container.get(grpc.aio.Server)
+    server.add_generic_rpc_handlers.assert_called_once()
+
+
+def test_register_services_registers_descriptor_in_registry(
+    processor: RegisterServicesPostProcessor,
+) -> None:
+    """Processing a controller should register its descriptor."""
+    controller_instance = GreeterController()
+    processor.post_process(controller_instance)
+
+    container = (
+        processor._RegisterServicesPostProcessor__container  # pyrefly: ignore - name-mangled private attr access
+    )
+    registry: DescriptorRegistry = container.get(DescriptorRegistry)
+    assert registry.is_registered("test/v1/GreeterController.proto")
+
+
+def test_register_services_skips_already_registered_descriptor(
+    processor: RegisterServicesPostProcessor,
+) -> None:
+    """Processing the same controller twice should not raise."""
+    controller_instance = GreeterController()
+    processor.post_process(controller_instance)
+
+    controller_instance_2 = GreeterController()
+    result = processor.post_process(controller_instance_2)
+    assert result is controller_instance_2

--- a/plugins/spakky-grpc/tests/unit/test_register_services.py
+++ b/plugins/spakky-grpc/tests/unit/test_register_services.py
@@ -6,7 +6,6 @@ import grpc.aio
 import pytest
 from spakky.core.pod.interfaces.application_context import IApplicationContext
 from spakky.core.pod.interfaces.container import IContainer
-
 from spakky.plugins.grpc.post_processors.register_services import (
     RegisterServicesPostProcessor,
 )

--- a/plugins/spakky-grpc/tests/unit/test_register_services.py
+++ b/plugins/spakky-grpc/tests/unit/test_register_services.py
@@ -1,9 +1,11 @@
 """Unit tests for RegisterServicesPostProcessor."""
 
+from types import new_class
 from unittest.mock import MagicMock
 
 import grpc.aio
 import pytest
+from spakky.core.common.constants import DYNAMIC_PROXY_CLASS_NAME_SUFFIX
 from spakky.core.pod.interfaces.application_context import IApplicationContext
 from spakky.core.pod.interfaces.container import IContainer
 from spakky.plugins.grpc.post_processors.register_services import (
@@ -87,3 +89,39 @@ def test_register_services_skips_already_registered_descriptor(
     controller_instance_2 = GreeterController()
     result = processor.post_process(controller_instance_2)
     assert result is controller_instance_2
+
+
+def test_register_services_unwraps_aop_proxy_type(
+    processor: RegisterServicesPostProcessor,
+) -> None:
+    """AOP proxy Pod should be unwrapped to the original controller type."""
+    proxy_class = new_class(
+        GreeterController.__name__ + DYNAMIC_PROXY_CLASS_NAME_SUFFIX,
+        bases=(GreeterController,),
+    )
+    proxy_instance = object.__new__(proxy_class)
+
+    result = processor.post_process(proxy_instance)
+    assert result is proxy_instance
+
+    container = (
+        processor._RegisterServicesPostProcessor__container  # pyrefly: ignore - name-mangled private attr access
+    )
+    server = container.get(grpc.aio.Server)
+    server.add_generic_rpc_handlers.assert_called_once()
+
+
+def test_unwrap_proxy_type_returns_original_class() -> None:
+    """_unwrap_proxy_type should strip the @DynamicProxy suffix."""
+    proxy_class = new_class(
+        GreeterController.__name__ + DYNAMIC_PROXY_CLASS_NAME_SUFFIX,
+        bases=(GreeterController,),
+    )
+    result = RegisterServicesPostProcessor._unwrap_proxy_type(proxy_class)
+    assert result is GreeterController
+
+
+def test_unwrap_proxy_type_returns_non_proxy_unchanged() -> None:
+    """_unwrap_proxy_type should return non-proxy types unchanged."""
+    result = RegisterServicesPostProcessor._unwrap_proxy_type(GreeterController)
+    assert result is GreeterController


### PR DESCRIPTION
## Summary

Closes #86

`spakky-grpc` 플러그인의 PostProcessor를 구현하여 동적 서비스 등록, 인터셉터 적용, 서버 라이프사이클 관리를 수행합니다.

## Changes

### New Files

- **`handler.py`** — `GrpcServiceHandler(grpc.GenericRpcHandler)`: 런타임 protobuf 디스크립터 기반으로 gRPC 요청을 `@GrpcController` 메서드에 디스패치. 4가지 스트리밍 패턴(UNARY, SERVER_STREAMING, CLIENT_STREAMING, BIDI_STREAMING) 지원. protobuf ↔ dataclass 자동 변환.
- **`post_processors/register_services.py`** — `RegisterServicesPostProcessor(@Order(0))`: `@GrpcController` Pod 감지 시 FileDescriptorProto 빌드 → DescriptorRegistry 등록 → GrpcServiceHandler 생성 → `grpc.aio.Server`에 추가
- **`post_processors/add_interceptors.py`** — `AddInterceptorsPostProcessor(@Order(1))`: `grpc.aio.Server` Pod 감지 시 `ErrorHandlingInterceptor` + (선택적) `TracingInterceptor`를 적용한 새 서버로 교체
- **`post_processors/bind_server.py`** — `BindServerPostProcessor(@Order(2))`: `grpc.aio.Server` Pod 감지 시 `GrpcServerService(IAsyncService)` 생성 → `ApplicationContext`에 서비스 등록 (graceful shutdown 포함)

### Modified Files

- **`main.py`** — `initialize(app)` 에서 3개 PostProcessor를 `app.add()`로 등록

### Test Files (154 tests, 100% coverage)

- `conftest.py`, `test_handler.py`, `test_register_services.py`, `test_add_interceptors.py`, `test_bind_server.py`, `test_main.py`

## Design Decisions

- **`@Order` 순서**: RegisterServices(0) → AddInterceptors(1) → BindServer(2). 서버 Pod가 먼저 생성되므로 인터셉터가 적용된 후 컨트롤러가 등록됨
- **Request-scoped isolation**: 매 요청마다 `container.get(controller_type)`으로 fresh 인스턴스 획득, `application_context.clear_context()` 호출
- **spakky-fastapi PostProcessor 패턴** 기반: `IPostProcessor + IContainerAware + IApplicationContextAware + @Order + @Pod`