### PR TITLE
refactor(grpc): rewrite PostProcessor unit tests as behavior-based (#128)

### DIFF
--- a/plugins/spakky-grpc/tests/unit/test_bind_server.py
+++ b/plugins/spakky-grpc/tests/unit/test_bind_server.py
@@ -1,7 +1,7 @@
 """Unit tests for BindServerPostProcessor."""
 
-import asyncio
 from asyncio import Event as AsyncEvent
+from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock
 
 import grpc.aio
@@ -15,46 +15,72 @@ from spakky.plugins.grpc.post_processors.bind_server import (
 from spakky.plugins.grpc.server_spec import GrpcServerSpec
 
 
+@dataclass
+class BindServerHarness:
+    """Bundle of processor + observable collaborators for behavior assertions."""
+
+    processor: BindServerPostProcessor
+    application_context: MagicMock
+    container: MagicMock
+    task_stop_event: AsyncEvent
+
+
 @pytest.fixture
-def processor() -> BindServerPostProcessor:
-    """Create a configured BindServerPostProcessor."""
+def harness() -> BindServerHarness:
+    """Create a BindServerPostProcessor wired to observable mock collaborators."""
     proc = BindServerPostProcessor.__new__(BindServerPostProcessor)
     container = MagicMock(spec=IContainer)
     application_context = MagicMock(spec=IApplicationContext)
-    application_context.task_stop_event = AsyncEvent()
+    task_stop_event = AsyncEvent()
+    application_context.task_stop_event = task_stop_event
     proc.set_container(container)
     proc.set_application_context(application_context)
-    return proc
+    return BindServerHarness(
+        processor=proc,
+        application_context=application_context,
+        container=container,
+        task_stop_event=task_stop_event,
+    )
 
 
-def test_bind_server_with_non_spec_pod_expect_unchanged(
-    processor: BindServerPostProcessor,
+def test_bind_server_with_non_spec_pod_expect_pod_returned_and_no_service_registered(
+    harness: BindServerHarness,
 ) -> None:
-    """Non-spec Pods should be returned unchanged."""
+    """Non-spec Pods should pass through without touching the application context."""
     plain_pod = object()
-    result = processor.post_process(plain_pod)
+
+    result = harness.processor.post_process(plain_pod)
+
     assert result is plain_pod
+    harness.application_context.add_service.assert_not_called()
 
 
-def test_bind_server_with_spec_pod_expect_service_registered(
-    processor: BindServerPostProcessor,
+async def test_bind_server_with_spec_pod_expect_service_wrapping_spec_added_to_context(
+    harness: BindServerHarness,
 ) -> None:
-    """Spec Pod should be registered as a service in the application context."""
-    spec = GrpcServerSpec()
+    """Spec Pod should yield a GrpcServerService that builds the same spec on start."""
+    built_server = MagicMock(spec=grpc.aio.Server)
+    built_server.start = AsyncMock()
+    spec = MagicMock(spec=GrpcServerSpec)
+    spec.build = MagicMock(return_value=built_server)
 
-    result = processor.post_process(spec)
+    result = harness.processor.post_process(spec)
 
     assert result is spec
-    app_ctx = (
-        processor._BindServerPostProcessor__application_context  # pyrefly: ignore - name-mangled private attr access
-    )
-    app_ctx.add_service.assert_called_once()
-    service_arg = app_ctx.add_service.call_args[0][0]
+    harness.application_context.add_service.assert_called_once()
+    (service_arg,) = harness.application_context.add_service.call_args[0]
     assert isinstance(service_arg, GrpcServerService)
+
+    # Observable behavior: the registered service, when started, drives
+    # the exact spec we passed in — proving the processor wrapped it
+    # correctly without inspecting private attributes.
+    await service_arg.start_async()
+    spec.build.assert_called_once()
+    built_server.start.assert_awaited_once()
 
 
 async def test_grpc_server_service_start_async_expect_build_and_start() -> None:
-    """GrpcServerService.start_async() should build and start the server."""
+    """GrpcServerService.start_async() should build the spec and start the server."""
     spec = MagicMock(spec=GrpcServerSpec)
     built_server = MagicMock(spec=grpc.aio.Server)
     built_server.start = AsyncMock()
@@ -80,7 +106,7 @@ async def test_grpc_server_service_stop_async_without_start_expect_noop() -> Non
 async def test_grpc_server_service_stop_async_after_start_expect_graceful_stop() -> (
     None
 ):
-    """stop_async() should stop the underlying server with grace."""
+    """stop_async() should stop the underlying server with the configured grace."""
     spec = MagicMock(spec=GrpcServerSpec)
     built_server = MagicMock(spec=grpc.aio.Server)
     built_server.start = AsyncMock()
@@ -94,12 +120,19 @@ async def test_grpc_server_service_stop_async_after_start_expect_graceful_stop()
     built_server.stop.assert_awaited_once_with(grace=5.0)
 
 
-def test_grpc_server_service_set_stop_event_expect_stored() -> None:
-    """GrpcServerService should accept a stop event."""
+async def test_grpc_server_service_stop_async_twice_expect_single_graceful_stop() -> (
+    None
+):
+    """Calling stop_async() twice should stop the server only once."""
     spec = MagicMock(spec=GrpcServerSpec)
+    built_server = MagicMock(spec=grpc.aio.Server)
+    built_server.start = AsyncMock()
+    built_server.stop = AsyncMock()
+    spec.build = MagicMock(return_value=built_server)
     service = GrpcServerService(spec)
-    event = asyncio.Event()
+    await service.start_async()
 
-    service.set_stop_event(event)
+    await service.stop_async()
+    await service.stop_async()
 
-    assert service._stop_event is event
+    built_server.stop.assert_awaited_once_with(grace=5.0)

--- a/plugins/spakky-grpc/tests/unit/test_register_services.py
+++ b/plugins/spakky-grpc/tests/unit/test_register_services.py
@@ -1,5 +1,6 @@
 """Unit tests for RegisterServicesPostProcessor."""
 
+from dataclasses import dataclass
 from types import new_class
 from unittest.mock import MagicMock
 
@@ -16,9 +17,20 @@ from spakky.plugins.grpc.server_spec import GrpcServerSpec
 from tests.unit.conftest import GreeterController
 
 
+@dataclass
+class RegisterServicesHarness:
+    """Bundle of processor + observable collaborators for behavior assertions."""
+
+    processor: RegisterServicesPostProcessor
+    container: MagicMock
+    application_context: MagicMock
+    registry: DescriptorRegistry
+    spec: GrpcServerSpec
+
+
 @pytest.fixture
-def processor() -> RegisterServicesPostProcessor:
-    """Create a configured RegisterServicesPostProcessor."""
+def harness() -> RegisterServicesHarness:
+    """Create a processor wired to a real registry/spec plus a mock container."""
     proc = RegisterServicesPostProcessor.__new__(RegisterServicesPostProcessor)
 
     container = MagicMock(spec=IContainer)
@@ -37,90 +49,96 @@ def processor() -> RegisterServicesPostProcessor:
 
     proc.set_container(container)
     proc.set_application_context(application_context)
-    return proc
+    return RegisterServicesHarness(
+        processor=proc,
+        container=container,
+        application_context=application_context,
+        registry=registry,
+        spec=spec,
+    )
 
 
-def test_register_services_skips_non_controller(
-    processor: RegisterServicesPostProcessor,
+def test_register_services_with_non_controller_pod_expect_pod_returned_untouched(
+    harness: RegisterServicesHarness,
 ) -> None:
-    """Non-controller Pods should be returned unchanged."""
+    """Non-controller Pods should pass through without affecting spec or registry."""
     plain_pod = object()
-    result = processor.post_process(plain_pod)
+
+    result = harness.processor.post_process(plain_pod)
+
     assert result is plain_pod
+    assert harness.spec.handlers == []
+    assert harness.registry.is_registered("test/v1/GreeterController.proto") is False
 
 
-def test_register_services_processes_grpc_controller(
-    processor: RegisterServicesPostProcessor,
+def test_register_services_with_grpc_controller_expect_handler_appended_to_spec(
+    harness: RegisterServicesHarness,
 ) -> None:
-    """@GrpcController Pod should append a handler to the shared spec."""
+    """A @GrpcController Pod should append exactly one handler to the shared spec."""
     controller_instance = GreeterController()
-    result = processor.post_process(controller_instance)
+
+    result = harness.processor.post_process(controller_instance)
 
     assert result is controller_instance
-    container = (
-        processor._RegisterServicesPostProcessor__container  # pyrefly: ignore - name-mangled private attr access
-    )
-    spec = container.get(GrpcServerSpec)
-    assert len(spec.handlers) == 1
+    assert len(harness.spec.handlers) == 1
 
 
-def test_register_services_registers_descriptor_in_registry(
-    processor: RegisterServicesPostProcessor,
+def test_register_services_with_grpc_controller_expect_descriptor_registered(
+    harness: RegisterServicesHarness,
 ) -> None:
-    """Processing a controller should register its descriptor."""
+    """Processing a controller should publish its file descriptor to the registry."""
     controller_instance = GreeterController()
-    processor.post_process(controller_instance)
 
-    container = (
-        processor._RegisterServicesPostProcessor__container  # pyrefly: ignore - name-mangled private attr access
-    )
-    registry: DescriptorRegistry = container.get(DescriptorRegistry)
-    assert registry.is_registered("test/v1/GreeterController.proto")
+    harness.processor.post_process(controller_instance)
+
+    assert harness.registry.is_registered("test/v1/GreeterController.proto") is True
 
 
-def test_register_services_skips_already_registered_descriptor(
-    processor: RegisterServicesPostProcessor,
+def test_register_services_with_same_controller_twice_expect_descriptor_registered_once(
+    harness: RegisterServicesHarness,
 ) -> None:
-    """Processing the same controller twice should not raise."""
-    controller_instance = GreeterController()
-    processor.post_process(controller_instance)
+    """Processing the same controller twice should not double-register the descriptor."""
+    harness.processor.post_process(GreeterController())
 
-    controller_instance_2 = GreeterController()
-    result = processor.post_process(controller_instance_2)
-    assert result is controller_instance_2
+    second_result = harness.processor.post_process(GreeterController())
+
+    assert isinstance(second_result, GreeterController)
+    assert harness.registry.is_registered("test/v1/GreeterController.proto") is True
+    # Two handlers (one per Pod instance) but the descriptor is registered once.
+    assert len(harness.spec.handlers) == 2
 
 
-def test_register_services_unwraps_aop_proxy_type(
-    processor: RegisterServicesPostProcessor,
+def test_register_services_with_aop_proxy_pod_expect_handler_appended_from_original_type(
+    harness: RegisterServicesHarness,
 ) -> None:
-    """AOP proxy Pod should be unwrapped to the original controller type."""
+    """AOP proxy Pods should be unwrapped so the original controller is registered."""
     proxy_class = new_class(
         GreeterController.__name__ + DYNAMIC_PROXY_CLASS_NAME_SUFFIX,
         bases=(GreeterController,),
     )
     proxy_instance = object.__new__(proxy_class)
 
-    result = processor.post_process(proxy_instance)
+    result = harness.processor.post_process(proxy_instance)
+
     assert result is proxy_instance
-
-    container = (
-        processor._RegisterServicesPostProcessor__container  # pyrefly: ignore - name-mangled private attr access
-    )
-    spec = container.get(GrpcServerSpec)
-    assert len(spec.handlers) == 1
+    assert len(harness.spec.handlers) == 1
+    assert harness.registry.is_registered("test/v1/GreeterController.proto") is True
 
 
-def test_unwrap_proxy_type_returns_original_class() -> None:
-    """_unwrap_proxy_type should strip the @DynamicProxy suffix."""
+def test_unwrap_proxy_type_with_proxy_class_expect_original_base_returned() -> None:
+    """_unwrap_proxy_type should strip the @DynamicProxy suffix to the original class."""
     proxy_class = new_class(
         GreeterController.__name__ + DYNAMIC_PROXY_CLASS_NAME_SUFFIX,
         bases=(GreeterController,),
     )
+
     result = RegisterServicesPostProcessor._unwrap_proxy_type(proxy_class)
+
     assert result is GreeterController
 
 
-def test_unwrap_proxy_type_returns_non_proxy_unchanged() -> None:
+def test_unwrap_proxy_type_with_non_proxy_class_expect_same_class_returned() -> None:
     """_unwrap_proxy_type should return non-proxy types unchanged."""
     result = RegisterServicesPostProcessor._unwrap_proxy_type(GreeterController)
+
     assert result is GreeterController


### PR DESCRIPTION
## Summary

- `test_bind_server.py` / `test_register_services.py` 에서 `processor._BindServerPostProcessor__application_context` / `processor._RegisterServicesPostProcessor__container` 같은 name-mangled private 접근을 모두 제거합니다.
- 검증 대상을 PostProcessor 의 **관찰 가능한 side effect** 로 전환합니다: `application_context.add_service` 호출 + 등록된 `GrpcServerService` 가 `start_async()` 시 전달된 spec 을 build, 그리고 공용 `GrpcServerSpec.handlers` / `DescriptorRegistry.is_registered` 의 공개 상태.
- 내부 상태 확인을 위해 fixture 에서 `container` / `application_context` / `registry` / `spec` 을 묶은 `BindServerHarness` / `RegisterServicesHarness` 데이터클래스를 도입합니다. 테스트용 property 를 PostProcessor 프로덕션 코드에 노출하지 않습니다.
- 결과로 `# pyrefly: ignore - name-mangled private attr access` 주석 4개가 제거되며, `spakky-grpc` 브랜치 커버리지 100% 가 유지됩니다.

ADR-0008 §4.2 의 "behavior-based 재작성" 가이드를 따릅니다.

## Test plan

- [x] `cd plugins/spakky-grpc && uv run ruff format .`
- [x] `cd plugins/spakky-grpc && uv run ruff check .`
- [x] `cd plugins/spakky-grpc && uv run pyrefly check src tests`
- [x] `cd plugins/spakky-grpc && uv run pytest` — 190 passed, 100% branch coverage

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)