### PR TITLE
feat(spakky-grpc): complete integration tests and README

### DIFF
--- a/plugins/spakky-grpc/README.md
+++ b/plugins/spakky-grpc/README.md
@@ -1,6 +1,9 @@
 # spakky-grpc
 
-gRPC plugin for Spakky framework
+Spakky Framework용 code-first gRPC 플러그인입니다.
+
+Python dataclass와 어노테이션에서 protobuf descriptor를 생성하고,
+gRPC 서비스 등록/인터셉터 연결을 자동화합니다.
 
 ## Installation
 
@@ -8,10 +11,96 @@ gRPC plugin for Spakky framework
 pip install spakky-grpc
 ```
 
-## Usage
+## Quick Start
 
 ```python
-# TODO: Add usage examples
+from dataclasses import dataclass
+from typing import Annotated
+
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+from spakky.plugins.grpc.annotations.field import ProtoField
+from spakky.plugins.grpc.decorators.rpc import rpc
+from spakky.plugins.grpc.stereotypes.grpc_controller import GrpcController
+
+
+@dataclass
+class HelloRequest:
+	name: Annotated[str, ProtoField(number=1)]
+
+
+@dataclass
+class HelloReply:
+	message: Annotated[str, ProtoField(number=1)]
+
+
+@GrpcController(package="example.v1", service_name="GreeterService")
+class GreeterController:
+	@rpc(request_type=HelloRequest, response_type=HelloReply)
+	async def say_hello(self, request: HelloRequest) -> HelloReply:
+		return HelloReply(message=f"hello, {request.name}")
+
+
+app = (
+	SpakkyApplication(ApplicationContext())
+	.load_plugins()
+	.scan()
+	.start()
+)
+```
+
+## RPC Method Types
+
+`@rpc`는 네 가지 gRPC 통신 패턴을 지원합니다.
+
+- `RpcMethodType.UNARY`: 단일 요청, 단일 응답
+- `RpcMethodType.SERVER_STREAMING`: 단일 요청, 스트리밍 응답
+- `RpcMethodType.CLIENT_STREAMING`: 스트리밍 요청, 단일 응답
+- `RpcMethodType.BIDI_STREAMING`: 양방향 스트리밍
+
+권장사항:
+
+- 스트리밍 메서드에서는 `request_type`, `response_type`을 명시적으로 지정
+- 요청/응답 타입의 각 필드에 `ProtoField(number=...)` 지정
+
+## Type Mapping
+
+기본 Python 타입은 자동으로 protobuf 스칼라 타입으로 매핑됩니다.
+
+| Python | Protobuf |
+| --- | --- |
+| `str` | `string` |
+| `int` | `int64` |
+| `float` | `double` |
+| `bool` | `bool` |
+| `bytes` | `bytes` |
+
+`list[T]`, `Optional[T]`, nested dataclass도 descriptor 생성 시 처리됩니다.
+
+## Interceptors
+
+서버에는 기본적으로 다음 인터셉터가 연결됩니다.
+
+- `ErrorHandlingInterceptor`: `AbstractGrpcStatusError` 계열 예외를 gRPC status로 매핑
+- `TracingInterceptor`: `traceparent` 기반 컨텍스트 추출/전파
+
+### Error Mapping
+
+예를 들어 `NotFound`를 raise하면 클라이언트는 `NOT_FOUND` 상태를 받습니다.
+
+### Tracing
+
+요청 metadata의 `traceparent`를 읽어 child context를 만들고,
+응답 trailing metadata에 최신 trace context를 주입합니다.
+
+## Local Verification
+
+패키지 루트에서 아래 순서로 검증할 수 있습니다.
+
+```bash
+uv run ruff check src/ tests/
+uv run pyrefly check src/
+uv run pytest tests/ -v
 ```
 
 ## License

--- a/plugins/spakky-grpc/pyproject.toml
+++ b/plugins/spakky-grpc/pyproject.toml
@@ -6,7 +6,12 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
-dependencies = ["grpcio>=1.68.0", "spakky>=6.3.1", "spakky-tracing>=6.3.1"]
+dependencies = [
+    "grpcio>=1.68.0",
+    "protobuf>=5.0.0",
+    "spakky>=6.3.1",
+    "spakky-tracing>=6.3.1",
+]
 
 [project.entry-points."spakky.plugins"]
 spakky-grpc = "spakky.plugins.grpc.main:initialize"

--- a/plugins/spakky-grpc/tests/integration/conftest.py
+++ b/plugins/spakky-grpc/tests/integration/conftest.py
@@ -1,0 +1,241 @@
+"""Integration test fixtures for gRPC end-to-end behaviors."""
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Annotated
+from unittest.mock import MagicMock
+
+import grpc.aio
+import pytest
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.plugins.grpc.annotations.field import ProtoField
+from spakky.plugins.grpc.decorators.rpc import RpcMethodType, rpc
+from spakky.plugins.grpc.error import NotFound
+from spakky.plugins.grpc.handler import GrpcServiceHandler
+from spakky.plugins.grpc.interceptors.error_handling import ErrorHandlingInterceptor
+from spakky.plugins.grpc.interceptors.tracing import TracingInterceptor
+from spakky.plugins.grpc.schema.descriptor_builder import build_file_descriptor
+from spakky.plugins.grpc.schema.registry import DescriptorRegistry
+from spakky.plugins.grpc.stereotypes.grpc_controller import GrpcController
+from spakky.tracing.context import TraceContext
+from spakky.tracing.propagator import ITracePropagator
+from typing_extensions import override
+
+
+@dataclass
+class EchoRequest:
+    """Unary and bidi request payload."""
+
+    message: Annotated[str, ProtoField(number=1)]
+
+
+@dataclass
+class EchoReply:
+    """Unary and streaming response payload."""
+
+    message: Annotated[str, ProtoField(number=1)]
+
+
+@dataclass
+class CountRequest:
+    """Server-streaming request payload."""
+
+    count: Annotated[int, ProtoField(number=1)]
+
+
+@dataclass
+class NumberChunk:
+    """Client-streaming request payload."""
+
+    value: Annotated[int, ProtoField(number=1)]
+
+
+@dataclass
+class SumReply:
+    """Client-streaming aggregate response payload."""
+
+    total: Annotated[int, ProtoField(number=1)]
+
+
+@dataclass
+class FailRequest:
+    """Request payload for error-path testing."""
+
+    resource_id: Annotated[str, ProtoField(number=1)]
+
+
+@GrpcController(package="itest.v1", service_name="IntegrationService")
+class IntegrationController:
+    """Controller exposing all gRPC method shapes."""
+
+    @rpc(
+        method_type=RpcMethodType.UNARY,
+        request_type=EchoRequest,
+        response_type=EchoReply,
+    )
+    async def unary_echo(self, request: EchoRequest) -> EchoReply:
+        """Return the same message for unary requests."""
+        return EchoReply(message=request.message)
+
+    @rpc(
+        method_type=RpcMethodType.SERVER_STREAMING,
+        request_type=CountRequest,
+        response_type=EchoReply,
+    )
+    async def stream_count(self, request: CountRequest) -> AsyncIterator[EchoReply]:
+        """Yield count-prefixed messages as a server stream."""
+        for idx in range(request.count):
+            yield EchoReply(message=f"item-{idx}")
+
+    @rpc(
+        method_type=RpcMethodType.CLIENT_STREAMING,
+        request_type=NumberChunk,
+        response_type=SumReply,
+    )
+    async def sum_stream(self, request: AsyncIterator[NumberChunk]) -> SumReply:
+        """Aggregate client stream values into a single response."""
+        total = 0
+        async for item in request:
+            total += item.value
+        return SumReply(total=total)
+
+    @rpc(
+        method_type=RpcMethodType.BIDI_STREAMING,
+        request_type=EchoRequest,
+        response_type=EchoReply,
+    )
+    async def chat(
+        self, request: AsyncIterator[EchoRequest]
+    ) -> AsyncIterator[EchoReply]:
+        """Echo each inbound message as a bidi stream."""
+        async for item in request:
+            yield EchoReply(message=f"echo:{item.message}")
+
+    @rpc(
+        method_type=RpcMethodType.UNARY,
+        request_type=FailRequest,
+        response_type=EchoReply,
+    )
+    async def fail_not_found(self, request: FailRequest) -> EchoReply:
+        """Always fail with a mapped gRPC status error."""
+        raise NotFound()
+
+
+class FakeTracePropagator(ITracePropagator):
+    """Simple propagator that records extract/inject interactions."""
+
+    def __init__(self) -> None:
+        self.extract_calls: list[dict[str, str]] = []
+        self.inject_calls: list[dict[str, str]] = []
+
+    @override
+    def inject(self, carrier: dict[str, str]) -> None:
+        """Inject active trace context into the outbound carrier."""
+        self.inject_calls.append(carrier)
+        current = TraceContext.get()
+        if current is not None:
+            carrier["traceparent"] = current.to_traceparent()
+
+    @override
+    def extract(self, carrier: dict[str, str]) -> TraceContext | None:
+        """Extract trace context from inbound metadata."""
+        self.extract_calls.append(carrier)
+        traceparent = carrier.get("traceparent")
+        if traceparent is None:
+            return None
+        return TraceContext.from_traceparent(traceparent)
+
+    @override
+    def fields(self) -> list[str]:
+        """Return the supported propagation field names."""
+        return ["traceparent", "tracestate"]
+
+
+@pytest.fixture
+def application_context() -> MagicMock:
+    """Application context mock used by handler dispatch."""
+    context = MagicMock(spec=IApplicationContext)
+    context.clear_context = MagicMock()
+    return context
+
+
+@pytest.fixture
+def registry() -> DescriptorRegistry:
+    """Descriptor registry populated with integration controller schema."""
+    descriptor_registry = DescriptorRegistry()
+    descriptor_registry.register(build_file_descriptor(IntegrationController))
+    return descriptor_registry
+
+
+@pytest.fixture
+def container() -> MagicMock:
+    """Container mock returning a fresh controller instance."""
+    container_mock = MagicMock(spec=IContainer)
+    container_mock.get = MagicMock(side_effect=lambda type_, name=None: type_())
+    return container_mock
+
+
+@pytest.fixture
+def propagator() -> FakeTracePropagator:
+    """Tracing propagator used by interceptor integration tests."""
+    return FakeTracePropagator()
+
+
+@pytest.fixture
+async def grpc_server(
+    application_context: MagicMock,
+    container: MagicMock,
+    propagator: FakeTracePropagator,
+    registry: DescriptorRegistry,
+) -> AsyncIterator[tuple[grpc.aio.Server, str]]:
+    """Start a real gRPC server with generic handler and interceptors."""
+    TraceContext.clear()
+    handler = GrpcServiceHandler(
+        controller_type=IntegrationController,
+        package="itest.v1",
+        service_name="IntegrationService",
+        container=container,
+        application_context=application_context,
+        registry=registry,
+    )
+    server = grpc.aio.server(
+        interceptors=[
+            ErrorHandlingInterceptor(),
+            TracingInterceptor(propagator=propagator),
+        ]
+    )
+    server.add_generic_rpc_handlers([handler])
+    port = server.add_insecure_port("127.0.0.1:0")
+    await server.start()
+    try:
+        yield server, f"127.0.0.1:{port}"
+    finally:
+        await server.stop(grace=0)
+        TraceContext.clear()
+
+
+@pytest.fixture
+async def grpc_channel(
+    grpc_server: tuple[grpc.aio.Server, str],
+) -> AsyncIterator[grpc.aio.Channel]:
+    """Create a connected gRPC channel for test calls."""
+    _server, address = grpc_server
+    channel = grpc.aio.insecure_channel(address)
+    try:
+        yield channel
+    finally:
+        await channel.close()
+
+
+@pytest.fixture
+def message_types(registry: DescriptorRegistry) -> dict[str, type]:
+    """Resolve runtime protobuf message classes from descriptor registry."""
+    return {
+        "EchoRequest": registry.get_message_class("itest.v1.EchoRequest"),
+        "EchoReply": registry.get_message_class("itest.v1.EchoReply"),
+        "CountRequest": registry.get_message_class("itest.v1.CountRequest"),
+        "NumberChunk": registry.get_message_class("itest.v1.NumberChunk"),
+        "SumReply": registry.get_message_class("itest.v1.SumReply"),
+        "FailRequest": registry.get_message_class("itest.v1.FailRequest"),
+    }

--- a/plugins/spakky-grpc/tests/integration/test_grpc_integration.py
+++ b/plugins/spakky-grpc/tests/integration/test_grpc_integration.py
@@ -1,0 +1,145 @@
+"""Integration tests for gRPC method shapes and interceptor behavior."""
+
+from collections.abc import AsyncIterator
+
+import grpc
+import pytest
+from google.protobuf.message import Message
+from spakky.tracing.context import TraceContext
+
+
+def _to_wire(message: Message) -> bytes:
+    """Serialize a dynamic protobuf message to wire bytes."""
+    return message.SerializeToString()
+
+
+async def _numbers(
+    number_cls: type,
+    values: list[int],
+) -> AsyncIterator[Message]:
+    """Build an async request stream from integers."""
+    for value in values:
+        yield number_cls(value=value)
+
+
+async def _messages(
+    message_cls: type,
+    values: list[str],
+) -> AsyncIterator[Message]:
+    """Build an async request stream from strings."""
+    for value in values:
+        yield message_cls(message=value)
+
+
+async def test_unary_roundtrip(
+    grpc_channel: grpc.aio.Channel,
+    message_types: dict[str, type],
+) -> None:
+    """Unary RPC should return dataclass-mapped response payload."""
+    stub = grpc_channel.unary_unary(
+        "/itest.v1.IntegrationService/unary_echo",
+        request_serializer=_to_wire,
+        response_deserializer=message_types["EchoReply"].FromString,
+    )
+
+    response = await stub(message_types["EchoRequest"](message="hello"))
+
+    assert response.message == "hello"
+
+
+async def test_server_streaming_roundtrip(
+    grpc_channel: grpc.aio.Channel,
+    message_types: dict[str, type],
+) -> None:
+    """Server-streaming RPC should yield all streamed responses."""
+    stub = grpc_channel.unary_stream(
+        "/itest.v1.IntegrationService/stream_count",
+        request_serializer=_to_wire,
+        response_deserializer=message_types["EchoReply"].FromString,
+    )
+
+    call = stub(message_types["CountRequest"](count=3))
+    responses = [item.message async for item in call]
+
+    assert responses == ["item-0", "item-1", "item-2"]
+
+
+async def test_client_streaming_roundtrip(
+    grpc_channel: grpc.aio.Channel,
+    message_types: dict[str, type],
+) -> None:
+    """Client-streaming RPC should aggregate stream values."""
+    stub = grpc_channel.stream_unary(
+        "/itest.v1.IntegrationService/sum_stream",
+        request_serializer=_to_wire,
+        response_deserializer=message_types["SumReply"].FromString,
+    )
+
+    response = await stub(_numbers(message_types["NumberChunk"], [3, 4, 5]))
+
+    assert response.total == 12
+
+
+async def test_bidi_streaming_roundtrip(
+    grpc_channel: grpc.aio.Channel,
+    message_types: dict[str, type],
+) -> None:
+    """Bidi-streaming RPC should echo each inbound message."""
+    stub = grpc_channel.stream_stream(
+        "/itest.v1.IntegrationService/chat",
+        request_serializer=_to_wire,
+        response_deserializer=message_types["EchoReply"].FromString,
+    )
+
+    call = stub(_messages(message_types["EchoRequest"], ["a", "b"]))
+    responses = [item.message async for item in call]
+
+    assert responses == ["echo:a", "echo:b"]
+
+
+async def test_error_mapping_to_grpc_status(
+    grpc_channel: grpc.aio.Channel,
+    message_types: dict[str, type],
+) -> None:
+    """Domain gRPC error should be mapped to expected status code."""
+    stub = grpc_channel.unary_unary(
+        "/itest.v1.IntegrationService/fail_not_found",
+        request_serializer=_to_wire,
+        response_deserializer=message_types["EchoReply"].FromString,
+    )
+
+    with pytest.raises(grpc.aio.AioRpcError) as exception_info:
+        await stub(message_types["FailRequest"](resource_id="missing"))
+
+    assert exception_info.value.code() == grpc.StatusCode.NOT_FOUND
+    assert exception_info.value.details() == "Not Found"
+
+
+async def test_tracing_interceptor_extracts_and_injects_context(
+    grpc_channel: grpc.aio.Channel,
+    message_types: dict[str, type],
+) -> None:
+    """Tracing interceptor should extract inbound and inject trailing context."""
+    parent = TraceContext.new_root()
+    stub = grpc_channel.unary_unary(
+        "/itest.v1.IntegrationService/unary_echo",
+        request_serializer=_to_wire,
+        response_deserializer=message_types["EchoReply"].FromString,
+    )
+
+    call = stub(
+        message_types["EchoRequest"](message="trace"),
+        metadata=(("traceparent", parent.to_traceparent()),),
+    )
+    response = await call
+
+    assert response.message == "trace"
+    trailing = dict(await call.trailing_metadata() or [])
+    assert "traceparent" in trailing
+    traceparent = trailing["traceparent"]
+    if isinstance(traceparent, bytes):
+        traceparent = traceparent.decode("utf-8")
+    extracted = TraceContext.from_traceparent(traceparent)
+    assert extracted.trace_id == parent.trace_id
+    assert extracted.span_id != parent.span_id
+    assert TraceContext.get() is None

--- a/uv.lock
+++ b/uv.lock
@@ -2931,6 +2931,7 @@ version = "6.3.1"
 source = { editable = "plugins/spakky-grpc" }
 dependencies = [
     { name = "grpcio" },
+    { name = "protobuf" },
     { name = "spakky" },
     { name = "spakky-tracing" },
 ]
@@ -2938,6 +2939,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "grpcio", specifier = ">=1.68.0" },
+    { name = "protobuf", specifier = ">=5.0.0" },
     { name = "spakky", editable = "core/spakky" },
     { name = "spakky-tracing", editable = "core/spakky-tracing" },
 ]


### PR DESCRIPTION
## Summary
- add end-to-end gRPC integration tests for unary/server-streaming/client-streaming/bidi flows
- validate interceptor behaviors for error mapping and tracing metadata propagation
- expand spakky-grpc README with quick start, method types, type mapping, interceptor behavior, and local verification commands

## Verification
- uv run --with ruff ruff check src/ tests/
- uv run --with pyrefly --with protobuf --with pytest pyrefly check src/ tests/
- uv run --with pytest --with pytest-asyncio --with pytest-cov --with pytest-xdist --with pytest-spec pytest tests/ -v

Closes #87