### PR TITLE
feat: implement saga runtime strategies and timeouts (#93)

### DIFF
--- a/core/spakky-saga/src/spakky/saga/engine.py
+++ b/core/spakky-saga/src/spakky/saga/engine.py
@@ -15,7 +15,6 @@ from spakky.saga.result import SagaResult, StepRecord, StepStatus
 from spakky.saga.status import SagaStatus
 from spakky.saga.strategy import Retry, Skip
 
-
 _CompensableEntry = tuple[str, Callable[[SagaDataT], Awaitable[None]]]
 
 
@@ -125,9 +124,16 @@ async def _run_compensation(
                     elapsed=timedelta(seconds=monotonic() - comp_start),
                 )
             )
+            compensation_error = SagaCompensationFailedError()
             if handler is not None:
-                await handler(data)
-            raise SagaCompensationFailedError() from comp_error
+                try:
+                    await handler(data)
+                except Exception as handler_error:  # noqa: BLE001 - keep original compensation failure
+                    compensation_error.add_note(
+                        "Compensation failure handler raised "
+                        f"{type(handler_error).__name__}: {handler_error}"
+                    )
+            raise compensation_error from comp_error
 
 
 async def _execute_flow_item(
@@ -167,16 +173,20 @@ async def _execute_parallel_item(
     handler: Callable[[SagaDataT], Awaitable[None]] | None,
 ) -> _ItemExecutionResult[SagaDataT]:
     """Parallel 그룹을 동시 실행한다."""
-    tasks = [
-        _execute_step_item(
-            item=child,
-            data=data,
-            saga_start=saga_start,
-            saga_timeout=saga_timeout,
-            allow_data_update=False,
+    tasks = []
+    for child in item.items:
+        promoted_child = _promote_flow_item(child)
+        if isinstance(promoted_child, Parallel):
+            raise SagaFlowDefinitionError
+        tasks.append(
+            _execute_step_item(
+                item=promoted_child,
+                data=data,
+                saga_start=saga_start,
+                saga_timeout=saga_timeout,
+                allow_data_update=False,
+            )
         )
-        for child in item.items
-    ]
     results = await asyncio.gather(*tasks)
 
     history: list[StepRecord] = []

--- a/core/spakky-saga/src/spakky/saga/engine.py
+++ b/core/spakky-saga/src/spakky/saga/engine.py
@@ -275,11 +275,15 @@ async def _execute_step_item(
             )
         except Exception as error:  # noqa: BLE001 - saga engine catches all step errors
             if _is_saga_timeout(saga_timeout=saga_timeout, saga_start=saga_start):
+                timeout_error = TimeoutError(
+                    f"Saga timed out while executing step '{step_name}'."
+                )
+                timeout_error.__cause__ = error
                 return _terminal_timeout_result(
                     step_name=step_name,
                     data=data,
                     step_start=step_start,
-                    error=error,
+                    error=timeout_error,
                 )
 
             retry = item.on_error if isinstance(item.on_error, Retry) else None

--- a/core/spakky-saga/src/spakky/saga/engine.py
+++ b/core/spakky-saga/src/spakky/saga/engine.py
@@ -2,15 +2,34 @@
 
 from __future__ import annotations
 
+import asyncio
+from dataclasses import dataclass, field
 from datetime import timedelta
 from time import monotonic
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Generic, cast
 
 from spakky.saga.data import AbstractSagaData
 from spakky.saga.error import SagaCompensationFailedError, SagaFlowDefinitionError
 from spakky.saga.flow import Parallel, SagaDataT, SagaFlow, SagaStep, Transaction
 from spakky.saga.result import SagaResult, StepRecord, StepStatus
 from spakky.saga.status import SagaStatus
+from spakky.saga.strategy import Retry, Skip
+
+
+_CompensableEntry = tuple[str, Callable[[SagaDataT], Awaitable[None]]]
+
+
+@dataclass(slots=True)
+class _ItemExecutionResult(Generic[SagaDataT]):
+    """단일 flow item 실행 결과."""
+
+    data: SagaDataT
+    history: list[StepRecord] = field(default_factory=list)
+    compensable: list[_CompensableEntry] = field(default_factory=list)
+    terminal_status: SagaStatus | None = None
+    failed_step: str | None = None
+    error: Exception | None = None
+    completed_at: float | None = None
 
 
 async def run_saga_flow(
@@ -30,38 +49,23 @@ async def run_saga_flow(
         SagaCompensationFailedError: 보상 실행 중 에러 발생
             (on_compensation_failure 미설정 시).
     """
-    normalized = _normalize_items(
-        flow.items  # pyrefly: ignore - saga_flow() promotes Callable to SagaStep before engine sees it
-    )
-    compensable: list[tuple[str, Callable[[SagaDataT], Awaitable[None]]]] = []
+    compensable: list[_CompensableEntry] = []
     history: list[StepRecord] = []
     saga_start = monotonic()
 
-    for name, action, compensate in normalized:
-        step_start = monotonic()
-        try:
-            result = await action(data)
-            if isinstance(result, AbstractSagaData):
-                data = result  # type: ignore[assignment] - runtime SagaData subtype check
-            step_elapsed = timedelta(seconds=monotonic() - step_start)
-            history.append(
-                StepRecord(
-                    name=name,
-                    status=StepStatus.COMMITTED,
-                    elapsed=step_elapsed,
-                )
-            )
-            if compensate is not None:
-                compensable.append((name, compensate))
-        except Exception as error:  # noqa: BLE001 - saga engine catches all step errors
-            step_elapsed = timedelta(seconds=monotonic() - step_start)
-            history.append(
-                StepRecord(
-                    name=name,
-                    status=StepStatus.FAILED,
-                    elapsed=step_elapsed,
-                )
-            )
+    for item in flow.items:
+        execution = await _execute_flow_item(
+            item=item,
+            data=data,
+            saga_start=saga_start,
+            saga_timeout=flow.saga_timeout,
+            handler=flow.compensation_failure_handler,
+        )
+        data = execution.data
+        history.extend(execution.history)
+        compensable.extend(execution.compensable)
+
+        if execution.terminal_status is not None:
             await _run_compensation(
                 compensable=compensable,
                 data=data,
@@ -69,10 +73,10 @@ async def run_saga_flow(
                 handler=flow.compensation_failure_handler,
             )
             return SagaResult(
-                status=SagaStatus.FAILED,
+                status=execution.terminal_status,
                 data=data,
-                failed_step=name,
-                error=error,
+                failed_step=execution.failed_step,
+                error=execution.error,
                 history=tuple(history),
                 elapsed=timedelta(seconds=monotonic() - saga_start),
             )
@@ -86,7 +90,7 @@ async def run_saga_flow(
 
 
 async def _run_compensation(
-    compensable: list[tuple[str, Callable[[SagaDataT], Awaitable[None]]]],
+    compensable: list[_CompensableEntry],
     data: SagaDataT,
     history: list[StepRecord],
     handler: Callable[[SagaDataT], Awaitable[None]] | None,
@@ -126,36 +130,312 @@ async def _run_compensation(
             raise SagaCompensationFailedError() from comp_error
 
 
-_NormalizedStep = tuple[
-    str,
-    Callable[[SagaDataT], Awaitable[SagaDataT | None]],
-    Callable[[SagaDataT], Awaitable[None]] | None,
-]
-"""(name, action, compensate_or_none) 튜플."""
+async def _execute_flow_item(
+    item: SagaStep[SagaDataT]
+    | Transaction[SagaDataT]
+    | Parallel[SagaDataT]
+    | Callable[[SagaDataT], Awaitable[SagaDataT | None]],
+    data: SagaDataT,
+    saga_start: float,
+    saga_timeout: timedelta | None,
+    handler: Callable[[SagaDataT], Awaitable[None]] | None,
+) -> _ItemExecutionResult[SagaDataT]:
+    """Flow item을 실행한다."""
+    promoted = _promote_flow_item(item)
+    if isinstance(promoted, Parallel):
+        return await _execute_parallel_item(
+            item=promoted,
+            data=data,
+            saga_start=saga_start,
+            saga_timeout=saga_timeout,
+            handler=handler,
+        )
+    return await _execute_step_item(
+        item=promoted,
+        data=data,
+        saga_start=saga_start,
+        saga_timeout=saga_timeout,
+        allow_data_update=True,
+    )
 
 
-def _normalize_items(
-    items: tuple[  # pyrefly: ignore - SagaFlow.items union includes Callable but saga_flow() promotes it
-        SagaStep[SagaDataT] | Transaction[SagaDataT] | Parallel[SagaDataT], ...
-    ],
-) -> list[_NormalizedStep]:
-    """flow items를 (name, action, compensate) 튜플 리스트로 정규화한다."""
-    result: list[_NormalizedStep] = []
-    for item in items:
-        if isinstance(item, Transaction):
-            # dynamic __name__ access: runtime function name for logging/debugging
-            name = getattr(item.action, "__name__", "<unknown>")
-            result.append((name, item.action, item.compensate))
-        elif isinstance(item, SagaStep):
-            # dynamic __name__ access: runtime function name for logging/debugging
-            name = getattr(item.action, "__name__", "<unknown>")
-            result.append((name, item.action, None))
-        elif isinstance(item, Parallel):
-            result.extend(_normalize_items(item.items))
-        elif callable(item):
-            # dynamic __name__ access: runtime function name for logging/debugging
-            name = getattr(item, "__name__", "<unknown>")
-            result.append((name, item, None))
-        else:
-            raise SagaFlowDefinitionError
+async def _execute_parallel_item(
+    item: Parallel[SagaDataT],
+    data: SagaDataT,
+    saga_start: float,
+    saga_timeout: timedelta | None,
+    handler: Callable[[SagaDataT], Awaitable[None]] | None,
+) -> _ItemExecutionResult[SagaDataT]:
+    """Parallel 그룹을 동시 실행한다."""
+    tasks = [
+        _execute_step_item(
+            item=child,
+            data=data,
+            saga_start=saga_start,
+            saga_timeout=saga_timeout,
+            allow_data_update=False,
+        )
+        for child in item.items
+    ]
+    results = await asyncio.gather(*tasks)
+
+    history: list[StepRecord] = []
+    completed_results: list[_ItemExecutionResult[SagaDataT]] = []
+    first_terminal: _ItemExecutionResult[SagaDataT] | None = None
+    timeout_terminal: _ItemExecutionResult[SagaDataT] | None = None
+
+    for result in results:
+        history.extend(result.history)
+        if result.terminal_status is None:
+            completed_results.append(result)
+            continue
+        if result.terminal_status is SagaStatus.TIMED_OUT and timeout_terminal is None:
+            timeout_terminal = result
+        if first_terminal is None:
+            first_terminal = result
+
+    completed_results.sort(
+        key=lambda result: result.completed_at if result.completed_at is not None else 0
+    )
+    compensable: list[_CompensableEntry] = []
+    for result in completed_results:
+        compensable.extend(result.compensable)
+
+    terminal = timeout_terminal if timeout_terminal is not None else first_terminal
+
+    if terminal is None:
+        return _ItemExecutionResult(data=data, history=history, compensable=compensable)
+
+    await _run_compensation(
+        compensable=compensable,
+        data=data,
+        history=history,
+        handler=handler,
+    )
+    return _ItemExecutionResult(
+        data=data,
+        history=history,
+        terminal_status=terminal.terminal_status,
+        failed_step=terminal.failed_step,
+        error=terminal.error,
+    )
+
+
+async def _execute_step_item(
+    item: SagaStep[SagaDataT] | Transaction[SagaDataT],
+    data: SagaDataT,
+    saga_start: float,
+    saga_timeout: timedelta | None,
+    *,
+    allow_data_update: bool,
+) -> _ItemExecutionResult[SagaDataT]:
+    """단일 step 또는 transaction을 실행한다."""
+    step_name = _resolve_step_name(item.action)
+    step_start = monotonic()
+    attempts = 0
+
+    while True:
+        attempts += 1
+        remaining_saga = _remaining_saga_seconds(
+            saga_timeout=saga_timeout,
+            saga_start=saga_start,
+        )
+        if remaining_saga is not None and remaining_saga <= 0:
+            return _terminal_timeout_result(
+                step_name=step_name, data=data, step_start=step_start
+            )
+
+        timeout_seconds = _resolve_timeout_seconds(
+            step_timeout=item.timeout,
+            remaining_saga=remaining_saga,
+        )
+
+        try:
+            result = await _await_with_timeout(item.action(data), timeout_seconds)
+            completed_at = monotonic()
+            resolved_data = data
+            if allow_data_update and isinstance(result, AbstractSagaData):
+                resolved_data = cast(SagaDataT, result)
+
+            compensable: list[_CompensableEntry] = []
+            if isinstance(item, Transaction):
+                compensable.append((step_name, item.compensate))
+
+            return _ItemExecutionResult(
+                data=resolved_data,
+                history=[
+                    StepRecord(
+                        name=step_name,
+                        status=StepStatus.COMMITTED,
+                        elapsed=timedelta(seconds=completed_at - step_start),
+                    )
+                ],
+                compensable=compensable,
+                completed_at=completed_at,
+            )
+        except Exception as error:  # noqa: BLE001 - saga engine catches all step errors
+            if _is_saga_timeout(saga_timeout=saga_timeout, saga_start=saga_start):
+                return _terminal_timeout_result(
+                    step_name=step_name,
+                    data=data,
+                    step_start=step_start,
+                    error=error,
+                )
+
+            retry = item.on_error if isinstance(item.on_error, Retry) else None
+            if retry is not None and attempts < retry.max_attempts:
+                await _sleep_backoff(
+                    retry=retry,
+                    attempts=attempts,
+                    saga_timeout=saga_timeout,
+                    saga_start=saga_start,
+                )
+                continue
+
+            return _resolve_terminal_strategy(
+                item=item,
+                data=data,
+                step_name=step_name,
+                step_start=step_start,
+                error=error,
+            )
+
+
+def _promote_flow_item(
+    item: SagaStep[SagaDataT]
+    | Transaction[SagaDataT]
+    | Parallel[SagaDataT]
+    | Callable[[SagaDataT], Awaitable[SagaDataT | None]],
+) -> SagaStep[SagaDataT] | Transaction[SagaDataT] | Parallel[SagaDataT]:
+    """런타임 실행용 FlowItem으로 승격한다."""
+    if isinstance(item, (SagaStep, Transaction, Parallel)):
+        return item
+    if callable(item):
+        return SagaStep(action=item)
+    raise SagaFlowDefinitionError
+
+
+def _resolve_terminal_strategy(
+    item: SagaStep[SagaDataT] | Transaction[SagaDataT],
+    data: SagaDataT,
+    step_name: str,
+    step_start: float,
+    error: Exception,
+) -> _ItemExecutionResult[SagaDataT]:
+    """최종 에러 전략을 적용한다."""
+    strategy = item.on_error.then if isinstance(item.on_error, Retry) else item.on_error
+    result = _ItemExecutionResult(
+        data=data,
+        history=[
+            StepRecord(
+                name=step_name,
+                status=StepStatus.FAILED,
+                elapsed=timedelta(seconds=monotonic() - step_start),
+            )
+        ],
+    )
+    if isinstance(strategy, Skip):
+        return result
+    result.terminal_status = SagaStatus.FAILED
+    result.failed_step = step_name
+    result.error = error
     return result
+
+
+def _terminal_timeout_result(
+    step_name: str,
+    data: SagaDataT,
+    step_start: float,
+    error: Exception | None = None,
+) -> _ItemExecutionResult[SagaDataT]:
+    """타임아웃 종료 결과를 생성한다."""
+    return _ItemExecutionResult(
+        data=data,
+        history=[
+            StepRecord(
+                name=step_name,
+                status=StepStatus.FAILED,
+                elapsed=timedelta(seconds=monotonic() - step_start),
+            )
+        ],
+        terminal_status=SagaStatus.TIMED_OUT,
+        failed_step=step_name,
+        error=error if error is not None else TimeoutError(),
+    )
+
+
+async def _await_with_timeout(
+    task: Awaitable[SagaDataT | None],
+    timeout_seconds: float | None,
+) -> SagaDataT | None:
+    """필요 시 wait_for를 통해 액션을 실행한다."""
+    if timeout_seconds is None:
+        return await task
+    return await asyncio.wait_for(task, timeout=timeout_seconds)
+
+
+def _resolve_timeout_seconds(
+    step_timeout: timedelta | None,
+    remaining_saga: float | None,
+) -> float | None:
+    """step 실행에 적용할 timeout 초를 계산한다."""
+    step_seconds = None if step_timeout is None else step_timeout.total_seconds()
+    if remaining_saga is None:
+        return step_seconds
+    if step_seconds is None:
+        return remaining_saga
+    return min(step_seconds, remaining_saga)
+
+
+def _remaining_saga_seconds(
+    saga_timeout: timedelta | None,
+    saga_start: float,
+) -> float | None:
+    """남은 saga timeout budget을 계산한다."""
+    if saga_timeout is None:
+        return None
+    return saga_timeout.total_seconds() - (monotonic() - saga_start)
+
+
+def _is_saga_timeout(
+    saga_timeout: timedelta | None,
+    saga_start: float,
+) -> bool:
+    """사가 전체 timeout이 소진됐는지 확인한다."""
+    remaining = _remaining_saga_seconds(
+        saga_timeout=saga_timeout,
+        saga_start=saga_start,
+    )
+    return remaining is not None and remaining <= 0
+
+
+async def _sleep_backoff(
+    retry: Retry,
+    attempts: int,
+    saga_timeout: timedelta | None,
+    saga_start: float,
+) -> None:
+    """재시도 전 지수 백오프를 적용한다."""
+    delay_seconds = retry.backoff.base * (2 ** (attempts - 1))
+    if delay_seconds <= 0:
+        return
+
+    remaining_saga = _remaining_saga_seconds(
+        saga_timeout=saga_timeout,
+        saga_start=saga_start,
+    )
+    if remaining_saga is not None and remaining_saga <= 0:
+        return
+
+    if remaining_saga is None:
+        await asyncio.sleep(delay_seconds)
+        return
+    await asyncio.sleep(min(delay_seconds, remaining_saga))
+
+
+def _resolve_step_name(
+    action: Callable[[SagaDataT], Awaitable[SagaDataT | None]],
+) -> str:
+    """step 이름을 함수명에서 추출한다."""
+    # dynamic __name__ access: runtime function name for logging/debugging
+    return getattr(action, "__name__", "<unknown>")

--- a/core/spakky-saga/tests/unit/test_engine.py
+++ b/core/spakky-saga/tests/unit/test_engine.py
@@ -12,7 +12,7 @@ from spakky.core.common.mutability import immutable
 from spakky.saga.data import AbstractSagaData
 import spakky.saga.engine as saga_engine
 from spakky.saga.engine import run_saga_flow
-from spakky.saga.error import SagaCompensationFailedError
+from spakky.saga.error import SagaCompensationFailedError, SagaFlowDefinitionError
 from spakky.saga.flow import (
     Parallel,
     SagaFlow,
@@ -379,6 +379,75 @@ async def test_retry_positive_backoff_expect_sleep_called(
     assert result.status is SagaStatus.COMPLETED
     assert attempts == 2
     assert recorded_delays == [0.01]
+
+
+def test_promote_flow_item_callable_expect_saga_step() -> None:
+    """런타임 promotion이 plain callable을 SagaStep으로 승격하는지 검증한다."""
+    promoted = saga_engine._promote_flow_item(_succeed)
+
+    assert isinstance(promoted, SagaStep)
+    assert promoted.action is _succeed
+
+
+def test_promote_flow_item_invalid_expect_definition_error() -> None:
+    """런타임 promotion에 유효하지 않은 item이 들어오면 정의 에러가 발생하는지 검증한다."""
+    with pytest.raises(SagaFlowDefinitionError):
+        saga_engine._promote_flow_item(object())  # type: ignore[arg-type] - runtime invalid item path is intentional in this test
+
+
+def test_resolve_timeout_seconds_with_step_and_saga_expect_minimum() -> None:
+    """step timeout과 saga 잔여 budget이 함께 있으면 더 작은 값을 선택하는지 검증한다."""
+    resolved = saga_engine._resolve_timeout_seconds(
+        step_timeout=timedelta(seconds=1),
+        remaining_saga=0.25,
+    )
+
+    assert resolved == 0.25
+
+
+@pytest.mark.anyio
+async def test_sleep_backoff_with_exhausted_saga_expect_no_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """재시도 전 saga budget이 이미 소진됐으면 backoff sleep을 건너뛰는지 검증한다."""
+    recorded_delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        recorded_delays.append(delay)
+
+    monkeypatch.setattr(saga_engine.asyncio, "sleep", fake_sleep)
+
+    await saga_engine._sleep_backoff(
+        retry=Retry(backoff=ExponentialBackoff(base=0.1)),
+        attempts=1,
+        saga_timeout=timedelta(),
+        saga_start=saga_engine.monotonic(),
+    )
+
+    assert recorded_delays == []
+
+
+@pytest.mark.anyio
+async def test_sleep_backoff_with_remaining_saga_budget_expect_clamped_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """재시도 backoff는 남은 saga budget을 넘지 않도록 절삭되는지 검증한다."""
+    recorded_delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        recorded_delays.append(delay)
+
+    monkeypatch.setattr(saga_engine.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(saga_engine, "_remaining_saga_seconds", lambda **_: 0.03)
+
+    await saga_engine._sleep_backoff(
+        retry=Retry(backoff=ExponentialBackoff(base=0.1)),
+        attempts=1,
+        saga_timeout=timedelta(seconds=1),
+        saga_start=0,
+    )
+
+    assert recorded_delays == [0.03]
 
 
 # --- Parallel ---

--- a/core/spakky-saga/tests/unit/test_engine.py
+++ b/core/spakky-saga/tests/unit/test_engine.py
@@ -1,16 +1,15 @@
 """Unit tests for saga execution engine."""
 
 import asyncio
-
 from dataclasses import replace
 from datetime import timedelta
+from typing import cast
 from uuid import UUID, uuid4
 
 import pytest
-
+import spakky.saga.engine as saga_engine
 from spakky.core.common.mutability import immutable
 from spakky.saga.data import AbstractSagaData
-import spakky.saga.engine as saga_engine
 from spakky.saga.engine import run_saga_flow
 from spakky.saga.error import SagaCompensationFailedError, SagaFlowDefinitionError
 from spakky.saga.flow import (
@@ -24,7 +23,6 @@ from spakky.saga.flow import (
 from spakky.saga.result import StepStatus
 from spakky.saga.status import SagaStatus
 from spakky.saga.strategy import ExponentialBackoff, Retry, Skip
-
 
 _SHORT_DELAY_SECONDS = 0.05
 _TIMEOUT_DELAY_SECONDS = 0.2
@@ -220,6 +218,30 @@ async def test_first_step_fails_expect_no_compensation() -> None:
     assert result.history[0].status is StepStatus.FAILED
 
 
+@pytest.mark.anyio
+async def test_compensation_handler_failure_expect_original_error_preserved() -> None:
+    """보상 핸들러가 실패해도 원래 보상 실패가 SagaCompensationFailedError로 유지되는지 검증한다."""
+
+    async def fail_compensate(data: _OrderData) -> None:
+        raise RuntimeError("compensation failed")
+
+    async def fail_handler(data: _OrderData) -> None:
+        raise ValueError("handler failed")
+
+    flow = saga_flow(
+        step(_succeed, compensate=fail_compensate),
+        step(_fail),
+    ).on_compensation_failure(fail_handler)
+
+    with pytest.raises(SagaCompensationFailedError) as exc_info:
+        await run_saga_flow(flow, _OrderData(order_id=uuid4()))
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert exc_info.value.__notes__ == [
+        "Compensation failure handler raised ValueError: handler failed"
+    ]
+
+
 # --- Transaction (>> 연산자) ---
 
 
@@ -394,6 +416,26 @@ def test_promote_flow_item_invalid_expect_definition_error() -> None:
     """런타임 promotion에 유효하지 않은 item이 들어오면 정의 에러가 발생하는지 검증한다."""
     with pytest.raises(SagaFlowDefinitionError):
         saga_engine._promote_flow_item(object())  # type: ignore[arg-type] - runtime invalid item path is intentional in this test
+
+
+@pytest.mark.anyio
+async def test_parallel_nested_parallel_expect_definition_error() -> None:
+    """직접 구성된 중첩 Parallel은 런타임에서 정의 에러로 거부되는지 검증한다."""
+    nested_parallel = Parallel(
+        items=cast(
+            tuple[SagaStep[_OrderData] | Transaction[_OrderData], ...],
+            (
+                Parallel(items=(step(_succeed), step(_succeed))),
+                step(_succeed),
+            ),
+        )
+    )
+
+    with pytest.raises(SagaFlowDefinitionError):
+        await run_saga_flow(
+            SagaFlow(items=(nested_parallel,)),  # type: ignore[arg-type] - runtime invalid nested parallel path is intentional in this test
+            _OrderData(order_id=uuid4()),
+        )
 
 
 def test_resolve_timeout_seconds_with_step_and_saga_expect_minimum() -> None:

--- a/core/spakky-saga/tests/unit/test_engine.py
+++ b/core/spakky-saga/tests/unit/test_engine.py
@@ -26,10 +26,11 @@ from spakky.saga.status import SagaStatus
 from spakky.saga.strategy import ExponentialBackoff, Retry, Skip
 
 
-_SHORT_DELAY_SECONDS = 0.02
+_SHORT_DELAY_SECONDS = 0.05
+_TIMEOUT_DELAY_SECONDS = 0.2
 _WAIT_TIMEOUT_SECONDS = 1.0
-_STEP_TIMEOUT = timedelta(milliseconds=5)
-_SAGA_TIMEOUT = timedelta(milliseconds=5)
+_STEP_TIMEOUT = timedelta(milliseconds=100)
+_SAGA_TIMEOUT = timedelta(milliseconds=150)
 
 
 @immutable
@@ -74,7 +75,7 @@ async def _compensate_fail(data: _OrderData) -> None:
 
 async def _slow_succeed(data: _OrderData) -> None:
     """짧게 대기 후 성공하는 액션."""
-    await asyncio.sleep(_SHORT_DELAY_SECONDS)
+    await asyncio.sleep(_TIMEOUT_DELAY_SECONDS)
 
 
 @pytest.fixture(autouse=True)
@@ -533,15 +534,18 @@ async def test_parallel_failure_expect_successful_siblings_and_previous_steps_co
 async def test_parallel_compensation_order_expect_reverse_completion_order() -> None:
     """Parallel 보상 순서는 선언 순서가 아니라 실제 완료 역순인지 검증한다."""
     compensation_order: list[str] = []
+    fast_done = asyncio.Event()
+    slow_done = asyncio.Event()
 
     async def slow_success(data: _OrderData) -> None:
-        await asyncio.sleep(_SHORT_DELAY_SECONDS * 2)
+        await fast_done.wait()
+        slow_done.set()
 
     async def fast_success(data: _OrderData) -> None:
-        await asyncio.sleep(_SHORT_DELAY_SECONDS)
+        fast_done.set()
 
     async def fail_after_successes(data: _OrderData) -> None:
-        await asyncio.sleep(_SHORT_DELAY_SECONDS * 3)
+        await slow_done.wait()
         raise RuntimeError("parallel failed")
 
     async def compensate_slow(data: _OrderData) -> None:
@@ -581,6 +585,7 @@ async def test_parallel_timeout_and_failure_expect_timed_out() -> None:
     assert result.status is SagaStatus.TIMED_OUT
     assert result.failed_step == "_slow_succeed"
     assert isinstance(result.error, TimeoutError)
+    assert isinstance(result.error.__cause__, TimeoutError)
 
 
 @pytest.mark.anyio

--- a/core/spakky-saga/tests/unit/test_engine.py
+++ b/core/spakky-saga/tests/unit/test_engine.py
@@ -1,5 +1,7 @@
 """Unit tests for saga execution engine."""
 
+import asyncio
+
 from dataclasses import replace
 from datetime import timedelta
 from uuid import UUID, uuid4
@@ -8,6 +10,7 @@ import pytest
 
 from spakky.core.common.mutability import immutable
 from spakky.saga.data import AbstractSagaData
+import spakky.saga.engine as saga_engine
 from spakky.saga.engine import run_saga_flow
 from spakky.saga.error import SagaCompensationFailedError
 from spakky.saga.flow import (
@@ -20,6 +23,13 @@ from spakky.saga.flow import (
 )
 from spakky.saga.result import StepStatus
 from spakky.saga.status import SagaStatus
+from spakky.saga.strategy import ExponentialBackoff, Retry, Skip
+
+
+_SHORT_DELAY_SECONDS = 0.02
+_WAIT_TIMEOUT_SECONDS = 1.0
+_STEP_TIMEOUT = timedelta(milliseconds=5)
+_SAGA_TIMEOUT = timedelta(milliseconds=5)
 
 
 @immutable
@@ -60,6 +70,11 @@ async def _compensate_logged(data: _OrderData) -> None:
 async def _compensate_fail(data: _OrderData) -> None:
     """항상 실패하는 보상."""
     raise RuntimeError("compensation failed")
+
+
+async def _slow_succeed(data: _OrderData) -> None:
+    """짧게 대기 후 성공하는 액션."""
+    await asyncio.sleep(_SHORT_DELAY_SECONDS)
 
 
 @pytest.fixture(autouse=True)
@@ -232,24 +247,360 @@ async def test_transaction_failure_expect_compensated() -> None:
     assert len(_compensation_log) == 1
 
 
-# --- Parallel (순차 실행 폴백) ---
+# --- Retry / Skip ---
 
 
 @pytest.mark.anyio
-async def test_parallel_items_execute_sequentially_expect_completed() -> None:
-    """Parallel 아이템이 순차적으로 실행되어 COMPLETED를 반환하는지 검증한다."""
+async def test_retry_eventually_succeeds_expect_completed() -> None:
+    """Retry가 재시도 끝에 성공하면 COMPLETED를 반환하는지 검증한다."""
+    attempts = 0
+
+    async def flaky_step(data: _OrderData) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise RuntimeError("transient failure")
+
+    flow = saga_flow(
+        step(
+            flaky_step,
+            on_error=Retry(
+                max_attempts=3,
+                backoff=ExponentialBackoff(base=0),
+            ),
+        )
+    )
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.COMPLETED
+    assert attempts == 3
+    assert len(result.history) == 1
+    assert result.history[0].status is StepStatus.COMMITTED
+
+
+@pytest.mark.anyio
+async def test_retry_then_skip_expect_next_step_continues() -> None:
+    """Retry 소진 후 Skip이면 다음 step으로 진행하는지 검증한다."""
+    attempts = 0
+
+    async def flaky_step(data: _OrderData) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("non-critical failure")
+
+    flow = saga_flow(
+        step(
+            flaky_step,
+            on_error=Retry(
+                max_attempts=2,
+                backoff=ExponentialBackoff(base=0),
+                then=Skip(),
+            ),
+        ),
+        step(_succeed),
+    )
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.COMPLETED
+    assert attempts == 2
+    assert len(result.history) == 2
+    assert result.history[0].status is StepStatus.FAILED
+    assert result.history[1].status is StepStatus.COMMITTED
+    assert result.failed_step is None
+
+
+@pytest.mark.anyio
+async def test_retry_then_compensate_expect_failed_and_previous_steps_rolled_back() -> None:
+    """Retry 기본 then 전략은 보상을 시작하고 FAILED를 반환하는지 검증한다."""
+    attempts = 0
+
+    async def flaky_step(data: _OrderData) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("persistent failure")
+
+    flow = saga_flow(
+        step(_succeed, compensate=_compensate_logged),
+        step(
+            flaky_step,
+            on_error=Retry(
+                max_attempts=2,
+                backoff=ExponentialBackoff(base=0),
+            ),
+        ),
+    )
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.FAILED
+    assert attempts == 2
+    assert len(_compensation_log) == 1
+    assert len(result.history) == 3
+    assert result.history[0].status is StepStatus.COMMITTED
+    assert result.history[1].status is StepStatus.FAILED
+    assert result.history[2].status is StepStatus.COMPENSATED
+
+
+@pytest.mark.anyio
+async def test_retry_positive_backoff_expect_sleep_called(monkeypatch: pytest.MonkeyPatch) -> None:
+    """양수 backoff가 설정되면 retry 사이에 sleep이 호출되는지 검증한다."""
+    attempts = 0
+    recorded_delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        recorded_delays.append(delay)
+
+    async def flaky_step(data: _OrderData) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("transient failure")
+
+    monkeypatch.setattr(saga_engine.asyncio, "sleep", fake_sleep)
+
+    flow = saga_flow(
+        step(
+            flaky_step,
+            on_error=Retry(
+                max_attempts=2,
+                backoff=ExponentialBackoff(base=0.01),
+            ),
+        )
+    )
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.COMPLETED
+    assert attempts == 2
+    assert recorded_delays == [0.01]
+
+
+# --- Parallel ---
+
+
+@pytest.mark.anyio
+async def test_parallel_items_execute_concurrently_expect_completed() -> None:
+    """Parallel 아이템이 함께 시작되고 side-effect only로 처리되는지 검증한다."""
+    both_started = asyncio.Event()
+    release = asyncio.Event()
+    started_steps: list[str] = []
+
+    async def parallel_a(data: _OrderData) -> _OrderData:
+        started_steps.append("a")
+        if len(started_steps) == 2:
+            both_started.set()
+        await release.wait()
+        return replace(data, ticket_id=uuid4())
+
+    async def parallel_b(data: _OrderData) -> None:
+        started_steps.append("b")
+        if len(started_steps) == 2:
+            both_started.set()
+        await release.wait()
+
     par = Parallel(
         items=(
-            SagaStep(action=_succeed),
-            SagaStep(action=_succeed),
+            SagaStep(action=parallel_a),
+            SagaStep(action=parallel_b),
         ),
     )
     flow = SagaFlow(items=(par,))
+    data = _OrderData(order_id=uuid4())
+
+    task = asyncio.create_task(run_saga_flow(flow, data))
+    await asyncio.wait_for(both_started.wait(), timeout=_WAIT_TIMEOUT_SECONDS)
+    release.set()
+    result = await task
+
+    assert result.status is SagaStatus.COMPLETED
+    assert len(result.history) == 2
+    assert sorted(started_steps) == ["a", "b"]
+    assert result.data is data
+    assert result.data.ticket_id is None
+
+
+@pytest.mark.anyio
+async def test_parallel_failure_expect_successful_siblings_and_previous_steps_compensated() -> (
+    None
+):
+    """Parallel 실패 시 성공한 sibling과 이전 step이 보상되는지 검증한다."""
+    compensation_order: list[str] = []
+
+    async def compensate_previous(data: _OrderData) -> None:
+        compensation_order.append("previous")
+
+    async def compensate_parallel(data: _OrderData) -> None:
+        compensation_order.append("parallel")
+
+    par = Parallel(
+        items=(
+            Transaction(action=_succeed, compensate=compensate_parallel),
+            SagaStep(action=_fail),
+        )
+    )
+    flow = saga_flow(
+        step(_succeed, compensate=compensate_previous),
+        par,
+    )
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.FAILED
+    assert compensation_order == ["parallel", "previous"]
+    assert len(result.history) == 5
+    assert result.history[1].status is StepStatus.COMMITTED
+    assert result.history[2].status is StepStatus.FAILED
+    assert result.history[3].status is StepStatus.COMPENSATED
+    assert result.history[4].status is StepStatus.COMPENSATED
+
+
+@pytest.mark.anyio
+async def test_parallel_compensation_order_expect_reverse_completion_order() -> None:
+    """Parallel 보상 순서는 선언 순서가 아니라 실제 완료 역순인지 검증한다."""
+    compensation_order: list[str] = []
+
+    async def slow_success(data: _OrderData) -> None:
+        await asyncio.sleep(_SHORT_DELAY_SECONDS * 2)
+
+    async def fast_success(data: _OrderData) -> None:
+        await asyncio.sleep(_SHORT_DELAY_SECONDS)
+
+    async def fail_after_successes(data: _OrderData) -> None:
+        await asyncio.sleep(_SHORT_DELAY_SECONDS * 3)
+        raise RuntimeError("parallel failed")
+
+    async def compensate_slow(data: _OrderData) -> None:
+        compensation_order.append("slow")
+
+    async def compensate_fast(data: _OrderData) -> None:
+        compensation_order.append("fast")
+
+    par = Parallel(
+        items=(
+            Transaction(action=slow_success, compensate=compensate_slow),
+            Transaction(action=fast_success, compensate=compensate_fast),
+            SagaStep(action=fail_after_successes),
+        )
+    )
+    flow = saga_flow(par)
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.FAILED
+    assert compensation_order == ["slow", "fast"]
+
+
+@pytest.mark.anyio
+async def test_parallel_timeout_and_failure_expect_timed_out() -> None:
+    """Parallel에서 failure와 saga timeout이 함께 발생하면 TIMED_OUT을 우선 반환하는지 검증한다."""
+    par = Parallel(
+        items=(
+            SagaStep(action=_fail),
+            SagaStep(action=_slow_succeed),
+        )
+    )
+    flow = saga_flow(par).timeout(_SAGA_TIMEOUT)
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.TIMED_OUT
+    assert result.failed_step == "_slow_succeed"
+    assert isinstance(result.error, TimeoutError)
+
+
+@pytest.mark.anyio
+async def test_parallel_compensation_uses_original_data_expect_side_effect_only() -> None:
+    """Parallel transaction 보상은 action 반환 데이터가 아닌 원본 data를 받는지 검증한다."""
+    observed_ticket_ids: list[UUID | None] = []
+
+    async def compensate_parallel(data: _OrderData) -> None:
+        observed_ticket_ids.append(data.ticket_id)
+
+    par = Parallel(
+        items=(
+            Transaction(action=_succeed_with_data, compensate=compensate_parallel),
+            SagaStep(action=_fail),
+        )
+    )
+    flow = saga_flow(par)
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.FAILED
+    assert observed_ticket_ids == [None]
+    assert result.data is data
+
+
+# --- Timeout ---
+
+
+@pytest.mark.anyio
+async def test_step_timeout_with_skip_expect_next_step_continues() -> None:
+    """step timeout과 Skip 조합이면 다음 step으로 진행하는지 검증한다."""
+    flow = saga_flow(
+        step(_slow_succeed, timeout=_STEP_TIMEOUT, on_error=Skip()),
+        step(_succeed),
+    )
     data = _OrderData(order_id=uuid4())
     result = await run_saga_flow(flow, data)
 
     assert result.status is SagaStatus.COMPLETED
     assert len(result.history) == 2
+    assert result.history[0].status is StepStatus.FAILED
+    assert result.history[1].status is StepStatus.COMMITTED
+
+
+@pytest.mark.anyio
+async def test_saga_timeout_before_step_start_expect_timed_out_without_action() -> None:
+    """saga budget이 step 시작 전 이미 소진되면 action을 실행하지 않고 TIMED_OUT을 반환하는지 검증한다."""
+    action_called: list[bool] = []
+
+    async def never_started(data: _OrderData) -> None:
+        action_called.append(True)
+
+    flow = saga_flow(step(never_started)).timeout(timedelta())
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.TIMED_OUT
+    assert action_called == []
+    assert result.failed_step == "never_started"
+
+
+@pytest.mark.anyio
+async def test_step_and_saga_timeout_expect_smaller_saga_budget_wins() -> None:
+    """step timeout과 saga timeout이 함께 있으면 더 작은 saga budget이 우선 적용되는지 검증한다."""
+    flow = saga_flow(
+        step(_slow_succeed, timeout=timedelta(seconds=1)),
+    ).timeout(_SAGA_TIMEOUT)
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.TIMED_OUT
+    assert result.failed_step == "_slow_succeed"
+    assert isinstance(result.error, TimeoutError)
+
+
+@pytest.mark.anyio
+async def test_saga_timeout_expect_timed_out_and_compensated() -> None:
+    """saga timeout 소진 시 이미 커밋된 step을 보상하고 TIMED_OUT을 반환하는지 검증한다."""
+    flow = saga_flow(
+        step(_succeed, compensate=_compensate_logged),
+        step(_slow_succeed),
+    ).timeout(_SAGA_TIMEOUT)
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.TIMED_OUT
+    assert result.failed_step == "_slow_succeed"
+    assert isinstance(result.error, TimeoutError)
+    assert len(_compensation_log) == 1
+    assert len(result.history) == 3
+    assert result.history[0].status is StepStatus.COMMITTED
+    assert result.history[1].status is StepStatus.FAILED
+    assert result.history[2].status is StepStatus.COMPENSATED
 
 
 # --- history 기록 ---

--- a/core/spakky-saga/tests/unit/test_engine.py
+++ b/core/spakky-saga/tests/unit/test_engine.py
@@ -3,7 +3,6 @@
 import asyncio
 from dataclasses import replace
 from datetime import timedelta
-from typing import cast
 from uuid import UUID, uuid4
 
 import pytest
@@ -421,19 +420,19 @@ def test_promote_flow_item_invalid_expect_definition_error() -> None:
 @pytest.mark.anyio
 async def test_parallel_nested_parallel_expect_definition_error() -> None:
     """직접 구성된 중첩 Parallel은 런타임에서 정의 에러로 거부되는지 검증한다."""
-    nested_parallel = Parallel(
-        items=cast(
-            tuple[SagaStep[_OrderData] | Transaction[_OrderData], ...],
-            (
-                Parallel(items=(step(_succeed), step(_succeed))),
-                step(_succeed),
-            ),
-        )
+    nested_parallel = object.__new__(Parallel)
+    object.__setattr__(
+        nested_parallel,
+        "items",
+        (
+            Parallel(items=(step(_succeed), step(_succeed))),
+            step(_succeed),
+        ),
     )
 
     with pytest.raises(SagaFlowDefinitionError):
         await run_saga_flow(
-            SagaFlow(items=(nested_parallel,)),  # type: ignore[arg-type] - runtime invalid nested parallel path is intentional in this test
+            SagaFlow(items=(nested_parallel,)),
             _OrderData(order_id=uuid4()),
         )
 

--- a/core/spakky-saga/tests/unit/test_engine.py
+++ b/core/spakky-saga/tests/unit/test_engine.py
@@ -312,7 +312,9 @@ async def test_retry_then_skip_expect_next_step_continues() -> None:
 
 
 @pytest.mark.anyio
-async def test_retry_then_compensate_expect_failed_and_previous_steps_rolled_back() -> None:
+async def test_retry_then_compensate_expect_failed_and_previous_steps_rolled_back() -> (
+    None
+):
     """Retry 기본 then 전략은 보상을 시작하고 FAILED를 반환하는지 검증한다."""
     attempts = 0
 
@@ -344,7 +346,9 @@ async def test_retry_then_compensate_expect_failed_and_previous_steps_rolled_bac
 
 
 @pytest.mark.anyio
-async def test_retry_positive_backoff_expect_sleep_called(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_retry_positive_backoff_expect_sleep_called(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """양수 backoff가 설정되면 retry 사이에 sleep이 호출되는지 검증한다."""
     attempts = 0
     recorded_delays: list[float] = []
@@ -511,7 +515,9 @@ async def test_parallel_timeout_and_failure_expect_timed_out() -> None:
 
 
 @pytest.mark.anyio
-async def test_parallel_compensation_uses_original_data_expect_side_effect_only() -> None:
+async def test_parallel_compensation_uses_original_data_expect_side_effect_only() -> (
+    None
+):
     """Parallel transaction 보상은 action 반환 데이터가 아닌 원본 data를 받는지 검증한다."""
     observed_ticket_ids: list[UUID | None] = []
 


### PR DESCRIPTION
## Summary
- implement Retry, Skip, step timeout, saga timeout, and real Parallel execution in the saga engine
- preserve side-effect-only parallel data semantics while compensating successful siblings in reverse completion order
- add engine coverage for retry backoff, timeout precedence, pre-start timeout, and parallel rollback behavior

## Testing
- uv run --directory /Users/spakky/Documents/projects/feat-93 --group dev ruff check /Users/spakky/Documents/projects/feat-93/core/spakky-saga
- uv run --directory /Users/spakky/Documents/projects/feat-93 --group dev pyrefly check /Users/spakky/Documents/projects/feat-93/core/spakky-saga/src
- uv run --directory /Users/spakky/Documents/projects/feat-93 --group dev pytest /Users/spakky/Documents/projects/feat-93/core/spakky-saga/tests -q -c /Users/spakky/Documents/projects/feat-93/core/spakky-saga/pyproject.toml
- uv run --directory /Users/spakky/Documents/projects/feat-93 --group dev python /Users/spakky/Documents/projects/feat-93/scripts/run_coverage.py --package spakky-saga

Closes #93