### PR TITLE
chore(review-pr): bot/human 리뷰 스레드 resolve 권한 구분 규칙 추가 (#136)

### DIFF
--- a/.claude/skills/monitor-pr/SKILL.md
+++ b/.claude/skills/monitor-pr/SKILL.md
@@ -18,6 +18,10 @@ user-invocable: false
 - **자동화 봇 리뷰어만 submit까지 대기**: `reviewRequests`에 `__typename == "Bot"` 인 리뷰어(Copilot, Claude, Gemini 등)가 등록돼 있으면 submit(`COMMENTED`/`APPROVED`/`CHANGES_REQUESTED` 어느 것이든)할 때까지 `REVIEW_PENDING`으로 대기한다. 사람 리뷰어(`__typename == "User"`)는 응답 시간이 예측 불가능하므로 대기 대상에서 제외 — 사람 리뷰 확인은 Phase 7(PR 병합 승인) 단계에서 사용자가 직접 판단한다.
 - **BLOCKED는 조용히 지나치지 않는다**: `mergeStateStatus == BLOCKED` 는 GitHub 정책상 병합 불가 상태(미해결 review thread, 승인 부족, CODEOWNERS 미충족 등). 모니터는 이를 별도 이벤트(`BLOCKED`)로 상위 스킬에 전달하며, 상위 스킬은 반드시 원인을 분류하여 대응한다. BLOCKED 를 단순 대기 상태로 취급하면 무한 polling 에 빠진다.
 - **GraphQL 페이지네이션 안전장치**: `reviewRequests(first: 100)` 로 페치하고 `totalCount` 와 비교한다. `totalCount > nodes.length` 이면 페치 누락 가능성 있으므로 `pendingBotReviewers` 를 `totalCount` 로 반환하여 MERGEABLE 전환을 막는다(안전측 대기). `reviewThreads` 도 같은 원리로 `first: 100`.
+- **리뷰 스레드 resolve 권한 분리**: 스레드의 **첫 코멘트 작성자(`author.__typename`)를 기준**으로 처리를 구분한다.
+  - **Bot 스레드** (`__typename == "Bot"`, 예: `copilot-pull-request-reviewer`): 에이전트가 지적을 수용(코드 수정)하거나 반론(답변만) 후 `resolveReviewThread` mutation 으로 resolve 한다. 봇은 재판정 프로세스가 없으므로 에이전트 resolve 로 충분.
+  - **User 스레드** (`__typename == "User"`): 에이전트는 응답 코멘트(`addPullRequestReviewThreadReply`)만 달고 **resolve 하지 않는다**. 리뷰 적절성 판단은 리뷰어 본인의 권한. 에이전트가 강제 resolve 하면 사회적 계약을 깬다 — 리뷰어가 직접 닫을 때까지 `UNRESOLVED_THREAD` 는 유지된다.
+  - 혼합 스레드(첫 코멘트는 Bot, 이후 User 답변 존재 등)에서도 **첫 코멘트 작성자 기준**으로만 판단한다.
 
 ## 실행
 

--- a/.claude/skills/process-ticket/SKILL.md
+++ b/.claude/skills/process-ticket/SKILL.md
@@ -177,8 +177,8 @@ gh issue view $ARGUMENTS --comments
 | `CONFLICT` | develop 병합 시도 → conflict resolve → push → monitor 재시작 |
 | `BEHIND` | develop 병합 → push → monitor 재시작 |
 | `CI_FAILURE` | 실패한 체크의 로그 확인 → 로컬 재현 → 수정 → push → monitor 재시작 |
-| `OPEN_COMMENT` / `OPEN_REVIEW` / `UNRESOLVED_THREAD` | **`/review-pr {PR_NUMBER}` 서브스킬을 반드시 호출**하여 코멘트별로 수용/반론 판단 + 필요 시 수정 + 스레드 resolve. 그 후 monitor 재시작 |
-| `BLOCKED` | `mergeStateStatus == BLOCKED` 원인 분류: <br> • **미해결 review thread** 또는 **리뷰 코멘트 미반영** → `/review-pr {PR_NUMBER}` 호출 후 재시작 <br> • **승인 부족** (Copilot `COMMENTED` 만 있고 `APPROVED` 없음) / **CODEOWNERS 미충족** → Phase 7 로 전환하여 사용자 개입 요청 |
+| `OPEN_COMMENT` / `OPEN_REVIEW` / `UNRESOLVED_THREAD` | **`/review-pr {PR_NUMBER}` 서브스킬을 반드시 호출**하여 코멘트별로 수용/반론 판단 + 필요 시 수정. 스레드 resolve 는 **스레드 첫 코멘트 작성자가 Bot 인 경우에만** 수행. User 스레드는 응답만 달고 resolve 는 리뷰어 본인에게 맡김 (상세는 `monitor-pr` SKILL 의 "리뷰 스레드 resolve 권한 분리" 원칙). 그 후 monitor 재시작 |
+| `BLOCKED` | `mergeStateStatus == BLOCKED` 원인 분류: <br> • **미해결 Bot 스레드** 또는 **리뷰 코멘트 미반영** → `/review-pr {PR_NUMBER}` 호출 후 재시작 <br> • **미해결 User 스레드** (사람 리뷰어가 직접 닫아야 함) → Phase 7 로 전환하여 사용자 개입 요청 <br> • **승인 부족** (Copilot `COMMENTED` 만 있고 `APPROVED` 없음) / **CODEOWNERS 미충족** → Phase 7 로 전환하여 사용자 개입 요청 |
 | `CI_PENDING` / `REVIEW_PENDING` | polling 계속 (monitor 가 자동으로 유지) |
 | `MERGEABLE` | Phase 7 로 전환 |
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -84,13 +84,33 @@ gh issue view {이슈번호} --json body -q .body
 
 1. 코드를 수정하지 **않는다**.
 
-### PR 스레드 응답
+### PR 스레드 응답 + resolve
 
-수용/반론 모두 `gh api`로 해당 코멘트 스레드에 답변한다.
+수용/반론 모두 해당 코멘트 스레드에 답변한다. 응답은 GraphQL `addPullRequestReviewThreadReply` mutation 사용:
+
+```bash
+gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: "<THREAD_ID>", body: "<응답>" }) { comment { id } } }'
+```
 
 - **수용**: "수용합니다. [한 줄 이유]"
 - **반론**: "검토 결과 현행 유지로 판단했습니다. 근거: [판단 루프 #N 결과]" + 대안 제시
 - 감정적 표현 금지. 근거와 사실만 기술한다.
+
+### 스레드 resolve 권한 분리
+
+응답을 단 직후, **스레드의 첫 코멘트 작성자(`author.__typename`)를 확인**하여 resolve 여부를 결정한다:
+
+| 첫 코멘트 작성자 | 처리 |
+|---|---|
+| `Bot` (Copilot, Claude, Gemini 등) | `resolveReviewThread` mutation 으로 resolve. 봇은 재판정 프로세스가 없으므로 수정/응답 후 에이전트 resolve 로 충분 |
+| `User` (사람 리뷰어) | **resolve 하지 않는다.** 응답만 달고 리뷰어 본인에게 판단 권한을 양도. 에이전트가 강제 resolve 하면 사회적 계약을 깬다 |
+
+```bash
+# Bot 스레드만 resolve
+gh api graphql -f query='mutation { resolveReviewThread(input: { threadId: "<THREAD_ID>" }) { thread { isResolved } } }'
+```
+
+혼합 스레드(첫 코멘트 Bot, 이후 User 답변 존재 등)에서도 **첫 코멘트 작성자 기준**으로만 판단한다.
 
 ## 규칙
 


### PR DESCRIPTION
## Summary

리뷰 스레드 resolve 권한을 스레드의 **첫 코멘트 작성자** 기준으로 구분한다.

- **Bot 스레드** (Copilot, Claude, Gemini 등): 에이전트가 응답 후 `resolveReviewThread` 실행
- **User 스레드** (사람 리뷰어): 에이전트는 응답만 달고 resolve 하지 않음 — 수정/응답의 충분성 판단은 리뷰어 본인의 권한

### 변경 파일

- `.claude/skills/review-pr/SKILL.md`: "스레드 resolve 권한 분리" 섹션 추가, `addPullRequestReviewThreadReply` + `resolveReviewThread` GraphQL mutation 예시 포함
- `.claude/skills/monitor-pr/SKILL.md`: 원칙 섹션에 같은 규칙 요약 불릿 추가
- `.claude/skills/process-ticket/SKILL.md`: Phase 6 이벤트 처리 표의 `OPEN_*` / `UNRESOLVED_THREAD` 대응에 Bot/User 분기 반영, `BLOCKED` 원인 분류에 "미해결 User 스레드 → Phase 7 수동 개입" 케이스 추가

## 배경

직전 PR #135 머지 과정에서 Copilot 리뷰에 에이전트가 응답 + resolve 한 것이 올바른 처리였지만, 같은 로직이 사람 리뷰어 스레드에 적용되면 사회적 계약 위반이 된다. 현재 스킬은 bot/user 구분 없이 "스레드 resolve" 만 기술돼 있어 일관성이 없었다.

## Test Plan

- [x] 세 스킬 문서가 동일한 분기 규칙을 참조하며, 세부 구현은 `review-pr` SKILL 에 중앙화되어 있는지 확인
- [x] `review-pr` SKILL 의 GraphQL mutation 예시가 실제 동작하는 형식인지 확인 (PR #135 에서 실제로 실행한 `addPullRequestReviewThreadReply` + `resolveReviewThread` 패턴 그대로)

## Breaking Changes

없음. 스킬 문서 변경만.

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)