### PR TITLE
refactor(domain): IAsync*UseCase.run을 Awaitable 반환 시그니처로 정정 (#126)

### DIFF
--- a/core/spakky-domain/src/spakky/domain/application/command.py
+++ b/core/spakky-domain/src/spakky/domain/application/command.py
@@ -5,7 +5,7 @@ command use cases in CQRS architecture.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import Any, Awaitable, Generic, TypeVar
 
 from spakky.core.common.mutability import immutable
 
@@ -47,13 +47,19 @@ class IAsyncCommandUseCase(ABC, Generic[CommandT_contra, ResultT_co]):
     """Protocol for asynchronous command use cases."""
 
     @abstractmethod
-    async def run(self, command: CommandT_contra) -> ResultT_co:  # pyrefly: ignore - async abstractmethod covariance
+    def run(self, command: CommandT_contra) -> Awaitable[ResultT_co]:
         """Execute command asynchronously and return result.
+
+        The declaration uses ``Awaitable[ResultT_co]`` instead of
+        ``async def`` so that the covariant ``ResultT_co`` remains sound
+        under pyrefly's variance analysis. Concrete implementations may
+        still use ``async def run`` because ``Coroutine`` is a subtype of
+        ``Awaitable``.
 
         Args:
             command: The command to execute.
 
         Returns:
-            Result of command execution.
+            Awaitable resolving to the result of command execution.
         """
         ...

--- a/core/spakky-domain/src/spakky/domain/application/query.py
+++ b/core/spakky-domain/src/spakky/domain/application/query.py
@@ -5,7 +5,7 @@ query use cases in CQRS architecture.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import Any, Awaitable, Generic, TypeVar
 
 from spakky.core.common.mutability import immutable
 
@@ -47,13 +47,19 @@ class IAsyncQueryUseCase(ABC, Generic[QueryT_contra, ResultT_co]):
     """Protocol for asynchronous query use cases."""
 
     @abstractmethod
-    async def run(self, query: QueryT_contra) -> ResultT_co:  # pyrefly: ignore - async abstractmethod covariance
+    def run(self, query: QueryT_contra) -> Awaitable[ResultT_co]:
         """Execute query asynchronously and return result.
+
+        The declaration uses ``Awaitable[ResultT_co]`` instead of
+        ``async def`` so that the covariant ``ResultT_co`` remains sound
+        under pyrefly's variance analysis. Concrete implementations may
+        still use ``async def run`` because ``Coroutine`` is a subtype of
+        ``Awaitable``.
 
         Args:
             query: The query to execute.
 
         Returns:
-            Query result.
+            Awaitable resolving to the query result.
         """
         ...

--- a/core/spakky-domain/tests/usecases/test_command.py
+++ b/core/spakky-domain/tests/usecases/test_command.py
@@ -1,13 +1,96 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Awaitable
+
+from typing_extensions import override
+
 from spakky.domain.application.command import (
     AbstractCommand,
+    IAsyncCommandUseCase,
+    ICommandUseCase,
 )
 
 
 def test_abstract_command() -> None:
     """AbstractCommand의 인스턴스를 생성할 수 있음을 검증한다."""
 
-    class TestCommand(AbstractCommand):
+    class _TestCommand(AbstractCommand):
         pass
 
-    command = TestCommand()
+    command = _TestCommand()
     assert isinstance(command, AbstractCommand)
+
+
+def test_sync_command_usecase_expect_runs_and_returns_result() -> None:
+    """동기 ICommandUseCase 구현이 커맨드를 실행하고 결과를 반환함을 검증한다."""
+
+    @dataclass(frozen=True)
+    class _AddCommand(AbstractCommand):
+        left: int
+        right: int
+
+    class _AddCommandUseCase(ICommandUseCase[_AddCommand, int]):
+        @override
+        def run(self, command: _AddCommand) -> int:
+            return command.left + command.right
+
+    use_case = _AddCommandUseCase()
+    result = use_case.run(_AddCommand(left=2, right=3))
+
+    assert result == 5
+
+
+def test_async_command_usecase_with_async_def_expect_awaitable_result() -> None:
+    """비동기 IAsyncCommandUseCase를 async def로 구현해도 유효함을 검증한다.
+
+    Coroutine은 Awaitable의 subtype이므로 추상 선언이
+    ``def run(...) -> Awaitable[ResultT_co]`` 이어도 ``async def run`` 구현이
+    정상적으로 호환됨을 검증한다.
+    """
+
+    @dataclass(frozen=True)
+    class _MultiplyCommand(AbstractCommand):
+        left: int
+        right: int
+
+    class _MultiplyCommandUseCase(IAsyncCommandUseCase[_MultiplyCommand, int]):
+        @override
+        async def run(self, command: _MultiplyCommand) -> int:
+            return command.left * command.right
+
+    use_case = _MultiplyCommandUseCase()
+    awaitable = use_case.run(_MultiplyCommand(left=4, right=5))
+
+    assert isinstance(awaitable, Awaitable)
+
+    async def _drive() -> int:
+        return await awaitable
+
+    result = asyncio.run(_drive())
+    assert result == 20
+
+
+def test_async_command_usecase_with_awaitable_return_expect_awaitable_result() -> None:
+    """비동기 IAsyncCommandUseCase를 동기 메서드가 Awaitable을 반환하는 방식으로
+    구현해도 유효함을 검증한다."""
+
+    @dataclass(frozen=True)
+    class _EchoCommand(AbstractCommand):
+        payload: str
+
+    class _EchoCommandUseCase(IAsyncCommandUseCase[_EchoCommand, str]):
+        @override
+        def run(self, command: _EchoCommand) -> Awaitable[str]:
+            async def _execute() -> str:
+                return command.payload
+
+            return _execute()
+
+    use_case = _EchoCommandUseCase()
+
+    async def _drive() -> str:
+        return await use_case.run(_EchoCommand(payload="ok"))
+
+    result = asyncio.run(_drive())
+
+    assert result == "ok"

--- a/core/spakky-domain/tests/usecases/test_query.py
+++ b/core/spakky-domain/tests/usecases/test_query.py
@@ -1,13 +1,94 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Awaitable
+
+from typing_extensions import override
+
 from spakky.domain.application.query import (
     AbstractQuery,
+    IAsyncQueryUseCase,
+    IQueryUseCase,
 )
 
 
 def test_abstract_query() -> None:
     """AbstractQuery의 인스턴스를 생성할 수 있음을 검증한다."""
 
-    class TestQuery(AbstractQuery):
+    class _TestQuery(AbstractQuery):
         pass
 
-    query = TestQuery()
+    query = _TestQuery()
     assert isinstance(query, AbstractQuery)
+
+
+def test_sync_query_usecase_expect_runs_and_returns_result() -> None:
+    """동기 IQueryUseCase 구현이 쿼리를 실행하고 결과를 반환함을 검증한다."""
+
+    @dataclass(frozen=True)
+    class _LookupQuery(AbstractQuery):
+        key: str
+
+    class _LookupQueryUseCase(IQueryUseCase[_LookupQuery, str]):
+        @override
+        def run(self, query: _LookupQuery) -> str:
+            return f"value:{query.key}"
+
+    use_case = _LookupQueryUseCase()
+    result = use_case.run(_LookupQuery(key="k"))
+
+    assert result == "value:k"
+
+
+def test_async_query_usecase_with_async_def_expect_awaitable_result() -> None:
+    """비동기 IAsyncQueryUseCase를 async def로 구현해도 유효함을 검증한다.
+
+    Coroutine은 Awaitable의 subtype이므로 추상 선언이
+    ``def run(...) -> Awaitable[ResultT_co]`` 이어도 ``async def run`` 구현이
+    정상적으로 호환됨을 검증한다.
+    """
+
+    @dataclass(frozen=True)
+    class _CountQuery(AbstractQuery):
+        value: str
+
+    class _CountQueryUseCase(IAsyncQueryUseCase[_CountQuery, int]):
+        @override
+        async def run(self, query: _CountQuery) -> int:
+            return len(query.value)
+
+    use_case = _CountQueryUseCase()
+    awaitable = use_case.run(_CountQuery(value="hello"))
+
+    assert isinstance(awaitable, Awaitable)
+
+    async def _drive() -> int:
+        return await awaitable
+
+    result = asyncio.run(_drive())
+    assert result == 5
+
+
+def test_async_query_usecase_with_awaitable_return_expect_awaitable_result() -> None:
+    """비동기 IAsyncQueryUseCase를 동기 메서드가 Awaitable을 반환하는 방식으로
+    구현해도 유효함을 검증한다."""
+
+    @dataclass(frozen=True)
+    class _UpperQuery(AbstractQuery):
+        value: str
+
+    class _UpperQueryUseCase(IAsyncQueryUseCase[_UpperQuery, str]):
+        @override
+        def run(self, query: _UpperQuery) -> Awaitable[str]:
+            async def _execute() -> str:
+                return query.value.upper()
+
+            return _execute()
+
+    use_case = _UpperQueryUseCase()
+
+    async def _drive() -> str:
+        return await use_case.run(_UpperQuery(value="hi"))
+
+    result = asyncio.run(_drive())
+
+    assert result == "HI"


### PR DESCRIPTION
## Summary

- `IAsyncCommandUseCase.run` / `IAsyncQueryUseCase.run` 추상 선언을 `async def run(...) -> ResultT_co` 에서 `def run(...) -> Awaitable[ResultT_co]` 로 변경
- `# pyrefly: ignore - async abstractmethod covariance` 주석 2개 제거
- 동기/비동기 구현체가 정상 동작함을 검증하는 단위 테스트 추가 (`test_command.py`, `test_query.py`)

`ResultT_co` covariant TypeVar가 `async def` 의 암묵 `Coroutine[Any, Any, ResultT_co]` 반환 타입과 결합되며 pyrefly variance 분석이 실패하던 구조적 문제를 ADR-0008 §4.4 결정에 따라 해결한다. `Coroutine` 은 `Awaitable` 의 subtype 이므로 구현체는 기존대로 `async def run` 을 사용할 수 있다.

## Test Plan

- [x] `cd core/spakky-domain && uv run ruff format .`
- [x] `cd core/spakky-domain && uv run ruff check .`
- [x] `cd core/spakky-domain && uv run pyrefly check src tests` — 0 errors
- [x] `cd core/spakky-domain && uv run pytest --cov` — 40 passed, 100% branch coverage
- [x] `async def run` 구현체 테스트 (`test_async_*_usecase_with_async_def_expect_awaitable_result`)
- [x] `def run(...) -> Awaitable[...]` 구현체 테스트 (`test_async_*_usecase_with_awaitable_return_expect_awaitable_result`)

Refs: ADR-0008 (타입 안전성 강화 — pyrefly ignore 박멸)
Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)