### PR TITLE
test: add grpc integration coverage and docs (#87)

### DIFF
--- a/core/spakky-data/.pre-commit-config.yaml
+++ b/core/spakky-data/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/core/spakky-domain/.pre-commit-config.yaml
+++ b/core/spakky-domain/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/core/spakky-domain/src/spakky/domain/application/command.py
+++ b/core/spakky-domain/src/spakky/domain/application/command.py
@@ -47,7 +47,9 @@ class IAsyncCommandUseCase(ABC, Generic[CommandT_contra, ResultT_co]):
     """Protocol for asynchronous command use cases."""
 
     @abstractmethod
-    async def run(self, command: CommandT_contra) -> ResultT_co:  # pyrefly: ignore - async abstractmethod covariance
+    async def run(
+        self, command: CommandT_contra
+    ) -> ResultT_co:  # pyrefly: ignore - async abstractmethod covariance
         """Execute command asynchronously and return result.
 
         Args:

--- a/core/spakky-domain/src/spakky/domain/application/command.py
+++ b/core/spakky-domain/src/spakky/domain/application/command.py
@@ -47,9 +47,7 @@ class IAsyncCommandUseCase(ABC, Generic[CommandT_contra, ResultT_co]):
     """Protocol for asynchronous command use cases."""
 
     @abstractmethod
-    async def run(
-        self, command: CommandT_contra
-    ) -> ResultT_co:  # pyrefly: ignore - async abstractmethod covariance
+    async def run(self, command: CommandT_contra) -> ResultT_co:  # pyrefly: ignore - async abstractmethod covariance
         """Execute command asynchronously and return result.
 
         Args:

--- a/core/spakky-domain/src/spakky/domain/application/query.py
+++ b/core/spakky-domain/src/spakky/domain/application/query.py
@@ -47,9 +47,7 @@ class IAsyncQueryUseCase(ABC, Generic[QueryT_contra, ResultT_co]):
     """Protocol for asynchronous query use cases."""
 
     @abstractmethod
-    async def run(
-        self, query: QueryT_contra
-    ) -> ResultT_co:  # pyrefly: ignore - async abstractmethod covariance
+    async def run(self, query: QueryT_contra) -> ResultT_co:  # pyrefly: ignore - async abstractmethod covariance
         """Execute query asynchronously and return result.
 
         Args:

--- a/core/spakky-domain/src/spakky/domain/application/query.py
+++ b/core/spakky-domain/src/spakky/domain/application/query.py
@@ -47,7 +47,9 @@ class IAsyncQueryUseCase(ABC, Generic[QueryT_contra, ResultT_co]):
     """Protocol for asynchronous query use cases."""
 
     @abstractmethod
-    async def run(self, query: QueryT_contra) -> ResultT_co:  # pyrefly: ignore - async abstractmethod covariance
+    async def run(
+        self, query: QueryT_contra
+    ) -> ResultT_co:  # pyrefly: ignore - async abstractmethod covariance
         """Execute query asynchronously and return result.
 
         Args:

--- a/core/spakky-event/.pre-commit-config.yaml
+++ b/core/spakky-event/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/core/spakky-outbox/.pre-commit-config.yaml
+++ b/core/spakky-outbox/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/core/spakky-saga/.pre-commit-config.yaml
+++ b/core/spakky-saga/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/core/spakky-task/.pre-commit-config.yaml
+++ b/core/spakky-task/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/core/spakky-tracing/.pre-commit-config.yaml
+++ b/core/spakky-tracing/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/core/spakky/.pre-commit-config.yaml
+++ b/core/spakky/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/core/spakky/src/spakky/core/application/application_context.py
+++ b/core/spakky/src/spakky/core/application/application_context.py
@@ -1,5 +1,5 @@
 import threading
-from asyncio import locks
+from asyncio import get_event_loop, locks
 from asyncio.events import AbstractEventLoop, new_event_loop, set_event_loop
 from asyncio.tasks import run_coroutine_threadsafe
 from contextvars import ContextVar
@@ -93,6 +93,9 @@ class ApplicationContext(IApplicationContext):
     __event_loop: AbstractEventLoop | None
     """Event loop for running async services."""
 
+    __previous_event_loop: AbstractEventLoop | None
+    """Default event loop that existed before start()."""
+
     __event_thread: Thread | None
     """Thread running the event loop."""
 
@@ -113,6 +116,7 @@ class ApplicationContext(IApplicationContext):
         self.__services = []
         self.__async_services = []
         self.__event_loop = None
+        self.__previous_event_loop = None
         self.__event_thread = None
         self.__is_started = False
         self.task_stop_event = locks.Event()
@@ -355,6 +359,10 @@ class ApplicationContext(IApplicationContext):
         """Create the event loop early for loop-bound async Pod instances."""
         if self.__event_loop is not None:  # pragma: no cover
             raise EventLoopThreadAlreadyStartedInApplicationContextError
+        try:
+            self.__previous_event_loop = get_event_loop()
+        except RuntimeError:
+            self.__previous_event_loop = None
         event_loop = new_event_loop()
         self.__event_loop = event_loop
         set_event_loop(event_loop)
@@ -418,7 +426,8 @@ class ApplicationContext(IApplicationContext):
         # Clear references after thread has joined
         self.__event_loop = None
         self.__event_thread = None
-        set_event_loop(None)
+        set_event_loop(self.__previous_event_loop)
+        self.__previous_event_loop = None
 
     @property
     @override

--- a/core/spakky/src/spakky/core/application/application_context.py
+++ b/core/spakky/src/spakky/core/application/application_context.py
@@ -352,21 +352,29 @@ class ApplicationContext(IApplicationContext):
         loop.run_forever()
         loop.close()
 
+    def __prepare_event_loop(self) -> AbstractEventLoop:
+        """Create the event loop early for loop-bound async Pod instances."""
+        if self.__event_loop is not None:  # pragma: no cover
+            raise EventLoopThreadAlreadyStartedInApplicationContextError
+        event_loop = new_event_loop()
+        self.__event_loop = event_loop
+        set_event_loop(event_loop)
+        return event_loop
+
     def __start_services(self) -> None:
         """Start all registered sync and async services.
 
         Raises:
             EventLoopThreadAlreadyStartedInApplicationContextError: If already started.
         """
-        if self.__event_loop is not None:  # pragma: no cover
-            raise EventLoopThreadAlreadyStartedInApplicationContextError
+        event_loop = self.__event_loop
+        if event_loop is None:
+            event_loop = self.__prepare_event_loop()
         if self.__event_thread is not None:  # pragma: no cover
             raise EventLoopThreadAlreadyStartedInApplicationContextError
-
-        self.__event_loop = new_event_loop()
         self.__event_thread = Thread(
             target=self.__run_event_loop,
-            args=(self.__event_loop,),
+            args=(event_loop,),
             daemon=True,
         )
         self.__event_thread.start()
@@ -380,7 +388,7 @@ class ApplicationContext(IApplicationContext):
             for service in self.__async_services:
                 await service.start_async()
 
-        run_coroutine_threadsafe(start_async_services(), self.__event_loop).result()
+        run_coroutine_threadsafe(start_async_services(), event_loop).result()
 
     def __stop_services(self) -> None:
         """Stop all services and shutdown event loop.
@@ -411,6 +419,7 @@ class ApplicationContext(IApplicationContext):
         # Clear references after thread has joined
         self.__event_loop = None
         self.__event_thread = None
+        set_event_loop(None)
 
     @property
     @override
@@ -518,6 +527,7 @@ class ApplicationContext(IApplicationContext):
         if self.__is_started:  # pragma: no cover
             raise ApplicationContextAlreadyStartedError()
         self.__is_started = True
+        self.__prepare_event_loop()
         self.__register_post_processors()
         self.__initialize_pods()
         self.__start_services()

--- a/core/spakky/src/spakky/core/application/application_context.py
+++ b/core/spakky/src/spakky/core/application/application_context.py
@@ -8,8 +8,6 @@ from types import MappingProxyType
 from typing import Callable, cast, overload
 from uuid import UUID, uuid4
 
-from typing_extensions import override
-
 from spakky.core.aop.post_processor import AspectPostProcessor
 from spakky.core.application.error import AbstractSpakkyApplicationError
 from spakky.core.common.constants import CONTEXT_ID, CONTEXT_SCOPE_CACHE
@@ -39,6 +37,7 @@ from spakky.core.pod.post_processors.aware_post_processor import (
 )
 from spakky.core.service.interfaces.service import IAsyncService, IService
 from spakky.core.service.post_processor import ServicePostProcessor
+from typing_extensions import override
 
 """Application context managing Pod lifecycle and dependency injection.
 

--- a/core/spakky/tests/pod/test_application_context.py
+++ b/core/spakky/tests/pod/test_application_context.py
@@ -63,3 +63,21 @@ async def test_context_scoped_pod_creates_isolated_instances_per_async_flow() ->
 
     await asyncio.gather(*(task_logic() for _ in range(5)))
     assert len(set(map(id, results))) == 5
+
+
+def test_start_stop_restores_previous_default_event_loop() -> None:
+    """start()/stop()가 기존 default event loop를 보존하고 복원함을 검증한다."""
+
+    previous_event_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(previous_event_loop)
+
+    context = ApplicationContext()
+
+    try:
+        context.start()
+        context.stop()
+
+        assert asyncio.get_event_loop() is previous_event_loop
+    finally:
+        asyncio.set_event_loop(None)
+        previous_event_loop.close()

--- a/docs/guides/grpc.md
+++ b/docs/guides/grpc.md
@@ -17,23 +17,45 @@
 ## 설정
 
 ```bash
-pip install spakky-grpc
+pip install spakky-grpc spakky-tracing
 ```
 
 `spakky-grpc`는 `spakky`, `spakky-tracing`, `grpcio`에 의존합니다.
 
 ```python
+import grpc.aio
 import spakky.plugins.grpc
+import spakky.tracing
+
+from spakky.core.pod.annotations.pod import Pod
+from spakky.plugins.grpc.schema.registry import DescriptorRegistry
+
+
+@Pod()
+def get_descriptor_registry() -> DescriptorRegistry:
+    return DescriptorRegistry()
+
+
+@Pod()
+def get_grpc_server() -> grpc.aio.Server:
+    server = grpc.aio.server()
+    server.add_insecure_port("127.0.0.1:50051")
+    return server
 
 app = (
     SpakkyApplication(ApplicationContext())
     .load_plugins(include={
         spakky.plugins.grpc.PLUGIN_NAME,
+        spakky.tracing.PLUGIN_NAME,
     })
     .scan(apps)
+    .add(get_descriptor_registry)
+    .add(get_grpc_server)
     .start()
 )
 ```
+
+`DescriptorRegistry`는 런타임 protobuf descriptor와 message class를 캐싱하며, `grpc.aio.Server` Pod는 실제 포트 바인딩과 서버 옵션의 소유권을 가집니다.
 
 ---
 

--- a/docs/guides/grpc.md
+++ b/docs/guides/grpc.md
@@ -27,6 +27,10 @@ import grpc.aio
 import spakky.plugins.grpc
 import spakky.tracing
 
+from your_project import apps
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+
 from spakky.core.pod.annotations.pod import Pod
 from spakky.plugins.grpc.schema.registry import DescriptorRegistry
 
@@ -51,8 +55,8 @@ app = (
     .scan(apps)
     .add(get_descriptor_registry)
     .add(get_grpc_server)
-    .start()
 )
+app.start()
 ```
 
 `DescriptorRegistry`는 런타임 protobuf descriptor와 message class를 캐싱하며, `grpc.aio.Server` Pod는 실제 포트 바인딩과 서버 옵션의 소유권을 가집니다.

--- a/plugins/spakky-celery/.pre-commit-config.yaml
+++ b/plugins/spakky-celery/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/plugins/spakky-fastapi/.pre-commit-config.yaml
+++ b/plugins/spakky-fastapi/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/plugins/spakky-grpc/.pre-commit-config.yaml
+++ b/plugins/spakky-grpc/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/plugins/spakky-grpc/README.md
+++ b/plugins/spakky-grpc/README.md
@@ -1,18 +1,122 @@
 # spakky-grpc
 
-gRPC plugin for Spakky framework
+Spakky Framework용 code-first gRPC 플러그인
 
 ## Installation
 
 ```bash
-pip install spakky-grpc
+pip install spakky-grpc spakky-tracing
 ```
 
-## Usage
+## Quick Start
 
 ```python
-# TODO: Add usage examples
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import Annotated
+
+import grpc.aio
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.annotations.pod import Pod
+from spakky.plugins.grpc.annotations.field import ProtoField
+from spakky.plugins.grpc.decorators.rpc import RpcMethodType, rpc
+from spakky.plugins.grpc.schema.registry import DescriptorRegistry
+from spakky.plugins.grpc.stereotypes.grpc_controller import GrpcController
+
+import spakky.plugins.grpc
+import spakky.tracing
+
+
+@dataclass
+class HelloRequest:
+	name: Annotated[str, ProtoField(number=1)]
+
+
+@dataclass
+class HelloReply:
+	message: Annotated[str, ProtoField(number=1)]
+
+
+@GrpcController(package="example.v1", service_name="GreeterService")
+class GreeterController:
+	@rpc()
+	async def say_hello(self, request: HelloRequest) -> HelloReply:
+		return HelloReply(message=f"Hello, {request.name}!")
+
+
+@Pod()
+def get_descriptor_registry() -> DescriptorRegistry:
+	return DescriptorRegistry()
+
+
+@Pod()
+def get_grpc_server() -> grpc.aio.Server:
+	server = grpc.aio.server()
+	server.add_insecure_port("127.0.0.1:50051")
+	return server
+
+
+app = (
+	SpakkyApplication(ApplicationContext())
+	.load_plugins(
+		include={
+			spakky.plugins.grpc.PLUGIN_NAME,
+			spakky.tracing.PLUGIN_NAME,
+		}
+	)
+	.scan()
+	.add(get_descriptor_registry)
+	.add(get_grpc_server)
+)
+app.start()
 ```
+
+## Streaming RPC
+
+네 가지 gRPC 패턴을 모두 지원합니다.
+
+| RpcMethodType | 설명 |
+|---|---|
+| `UNARY` | 단일 요청, 단일 응답 |
+| `SERVER_STREAMING` | 단일 요청, 스트림 응답 |
+| `CLIENT_STREAMING` | 스트림 요청, 단일 응답 |
+| `BIDI_STREAMING` | 양방향 스트리밍 |
+
+client-streaming과 bidirectional-streaming 메서드는 `request_type`과 `response_type`을 명시하면 descriptor 생성이 안정적입니다.
+
+## Type Mapping
+
+| Python 타입 | Protobuf 타입 |
+|---|---|
+| `str` | `string` |
+| `int` | `int64` |
+| `float` | `double` |
+| `bool` | `bool` |
+| `bytes` | `bytes` |
+
+모든 메시지 필드는 `Annotated[..., ProtoField(number=N)]` 형식으로 protobuf 필드 번호를 가져야 합니다.
+
+## Interceptors
+
+- `ErrorHandlingInterceptor`: `AbstractGrpcStatusError` 계열 예외를 대응하는 gRPC status code로 변환합니다.
+- `TracingInterceptor`: `traceparent` 메타데이터를 추출하고 trailing metadata로 새 trace context를 주입합니다.
+
+트레이싱을 사용하려면 `spakky-tracing` 플러그인도 함께 로드해야 합니다.
+
+## Verified Scenarios
+
+- unary RPC
+- server-streaming RPC
+- client-streaming RPC
+- bidirectional streaming RPC
+- managed gRPC error to status code mapping
+- W3C Trace Context propagation
+
+## Documentation
+
+- 사용자 가이드: [../../docs/guides/grpc.md](../../docs/guides/grpc.md)
+- API 레퍼런스: [../../docs/api/plugins/spakky-grpc.md](../../docs/api/plugins/spakky-grpc.md)
 
 ## License
 

--- a/plugins/spakky-grpc/README.md
+++ b/plugins/spakky-grpc/README.md
@@ -16,6 +16,9 @@ from dataclasses import dataclass
 from typing import Annotated
 
 import grpc.aio
+import spakky.plugins.grpc
+import spakky.tracing
+from your_project import apps
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
 from spakky.core.pod.annotations.pod import Pod
@@ -24,25 +27,22 @@ from spakky.plugins.grpc.decorators.rpc import RpcMethodType, rpc
 from spakky.plugins.grpc.schema.registry import DescriptorRegistry
 from spakky.plugins.grpc.stereotypes.grpc_controller import GrpcController
 
-import spakky.plugins.grpc
-import spakky.tracing
-
 
 @dataclass
 class HelloRequest:
-	name: Annotated[str, ProtoField(number=1)]
+    name: Annotated[str, ProtoField(number=1)]
 
 
 @dataclass
 class HelloReply:
-	message: Annotated[str, ProtoField(number=1)]
+    message: Annotated[str, ProtoField(number=1)]
 
 
 @GrpcController(package="example.v1", service_name="GreeterService")
 class GreeterController:
-	@rpc()
-	async def say_hello(self, request: HelloRequest) -> HelloReply:
-		return HelloReply(message=f"Hello, {request.name}!")
+    @rpc(method_type=RpcMethodType.UNARY)
+    async def say_hello(self, request: HelloRequest) -> HelloReply:
+        return HelloReply(message=f"Hello, {request.name}!")
 
 
 @Pod()
@@ -58,16 +58,16 @@ def get_grpc_server() -> grpc.aio.Server:
 
 
 app = (
-	SpakkyApplication(ApplicationContext())
-	.load_plugins(
-		include={
-			spakky.plugins.grpc.PLUGIN_NAME,
-			spakky.tracing.PLUGIN_NAME,
-		}
-	)
-	.scan()
-	.add(get_descriptor_registry)
-	.add(get_grpc_server)
+    SpakkyApplication(ApplicationContext())
+    .load_plugins(
+        include={
+            spakky.plugins.grpc.PLUGIN_NAME,
+            spakky.tracing.PLUGIN_NAME,
+        }
+    )
+    .scan(apps)
+    .add(get_descriptor_registry)
+    .add(get_grpc_server)
 )
 app.start()
 ```

--- a/plugins/spakky-grpc/pyproject.toml
+++ b/plugins/spakky-grpc/pyproject.toml
@@ -8,6 +8,9 @@ license = { text = "MIT" }
 authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
 dependencies = ["grpcio>=1.68.0", "spakky>=6.3.1", "spakky-tracing>=6.3.1"]
 
+[dependency-groups]
+dev = ["pytest-integration-mark>=0.2.0"]
+
 [project.entry-points."spakky.plugins"]
 spakky-grpc = "spakky.plugins.grpc.main:initialize"
 
@@ -45,6 +48,10 @@ addopts = """
     --spec
 """
 spec_test_format = "{result} {docstring_summary}"
+markers = ["integration: grpc.aio 기반 통합 테스트 (느림)"]
+
+[tool.pytest-integration-mark]
+integration_path = "tests/integration"
 
 [tool.coverage.run]
 include = ["src/spakky/plugins/grpc/**/*.py"]

--- a/plugins/spakky-grpc/tests/integration/apps/__init__.py
+++ b/plugins/spakky-grpc/tests/integration/apps/__init__.py
@@ -1,0 +1,3 @@
+from tests.integration.apps.service import IntegrationServiceController
+
+__all__ = ["IntegrationServiceController"]

--- a/plugins/spakky-grpc/tests/integration/apps/service.py
+++ b/plugins/spakky-grpc/tests/integration/apps/service.py
@@ -1,0 +1,100 @@
+from collections.abc import AsyncGenerator, AsyncIterator
+from dataclasses import dataclass
+from typing import Annotated
+
+from spakky.plugins.grpc.annotations.field import ProtoField
+from spakky.plugins.grpc.decorators.rpc import RpcMethodType, rpc
+from spakky.plugins.grpc.error import InternalError, InvalidArgument
+from spakky.plugins.grpc.stereotypes.grpc_controller import GrpcController
+from spakky.tracing.context import TraceContext
+
+
+@dataclass
+class HelloRequest:
+    """Request message for integration scenarios."""
+
+    name: Annotated[str, ProtoField(number=1)]
+
+
+@dataclass
+class HelloReply:
+    """Response message for greeting scenarios."""
+
+    message: Annotated[str, ProtoField(number=1)]
+
+
+@dataclass
+class NamesReply:
+    """Response message for aggregated streaming requests."""
+
+    summary: Annotated[str, ProtoField(number=1)]
+
+
+@dataclass
+class TraceSnapshotReply:
+    """Response carrying the trace context observed in the controller."""
+
+    trace_id: Annotated[str, ProtoField(number=1)]
+    span_id: Annotated[str, ProtoField(number=2)]
+    parent_span_id: Annotated[str, ProtoField(number=3)]
+
+
+@GrpcController(package="integration.v1", service_name="IntegrationService")
+class IntegrationServiceController:
+    """Test gRPC controller covering unary, streaming, and interceptors."""
+
+    @rpc()
+    async def say_hello(self, request: HelloRequest) -> HelloReply:
+        """Return a unary greeting."""
+        return HelloReply(message=f"Hello, {request.name}!")
+
+    @rpc(method_type=RpcMethodType.SERVER_STREAMING, response_type=HelloReply)
+    async def stream_hello(
+        self, request: HelloRequest
+    ) -> AsyncGenerator[HelloReply, None]:
+        """Emit multiple greetings for a single request."""
+        yield HelloReply(message=f"Hello, {request.name}!")
+        yield HelloReply(message=f"Goodbye, {request.name}!")
+
+    @rpc(
+        method_type=RpcMethodType.CLIENT_STREAMING,
+        request_type=HelloRequest,
+        response_type=NamesReply,
+    )
+    async def collect_names(
+        self, request_iterator: AsyncIterator[HelloRequest]
+    ) -> NamesReply:
+        """Aggregate a stream of names into one response."""
+        names: list[str] = []
+        async for request in request_iterator:
+            names.append(request.name)
+        return NamesReply(summary=",".join(names))
+
+    @rpc(
+        method_type=RpcMethodType.BIDI_STREAMING,
+        request_type=HelloRequest,
+        response_type=HelloReply,
+    )
+    async def echo_names(
+        self, request_iterator: AsyncIterator[HelloRequest]
+    ) -> AsyncGenerator[HelloReply, None]:
+        """Echo each streamed request as an uppercase greeting."""
+        async for request in request_iterator:
+            yield HelloReply(message=request.name.upper())
+
+    @rpc()
+    async def fail_invalid_argument(self, request: HelloRequest) -> HelloReply:
+        """Raise a managed gRPC error for interceptor validation."""
+        raise InvalidArgument()
+
+    @rpc()
+    async def capture_trace(self, request: HelloRequest) -> TraceSnapshotReply:
+        """Return the active trace context seen in the controller."""
+        trace_context = TraceContext.get()
+        if trace_context is None:
+            raise InternalError()
+        return TraceSnapshotReply(
+            trace_id=trace_context.trace_id,
+            span_id=trace_context.span_id,
+            parent_span_id=trace_context.parent_span_id or "",
+        )

--- a/plugins/spakky-grpc/tests/integration/conftest.py
+++ b/plugins/spakky-grpc/tests/integration/conftest.py
@@ -85,7 +85,9 @@ class GrpcIntegrationClient:
         message_class = self.registry.get_message_class(full_name)
         message = message_class()
         for key, value in values.items():
-            setattr(message, key, value)  # pyrefly: ignore - runtime protobuf field assignment
+            setattr(
+                message, key, value
+            )  # pyrefly: ignore - runtime protobuf field assignment
         return message
 
     async def unary_unary(

--- a/plugins/spakky-grpc/tests/integration/conftest.py
+++ b/plugins/spakky-grpc/tests/integration/conftest.py
@@ -52,7 +52,6 @@ class GrpcServerPortBinder(IService):
     """Bind an ephemeral localhost port before the async server starts."""
 
     _server: grpc.aio.Server
-    _stop_event: threading.Event
     address: str
     port: int
 
@@ -62,7 +61,7 @@ class GrpcServerPortBinder(IService):
         self.port = 0
 
     def set_stop_event(self, stop_event: threading.Event) -> None:
-        _ = stop_event
+        pass
 
     def start(self) -> None:
         self.port = self._server.add_insecure_port("127.0.0.1:0")

--- a/plugins/spakky-grpc/tests/integration/conftest.py
+++ b/plugins/spakky-grpc/tests/integration/conftest.py
@@ -1,0 +1,224 @@
+import threading
+import importlib
+from collections.abc import AsyncGenerator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+from typing import Callable, Generator
+
+import grpc.aio
+import pytest
+from google.protobuf.message import Message
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.service.interfaces.service import IService
+from spakky.plugins.grpc.schema.registry import DescriptorRegistry
+from spakky.tracing import PLUGIN_NAME as SPAKKY_TRACING_PLUGIN_NAME
+import spakky.plugins.grpc
+
+TESTS_ROOT = Path(__file__).resolve().parents[2]
+if str(TESTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(TESTS_ROOT))
+
+
+def _serialize_message(message: Message) -> bytes:
+    return message.SerializeToString()
+
+
+def _build_deserializer(
+    message_class: type[Message],
+) -> Callable[[bytes], Message]:
+    def deserialize(payload: bytes) -> Message:
+        message = message_class()
+        message.ParseFromString(payload)
+        return message
+
+    return deserialize
+
+
+@Pod()
+def get_descriptor_registry() -> DescriptorRegistry:
+    return DescriptorRegistry()
+
+
+@Pod()
+def get_grpc_server() -> grpc.aio.Server:
+    return grpc.aio.server()
+
+
+@Pod()
+class GrpcServerPortBinder(IService):
+    """Bind an ephemeral localhost port before the async server starts."""
+
+    _server: grpc.aio.Server
+    _stop_event: threading.Event
+    address: str
+    port: int
+
+    def __init__(self, server: grpc.aio.Server) -> None:
+        self._server = server
+        self.address = ""
+        self.port = 0
+
+    def set_stop_event(self, stop_event: threading.Event) -> None:
+        _ = stop_event
+
+    def start(self) -> None:
+        self.port = self._server.add_insecure_port("127.0.0.1:0")
+        assert self.port != 0
+        self.address = f"127.0.0.1:{self.port}"
+
+    def stop(self) -> None:
+        self.address = ""
+        self.port = 0
+
+
+@dataclass
+class GrpcIntegrationClient:
+    """Thin client helper for dynamic runtime protobuf calls."""
+
+    channel: grpc.aio.Channel
+    registry: DescriptorRegistry
+
+    def make_message(self, full_name: str, **values: str) -> Message:
+        message_class = self.registry.get_message_class(full_name)
+        message = message_class()
+        for key, value in values.items():
+            setattr(message, key, value)  # pyrefly: ignore - runtime protobuf field assignment
+        return message
+
+    async def unary_unary(
+        self,
+        *,
+        method_path: str,
+        request_full_name: str,
+        response_full_name: str,
+        metadata: Sequence[tuple[str, str]] | None = None,
+        **values: str,
+    ) -> tuple[Message, grpc.aio.UnaryUnaryCall]:
+        response_class = self.registry.get_message_class(response_full_name)
+        call = self.channel.unary_unary(
+            method_path,
+            request_serializer=_serialize_message,
+            response_deserializer=_build_deserializer(response_class),
+        )(
+            self.make_message(request_full_name, **values),
+            metadata=metadata,
+        )
+        response = await call
+        return response, call
+
+    async def unary_stream(
+        self,
+        *,
+        method_path: str,
+        request_full_name: str,
+        response_full_name: str,
+        metadata: Sequence[tuple[str, str]] | None = None,
+        **values: str,
+    ) -> tuple[list[Message], grpc.aio.UnaryStreamCall]:
+        response_class = self.registry.get_message_class(response_full_name)
+        call = self.channel.unary_stream(
+            method_path,
+            request_serializer=_serialize_message,
+            response_deserializer=_build_deserializer(response_class),
+        )(
+            self.make_message(request_full_name, **values),
+            metadata=metadata,
+        )
+        responses = [item async for item in call]
+        return responses, call
+
+    async def stream_unary(
+        self,
+        *,
+        method_path: str,
+        request_full_name: str,
+        response_full_name: str,
+        request_values: Sequence[dict[str, str]],
+        metadata: Sequence[tuple[str, str]] | None = None,
+    ) -> tuple[Message, grpc.aio.StreamUnaryCall]:
+        response_class = self.registry.get_message_class(response_full_name)
+
+        async def request_iterator() -> AsyncGenerator[Message, None]:
+            for values in request_values:
+                yield self.make_message(request_full_name, **values)
+
+        call = self.channel.stream_unary(
+            method_path,
+            request_serializer=_serialize_message,
+            response_deserializer=_build_deserializer(response_class),
+        )(
+            request_iterator(),
+            metadata=metadata,
+        )
+        response = await call
+        return response, call
+
+    async def stream_stream(
+        self,
+        *,
+        method_path: str,
+        request_full_name: str,
+        response_full_name: str,
+        request_values: Sequence[dict[str, str]],
+        metadata: Sequence[tuple[str, str]] | None = None,
+    ) -> tuple[list[Message], grpc.aio.StreamStreamCall]:
+        response_class = self.registry.get_message_class(response_full_name)
+
+        async def request_iterator() -> AsyncGenerator[Message, None]:
+            for values in request_values:
+                yield self.make_message(request_full_name, **values)
+
+        call = self.channel.stream_stream(
+            method_path,
+            request_serializer=_serialize_message,
+            response_deserializer=_build_deserializer(response_class),
+        )(
+            request_iterator(),
+            metadata=metadata,
+        )
+        responses = [item async for item in call]
+        return responses, call
+
+
+@pytest.fixture(name="app", scope="function")
+def get_app_fixture() -> Generator[SpakkyApplication, None, None]:
+    apps = importlib.import_module("tests.integration.apps")
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .load_plugins(
+            include={
+                spakky.plugins.grpc.PLUGIN_NAME,
+                SPAKKY_TRACING_PLUGIN_NAME,
+            }
+        )
+        .scan(apps)
+        .add(get_descriptor_registry)
+        .add(get_grpc_server)
+        .add(GrpcServerPortBinder)
+    )
+    app.start()
+
+    yield app
+
+    app.stop()
+
+
+@pytest.fixture(name="channel", scope="function")
+async def get_channel_fixture(
+    app: SpakkyApplication,
+) -> AsyncGenerator[grpc.aio.Channel, None]:
+    binder = app.container.get(GrpcServerPortBinder)
+    async with grpc.aio.insecure_channel(binder.address) as channel:
+        yield channel
+
+
+@pytest.fixture(name="grpc_client", scope="function")
+def get_grpc_client_fixture(
+    app: SpakkyApplication,
+    channel: grpc.aio.Channel,
+) -> GrpcIntegrationClient:
+    registry = app.container.get(DescriptorRegistry)
+    return GrpcIntegrationClient(channel=channel, registry=registry)

--- a/plugins/spakky-grpc/tests/integration/conftest.py
+++ b/plugins/spakky-grpc/tests/integration/conftest.py
@@ -85,9 +85,7 @@ class GrpcIntegrationClient:
         message_class = self.registry.get_message_class(full_name)
         message = message_class()
         for key, value in values.items():
-            setattr(
-                message, key, value
-            )  # pyrefly: ignore - runtime protobuf field assignment
+            setattr(message, key, value)  # pyrefly: ignore - runtime protobuf field assignment
         return message
 
     async def unary_unary(

--- a/plugins/spakky-grpc/tests/integration/conftest.py
+++ b/plugins/spakky-grpc/tests/integration/conftest.py
@@ -1,13 +1,14 @@
-import threading
 import importlib
+import sys
+import threading
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-import sys
 from typing import Callable, Generator
 
 import grpc.aio
 import pytest
+import spakky.plugins.grpc
 from google.protobuf.message import Message
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
@@ -15,7 +16,6 @@ from spakky.core.pod.annotations.pod import Pod
 from spakky.core.service.interfaces.service import IService
 from spakky.plugins.grpc.schema.registry import DescriptorRegistry
 from spakky.tracing import PLUGIN_NAME as SPAKKY_TRACING_PLUGIN_NAME
-import spakky.plugins.grpc
 
 TESTS_ROOT = Path(__file__).resolve().parents[2]
 if str(TESTS_ROOT) not in sys.path:

--- a/plugins/spakky-grpc/tests/integration/test_interceptors.py
+++ b/plugins/spakky-grpc/tests/integration/test_interceptors.py
@@ -38,9 +38,9 @@ async def test_capture_trace_when_traceparent_provided_expect_child_context_and_
         name="trace",
     )
 
-    assert response.trace_id == parent_context.trace_id  # pyrefly: ignore - runtime protobuf attr
-    assert response.parent_span_id == parent_context.span_id  # pyrefly: ignore - runtime protobuf attr
-    assert response.span_id != parent_context.span_id  # pyrefly: ignore - runtime protobuf attr
+    assert getattr(response, "trace_id") == parent_context.trace_id
+    assert getattr(response, "parent_span_id") == parent_context.span_id
+    assert getattr(response, "span_id") != parent_context.span_id
 
     trailing_metadata = dict(await call.trailing_metadata())
     assert "traceparent" in trailing_metadata

--- a/plugins/spakky-grpc/tests/integration/test_interceptors.py
+++ b/plugins/spakky-grpc/tests/integration/test_interceptors.py
@@ -5,8 +5,9 @@ from tests.integration.conftest import GrpcIntegrationClient
 
 SERVICE_PATH = "/integration.v1.IntegrationService"
 
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
-@pytest.mark.asyncio
+
 async def test_fail_invalid_argument_when_managed_error_raised_expect_grpc_status_code(
     grpc_client: GrpcIntegrationClient,
 ) -> None:
@@ -23,7 +24,6 @@ async def test_fail_invalid_argument_when_managed_error_raised_expect_grpc_statu
     assert exc_info.value.details() == "Invalid Argument"
 
 
-@pytest.mark.asyncio
 async def test_capture_trace_when_traceparent_provided_expect_child_context_and_trailing_metadata(
     grpc_client: GrpcIntegrationClient,
 ) -> None:

--- a/plugins/spakky-grpc/tests/integration/test_interceptors.py
+++ b/plugins/spakky-grpc/tests/integration/test_interceptors.py
@@ -1,6 +1,5 @@
 import grpc
 import pytest
-
 from spakky.tracing.context import TraceContext
 from tests.integration.conftest import GrpcIntegrationClient
 

--- a/plugins/spakky-grpc/tests/integration/test_interceptors.py
+++ b/plugins/spakky-grpc/tests/integration/test_interceptors.py
@@ -1,0 +1,52 @@
+import grpc
+import pytest
+
+from spakky.tracing.context import TraceContext
+from tests.integration.conftest import GrpcIntegrationClient
+
+SERVICE_PATH = "/integration.v1.IntegrationService"
+
+
+@pytest.mark.asyncio
+async def test_fail_invalid_argument_when_managed_error_raised_expect_grpc_status_code(
+    grpc_client: GrpcIntegrationClient,
+) -> None:
+    """Managed gRPC 에러가 클라이언트에서 대응하는 status code로 관측됨을 검증한다."""
+    with pytest.raises(grpc.aio.AioRpcError) as exc_info:
+        await grpc_client.unary_unary(
+            method_path=f"{SERVICE_PATH}/fail_invalid_argument",
+            request_full_name="integration.v1.HelloRequest",
+            response_full_name="integration.v1.HelloReply",
+            name="boom",
+        )
+
+    assert exc_info.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert exc_info.value.details() == "Invalid Argument"
+
+
+@pytest.mark.asyncio
+async def test_capture_trace_when_traceparent_provided_expect_child_context_and_trailing_metadata(
+    grpc_client: GrpcIntegrationClient,
+) -> None:
+    """traceparent 메타데이터가 컨트롤러와 trailing metadata까지 전파됨을 검증한다."""
+    parent_context = TraceContext.new_root()
+    response, call = await grpc_client.unary_unary(
+        method_path=f"{SERVICE_PATH}/capture_trace",
+        request_full_name="integration.v1.HelloRequest",
+        response_full_name="integration.v1.TraceSnapshotReply",
+        metadata=(("traceparent", parent_context.to_traceparent()),),
+        name="trace",
+    )
+
+    assert response.trace_id == parent_context.trace_id  # pyrefly: ignore - runtime protobuf attr
+    assert response.parent_span_id == parent_context.span_id  # pyrefly: ignore - runtime protobuf attr
+    assert response.span_id != parent_context.span_id  # pyrefly: ignore - runtime protobuf attr
+
+    trailing_metadata = dict(await call.trailing_metadata())
+    assert "traceparent" in trailing_metadata
+
+    traceparent = trailing_metadata["traceparent"]
+    if isinstance(traceparent, bytes):
+        traceparent = traceparent.decode("utf-8")
+    downstream_context = TraceContext.from_traceparent(traceparent)
+    assert downstream_context.trace_id == parent_context.trace_id

--- a/plugins/spakky-grpc/tests/integration/test_streaming.py
+++ b/plugins/spakky-grpc/tests/integration/test_streaming.py
@@ -1,5 +1,4 @@
 import pytest
-
 from tests.integration.conftest import GrpcIntegrationClient
 
 SERVICE_PATH = "/integration.v1.IntegrationService"

--- a/plugins/spakky-grpc/tests/integration/test_streaming.py
+++ b/plugins/spakky-grpc/tests/integration/test_streaming.py
@@ -3,8 +3,9 @@ from tests.integration.conftest import GrpcIntegrationClient
 
 SERVICE_PATH = "/integration.v1.IntegrationService"
 
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
-@pytest.mark.asyncio
+
 async def test_stream_hello_when_server_streaming_request_expect_two_messages(
     grpc_client: GrpcIntegrationClient,
 ) -> None:
@@ -22,7 +23,6 @@ async def test_stream_hello_when_server_streaming_request_expect_two_messages(
     ]
 
 
-@pytest.mark.asyncio
 async def test_collect_names_when_client_streaming_requests_expect_aggregated_response(
     grpc_client: GrpcIntegrationClient,
 ) -> None:
@@ -37,7 +37,6 @@ async def test_collect_names_when_client_streaming_requests_expect_aggregated_re
     assert getattr(response, "summary") == "alpha,beta,gamma"
 
 
-@pytest.mark.asyncio
 async def test_echo_names_when_bidirectional_streaming_requests_expect_echoed_messages(
     grpc_client: GrpcIntegrationClient,
 ) -> None:

--- a/plugins/spakky-grpc/tests/integration/test_streaming.py
+++ b/plugins/spakky-grpc/tests/integration/test_streaming.py
@@ -1,0 +1,53 @@
+import pytest
+
+from tests.integration.conftest import GrpcIntegrationClient
+
+SERVICE_PATH = "/integration.v1.IntegrationService"
+
+
+@pytest.mark.asyncio
+async def test_stream_hello_when_server_streaming_request_expect_two_messages(
+    grpc_client: GrpcIntegrationClient,
+) -> None:
+    """Server-streaming RPC가 순서대로 두 응답을 반환함을 검증한다."""
+    responses, _call = await grpc_client.unary_stream(
+        method_path=f"{SERVICE_PATH}/stream_hello",
+        request_full_name="integration.v1.HelloRequest",
+        response_full_name="integration.v1.HelloReply",
+        name="Spakky",
+    )
+
+    assert [item.message for item in responses] == [  # pyrefly: ignore - runtime protobuf attr
+        "Hello, Spakky!",
+        "Goodbye, Spakky!",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_collect_names_when_client_streaming_requests_expect_aggregated_response(
+    grpc_client: GrpcIntegrationClient,
+) -> None:
+    """Client-streaming RPC가 요청 스트림을 집계해 단일 응답을 반환함을 검증한다."""
+    response, _call = await grpc_client.stream_unary(
+        method_path=f"{SERVICE_PATH}/collect_names",
+        request_full_name="integration.v1.HelloRequest",
+        response_full_name="integration.v1.NamesReply",
+        request_values=[{"name": "alpha"}, {"name": "beta"}, {"name": "gamma"}],
+    )
+
+    assert response.summary == "alpha,beta,gamma"  # pyrefly: ignore - runtime protobuf attr
+
+
+@pytest.mark.asyncio
+async def test_echo_names_when_bidirectional_streaming_requests_expect_echoed_messages(
+    grpc_client: GrpcIntegrationClient,
+) -> None:
+    """Bidirectional streaming RPC가 각 요청에 대응하는 응답 스트림을 반환함을 검증한다."""
+    responses, _call = await grpc_client.stream_stream(
+        method_path=f"{SERVICE_PATH}/echo_names",
+        request_full_name="integration.v1.HelloRequest",
+        response_full_name="integration.v1.HelloReply",
+        request_values=[{"name": "first"}, {"name": "second"}],
+    )
+
+    assert [item.message for item in responses] == ["FIRST", "SECOND"]  # pyrefly: ignore - runtime protobuf attr

--- a/plugins/spakky-grpc/tests/integration/test_streaming.py
+++ b/plugins/spakky-grpc/tests/integration/test_streaming.py
@@ -17,7 +17,7 @@ async def test_stream_hello_when_server_streaming_request_expect_two_messages(
         name="Spakky",
     )
 
-    assert [item.message for item in responses] == [  # pyrefly: ignore - runtime protobuf attr
+    assert [getattr(item, "message") for item in responses] == [
         "Hello, Spakky!",
         "Goodbye, Spakky!",
     ]
@@ -35,7 +35,7 @@ async def test_collect_names_when_client_streaming_requests_expect_aggregated_re
         request_values=[{"name": "alpha"}, {"name": "beta"}, {"name": "gamma"}],
     )
 
-    assert response.summary == "alpha,beta,gamma"  # pyrefly: ignore - runtime protobuf attr
+    assert getattr(response, "summary") == "alpha,beta,gamma"
 
 
 @pytest.mark.asyncio
@@ -50,4 +50,7 @@ async def test_echo_names_when_bidirectional_streaming_requests_expect_echoed_me
         request_values=[{"name": "first"}, {"name": "second"}],
     )
 
-    assert [item.message for item in responses] == ["FIRST", "SECOND"]  # pyrefly: ignore - runtime protobuf attr
+    assert [getattr(item, "message") for item in responses] == [
+        "FIRST",
+        "SECOND",
+    ]

--- a/plugins/spakky-grpc/tests/integration/test_unary.py
+++ b/plugins/spakky-grpc/tests/integration/test_unary.py
@@ -3,8 +3,9 @@ from tests.integration.conftest import GrpcIntegrationClient
 
 SERVICE_PATH = "/integration.v1.IntegrationService"
 
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
-@pytest.mark.asyncio
+
 async def test_say_hello_when_unary_request_expect_greeting_response(
     grpc_client: GrpcIntegrationClient,
 ) -> None:

--- a/plugins/spakky-grpc/tests/integration/test_unary.py
+++ b/plugins/spakky-grpc/tests/integration/test_unary.py
@@ -1,5 +1,4 @@
 import pytest
-
 from tests.integration.conftest import GrpcIntegrationClient
 
 SERVICE_PATH = "/integration.v1.IntegrationService"

--- a/plugins/spakky-grpc/tests/integration/test_unary.py
+++ b/plugins/spakky-grpc/tests/integration/test_unary.py
@@ -1,0 +1,20 @@
+import pytest
+
+from tests.integration.conftest import GrpcIntegrationClient
+
+SERVICE_PATH = "/integration.v1.IntegrationService"
+
+
+@pytest.mark.asyncio
+async def test_say_hello_when_unary_request_expect_greeting_response(
+    grpc_client: GrpcIntegrationClient,
+) -> None:
+    """Unary RPC 호출이 실제 grpc.aio 서버에서 정상 응답함을 검증한다."""
+    response, _call = await grpc_client.unary_unary(
+        method_path=f"{SERVICE_PATH}/say_hello",
+        request_full_name="integration.v1.HelloRequest",
+        response_full_name="integration.v1.HelloReply",
+        name="Spakky",
+    )
+
+    assert response.message == "Hello, Spakky!"  # pyrefly: ignore - runtime protobuf attr

--- a/plugins/spakky-grpc/tests/integration/test_unary.py
+++ b/plugins/spakky-grpc/tests/integration/test_unary.py
@@ -17,4 +17,4 @@ async def test_say_hello_when_unary_request_expect_greeting_response(
         name="Spakky",
     )
 
-    assert response.message == "Hello, Spakky!"  # pyrefly: ignore - runtime protobuf attr
+    assert getattr(response, "message") == "Hello, Spakky!"

--- a/plugins/spakky-kafka/.pre-commit-config.yaml
+++ b/plugins/spakky-kafka/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/plugins/spakky-logging/.pre-commit-config.yaml
+++ b/plugins/spakky-logging/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/plugins/spakky-opentelemetry/.pre-commit-config.yaml
+++ b/plugins/spakky-opentelemetry/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/plugins/spakky-rabbitmq/.pre-commit-config.yaml
+++ b/plugins/spakky-rabbitmq/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/plugins/spakky-security/.pre-commit-config.yaml
+++ b/plugins/spakky-security/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/plugins/spakky-sqlalchemy/.pre-commit-config.yaml
+++ b/plugins/spakky-sqlalchemy/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/plugins/spakky-typer/.pre-commit-config.yaml
+++ b/plugins/spakky-typer/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ['--unsafe']
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.9
     hooks:
       - id: ruff
         types_or: [python, pyi]

--- a/uv.lock
+++ b/uv.lock
@@ -2935,12 +2935,20 @@ dependencies = [
     { name = "spakky-tracing" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-integration-mark" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "grpcio", specifier = ">=1.68.0" },
     { name = "spakky", editable = "core/spakky" },
     { name = "spakky-tracing", editable = "core/spakky-tracing" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-integration-mark", specifier = ">=0.2.0" }]
 
 [[package]]
 name = "spakky-kafka"


### PR DESCRIPTION
## Summary
- add grpc.aio end-to-end integration tests for unary, server streaming, client streaming, bidi streaming, error mapping, and trace propagation
- document the runtime server/registry setup in the plugin README and grpc guide
- prepare the application event loop before loop-bound async Pods so grpc server startup uses a consistent loop

## Validation
- cd core/spakky && uv run ruff check . && uv run pyrefly check
- cd plugins/spakky-grpc && uv run ruff check . && uv run pyrefly check
- cd plugins/spakky-grpc && uv run pytest --with-integration
- cd /Users/spakky/Documents/projects/feat-87 && uv run python scripts/run_coverage.py --package spakky-grpc

Closes #87