### PR TITLE
feat(core): add DI dependency diagnostics (#146)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -269,6 +269,7 @@ class UserService:
 
 - 불변 튜플 `dependency_hierarchy`로 재귀 경로를 추적
 - 이미 방문한 타입 발견 시 `CircularDependencyGraphDetectedError` (체인 정보 포함)
+- 누락·순환 의존성 진단은 `Pod.dependencies` 메타데이터에서 실패 Pod, 파라미터, 요청 타입, 경로를 구성합니다.
 
 ### Post-Processor 파이프라인
 

--- a/core/spakky/README.md
+++ b/core/spakky/README.md
@@ -97,6 +97,10 @@ count, success/failure status, and an optional structured failure summary.
 Failure summaries keep the exception type name, message, and diagnostic
 details without retaining the raw exception object.
 
+DI dependency failures preserve their existing exception types while attaching
+structured dependency diagnostics from `Pod.dependencies`, including the failed
+Pod, dependency parameter, requested type, and dependency path.
+
 ## Pod Scopes
 
 ```python

--- a/core/spakky/src/spakky/core/application/application_context.py
+++ b/core/spakky/src/spakky/core/application/application_context.py
@@ -4,7 +4,7 @@ from asyncio.events import AbstractEventLoop, new_event_loop, set_event_loop
 from asyncio.tasks import run_coroutine_threadsafe
 from contextvars import ContextVar
 from threading import RLock, Thread
-from types import MappingProxyType
+from types import MappingProxyType, NoneType
 from typing import Callable, cast, overload
 from uuid import UUID, uuid4
 
@@ -16,9 +16,17 @@ from spakky.core.common.constants import CONTEXT_ID, CONTEXT_SCOPE_CACHE
 from spakky.core.common.types import ObjectT, is_optional, remove_none
 from spakky.core.pod.annotations.lazy import Lazy
 from spakky.core.pod.annotations.order import Order
-from spakky.core.pod.annotations.pod import Pod, PodType
+from spakky.core.pod.annotations.pod import (
+    Pod,
+    PodType,
+    UnexpectedDependencyTypeInjectedError,
+)
 from spakky.core.pod.annotations.qualifier import Qualifier
 from spakky.core.pod.annotations.tag import Tag
+from spakky.core.pod.diagnostics import (
+    PodDependencyPathNode,
+    PodDependencyResolutionDiagnostic,
+)
 from spakky.core.pod.interfaces.application_context import (
     ApplicationContextAlreadyStartedError,
     ApplicationContextAlreadyStoppedError,
@@ -119,6 +127,48 @@ class ApplicationContext(IApplicationContext):
         self.task_stop_event = locks.Event()
         self.thread_stop_event = threading.Event()
 
+    def __type_name(self, type_: object) -> str:
+        """Return a stable diagnostic name for a dependency type."""
+        if isinstance(type_, type):
+            return type_.__name__
+        return str(type_)
+
+    def __dependency_path_node(
+        self,
+        pod: Pod,
+        dependency_parameter_name: str | None = None,
+        requested_type: object | None = None,
+    ) -> PodDependencyPathNode:
+        """Create one dependency path node from registered Pod metadata."""
+        requested_type_name = (
+            None if requested_type is None else self.__type_name(requested_type)
+        )
+        return PodDependencyPathNode(
+            pod_name=pod.name,
+            pod_type_name=self.__type_name(pod.type_),
+            dependency_parameter_name=dependency_parameter_name,
+            requested_type_name=requested_type_name,
+        )
+
+    def __dependency_diagnostic(
+        self,
+        pod: Pod,
+        dependency_parameter_name: str | None,
+        requested_type: object | None,
+        dependency_path: tuple[PodDependencyPathNode, ...],
+    ) -> PodDependencyResolutionDiagnostic:
+        """Build structured diagnostics from the active Pod dependency path."""
+        requested_type_name = (
+            None if requested_type is None else self.__type_name(requested_type)
+        )
+        return PodDependencyResolutionDiagnostic(
+            failed_pod_name=pod.name,
+            failed_pod_type_name=self.__type_name(pod.type_),
+            dependency_parameter_name=dependency_parameter_name,
+            requested_type_name=requested_type_name,
+            path=dependency_path,
+        )
+
     def __resolve_candidate(
         self,
         type_: type,
@@ -164,7 +214,10 @@ class ApplicationContext(IApplicationContext):
         raise NoUniquePodError(type_, [p.name for p in qualified])
 
     def __instantiate_pod(
-        self, pod: Pod, dependency_hierarchy: tuple[type, ...]
+        self,
+        pod: Pod,
+        dependency_hierarchy: tuple[type, ...],
+        dependency_path: tuple[PodDependencyPathNode, ...],
     ) -> object:
         """Instantiate a Pod with its dependencies recursively resolved.
 
@@ -179,21 +232,65 @@ class ApplicationContext(IApplicationContext):
             CircularDependencyGraphDetectedError: If circular dependency detected.
         """
         if pod.type_ in dependency_hierarchy:
+            circular_path = dependency_path + (self.__dependency_path_node(pod),)
+            last_node = dependency_path[-1] if dependency_path else None
             raise CircularDependencyGraphDetectedError(
-                list(dependency_hierarchy) + [pod.type_]
+                list(dependency_hierarchy) + [pod.type_],
+                dependency_diagnostic=self.__dependency_diagnostic(
+                    pod=pod,
+                    dependency_parameter_name=None
+                    if last_node is None
+                    else last_node.dependency_parameter_name,
+                    requested_type=None
+                    if last_node is None
+                    else last_node.requested_type_name,
+                    dependency_path=circular_path,
+                ),
             )
         new_hierarchy = dependency_hierarchy + (pod.type_,)
-        dependencies = {
-            name: self.__get_internal(
+        dependencies: dict[str, object | None] = {}
+        for name, dependency in pod.dependencies.items():
+            requested_type = (
+                remove_none(dependency.type_)
+                if is_optional(dependency.type_)
+                else dependency.type_
+            )
+            current_path = dependency_path + (
+                self.__dependency_path_node(
+                    pod=pod,
+                    dependency_parameter_name=name,
+                    requested_type=requested_type,
+                ),
+            )
+            resolved_dependency = self.__get_internal(
                 type_=remove_none(dependency.type_)
                 if is_optional(dependency.type_)
                 else dependency.type_,
                 name=name,
                 dependency_hierarchy=new_hierarchy,
+                dependency_path=current_path,
                 qualifiers=dependency.qualifiers,
             )
-            for name, dependency in pod.dependencies.items()
-        }
+            if (
+                resolved_dependency is None
+                and not dependency.has_default
+                and not dependency.is_optional
+            ):
+                raise UnexpectedDependencyTypeInjectedError(
+                    pod.type_,
+                    {
+                        "name": name,
+                        "expected": dependency.type_,
+                        "actual": NoneType,
+                    },
+                    dependency_diagnostic=self.__dependency_diagnostic(
+                        pod=pod,
+                        dependency_parameter_name=name,
+                        requested_type=requested_type,
+                        dependency_path=current_path,
+                    ),
+                )
+            dependencies[name] = resolved_dependency
         instance: object = pod.instantiate(dependencies=dependencies)
         post_processed: object = self.__post_process_pod(instance)
         return post_processed
@@ -282,6 +379,7 @@ class ApplicationContext(IApplicationContext):
         type_: type[ObjectT],
         name: str | None,
         dependency_hierarchy: tuple[type, ...] | None = None,
+        dependency_path: tuple[PodDependencyPathNode, ...] | None = None,
         qualifiers: list[Qualifier] | None = None,
     ) -> ObjectT | None:
         """Internal method to get or create a Pod instance.
@@ -299,6 +397,8 @@ class ApplicationContext(IApplicationContext):
             # If dependency_hierarchy is None
             # it means that this is the first call on recursive cycle
             dependency_hierarchy = ()
+        if dependency_path is None:
+            dependency_path = ()
         if qualifiers is None:
             # If qualifiers is None, it means that no qualifier is specified
             qualifiers = []
@@ -321,7 +421,11 @@ class ApplicationContext(IApplicationContext):
                     # Re-check cache after acquiring lock
                     if (cached := self.__singleton_cache.get(pod.name)) is not None:
                         return cast(ObjectT, cached)
-                    instance = self.__instantiate_pod(pod, dependency_hierarchy)
+                    instance = self.__instantiate_pod(
+                        pod,
+                        dependency_hierarchy,
+                        dependency_path,
+                    )
                     self.__set_singleton_cache(pod, instance)
                     return cast(ObjectT, instance)
             case Pod.Scope.CONTEXT:
@@ -331,6 +435,7 @@ class ApplicationContext(IApplicationContext):
         instance = self.__instantiate_pod(
             pod,
             dependency_hierarchy,
+            dependency_path,
         )
 
         # Cache the instance based on pod scope

--- a/core/spakky/src/spakky/core/pod/annotations/pod.py
+++ b/core/spakky/src/spakky/core/pod/annotations/pod.py
@@ -16,6 +16,7 @@ from spakky.core.common.annotation import Annotation
 from spakky.core.common.interfaces.equatable import IEquatable
 from spakky.core.common.mro import generic_mro
 from spakky.core.common.types import Class, Func, is_optional
+from spakky.core.pod.diagnostics import PodDependencyResolutionDiagnostic
 from spakky.core.pod.annotations.primary import Primary
 from spakky.core.pod.annotations.qualifier import Qualifier
 from spakky.core.pod.error import PodAnnotationFailedError, PodInstantiationFailedError
@@ -83,6 +84,16 @@ class UnexpectedDependencyTypeInjectedError(PodInstantiationFailedError):
     """Raised when an injected dependency has wrong type."""
 
     message = "Unexpected dependency type injected into pod"
+    dependency_diagnostic: PodDependencyResolutionDiagnostic | None
+
+    def __init__(
+        self,
+        *args: object,
+        dependency_diagnostic: PodDependencyResolutionDiagnostic | None = None,
+    ) -> None:
+        """Initialize with optional dependency graph diagnostics."""
+        self.dependency_diagnostic = dependency_diagnostic
+        super().__init__(*args)
 
 
 @dataclass(eq=False)

--- a/core/spakky/src/spakky/core/pod/diagnostics.py
+++ b/core/spakky/src/spakky/core/pod/diagnostics.py
@@ -1,0 +1,63 @@
+"""Structured diagnostics for Pod dependency resolution."""
+
+from spakky.core.common.mutability import immutable
+
+
+@immutable
+class PodDependencyPathNode:
+    """One Pod dependency graph edge observed during resolution."""
+
+    pod_name: str
+    """Registered Pod name for the node being instantiated."""
+
+    pod_type_name: str
+    """Registered Pod type name for the node being instantiated."""
+
+    dependency_parameter_name: str | None = None
+    """Constructor or factory parameter that requested the next dependency."""
+
+    requested_type_name: str | None = None
+    """Requested dependency type name for this graph edge."""
+
+
+@immutable
+class PodDependencyResolutionDiagnostic:
+    """Structured dependency resolution failure details."""
+
+    failed_pod_name: str
+    """Registered Pod name where resolution failed."""
+
+    failed_pod_type_name: str
+    """Registered Pod type name where resolution failed."""
+
+    dependency_parameter_name: str | None
+    """Dependency parameter that could not be resolved, when applicable."""
+
+    requested_type_name: str | None
+    """Requested dependency type name that failed, when applicable."""
+
+    path: tuple[PodDependencyPathNode, ...]
+    """Dependency path from the root Pod to the failure point."""
+
+    def as_detail_pairs(self) -> tuple[tuple[str, str], ...]:
+        """Return stable key/value details for report adapters."""
+        path_value = " -> ".join(
+            node.pod_type_name
+            if node.dependency_parameter_name is None
+            else (
+                f"{node.pod_type_name}.{node.dependency_parameter_name}"
+                f":{node.requested_type_name}"
+            )
+            for node in self.path
+        )
+        details = (
+            ("failed_pod", self.failed_pod_name),
+            ("failed_pod_type", self.failed_pod_type_name),
+            ("dependency_path", path_value),
+        )
+        if self.dependency_parameter_name is None:
+            return details
+        return details + (
+            ("dependency_parameter", self.dependency_parameter_name),
+            ("requested_type", self.requested_type_name or ""),
+        )

--- a/core/spakky/src/spakky/core/pod/interfaces/container.py
+++ b/core/spakky/src/spakky/core/pod/interfaces/container.py
@@ -10,6 +10,7 @@ from typing import Callable, overload
 from spakky.core.common.interfaces.representable import IRepresentable
 from spakky.core.common.types import ObjectT
 from spakky.core.pod.annotations.pod import Pod, PodType
+from spakky.core.pod.diagnostics import PodDependencyResolutionDiagnostic
 from spakky.core.pod.error import AbstractSpakkyPodError
 
 
@@ -22,14 +23,21 @@ class CircularDependencyGraphDetectedError(AbstractSpakkyPodError, IRepresentabl
 
     message = "Circular dependency graph detected"
     dependency_chain: list[type]
+    dependency_diagnostic: PodDependencyResolutionDiagnostic | None
 
-    def __init__(self, dependency_chain: list[type]) -> None:
+    def __init__(
+        self,
+        dependency_chain: list[type],
+        dependency_diagnostic: PodDependencyResolutionDiagnostic | None = None,
+    ) -> None:
         """Initialize with dependency chain information.
 
         Args:
             dependency_chain: List of types in dependency order, ending with the duplicate type.
+            dependency_diagnostic: Optional structured dependency path details.
         """
         self.dependency_chain = dependency_chain
+        self.dependency_diagnostic = dependency_diagnostic
         if not dependency_chain:
             super().__init__(self.message)
             return

--- a/core/spakky/tests/application/test_application_context.py
+++ b/core/spakky/tests/application/test_application_context.py
@@ -566,6 +566,55 @@ def test_circular_dependency_error_message_format() -> None:
     assert "A" in error_msg or "B" in error_msg
 
 
+def test_circular_dependency_error_expect_structured_diagnostic_path() -> None:
+    """순환 의존성 실패가 기존 의미와 구조화된 graph path를 함께 보존함을 검증한다."""
+
+    class IA:
+        def a(self) -> str: ...
+
+    class IB:
+        def b(self) -> str: ...
+
+    @Pod()
+    class A(IA):
+        def __init__(self, b: IB) -> None:
+            self.b = b
+
+        def a(self) -> str:
+            return self.b.b()
+
+    @Pod()
+    class B(IB):
+        def __init__(self, a: IA) -> None:
+            self.a = a
+
+        def b(self) -> str:
+            return self.a.a()
+
+    context: ApplicationContext = ApplicationContext()
+    context.add(A)
+    context.add(B)
+
+    with pytest.raises(CircularDependencyGraphDetectedError) as exc_info:
+        context.start()
+
+    assert "Circular dependency graph detected" in str(exc_info.value)
+    diagnostic = exc_info.value.dependency_diagnostic
+    assert diagnostic is not None
+    assert diagnostic.failed_pod_type_name == "A"
+    assert diagnostic.dependency_parameter_name == "a"
+    assert diagnostic.requested_type_name == "IA"
+    assert len(diagnostic.path) == 3
+    assert diagnostic.path[0].pod_type_name == "A"
+    assert diagnostic.path[0].dependency_parameter_name == "b"
+    assert diagnostic.path[0].requested_type_name == "IB"
+    assert diagnostic.path[1].pod_type_name == "B"
+    assert diagnostic.path[1].dependency_parameter_name == "a"
+    assert diagnostic.path[1].requested_type_name == "IA"
+    assert diagnostic.path[2].pod_type_name == "A"
+    assert diagnostic.path[2].dependency_parameter_name is None
+
+
 def test_application_context_with_multiple_children_list_not_exists() -> None:
     """list 타입 의존성에 해당하는 Pod가 없을 때 PodInstantiationFailedError가 발생함을 검증한다."""
 
@@ -1061,6 +1110,39 @@ def test_application_context_initialize_pods_missing_raises_error() -> None:
     # since the missing_dep cannot be resolved and is not optional
     with pytest.raises(UnexpectedDependencyTypeInjectedError):
         context.start()
+
+
+def test_application_context_missing_dependency_expect_structured_diagnostic() -> None:
+    """누락된 Pod 의존성 실패가 Pod.dependencies 기반 경로 진단을 포함함을 검증한다."""
+    from spakky.core.pod.annotations.pod import UnexpectedDependencyTypeInjectedError
+
+    class MissingDependency:
+        """Unregistered dependency type."""
+
+    @Pod(name="sample_pod")
+    class SamplePod:
+        def __init__(self, missing_dep: MissingDependency) -> None:
+            self.missing_dep = missing_dep
+
+    context = ApplicationContext()
+    context.add(SamplePod)
+
+    with pytest.raises(UnexpectedDependencyTypeInjectedError) as exc_info:
+        context.start()
+
+    diagnostic = exc_info.value.dependency_diagnostic
+    assert diagnostic is not None
+    assert diagnostic.failed_pod_name == "sample_pod"
+    assert diagnostic.failed_pod_type_name == "SamplePod"
+    assert diagnostic.dependency_parameter_name == "missing_dep"
+    assert diagnostic.requested_type_name == "MissingDependency"
+    assert len(diagnostic.path) == 1
+    path_node = diagnostic.path[0]
+    assert path_node.pod_name == "sample_pod"
+    assert path_node.pod_type_name == "SamplePod"
+    assert path_node.dependency_parameter_name == "missing_dep"
+    assert path_node.requested_type_name == "MissingDependency"
+    assert ("dependency_parameter", "missing_dep") in diagnostic.as_detail_pairs()
 
 
 def test_set_singleton_cache_with_non_singleton_pod() -> None:

--- a/docs/di-container.md
+++ b/docs/di-container.md
@@ -220,6 +220,11 @@ class UserService:
 
 ## 순환 참조 감지
 
+누락되거나 순환된 의존성은 기존 예외 의미를 유지하면서 구조화된
+dependency diagnostic을 함께 제공합니다. 이 진단은 별도 graph cache가
+아니라 등록된 `Pod.dependencies` 메타데이터에서 실패 Pod, 파라미터,
+요청 타입, 의존성 경로를 구성합니다.
+
 컨테이너는 의존성 체인에서 순환 참조를 감지합니다.
 
 ```python
@@ -407,4 +412,3 @@ service = context.get(UserService)
 # 종료 - 서비스 정지, 리소스 정리
 context.stop()
 ```
-


### PR DESCRIPTION
## Summary
- Add structured `PodDependencyResolutionDiagnostic` path details built from `Pod.dependencies`.
- Preserve existing missing dependency and circular dependency exception types while attaching diagnostic data.
- Cover missing and circular DI graph failures with tests and sync DI docs.

## Acceptance Criteria
- FR-003: `Pod.dependencies` is used as the graph source for path diagnostics.
- FR-004: Missing dependency startup resolution exposes failed Pod, dependency parameter, requested type, and path via `dependency_diagnostic`.
- FR-004: Circular dependency keeps `CircularDependencyGraphDetectedError` behavior and exposes path details.
- Scenario tests: added missing/circular dependency diagnostics tests.

## Acceptance Criteria (self grep)
- acceptance_check: missing (issue body has no explicit grep/find/rg command lines)

## Validation
- `cd core/spakky && uv run ruff format . && uv run ruff check .`
- `cd core/spakky && uv run pyrefly check src tests`
- `cd core/spakky && uv run pytest` (317 passed, coverage 100%)
- `uv run python scripts/run_coverage.py --package spakky` (317 passed, coverage 100%)
- `cd core/spakky && rg -n "from spakky\\.(domain|data|event|outbox|task|tracing|saga)|import spakky\\.(domain|data|event|outbox|task|tracing|saga)" src tests` (0 matches)

Closes #146
