### PR TITLE
feat(core): instrument startup diagnostics pipeline (#147)

### DIFF
--- a/core/spakky/src/spakky/core/application/application.py
+++ b/core/spakky/src/spakky/core/application/application.py
@@ -32,6 +32,10 @@ from spakky.core.pod.annotations.tag import Tag
 from spakky.core.pod.interfaces.application_context import IApplicationContext
 from spakky.core.pod.interfaces.container import IContainer
 
+STARTUP_PHASE_LOAD_PLUGINS = "load_plugins"
+STARTUP_PHASE_SCAN = "scan"
+STARTUP_PHASE_REGISTRATION = "registration"
+
 
 class CannotDetermineScanPathError(AbstractSpakkyApplicationError):
     """Raised when the scan path cannot be automatically determined."""
@@ -149,39 +153,50 @@ class SpakkyApplication:
         """
         modules: set[ModuleType]
         caller_module: ModuleType | None = None
-        if path is None:  # pragma: no cover
-            caller_frame = inspect.stack()[1]
-            caller_file = caller_frame.filename
-            caller_dir = Path(caller_file).parent
+        with self._startup_phase_recorder.record_phase(
+            phase_name=STARTUP_PHASE_SCAN
+        ) as scan_phase:
+            if path is None:  # pragma: no cover
+                caller_frame = inspect.stack()[1]
+                caller_file = caller_frame.filename
+                caller_dir = Path(caller_file).parent
 
-            # Check if caller is inside a package (has __init__.py)
-            if not (caller_dir / "__init__.py").exists():
-                raise CannotDetermineScanPathError
+                # Check if caller is inside a package (has __init__.py)
+                if not (caller_dir / "__init__.py").exists():
+                    raise CannotDetermineScanPathError
 
-            # Ensure the package is importable (adds to sys.path if needed)
-            ensure_importable(caller_dir)
+                # Ensure the package is importable (adds to sys.path if needed)
+                ensure_importable(caller_dir)
 
-            try:
-                path = resolve_module(caller_dir.name)
-            except ImportError as e:
-                raise CannotDetermineScanPathError from e
+                try:
+                    path = resolve_module(caller_dir.name)
+                except ImportError as e:
+                    raise CannotDetermineScanPathError from e
 
-            caller_module = inspect.getmodule(caller_frame[0])
+                caller_module = inspect.getmodule(caller_frame[0])
 
-        if exclude is None:
-            exclude = {caller_module} if caller_module else set()
-        if is_package(path):
-            modules = list_modules(path, exclude)
-        else:  # pragma: no cover
-            modules = {resolve_module(path)}
+            if exclude is None:
+                exclude = {caller_module} if caller_module else set()
+            if is_package(path):
+                modules = list_modules(path, exclude)
+            else:  # pragma: no cover
+                modules = {resolve_module(path)}
+            scan_phase.set_processed_count(len(modules))
 
-        for item in modules:
-            for obj in list_objects(item, lambda x: Pod.exists(x) or Tag.exists(x)):
-                if Pod.exists(obj):
-                    self._application_context.add(obj)
-                if Tag.exists(obj):
-                    tag = Tag.get(obj)
-                    self._application_context.register_tag(tag)
+        registration_count = 0
+        with self._startup_phase_recorder.record_phase(
+            phase_name=STARTUP_PHASE_REGISTRATION
+        ) as registration_phase:
+            for item in modules:
+                for obj in list_objects(item, lambda x: Pod.exists(x) or Tag.exists(x)):
+                    if Pod.exists(obj):
+                        self._application_context.add(obj)
+                        registration_count += 1
+                    if Tag.exists(obj):
+                        tag = Tag.get(obj)
+                        self._application_context.register_tag(tag)
+                        registration_count += 1
+            registration_phase.set_processed_count(registration_count)
 
         return self
 
@@ -197,14 +212,20 @@ class SpakkyApplication:
         Returns:
             Self for method chaining.
         """
-        for entry_point in entry_points(group=PLUGIN_PATH):  # pragma: no cover
-            if include is not None:  # pragma: no cover
-                if Plugin(name=entry_point.name) not in include:  # pragma: no cover
-                    continue  # pragma: no cover
-            entry_point_function: Callable[[SpakkyApplication], None] = (
-                entry_point.load()
-            )  # pragma: no cover
-            entry_point_function(self)  # pragma: no cover
+        loaded_count = 0
+        with self._startup_phase_recorder.record_phase(
+            phase_name=STARTUP_PHASE_LOAD_PLUGINS
+        ) as plugin_phase:
+            for entry_point in entry_points(group=PLUGIN_PATH):  # pragma: no cover
+                if include is not None:  # pragma: no cover
+                    if Plugin(name=entry_point.name) not in include:  # pragma: no cover
+                        continue  # pragma: no cover
+                entry_point_function: Callable[[SpakkyApplication], None] = (
+                    entry_point.load()
+                )
+                loaded_count += 1
+                plugin_phase.set_processed_count(loaded_count)
+                entry_point_function(self)  # pragma: no cover
         return self
 
     def start(self) -> Self:
@@ -213,7 +234,9 @@ class SpakkyApplication:
         Returns:
             Self for method chaining.
         """
-        self._application_context.start()
+        self._application_context.start(
+            startup_phase_recorder=self._startup_phase_recorder
+        )
         return self
 
     def stop(self) -> Self:

--- a/core/spakky/src/spakky/core/application/application_context.py
+++ b/core/spakky/src/spakky/core/application/application_context.py
@@ -1,9 +1,11 @@
 import threading
+from dataclasses import dataclass
 from asyncio import locks
 from asyncio.events import AbstractEventLoop, new_event_loop, set_event_loop
 from asyncio.tasks import run_coroutine_threadsafe
 from contextvars import ContextVar
 from threading import RLock, Thread
+from time import perf_counter
 from types import MappingProxyType, NoneType
 from typing import Callable, cast, overload
 from uuid import UUID, uuid4
@@ -12,6 +14,10 @@ from typing_extensions import override
 
 from spakky.core.aop.post_processor import AspectPostProcessor
 from spakky.core.application.error import AbstractSpakkyApplicationError
+from spakky.core.application.startup_diagnostics import (
+    IStartupPhaseRecorder,
+    NoOpStartupPhaseRecorder,
+)
 from spakky.core.common.constants import CONTEXT_ID, CONTEXT_SCOPE_CACHE
 from spakky.core.common.types import ObjectT, is_optional, remove_none
 from spakky.core.pod.annotations.lazy import Lazy
@@ -61,6 +67,21 @@ class CannotAssignSystemContextIDError(AbstractSpakkyApplicationError):
     message = f"Cannot override {CONTEXT_ID} value."
 
 
+STARTUP_PHASE_POST_PROCESSOR_REGISTRATION = "post_processor_registration"
+STARTUP_PHASE_INSTANTIATION = "instantiation"
+STARTUP_PHASE_POST_PROCESSING = "post_processing"
+STARTUP_PHASE_SERVICE_START = "service_start"
+
+
+@dataclass
+class _ApplicationContextStartupMetrics:
+    instantiation_attempt_count: int = 0
+    instantiation_elapsed_seconds: float = 0
+    post_processing_application_count: int = 0
+    post_processing_elapsed_seconds: float = 0
+    post_processing_exception: BaseException | None = None
+
+
 class ApplicationContext(IApplicationContext):
     """Container managing Pod instances, dependencies, and application lifecycle.
 
@@ -108,6 +129,9 @@ class ApplicationContext(IApplicationContext):
     __is_started: bool
     """Whether the context has been started."""
 
+    __startup_metrics: _ApplicationContextStartupMetrics | None
+    """Startup lifecycle metrics for the active start attempt."""
+
     def __init__(self) -> None:
         """Initialize application context."""
         self.__forward_type_map = {}
@@ -124,6 +148,7 @@ class ApplicationContext(IApplicationContext):
         self.__event_loop = None
         self.__event_thread = None
         self.__is_started = False
+        self.__startup_metrics = None
         self.task_stop_event = locks.Event()
         self.thread_stop_event = threading.Event()
 
@@ -291,9 +316,20 @@ class ApplicationContext(IApplicationContext):
                     ),
                 )
             dependencies[name] = resolved_dependency
-        instance: object = pod.instantiate(dependencies=dependencies)
+        started_at = perf_counter()
+        try:
+            instance: object = pod.instantiate(dependencies=dependencies)
+        except BaseException:
+            self.__record_instantiation_attempt(perf_counter() - started_at)
+            raise
+        self.__record_instantiation_attempt(perf_counter() - started_at)
         post_processed: object = self.__post_process_pod(instance)
         return post_processed
+
+    def __record_instantiation_attempt(self, elapsed_seconds: float) -> None:
+        if self.__startup_metrics is None:
+            return
+        self.__startup_metrics.instantiation_elapsed_seconds += elapsed_seconds
 
     def __post_process_pod(self, pod: object) -> object:
         """Apply all registered post-processors to a Pod instance.
@@ -305,8 +341,26 @@ class ApplicationContext(IApplicationContext):
             The post-processed Pod instance.
         """
         for post_processor in self.__post_processors:
-            pod = post_processor.post_process(pod)
+            started_at = perf_counter()
+            try:
+                pod = post_processor.post_process(pod)
+            except BaseException as e:
+                self.__record_post_processing_attempt(perf_counter() - started_at, e)
+                raise
+            self.__record_post_processing_attempt(perf_counter() - started_at)
         return pod
+
+    def __record_post_processing_attempt(
+        self,
+        elapsed_seconds: float,
+        exception: BaseException | None = None,
+    ) -> None:
+        if self.__startup_metrics is None:
+            return
+        self.__startup_metrics.post_processing_application_count += 1
+        self.__startup_metrics.post_processing_elapsed_seconds += elapsed_seconds
+        if exception is not None:
+            self.__startup_metrics.post_processing_exception = exception
 
     def __register_post_processors(self) -> None:
         """Register built-in and user-defined post-processors.
@@ -343,6 +397,8 @@ class ApplicationContext(IApplicationContext):
             pod for pod in self.__pods.values() if not Lazy.exists(pod.target)
         ]
         for pod in non_lazy_pods:
+            if self.__startup_metrics is not None:
+                self.__startup_metrics.instantiation_attempt_count += 1
             if (
                 self.__get_internal(type_=pod.type_, name=pod.name) is None
             ):  # pragma: no cover
@@ -608,7 +664,10 @@ class ApplicationContext(IApplicationContext):
             self.__async_services.append(service)
 
     @override
-    def start(self) -> None:
+    def start(
+        self,
+        startup_phase_recorder: IStartupPhaseRecorder | None = None,
+    ) -> None:
         """Start the application context.
 
         Registers post-processors, initializes Pods, and starts services.
@@ -618,10 +677,64 @@ class ApplicationContext(IApplicationContext):
         """
         if self.__is_started:  # pragma: no cover
             raise ApplicationContextAlreadyStartedError()
+        recorder = (
+            startup_phase_recorder
+            if startup_phase_recorder is not None
+            else NoOpStartupPhaseRecorder()
+        )
         self.__is_started = True
-        self.__register_post_processors()
-        self.__initialize_pods()
-        self.__start_services()
+        try:
+            with recorder.record_phase(
+                phase_name=STARTUP_PHASE_POST_PROCESSOR_REGISTRATION
+            ) as phase:
+                self.__register_post_processors()
+                phase.set_processed_count(len(self.__post_processors))
+
+            startup_metrics = _ApplicationContextStartupMetrics()
+            self.__startup_metrics = startup_metrics
+            try:
+                self.__initialize_pods()
+            except BaseException as e:
+                if startup_metrics.post_processing_exception is None:
+                    recorder.record_failure(
+                        phase_name=STARTUP_PHASE_INSTANTIATION,
+                        elapsed_seconds=startup_metrics.instantiation_elapsed_seconds,
+                        exception=e,
+                        processed_count=startup_metrics.instantiation_attempt_count,
+                    )
+                else:
+                    recorder.record_success(
+                        phase_name=STARTUP_PHASE_INSTANTIATION,
+                        elapsed_seconds=startup_metrics.instantiation_elapsed_seconds,
+                        processed_count=startup_metrics.instantiation_attempt_count,
+                    )
+                    recorder.record_failure(
+                        phase_name=STARTUP_PHASE_POST_PROCESSING,
+                        elapsed_seconds=startup_metrics.post_processing_elapsed_seconds,
+                        exception=startup_metrics.post_processing_exception,
+                        processed_count=startup_metrics.post_processing_application_count,
+                    )
+                raise
+
+            recorder.record_success(
+                phase_name=STARTUP_PHASE_INSTANTIATION,
+                elapsed_seconds=startup_metrics.instantiation_elapsed_seconds,
+                processed_count=startup_metrics.instantiation_attempt_count,
+            )
+            recorder.record_success(
+                phase_name=STARTUP_PHASE_POST_PROCESSING,
+                elapsed_seconds=startup_metrics.post_processing_elapsed_seconds,
+                processed_count=startup_metrics.post_processing_application_count,
+            )
+
+            service_start_count = len(self.__services) + len(self.__async_services)
+            with recorder.record_phase(
+                phase_name=STARTUP_PHASE_SERVICE_START,
+                processed_count=service_start_count,
+            ):
+                self.__start_services()
+        finally:
+            self.__startup_metrics = None
 
     @override
     def stop(self) -> None:

--- a/core/spakky/src/spakky/core/pod/interfaces/application_context.py
+++ b/core/spakky/src/spakky/core/pod/interfaces/application_context.py
@@ -10,6 +10,7 @@ from threading import Event
 from uuid import UUID
 
 from spakky.core.application.error import AbstractSpakkyApplicationError
+from spakky.core.application.startup_diagnostics import IStartupPhaseRecorder
 from spakky.core.pod.interfaces.container import IContainer
 from spakky.core.pod.interfaces.tag_registry import ITagRegistry
 from spakky.core.service.interfaces.service import IAsyncService, IService
@@ -75,7 +76,10 @@ class IApplicationContext(IContainer, ITagRegistry, ABC):
         ...
 
     @abstractmethod
-    def start(self) -> None:
+    def start(
+        self,
+        startup_phase_recorder: IStartupPhaseRecorder | None = None,
+    ) -> None:
         """Start the application context and all services."""
         ...
 

--- a/core/spakky/tests/application/test_startup_diagnostics.py
+++ b/core/spakky/tests/application/test_startup_diagnostics.py
@@ -1,7 +1,11 @@
 """Tests for startup diagnostics contracts."""
 
-import pytest
+import threading
 
+import pytest
+from typing_extensions import override
+
+import spakky.core.application.application_context as application_context_module
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
 from spakky.core.application.startup_diagnostics import (
@@ -16,6 +20,51 @@ from spakky.core.application.startup_diagnostics import (
     StartupPhaseStatus,
     StartupProcessedCountCannotBeNegativeError,
 )
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.post_processor import IPostProcessor
+from spakky.core.service.interfaces.service import IService
+
+
+class FailingStartupService(IService):
+    """Synchronous service that fails during startup."""
+
+    _stop_event: threading.Event | None
+    _stopped: bool
+
+    def __init__(self) -> None:
+        self._stop_event = None
+        self._stopped = False
+
+    @override
+    def set_stop_event(self, stop_event: threading.Event) -> None:
+        self._stop_event = stop_event
+
+    @override
+    def start(self) -> None:
+        raise RuntimeError("service failed")
+
+    @override
+    def stop(self) -> None:
+        self._stopped = True
+
+
+@Pod()
+class FailingPostProcessor(IPostProcessor):
+    """Post-processor that fails during startup pod processing."""
+
+    @override
+    def post_process(self, pod: object) -> object:
+        raise RuntimeError("post processing failed")
+
+
+@Pod()
+class PostProcessingTarget:
+    """Pod used to trigger user post-processing during startup."""
+
+
+@Pod()
+class TimedInstantiationTarget:
+    """Pod used to verify separate instantiation and post-processing timings."""
 
 
 def test_active_startup_phase_recorder_success_expect_report_contains_phase() -> None:
@@ -152,6 +201,141 @@ def test_spakky_application_enable_startup_diagnostics_expect_active_report() ->
     assert result is app
     assert isinstance(app.startup_phase_recorder, ActiveStartupPhaseRecorder)
     assert len(app.startup_report.records) == 1
+
+
+def test_spakky_application_startup_pipeline_diagnostics_expect_phase_records() -> None:
+    """diagnostics 활성화 시 startup pipeline phase들이 report에 기록됨을 검증한다."""
+    from tests.dummy import dummy_package
+
+    app = SpakkyApplication(ApplicationContext()).enable_startup_diagnostics()
+
+    app.load_plugins(include=set()).scan(dummy_package).start()
+
+    try:
+        records_by_phase = {
+            record.phase_name: record for record in app.startup_report.records
+        }
+
+        assert records_by_phase["load_plugins"].processed_count == 0
+        assert records_by_phase["scan"].processed_count > 0
+        assert records_by_phase["registration"].processed_count > 0
+        assert records_by_phase["post_processor_registration"].processed_count > 0
+        assert records_by_phase["instantiation"].processed_count > 0
+        assert records_by_phase["post_processing"].processed_count > 0
+        assert records_by_phase["service_start"].processed_count == 0
+        assert all(
+            record.status is StartupPhaseStatus.SUCCESS
+            for record in app.startup_report.records
+        )
+    finally:
+        app.stop()
+
+
+def test_spakky_application_startup_diagnostics_expect_instantiation_time_excludes_post_processing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """instantiation phase 시간이 post_processing phase 시간과 중복되지 않음을 검증한다."""
+    perf_counter_values = iter((10.0, 12.0, 13.0, 15.0, 17.0, 20.0, 23.0, 30.0))
+    monkeypatch.setattr(
+        application_context_module,
+        "perf_counter",
+        lambda: next(perf_counter_values),
+    )
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .add(TimedInstantiationTarget)
+        .enable_startup_diagnostics()
+    )
+
+    app.start()
+
+    try:
+        records_by_phase = {
+            record.phase_name: record for record in app.startup_report.records
+        }
+
+        assert records_by_phase["post_processing"].elapsed_seconds == 12.0
+        assert records_by_phase["instantiation"].elapsed_seconds == 2.0
+    finally:
+        app.stop()
+
+
+def test_spakky_application_disabled_diagnostics_expect_existing_behavior() -> None:
+    """diagnostics 비활성화 시 기존 startup behavior와 빈 report가 보존됨을 검증한다."""
+    from tests.dummy import dummy_package
+
+    app = SpakkyApplication(ApplicationContext())
+
+    app.load_plugins(include=set()).scan(dummy_package).start()
+
+    try:
+        assert app.startup_report.records == ()
+    finally:
+        app.stop()
+
+
+def test_spakky_application_start_without_pods_expect_zero_post_processing() -> None:
+    """post-processor 적용 대상이 0개여도 post_processing phase가 실패하지 않음을 검증한다."""
+    app = SpakkyApplication(ApplicationContext()).enable_startup_diagnostics()
+
+    app.start()
+
+    try:
+        records_by_phase = {
+            record.phase_name: record for record in app.startup_report.records
+        }
+
+        assert records_by_phase["post_processing"].processed_count == 0
+        assert records_by_phase["post_processing"].status is StartupPhaseStatus.SUCCESS
+    finally:
+        app.stop()
+
+
+def test_spakky_application_start_failure_expect_recorded_and_propagated() -> None:
+    """startup phase 실패 시 실패 record를 남기고 기존 예외를 그대로 전파함을 검증한다."""
+    context = ApplicationContext()
+    context.add_service(FailingStartupService())
+    app = SpakkyApplication(context).enable_startup_diagnostics()
+
+    try:
+        with pytest.raises(RuntimeError, match="service failed"):
+            app.start()
+
+        failure = app.startup_report.records[-1]
+        assert failure.phase_name == "service_start"
+        assert failure.status is StartupPhaseStatus.FAILURE
+        assert failure.failure_summary is not None
+        assert failure.failure_summary.exception_type_name == "RuntimeError"
+        assert failure.failure_summary.message == "service failed"
+    finally:
+        if context.is_started:
+            app.stop()
+
+
+def test_spakky_application_post_processing_failure_expect_phase_failure() -> None:
+    """post-processing 실패 시 해당 phase 실패 record를 남기고 기존 예외를 전파함을 검증한다."""
+    context = ApplicationContext()
+    app = (
+        SpakkyApplication(context)
+        .add(FailingPostProcessor)
+        .add(PostProcessingTarget)
+        .enable_startup_diagnostics()
+    )
+
+    with pytest.raises(RuntimeError, match="post processing failed"):
+        app.start()
+
+    records_by_phase = {
+        record.phase_name: record for record in app.startup_report.records
+    }
+    instantiation = records_by_phase["instantiation"]
+    post_processing = records_by_phase["post_processing"]
+
+    assert instantiation.status is StartupPhaseStatus.SUCCESS
+    assert post_processing.status is StartupPhaseStatus.FAILURE
+    assert post_processing.failure_summary is not None
+    assert post_processing.failure_summary.exception_type_name == "RuntimeError"
+    assert post_processing.failure_summary.message == "post processing failed"
 
 
 def test_startup_failure_summary_from_exception_expect_no_raw_exception() -> None:


### PR DESCRIPTION
## Summary
- Wire the startup phase recorder into `SpakkyApplication.load_plugins`, `scan`, and `start`.
- Record scan, registration, context lifecycle, post-processing, and service-start counts/status in execution order.
- Preserve no-op diagnostics behavior and original exception propagation on failed startup phases.

## Acceptance Criteria
- FR-001: diagnostics-enabled `load_plugins().scan().start()` records startup phase records.
- FR-002: scan/registration/lifecycle counts follow milestone count semantics covered by package tests.
- FR-002: diagnostics-disabled startup keeps an empty report and existing behavior.
- FR-002: failed startup phases record structured failure summary and re-raise the original exception.
- acceptance_check: missing (issue body has no executable grep/find/rg acceptance lines)

## Checks
- `cd core/spakky && uv run --with ruff ruff format .`
- `cd core/spakky && uv run --with ruff ruff check .`
- `cd core/spakky && uv run --isolated --with pyrefly --with pytest pyrefly check src tests --config pyproject.toml --use-ignore-files=false`
- `cd core/spakky && uv run --isolated --with pytest --with pytest-cov --with pytest-xdist --with pytest-spec --with pytest-asyncio pytest` (320 passed, coverage 100.00%)
- commit hook: monorepo pre-commit passed
- push hook: monorepo pre-push tests passed

Notes: likely overlap area with #146 is limited to `ApplicationContext.start`/lifecycle flow; dependency-resolution diagnostics paths are not redefined.

Closes #147
