### PR TITLE
feat(core): add discovery manifest scan reuse (#145)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -306,6 +306,8 @@ app = (
 
 **`scan()` 자동 감지**: `inspect.stack()`으로 호출자의 패키지를 찾고, 하위 모듈을 재귀 순회하며 `Pod.exists()` 또는 `Tag.exists()`인 객체를 등록합니다.
 
+**DiscoveryManifest 재사용**: `enable_discovery_manifest(path=None)`을 `scan()` 전에 호출하면 scan discovery 결과를 JSON manifest로 저장합니다. manifest fingerprint는 schema version, Python major/minor version, scan 대상 module/package, exclude pattern, source file mtime/size로 구성됩니다. decision은 `miss`, `hit`, `stale_schema`, `stale_input` 중 하나이며 startup diagnostics의 scan phase diagnostic detail로 기록됩니다. `hit`은 저장된 Pod/Tag 후보를 기존 등록 경로로 재생하고, stale/miss는 기존 fresh discovery로 돌아갑니다. container lookup/type cache는 변경하지 않습니다.
+
 ---
 
 ## 코어: AOP 시스템

--- a/core/spakky/README.md
+++ b/core/spakky/README.md
@@ -67,6 +67,34 @@ user_service = app.container.get(UserService)
 
 > **📘 Auto-scan**: When `scan()` is called without arguments, it automatically detects the caller's package and scans it. This also works in Docker environments where the application root may not be in `sys.path` - the framework automatically adds the necessary path.
 
+### Discovery Manifest
+
+Scan discovery manifest reuse is opt-in and does not replace container caches.
+Enable it before `scan()` to persist discovered Pod/Tag candidates and reuse
+them when the scan target, exclude patterns, Python version, schema version, and
+source file mtimes/sizes are unchanged:
+
+```python
+from pathlib import Path
+
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+
+app = (
+    SpakkyApplication(ApplicationContext())
+    .enable_startup_diagnostics()
+    .enable_discovery_manifest(Path(".spakky/cache/discovery-manifest.json"))
+    .scan(my_app)
+)
+
+scan_record = app.startup_report.records[0]
+decision = scan_record.diagnostic_details[0].value  # miss, hit, stale_schema, stale_input
+```
+
+If no path is provided, Spakky uses the deterministic project-local cache path
+`.spakky/cache/discovery-manifest.json`. Missing, stale, or malformed manifests
+fall back to fresh discovery and record the decision in startup diagnostics.
+
 ### Startup Diagnostics
 
 Startup diagnostics are opt-in. The default recorder is no-op, so existing
@@ -93,9 +121,9 @@ first_phase = report.records[0]
 ```
 
 `StartupReport` stores each startup phase name, elapsed seconds, processed
-count, success/failure status, and an optional structured failure summary.
-Failure summaries keep the exception type name, message, and diagnostic
-details without retaining the raw exception object.
+count, success/failure status, optional diagnostic details, and an optional
+structured failure summary. Failure summaries keep the exception type name,
+message, and diagnostic details without retaining the raw exception object.
 
 DI dependency failures preserve their existing exception types while attaching
 structured dependency diagnostics from `Pod.dependencies`, including the failed

--- a/core/spakky/src/spakky/core/application/__init__.py
+++ b/core/spakky/src/spakky/core/application/__init__.py
@@ -1,3 +1,16 @@
+from spakky.core.application.discovery_manifest import (
+    DISCOVERY_MANIFEST_DETAIL_KEY,
+    DISCOVERY_MANIFEST_SCHEMA_VERSION,
+    DEFAULT_DISCOVERY_MANIFEST_PATH,
+    DiscoveryManifest,
+    DiscoveryManifestCandidate,
+    DiscoveryManifestDecision,
+    DiscoveryManifestFingerprint,
+    DiscoveryManifestLoadResult,
+    DiscoveryManifestSourceFingerprint,
+    DiscoveryManifestStore,
+    default_discovery_manifest_path,
+)
 from spakky.core.application.startup_diagnostics import (
     ActiveStartupPhaseRecorder,
     IStartupPhaseRecorder,
@@ -15,7 +28,17 @@ from spakky.core.application.startup_diagnostics import (
 )
 
 __all__ = [
+    "DEFAULT_DISCOVERY_MANIFEST_PATH",
+    "DISCOVERY_MANIFEST_DETAIL_KEY",
+    "DISCOVERY_MANIFEST_SCHEMA_VERSION",
     "ActiveStartupPhaseRecorder",
+    "DiscoveryManifest",
+    "DiscoveryManifestCandidate",
+    "DiscoveryManifestDecision",
+    "DiscoveryManifestFingerprint",
+    "DiscoveryManifestLoadResult",
+    "DiscoveryManifestSourceFingerprint",
+    "DiscoveryManifestStore",
     "IStartupPhaseRecorder",
     "NoOpStartupPhaseRecorder",
     "StartupDiagnosticDetail",
@@ -28,4 +51,5 @@ __all__ = [
     "StartupPhaseStatus",
     "StartupProcessedCountCannotBeNegativeError",
     "StartupReport",
+    "default_discovery_manifest_path",
 ]

--- a/core/spakky/src/spakky/core/application/application.py
+++ b/core/spakky/src/spakky/core/application/application.py
@@ -7,15 +7,25 @@ for configuring and starting a Spakky application with DI/IoC and AOP support.
 import inspect
 from importlib.metadata import entry_points
 from pathlib import Path
-from types import ModuleType
+from types import FunctionType, ModuleType
 from typing import Callable, Self
 
+from spakky.core.application.discovery_manifest import (
+    DISCOVERY_MANIFEST_DETAIL_KEY,
+    DiscoveryManifest,
+    DiscoveryManifestCandidate,
+    DiscoveryManifestDecision,
+    DiscoveryManifestFingerprint,
+    DiscoveryManifestStore,
+    default_discovery_manifest_path,
+)
 from spakky.core.application.error import AbstractSpakkyApplicationError
 from spakky.core.application.plugin import Plugin
 from spakky.core.application.startup_diagnostics import (
     ActiveStartupPhaseRecorder,
     IStartupPhaseRecorder,
     NoOpStartupPhaseRecorder,
+    StartupDiagnosticDetail,
     StartupReport,
 )
 from spakky.core.common.constants import PLUGIN_PATH
@@ -27,6 +37,7 @@ from spakky.core.common.importing import (
     list_objects,
     resolve_module,
 )
+from spakky.core.common.mutability import immutable
 from spakky.core.pod.annotations.pod import Pod, PodType
 from spakky.core.pod.annotations.tag import Tag
 from spakky.core.pod.interfaces.application_context import IApplicationContext
@@ -35,6 +46,17 @@ from spakky.core.pod.interfaces.container import IContainer
 STARTUP_PHASE_LOAD_PLUGINS = "load_plugins"
 STARTUP_PHASE_SCAN = "scan"
 STARTUP_PHASE_REGISTRATION = "registration"
+
+
+@immutable
+class _DiscoveryManifestHit:
+    """Resolved DiscoveryManifest hit candidates."""
+
+    decision: DiscoveryManifestDecision
+    """Final manifest decision after object resolution."""
+
+    objects: tuple[PodType, ...]
+    """Resolved Pod or Tag objects."""
 
 
 class CannotDetermineScanPathError(AbstractSpakkyApplicationError):
@@ -55,6 +77,9 @@ class SpakkyApplication:
 
     _startup_phase_recorder: IStartupPhaseRecorder
     """Recorder used by startup pipeline diagnostics."""
+
+    _discovery_manifest_path: Path | None
+    """Opt-in DiscoveryManifest path for scan result reuse."""
 
     @property
     def container(self) -> IContainer:
@@ -92,6 +117,15 @@ class SpakkyApplication:
         """
         return self._startup_phase_recorder.report
 
+    @property
+    def discovery_manifest_path(self) -> Path | None:
+        """Get the configured DiscoveryManifest path.
+
+        Returns:
+            Manifest path when reuse is enabled, otherwise None.
+        """
+        return self._discovery_manifest_path
+
     def __init__(self, application_context: IApplicationContext) -> None:
         """Initialize the Spakky application.
 
@@ -100,6 +134,7 @@ class SpakkyApplication:
         """
         self._application_context = application_context
         self._startup_phase_recorder = NoOpStartupPhaseRecorder()
+        self._discovery_manifest_path = None
 
     def enable_startup_diagnostics(self) -> Self:
         """Enable startup diagnostics with an active phase recorder.
@@ -108,6 +143,20 @@ class SpakkyApplication:
             Self for method chaining.
         """
         self._startup_phase_recorder = ActiveStartupPhaseRecorder()
+        return self
+
+    def enable_discovery_manifest(self, path: Path | str | None = None) -> Self:
+        """Enable reusable scan discovery manifests.
+
+        Args:
+            path: Explicit manifest path. None uses a deterministic project cache path.
+
+        Returns:
+            Self for method chaining.
+        """
+        self._discovery_manifest_path = (
+            default_discovery_manifest_path() if path is None else Path(path)
+        )
         return self
 
     def add(self, obj: PodType) -> Self:
@@ -153,6 +202,10 @@ class SpakkyApplication:
         """
         modules: set[ModuleType]
         caller_module: ModuleType | None = None
+        manifest_decision: DiscoveryManifestDecision | None = None
+        manifest_fingerprint: DiscoveryManifestFingerprint | None = None
+        discovery_candidates: list[DiscoveryManifestCandidate] = []
+        discovered_objects: tuple[PodType, ...] = ()
         with self._startup_phase_recorder.record_phase(
             phase_name=STARTUP_PHASE_SCAN
         ) as scan_phase:
@@ -177,28 +230,122 @@ class SpakkyApplication:
 
             if exclude is None:
                 exclude = {caller_module} if caller_module else set()
-            if is_package(path):
-                modules = list_modules(path, exclude)
-            else:  # pragma: no cover
-                modules = {resolve_module(path)}
+            if self._discovery_manifest_path is not None:
+                manifest_fingerprint = DiscoveryManifestFingerprint.from_scan_input(
+                    path=path,
+                    exclude=exclude,
+                )
+                manifest_load_result = DiscoveryManifestStore(
+                    self._discovery_manifest_path
+                ).load(manifest_fingerprint)
+                manifest_decision = manifest_load_result.decision
+                if manifest_load_result.manifest is not None:
+                    manifest_hit = self._resolve_manifest_hit(
+                        manifest_load_result.manifest.candidates
+                    )
+                    manifest_decision = manifest_hit.decision
+                    discovered_objects = manifest_hit.objects
+                    if manifest_decision is DiscoveryManifestDecision.HIT:
+                        modules = {
+                            resolve_module(module_name)
+                            for module_name in manifest_load_result.manifest.module_names
+                        }
+                    else:
+                        modules = self._discover_modules(path, exclude)
+                else:
+                    modules = self._discover_modules(path, exclude)
+                scan_phase.set_diagnostic_details(
+                    (
+                        StartupDiagnosticDetail(
+                            key=DISCOVERY_MANIFEST_DETAIL_KEY,
+                            value=manifest_decision.value,
+                        ),
+                    )
+                )
+            else:
+                modules = self._discover_modules(path, exclude)
             scan_phase.set_processed_count(len(modules))
 
         registration_count = 0
         with self._startup_phase_recorder.record_phase(
             phase_name=STARTUP_PHASE_REGISTRATION
         ) as registration_phase:
-            for item in modules:
-                for obj in list_objects(item, lambda x: Pod.exists(x) or Tag.exists(x)):
-                    if Pod.exists(obj):
-                        self._application_context.add(obj)
-                        registration_count += 1
-                    if Tag.exists(obj):
-                        tag = Tag.get(obj)
-                        self._application_context.register_tag(tag)
-                        registration_count += 1
+            if manifest_decision is DiscoveryManifestDecision.HIT:
+                for obj in discovered_objects:
+                    registration_count += self._register_discovered_object(obj)
+            else:
+                for item in modules:
+                    objects = list_objects(
+                        item,
+                        lambda x: Pod.exists(x) or Tag.exists(x),
+                    )
+                    for obj in objects:
+                        discovery_candidates.append(
+                            DiscoveryManifestCandidate.from_object(obj)
+                        )
+                        registration_count += self._register_discovered_object(obj)
             registration_phase.set_processed_count(registration_count)
 
+        if (
+            self._discovery_manifest_path is not None
+            and manifest_fingerprint is not None
+            and manifest_decision is not DiscoveryManifestDecision.HIT
+        ):
+            manifest = DiscoveryManifest(
+                fingerprint=manifest_fingerprint,
+                module_names=tuple(sorted(item.__name__ for item in modules)),
+                candidates=tuple(
+                    sorted(
+                        discovery_candidates,
+                        key=lambda candidate: (
+                            candidate.module_name,
+                            candidate.qualname,
+                        ),
+                    )
+                ),
+            )
+            DiscoveryManifestStore(self._discovery_manifest_path).save(manifest)
+
         return self
+
+    def _discover_modules(self, path: Module, exclude: set[Module]) -> set[ModuleType]:
+        if is_package(path):
+            return list_modules(path, exclude)
+        return {resolve_module(path)}
+
+    def _register_discovered_object(self, obj: PodType) -> int:
+        registration_count = 0
+        if Pod.exists(obj):
+            self._application_context.add(obj)
+            registration_count += 1
+        if Tag.exists(obj):
+            tag = Tag.get(obj)
+            self._application_context.register_tag(tag)
+            registration_count += 1
+        return registration_count
+
+    def _resolve_manifest_hit(
+        self,
+        candidates: tuple[DiscoveryManifestCandidate, ...],
+    ) -> "_DiscoveryManifestHit":
+        discovered_objects: list[PodType] = []
+        for candidate in candidates:
+            matches = list_objects(
+                resolve_module(candidate.module_name),
+                candidate.matches,
+            )
+            if len(matches) != 1:
+                return _DiscoveryManifestHit(
+                    decision=DiscoveryManifestDecision.STALE_INPUT,
+                    objects=(),
+                )
+            obj = next(iter(matches))
+            if isinstance(obj, FunctionType) or isinstance(obj, type):
+                discovered_objects.append(obj)
+        return _DiscoveryManifestHit(
+            decision=DiscoveryManifestDecision.HIT,
+            objects=tuple(discovered_objects),
+        )
 
     def load_plugins(
         self,

--- a/core/spakky/src/spakky/core/application/discovery_manifest.py
+++ b/core/spakky/src/spakky/core/application/discovery_manifest.py
@@ -1,0 +1,446 @@
+"""Discovery manifest storage for reusable scan discovery results."""
+
+import json
+import sys
+from enum import StrEnum
+from pathlib import Path
+from types import FunctionType, ModuleType
+
+from spakky.core.common.importing import Module, is_package, resolve_module
+from spakky.core.common.mutability import immutable
+
+DISCOVERY_MANIFEST_SCHEMA_VERSION = 1
+DISCOVERY_MANIFEST_DETAIL_KEY = "discovery_manifest_decision"
+DEFAULT_DISCOVERY_MANIFEST_PATH = Path(".spakky") / "cache" / "discovery-manifest.json"
+
+JsonObject = dict[str, object]
+
+
+class DiscoveryManifestDecision(StrEnum):
+    """Decision made while loading a discovery manifest."""
+
+    MISS = "miss"
+    HIT = "hit"
+    STALE_SCHEMA = "stale_schema"
+    STALE_INPUT = "stale_input"
+
+
+@immutable
+class DiscoveryManifestSourceFingerprint:
+    """Fingerprint for one Python source file involved in scan discovery."""
+
+    path: str
+    """Absolute source file path."""
+
+    mtime_ns: int
+    """Source file modification time in nanoseconds."""
+
+    size: int
+    """Source file size in bytes."""
+
+    def to_json(self) -> JsonObject:
+        """Serialize the source fingerprint.
+
+        Returns:
+            JSON-compatible object.
+        """
+        return {
+            "path": self.path,
+            "mtime_ns": self.mtime_ns,
+            "size": self.size,
+        }
+
+
+@immutable
+class DiscoveryManifestFingerprint:
+    """Input fingerprint used to decide whether a manifest is fresh."""
+
+    schema_version: int
+    """Manifest schema version used by the current runtime."""
+
+    python_version: str
+    """Major/minor Python version."""
+
+    module_name: str
+    """Scan target module name."""
+
+    is_package: bool
+    """Whether the target is a package scan."""
+
+    exclude: tuple[str, ...]
+    """Normalized exclude module patterns."""
+
+    sources: tuple[DiscoveryManifestSourceFingerprint, ...]
+    """Source files that affect scan discovery."""
+
+    @classmethod
+    def from_scan_input(
+        cls,
+        path: Module,
+        exclude: set[Module],
+    ) -> "DiscoveryManifestFingerprint":
+        """Build a fingerprint from scan inputs.
+
+        Args:
+            path: Scan target module or module name.
+            exclude: Exclude module patterns.
+
+        Returns:
+            Fingerprint for the current scan input.
+        """
+        module = resolve_module(path)
+        source_files = _source_files_for(module)
+        return cls(
+            schema_version=DISCOVERY_MANIFEST_SCHEMA_VERSION,
+            python_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+            module_name=module.__name__,
+            is_package=is_package(module),
+            exclude=tuple(sorted(_normalize_module_name(item) for item in exclude)),
+            sources=tuple(_source_fingerprint(source) for source in source_files),
+        )
+
+    def to_json(self) -> JsonObject:
+        """Serialize the fingerprint.
+
+        Returns:
+            JSON-compatible object.
+        """
+        return {
+            "schema_version": self.schema_version,
+            "python_version": self.python_version,
+            "module_name": self.module_name,
+            "is_package": self.is_package,
+            "exclude": list(self.exclude),
+            "sources": [source.to_json() for source in self.sources],
+        }
+
+
+@immutable
+class DiscoveryManifestCandidate:
+    """Pod or Tag candidate discovered during scan."""
+
+    module_name: str
+    """Module containing the candidate object."""
+
+    qualname: str
+    """Qualified object name inside the module."""
+
+    @classmethod
+    def from_object(cls, obj: type | FunctionType) -> "DiscoveryManifestCandidate":
+        """Build a candidate identity from a discovered object.
+
+        Args:
+            obj: Discovered class or function.
+
+        Returns:
+            Candidate identity.
+        """
+        return cls(module_name=obj.__module__, qualname=obj.__qualname__)
+
+    def matches(self, obj: object) -> bool:
+        """Check whether an object matches this candidate identity.
+
+        Args:
+            obj: Candidate object loaded from a module.
+
+        Returns:
+            True when the object has the same module and qualified name.
+        """
+        if isinstance(obj, FunctionType):
+            return (
+                obj.__module__ == self.module_name and obj.__qualname__ == self.qualname
+            )
+        if isinstance(obj, type):
+            return (
+                obj.__module__ == self.module_name and obj.__qualname__ == self.qualname
+            )
+        return False
+
+    def to_json(self) -> JsonObject:
+        """Serialize the candidate.
+
+        Returns:
+            JSON-compatible object.
+        """
+        return {
+            "module_name": self.module_name,
+            "qualname": self.qualname,
+        }
+
+
+@immutable
+class DiscoveryManifest:
+    """Reusable scan discovery manifest."""
+
+    fingerprint: DiscoveryManifestFingerprint
+    """Input fingerprint that produced this manifest."""
+
+    module_names: tuple[str, ...]
+    """Modules scanned during fresh discovery."""
+
+    candidates: tuple[DiscoveryManifestCandidate, ...]
+    """Pod and Tag candidates discovered during fresh discovery."""
+
+    def to_json(self) -> JsonObject:
+        """Serialize the manifest.
+
+        Returns:
+            JSON-compatible object.
+        """
+        return {
+            "schema_version": DISCOVERY_MANIFEST_SCHEMA_VERSION,
+            "fingerprint": self.fingerprint.to_json(),
+            "module_names": list(self.module_names),
+            "candidates": [candidate.to_json() for candidate in self.candidates],
+        }
+
+
+@immutable
+class DiscoveryManifestLoadResult:
+    """Result of attempting to load a discovery manifest."""
+
+    decision: DiscoveryManifestDecision
+    """Manifest reuse decision."""
+
+    manifest: DiscoveryManifest | None = None
+    """Loaded manifest when the decision is hit."""
+
+
+class DiscoveryManifestStore:
+    """File-backed DiscoveryManifest store."""
+
+    _path: Path
+
+    def __init__(self, path: Path) -> None:
+        """Initialize the store.
+
+        Args:
+            path: Manifest JSON file path.
+        """
+        self._path = path
+
+    def load(
+        self,
+        fingerprint: DiscoveryManifestFingerprint,
+    ) -> DiscoveryManifestLoadResult:
+        """Load a manifest and compare it to the current fingerprint.
+
+        Args:
+            fingerprint: Current scan input fingerprint.
+
+        Returns:
+            Manifest load decision and loaded manifest on hit.
+        """
+        if not self._path.exists():
+            return DiscoveryManifestLoadResult(
+                decision=DiscoveryManifestDecision.MISS,
+            )
+
+        try:
+            payload: object = json.loads(self._path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return DiscoveryManifestLoadResult(
+                decision=DiscoveryManifestDecision.MISS,
+            )
+
+        manifest = _manifest_from_json(payload)
+        if manifest is None:
+            return DiscoveryManifestLoadResult(
+                decision=DiscoveryManifestDecision.MISS,
+            )
+        if manifest.fingerprint.schema_version != DISCOVERY_MANIFEST_SCHEMA_VERSION:
+            return DiscoveryManifestLoadResult(
+                decision=DiscoveryManifestDecision.STALE_SCHEMA,
+            )
+        if manifest.fingerprint.to_json() != fingerprint.to_json():
+            return DiscoveryManifestLoadResult(
+                decision=DiscoveryManifestDecision.STALE_INPUT,
+            )
+        return DiscoveryManifestLoadResult(
+            decision=DiscoveryManifestDecision.HIT,
+            manifest=manifest,
+        )
+
+    def save(self, manifest: DiscoveryManifest) -> None:
+        """Persist a manifest.
+
+        Args:
+            manifest: Manifest generated from fresh discovery.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(
+            json.dumps(manifest.to_json(), indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+
+def default_discovery_manifest_path() -> Path:
+    """Return the deterministic project-local manifest path.
+
+    Returns:
+        Default DiscoveryManifest path under the project cache directory.
+    """
+    return Path.cwd() / DEFAULT_DISCOVERY_MANIFEST_PATH
+
+
+def _normalize_module_name(module: Module) -> str:
+    if isinstance(module, ModuleType):
+        return module.__name__
+    return module
+
+
+def _source_files_for(module: ModuleType) -> tuple[Path, ...]:
+    spec = module.__spec__
+    search_locations = spec.submodule_search_locations if spec is not None else None
+    if search_locations is not None:
+        source_paths = {
+            source.resolve()
+            for location in search_locations
+            for source in Path(location).rglob("*.py")
+        }
+        return tuple(sorted(source_paths))
+
+    module_file = module.__dict__.get("__file__")
+    if not isinstance(module_file, str):
+        return ()
+    return (Path(module_file).resolve(),)
+
+
+def _source_fingerprint(path: Path) -> DiscoveryManifestSourceFingerprint:
+    stat = path.stat()
+    return DiscoveryManifestSourceFingerprint(
+        path=str(path),
+        mtime_ns=stat.st_mtime_ns,
+        size=stat.st_size,
+    )
+
+
+def _manifest_from_json(payload: object) -> DiscoveryManifest | None:
+    if not isinstance(payload, dict):
+        return None
+    schema_version = payload.get("schema_version")
+    if not isinstance(schema_version, int):
+        return None
+    if schema_version != DISCOVERY_MANIFEST_SCHEMA_VERSION:
+        stale_fingerprint = DiscoveryManifestFingerprint(
+            schema_version=schema_version,
+            python_version="",
+            module_name="",
+            is_package=False,
+            exclude=(),
+            sources=(),
+        )
+        return DiscoveryManifest(
+            fingerprint=stale_fingerprint,
+            module_names=(),
+            candidates=(),
+        )
+
+    fingerprint_payload = payload.get("fingerprint")
+    module_names_payload = payload.get("module_names")
+    candidates_payload = payload.get("candidates")
+    fingerprint = _fingerprint_from_json(fingerprint_payload)
+    module_names = _module_names_from_json(module_names_payload)
+    candidates = _candidates_from_json(candidates_payload)
+    if fingerprint is None or module_names is None or candidates is None:
+        return None
+    return DiscoveryManifest(
+        fingerprint=fingerprint,
+        module_names=module_names,
+        candidates=candidates,
+    )
+
+
+def _fingerprint_from_json(payload: object) -> DiscoveryManifestFingerprint | None:
+    if not isinstance(payload, dict):
+        return None
+    schema_version = payload.get("schema_version")
+    python_version = payload.get("python_version")
+    module_name = payload.get("module_name")
+    target_is_package = payload.get("is_package")
+    exclude_payload = payload.get("exclude")
+    sources_payload = payload.get("sources")
+    exclude = _strings_from_json(exclude_payload)
+    sources = _sources_from_json(sources_payload)
+    if not isinstance(schema_version, int):
+        return None
+    if not isinstance(python_version, str):
+        return None
+    if not isinstance(module_name, str):
+        return None
+    if not isinstance(target_is_package, bool):
+        return None
+    if exclude is None or sources is None:
+        return None
+    return DiscoveryManifestFingerprint(
+        schema_version=schema_version,
+        python_version=python_version,
+        module_name=module_name,
+        is_package=target_is_package,
+        exclude=exclude,
+        sources=sources,
+    )
+
+
+def _sources_from_json(
+    payload: object,
+) -> tuple[DiscoveryManifestSourceFingerprint, ...] | None:
+    if not isinstance(payload, list):
+        return None
+    sources: list[DiscoveryManifestSourceFingerprint] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            return None
+        path = item.get("path")
+        mtime_ns = item.get("mtime_ns")
+        size = item.get("size")
+        if not isinstance(path, str):
+            return None
+        if not isinstance(mtime_ns, int):
+            return None
+        if not isinstance(size, int):
+            return None
+        sources.append(
+            DiscoveryManifestSourceFingerprint(
+                path=path,
+                mtime_ns=mtime_ns,
+                size=size,
+            )
+        )
+    return tuple(sources)
+
+
+def _strings_from_json(payload: object) -> tuple[str, ...] | None:
+    if not isinstance(payload, list):
+        return None
+    values: list[str] = []
+    for item in payload:
+        if not isinstance(item, str):
+            return None
+        values.append(item)
+    return tuple(values)
+
+
+def _module_names_from_json(payload: object) -> tuple[str, ...] | None:
+    return _strings_from_json(payload)
+
+
+def _candidates_from_json(
+    payload: object,
+) -> tuple[DiscoveryManifestCandidate, ...] | None:
+    if not isinstance(payload, list):
+        return None
+    candidates: list[DiscoveryManifestCandidate] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            return None
+        module_name = item.get("module_name")
+        qualname = item.get("qualname")
+        if not isinstance(module_name, str):
+            return None
+        if not isinstance(qualname, str):
+            return None
+        candidates.append(
+            DiscoveryManifestCandidate(module_name=module_name, qualname=qualname)
+        )
+    return tuple(candidates)

--- a/core/spakky/src/spakky/core/application/startup_diagnostics.py
+++ b/core/spakky/src/spakky/core/application/startup_diagnostics.py
@@ -116,6 +116,9 @@ class StartupPhaseRecord:
     failure_summary: StartupFailureSummary | None = None
     """Failure summary when status is failure; absent for success records."""
 
+    diagnostic_details: StartupDiagnosticDetails = ()
+    """Structured diagnostic details attached to the phase record."""
+
     def __post_init__(self) -> None:
         """Validate phase record numeric invariants."""
         if self.elapsed_seconds < 0:
@@ -173,6 +176,7 @@ class IStartupPhaseRecorder(ABC):
         phase_name: StartupPhaseName,
         elapsed_seconds: StartupElapsedSeconds,
         processed_count: StartupProcessedCount = 0,
+        diagnostic_details: StartupDiagnosticDetails = (),
     ) -> StartupPhaseRecord:
         """Record a successful startup phase."""
         ...
@@ -255,6 +259,7 @@ class StartupPhaseRecording:
                 phase_name=self._phase_name,
                 elapsed_seconds=elapsed_seconds,
                 processed_count=self._processed_count,
+                diagnostic_details=self._diagnostic_details,
             )
         else:
             self._recorder.record_failure(
@@ -275,6 +280,17 @@ class StartupPhaseRecording:
         if processed_count < 0:
             raise StartupProcessedCountCannotBeNegativeError()
         self._processed_count = processed_count
+
+    def set_diagnostic_details(
+        self,
+        diagnostic_details: StartupDiagnosticDetails,
+    ) -> None:
+        """Set structured diagnostic details before the phase exits.
+
+        Args:
+            diagnostic_details: Structured diagnostic details to attach.
+        """
+        self._diagnostic_details = diagnostic_details
 
 
 class ActiveStartupPhaseRecorder(IStartupPhaseRecorder):
@@ -303,6 +319,7 @@ class ActiveStartupPhaseRecorder(IStartupPhaseRecorder):
         phase_name: StartupPhaseName,
         elapsed_seconds: StartupElapsedSeconds,
         processed_count: StartupProcessedCount = 0,
+        diagnostic_details: StartupDiagnosticDetails = (),
     ) -> StartupPhaseRecord:
         """Record a successful startup phase."""
         record = StartupPhaseRecord(
@@ -310,6 +327,7 @@ class ActiveStartupPhaseRecorder(IStartupPhaseRecorder):
             elapsed_seconds=elapsed_seconds,
             processed_count=processed_count,
             status=StartupPhaseStatus.SUCCESS,
+            diagnostic_details=diagnostic_details,
         )
         self._report.add_record(record)
         return record
@@ -333,6 +351,7 @@ class ActiveStartupPhaseRecorder(IStartupPhaseRecorder):
                 exception,
                 diagnostic_details,
             ),
+            diagnostic_details=diagnostic_details,
         )
         self._report.add_record(record)
         return record
@@ -359,6 +378,7 @@ class NoOpStartupPhaseRecorder(IStartupPhaseRecorder):
         phase_name: StartupPhaseName,
         elapsed_seconds: StartupElapsedSeconds,
         processed_count: StartupProcessedCount = 0,
+        diagnostic_details: StartupDiagnosticDetails = (),
     ) -> StartupPhaseRecord:
         """Create a success record without mutating the report."""
         return StartupPhaseRecord(
@@ -366,6 +386,7 @@ class NoOpStartupPhaseRecorder(IStartupPhaseRecorder):
             elapsed_seconds=elapsed_seconds,
             processed_count=processed_count,
             status=StartupPhaseStatus.SUCCESS,
+            diagnostic_details=diagnostic_details,
         )
 
     @override
@@ -387,4 +408,5 @@ class NoOpStartupPhaseRecorder(IStartupPhaseRecorder):
                 exception,
                 diagnostic_details,
             ),
+            diagnostic_details=diagnostic_details,
         )

--- a/core/spakky/src/spakky/core/common/importing.py
+++ b/core/spakky/src/spakky/core/common/importing.py
@@ -6,7 +6,7 @@ from fnmatch import fnmatch
 from logging import getLogger
 from pathlib import Path
 from types import FunctionType, ModuleType
-from typing import Any, Callable, TypeAlias
+from typing import Callable, TypeAlias
 
 from spakky.core.common.constants import PATH
 from spakky.core.common.error import AbstractSpakkyFrameworkError
@@ -216,8 +216,8 @@ def list_functions(
 
 
 def list_objects(
-    module: ModuleType, selector: Callable[[Any], bool] | None = None
-) -> set[FunctionType]:
+    module: ModuleType, selector: Callable[[object], bool] | None = None
+) -> set[type | FunctionType]:
     """List all classes and functions in a module, optionally filtered by a selector.
 
     Args:

--- a/core/spakky/tests/application/test_application_scan.py
+++ b/core/spakky/tests/application/test_application_scan.py
@@ -1,7 +1,39 @@
 """Test application scan edge cases for complete coverage."""
 
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from spakky.core.application.discovery_manifest import (
+    DISCOVERY_MANIFEST_DETAIL_KEY,
+    DEFAULT_DISCOVERY_MANIFEST_PATH,
+    DiscoveryManifestCandidate,
+    DiscoveryManifestDecision,
+    DiscoveryManifestFingerprint,
+    DiscoveryManifestStore,
+)
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
+from spakky.core.application.application import STARTUP_PHASE_SCAN
+from spakky.core.application.startup_diagnostics import StartupPhaseRecord
+
+
+def _scan_record(app: SpakkyApplication) -> StartupPhaseRecord:
+    return next(
+        record
+        for record in app.startup_report.records
+        if record.phase_name == STARTUP_PHASE_SCAN
+    )
+
+
+def _manifest_decision(record: StartupPhaseRecord) -> str:
+    return next(
+        detail.value
+        for detail in record.diagnostic_details
+        if detail.key == DISCOVERY_MANIFEST_DETAIL_KEY
+    )
 
 
 def test_scan_without_path_in_exec_context() -> None:
@@ -42,3 +74,306 @@ def test_scan_with_exclude_set() -> None:
     result = app.scan(dummy_package, exclude={module_a})
 
     assert result is app
+
+
+def test_scan_discovery_manifest_missing_expect_miss_recorded(
+    tmp_path: Path,
+) -> None:
+    """manifest가 없으면 fresh discovery 후 miss decision과 manifest를 남긴다."""
+    from tests.dummy import dummy_package
+
+    manifest_path = tmp_path / "discovery-manifest.json"
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .enable_startup_diagnostics()
+        .enable_discovery_manifest(manifest_path)
+    )
+
+    result = app.scan(dummy_package)
+
+    assert result is app
+    assert manifest_path.exists()
+    assert _manifest_decision(_scan_record(app)) == DiscoveryManifestDecision.MISS
+    assert len(app.container.pods) > 0
+
+
+def test_enable_discovery_manifest_without_path_expect_project_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """manifest path 생략 시 project cache 경로를 결정적으로 사용한다."""
+    monkeypatch.chdir(tmp_path)
+    app = SpakkyApplication(ApplicationContext()).enable_discovery_manifest()
+
+    assert app.discovery_manifest_path == tmp_path / DEFAULT_DISCOVERY_MANIFEST_PATH
+
+
+def test_scan_discovery_manifest_unchanged_expect_hit_recorded(
+    tmp_path: Path,
+) -> None:
+    """동일 입력 scan은 manifest hit로 기록되고 후보를 기존 등록 흐름에 재사용한다."""
+    from tests.dummy import dummy_package
+
+    manifest_path = tmp_path / "discovery-manifest.json"
+    SpakkyApplication(ApplicationContext()).enable_discovery_manifest(
+        manifest_path
+    ).scan(dummy_package)
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .enable_startup_diagnostics()
+        .enable_discovery_manifest(manifest_path)
+    )
+
+    app.scan(dummy_package)
+
+    assert _manifest_decision(_scan_record(app)) == DiscoveryManifestDecision.HIT
+    assert len(app.container.pods) > 0
+
+
+def test_scan_discovery_manifest_stale_schema_expect_fresh_discovery(
+    tmp_path: Path,
+) -> None:
+    """schema 버전이 다르면 stale_schema로 기록하고 fresh discovery를 수행한다."""
+    from tests.dummy import dummy_package
+
+    manifest_path = tmp_path / "discovery-manifest.json"
+    manifest_path.write_text('{"schema_version": 0}', encoding="utf-8")
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .enable_startup_diagnostics()
+        .enable_discovery_manifest(manifest_path)
+    )
+
+    app.scan(dummy_package)
+
+    assert (
+        _manifest_decision(_scan_record(app)) == DiscoveryManifestDecision.STALE_SCHEMA
+    )
+    assert len(app.container.pods) > 0
+
+
+def test_scan_discovery_manifest_stale_exclude_expect_fresh_discovery(
+    tmp_path: Path,
+) -> None:
+    """exclude 입력이 바뀌면 stale_input으로 기록하고 fresh discovery를 수행한다."""
+    from tests.dummy import dummy_package
+    from tests.dummy.dummy_package import module_a
+
+    manifest_path = tmp_path / "discovery-manifest.json"
+    SpakkyApplication(ApplicationContext()).enable_discovery_manifest(
+        manifest_path
+    ).scan(dummy_package)
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .enable_startup_diagnostics()
+        .enable_discovery_manifest(manifest_path)
+    )
+
+    app.scan(dummy_package, exclude={module_a})
+
+    assert (
+        _manifest_decision(_scan_record(app)) == DiscoveryManifestDecision.STALE_INPUT
+    )
+    assert len(app.container.pods) > 0
+
+
+def test_scan_discovery_manifest_invalid_json_expect_miss_recorded(
+    tmp_path: Path,
+) -> None:
+    """manifest parse 실패는 miss로 기록하고 fresh discovery를 수행한다."""
+    from tests.dummy import dummy_package
+
+    manifest_path = tmp_path / "discovery-manifest.json"
+    manifest_path.write_text("{not-json", encoding="utf-8")
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .enable_startup_diagnostics()
+        .enable_discovery_manifest(manifest_path)
+    )
+
+    app.scan(dummy_package)
+
+    assert _manifest_decision(_scan_record(app)) == DiscoveryManifestDecision.MISS
+    assert len(app.container.pods) > 0
+
+
+def test_scan_discovery_manifest_malformed_payload_expect_miss_recorded(
+    tmp_path: Path,
+) -> None:
+    """manifest shape이 깨진 경우 miss로 기록하고 fresh discovery를 수행한다."""
+    from tests.dummy import dummy_package
+
+    manifest_path = tmp_path / "discovery-manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .enable_startup_diagnostics()
+        .enable_discovery_manifest(manifest_path)
+    )
+
+    app.scan(dummy_package)
+
+    assert _manifest_decision(_scan_record(app)) == DiscoveryManifestDecision.MISS
+    assert len(app.container.pods) > 0
+
+
+def test_scan_discovery_manifest_missing_candidate_expect_stale_input(
+    tmp_path: Path,
+) -> None:
+    """manifest 후보가 현재 모듈에서 해소되지 않으면 stale_input으로 fresh discovery한다."""
+    from tests.dummy import dummy_package
+
+    manifest_path = tmp_path / "discovery-manifest.json"
+    SpakkyApplication(ApplicationContext()).enable_discovery_manifest(
+        manifest_path
+    ).scan(dummy_package)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["candidates"][0]["qualname"] = "MissingPodA"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .enable_startup_diagnostics()
+        .enable_discovery_manifest(manifest_path)
+    )
+
+    app.scan(dummy_package)
+
+    assert (
+        _manifest_decision(_scan_record(app)) == DiscoveryManifestDecision.STALE_INPUT
+    )
+    assert len(app.container.pods) > 0
+
+
+def test_scan_discovery_manifest_single_module_expect_hit_recorded(
+    tmp_path: Path,
+) -> None:
+    """단일 파일 모듈 scan도 manifest hit semantics를 유지한다."""
+    from tests.dummy.dummy_package import module_a
+
+    manifest_path = tmp_path / "discovery-manifest.json"
+    SpakkyApplication(ApplicationContext()).enable_discovery_manifest(
+        manifest_path
+    ).scan(module_a)
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .enable_startup_diagnostics()
+        .enable_discovery_manifest(manifest_path)
+    )
+
+    app.scan(module_a)
+
+    assert _manifest_decision(_scan_record(app)) == DiscoveryManifestDecision.HIT
+    assert len(app.container.pods) > 0
+
+
+def test_discovery_manifest_candidate_matches_non_candidate_expect_false() -> None:
+    """candidate match는 class/function 외 객체를 후보로 인정하지 않는다."""
+    candidate = DiscoveryManifestCandidate(
+        module_name="tests.dummy.dummy_package.module_a",
+        qualname="PodA",
+    )
+
+    assert candidate.matches(object()) is False
+
+
+def test_discovery_manifest_fingerprint_in_memory_module_expect_no_sources() -> None:
+    """source file 없는 module scan fingerprint도 안정적으로 생성한다."""
+    module = ModuleType("in_memory_module")
+
+    fingerprint = DiscoveryManifestFingerprint.from_scan_input(
+        module,
+        exclude={"tests.dummy.dummy_package.module_a"},
+    )
+
+    assert fingerprint.module_name == "in_memory_module"
+    assert fingerprint.sources == ()
+    assert fingerprint.exclude == ("tests.dummy.dummy_package.module_a",)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {"schema_version": "1"},
+        {"schema_version": 1, "fingerprint": [], "module_names": [], "candidates": []},
+        {
+            "schema_version": 1,
+            "fingerprint": {
+                "schema_version": "1",
+                "python_version": "3.11",
+                "module_name": "tests.dummy.dummy_package",
+                "is_package": True,
+                "exclude": [],
+                "sources": [],
+            },
+            "module_names": [],
+            "candidates": [],
+        },
+        {
+            "schema_version": 1,
+            "fingerprint": {
+                "schema_version": 1,
+                "python_version": 311,
+                "module_name": "tests.dummy.dummy_package",
+                "is_package": True,
+                "exclude": [],
+                "sources": [],
+            },
+            "module_names": [],
+            "candidates": [],
+        },
+        {
+            "schema_version": 1,
+            "fingerprint": {
+                "schema_version": 1,
+                "python_version": "3.11",
+                "module_name": 311,
+                "is_package": True,
+                "exclude": [],
+                "sources": [],
+            },
+            "module_names": [],
+            "candidates": [],
+        },
+        {
+            "schema_version": 1,
+            "fingerprint": {
+                "schema_version": 1,
+                "python_version": "3.11",
+                "module_name": "tests.dummy.dummy_package",
+                "is_package": "true",
+                "exclude": [],
+                "sources": [],
+            },
+            "module_names": [],
+            "candidates": [],
+        },
+        {
+            "schema_version": 1,
+            "fingerprint": {
+                "schema_version": 1,
+                "python_version": "3.11",
+                "module_name": "tests.dummy.dummy_package",
+                "is_package": True,
+                "exclude": "tests",
+                "sources": [],
+            },
+            "module_names": [],
+            "candidates": [],
+        },
+    ],
+)
+def test_discovery_manifest_malformed_payload_expect_store_miss(
+    tmp_path: Path,
+    payload: object,
+) -> None:
+    """manifest payload가 구조적으로 깨져 있으면 store load는 miss를 반환한다."""
+    from tests.dummy import dummy_package
+
+    manifest_path = tmp_path / "discovery-manifest.json"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    fingerprint = DiscoveryManifestFingerprint.from_scan_input(dummy_package, set())
+
+    result = DiscoveryManifestStore(manifest_path).load(fingerprint)
+
+    assert result.decision is DiscoveryManifestDecision.MISS

--- a/docs/di-container.md
+++ b/docs/di-container.md
@@ -392,6 +392,29 @@ app.scan(path="myapp.services")  # 특정 패키지 스캔
 app.scan(exclude={"myapp.tests"})  # 제외 패턴
 ```
 
+반복 startup에서 scan discovery 결과를 재사용하려면 manifest를 명시적으로
+활성화합니다. manifest는 container cache가 아니라 scan artifact이며, 입력이
+바뀌거나 schema가 stale하면 fresh discovery로 돌아갑니다.
+
+```python
+from pathlib import Path
+
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+
+app = (
+    SpakkyApplication(ApplicationContext())
+    .enable_startup_diagnostics()
+    .enable_discovery_manifest(Path(".spakky/cache/discovery-manifest.json"))
+    .scan(path="myapp.services")
+)
+
+scan_record = app.startup_report.records[0]
+manifest_decision = scan_record.diagnostic_details[0].value
+```
+
+`manifest_decision`은 `miss`, `hit`, `stale_schema`, `stale_input` 중 하나입니다.
+
 ---
 
 ## 생명주기 관리

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -63,6 +63,10 @@ app = SpakkyApplication(ApplicationContext())
 app.scan()  # 현재 패키지의 Pod 자동 스캔
 ```
 
+### DiscoveryManifest
+
+`SpakkyApplication.scan()`의 discovery 결과를 재사용하기 위한 opt-in JSON artifact입니다. `enable_discovery_manifest()`로 활성화하며, schema version, Python version, scan 대상, exclude pattern, source file mtime/size fingerprint가 일치할 때만 hit로 사용됩니다. decision은 `miss`, `hit`, `stale_schema`, `stale_input` 중 하나로 startup diagnostics에 기록됩니다.
+
 ---
 
 ## Stereotype 데코레이터


### PR DESCRIPTION
## Summary
- Add opt-in DiscoveryManifest storage and `SpakkyApplication.enable_discovery_manifest()` for scan result reuse.
- Record scan manifest decisions (`miss`, `hit`, `stale_schema`, `stale_input`) through startup diagnostics.
- Preserve existing scan and registration behavior by replaying manifest candidates through the current Pod/Tag registration path.
- Sync architecture, package README, DI guide, and glossary docs.

## Acceptance Criteria (자가 grep)
- acceptance_check: missing — issue #145 has no explicit grep/rg/find acceptance lines.

## Verification
- `cd core/spakky && uv run ruff format .`
- `cd core/spakky && uv run ruff check .`
- `cd core/spakky && uv run pyrefly check $(rg --files src tests -g '*.py')`
- `cd core/spakky && uv run pytest` (342 passed, 100.00% coverage)
- pre-commit hook: passed
- pre-push hook: passed

Closes #145