### PR TITLE
refactor(sqlalchemy): SchemaRegistry 메서드 TypeVar를 AggregateRootT bound로 정교화 (#127)

### DIFF
--- a/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/orm/schema_registry.py
+++ b/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/orm/schema_registry.py
@@ -1,14 +1,16 @@
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
-from spakky.core.common.types import ObjectT
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.interfaces.aware.tag_registry_aware import ITagRegistryAware
 from spakky.core.pod.interfaces.tag_registry import ITagRegistry
+from spakky.domain.models.aggregate_root import AbstractAggregateRoot
 
 from spakky.plugins.sqlalchemy.orm.error import AbstractSpakkySqlAlchemyORMError
 from spakky.plugins.sqlalchemy.orm.table import AbstractMappableTable, Table
 from sqlalchemy import MetaData
 from sqlalchemy import Table as SQLAlchemyTable
+
+AggregateRootT = TypeVar("AggregateRootT", bound=AbstractAggregateRoot[Any])
 
 
 class NoSchemaFoundFromDomainError(AbstractSpakkySqlAlchemyORMError):
@@ -64,19 +66,21 @@ class SchemaRegistry(ITagRegistryAware):
             ] = tag.domain
 
     def get_type(
-        self, domain_type: type[ObjectT]
-    ) -> type[AbstractMappableTable[ObjectT]]:
+        self, domain_type: type[AggregateRootT]
+    ) -> type[AbstractMappableTable[AggregateRootT]]:
         """Look up the table class registered for the given domain type."""
         table = self._domain_to_table_map.get(domain_type)
         if table is None:
             raise NoSchemaFoundFromDomainError(domain_type)
-        return cast(type[AbstractMappableTable[ObjectT]], table)
+        return cast(type[AbstractMappableTable[AggregateRootT]], table)
 
-    def from_domain(self, domain: ObjectT) -> AbstractMappableTable[ObjectT]:
+    def from_domain(
+        self, aggregate: AggregateRootT
+    ) -> AbstractMappableTable[AggregateRootT]:
         """Convert a domain object to its corresponding table instance."""
-        table: type[AbstractMappableTable[ObjectT]] | None = (
-            self._domain_to_table_map.get(type(domain))
+        table: type[AbstractMappableTable[AggregateRootT]] | None = (
+            self._domain_to_table_map.get(type(aggregate))
         )
         if table is None:
-            raise NoSchemaFoundFromDomainError(domain)
-        return table.from_domain(domain)
+            raise NoSchemaFoundFromDomainError(aggregate)
+        return table.from_domain(aggregate)

--- a/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/persistency/repository.py
+++ b/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/persistency/repository.py
@@ -118,16 +118,12 @@ class AbstractGenericRepository(
     def _get_table_type(
         self,
     ) -> type[AbstractMappableTable[AggregateRootT]]:
-        return self._schema_registry.get_type(  # pyrefly: ignore - cross-package TypeVar narrowing: ObjectT is bound to AggregateRootT at runtime
-            self._aggregate_type
-        )
+        return self._schema_registry.get_type(self._aggregate_type)
 
     def _table_from_domain(
         self, aggregate: AggregateRootT
     ) -> AbstractMappableTable[AggregateRootT]:
-        return self._schema_registry.from_domain(  # pyrefly: ignore - cross-package TypeVar narrowing: ObjectT is bound to AggregateRootT at runtime
-            aggregate
-        )
+        return self._schema_registry.from_domain(aggregate)
 
     @override
     def get(self, aggregate_id: AggregateIdT_contra) -> AggregateRootT:
@@ -321,16 +317,12 @@ class AbstractAsyncGenericRepository(
     def _get_table_type(
         self,
     ) -> type[AbstractMappableTable[AggregateRootT]]:
-        return self._schema_registry.get_type(  # pyrefly: ignore - cross-package TypeVar narrowing: ObjectT is bound to AggregateRootT at runtime
-            self._aggregate_type
-        )
+        return self._schema_registry.get_type(self._aggregate_type)
 
     def _table_from_domain(
         self, aggregate: AggregateRootT
     ) -> AbstractMappableTable[AggregateRootT]:
-        return self._schema_registry.from_domain(  # pyrefly: ignore - cross-package TypeVar narrowing: ObjectT is bound to AggregateRootT at runtime
-            aggregate
-        )
+        return self._schema_registry.from_domain(aggregate)
 
     @override
     async def get(self, aggregate_id: AggregateIdT_contra) -> AggregateRootT:

--- a/plugins/spakky-sqlalchemy/tests/unit/orm/test_schema_registry.py
+++ b/plugins/spakky-sqlalchemy/tests/unit/orm/test_schema_registry.py
@@ -7,7 +7,7 @@ from spakky.core.common.mutability import mutable
 from spakky.core.pod.annotations.tag import Tag
 from spakky.core.pod.interfaces.tag_registry import ITagRegistry
 from spakky.core.utils.uuid import uuid7
-from spakky.domain.models import AbstractEntity
+from spakky.domain.models.aggregate_root import AbstractAggregateRoot
 from sqlalchemy import DateTime, Integer, String, Uuid
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -54,7 +54,7 @@ class InMemoryTagRegistry(ITagRegistry):
 
 
 @mutable
-class User(AbstractEntity[UUID]):
+class User(AbstractAggregateRoot[UUID]):
     """Test domain entity."""
 
     username: str


### PR DESCRIPTION
## Summary

- `SchemaRegistry.get_type` / `from_domain` 의 unbounded `ObjectT` TypeVar 를 `AggregateRootT = TypeVar(..., bound=AbstractAggregateRoot[Any])` 로 교체
- repository 의 4개 `# pyrefly: ignore - cross-package TypeVar narrowing` 주석 제거
- 테스트 도메인 `User` 를 `AbstractEntity` → `AbstractAggregateRoot` 로 변경하여 새 bound 와 정합

SchemaRegistry 는 공유 singleton 특성을 유지하기 위해 클래스 레벨 제네릭으로 승격하지 않고 메서드 레벨 TypeVar 만 조정했다.

Refs ADR-0008 §4.3
Closes #127

## Test Plan

- [x] `cd plugins/spakky-sqlalchemy && uv run ruff format .`
- [x] `cd plugins/spakky-sqlalchemy && uv run ruff check .`
- [x] `cd plugins/spakky-sqlalchemy && uv run pyrefly check .` (0 errors)
- [x] `cd plugins/spakky-sqlalchemy && uv run pytest --cov` (100 passed, 브랜치 커버리지 100%)