### PR TITLE
test(core): add diagnostics regression gate (#148)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -306,6 +306,8 @@ app = (
 
 **`scan()` 자동 감지**: `inspect.stack()`으로 호출자의 패키지를 찾고, 하위 모듈을 재귀 순회하며 `Pod.exists()` 또는 `Tag.exists()`인 객체를 등록합니다.
 
+**Startup diagnostics**: `enable_startup_diagnostics()`는 no-op 기본 recorder를 활성 recorder로 교체합니다. 활성화된 앱은 startup attempt별 `StartupReport`를 생성하고 `load_plugins`, `scan`, `registration`, `post_processor_registration`, `instantiation`, `post_processing`, `service_start` phase를 실행 순서대로 기록합니다. 각 record는 phase name, elapsed seconds, processed count, success/failure status, optional diagnostic details, optional structured failure summary를 포함합니다. 실패 phase는 기록된 뒤 기존 예외를 그대로 전파합니다.
+
 **DiscoveryManifest 재사용**: `enable_discovery_manifest(path=None)`을 `scan()` 전에 호출하면 scan discovery 결과를 JSON manifest로 저장합니다. manifest fingerprint는 schema version, Python major/minor version, scan 대상 module/package, exclude pattern, source file mtime/size로 구성됩니다. decision은 `miss`, `hit`, `stale_schema`, `stale_input` 중 하나이며 startup diagnostics의 scan phase diagnostic detail로 기록됩니다. `hit`은 저장된 Pod/Tag 후보를 기존 등록 경로로 재생하고, stale/miss는 기존 fresh discovery로 돌아갑니다. container lookup/type cache는 변경하지 않습니다.
 
 ---

--- a/core/spakky/README.md
+++ b/core/spakky/README.md
@@ -93,7 +93,10 @@ decision = scan_record.diagnostic_details[0].value  # miss, hit, stale_schema, s
 
 If no path is provided, Spakky uses the deterministic project-local cache path
 `.spakky/cache/discovery-manifest.json`. Missing, stale, or malformed manifests
-fall back to fresh discovery and record the decision in startup diagnostics.
+fall back to fresh discovery and record the decision in startup diagnostics. The
+decision values are `miss`, `hit`, `stale_schema`, and `stale_input`; `hit`
+replays stored candidates through the normal registration path, while every
+other decision performs fresh discovery.
 
 ### Startup Diagnostics
 
@@ -124,6 +127,9 @@ first_phase = report.records[0]
 count, success/failure status, optional diagnostic details, and an optional
 structured failure summary. Failure summaries keep the exception type name,
 message, and diagnostic details without retaining the raw exception object.
+The application startup pipeline records phases in execution order:
+`load_plugins`, `scan`, `registration`, `post_processor_registration`,
+`instantiation`, `post_processing`, and `service_start`.
 
 DI dependency failures preserve their existing exception types while attaching
 structured dependency diagnostics from `Pod.dependencies`, including the failed

--- a/core/spakky/tests/application/test_application_context.py
+++ b/core/spakky/tests/application/test_application_context.py
@@ -613,6 +613,13 @@ def test_circular_dependency_error_expect_structured_diagnostic_path() -> None:
     assert diagnostic.path[1].requested_type_name == "IA"
     assert diagnostic.path[2].pod_type_name == "A"
     assert diagnostic.path[2].dependency_parameter_name is None
+    assert diagnostic.as_detail_pairs() == (
+        ("failed_pod", "a"),
+        ("failed_pod_type", "A"),
+        ("dependency_path", "A.b:IB -> B.a:IA -> A"),
+        ("dependency_parameter", "a"),
+        ("requested_type", "IA"),
+    )
 
 
 def test_application_context_with_multiple_children_list_not_exists() -> None:
@@ -1142,7 +1149,13 @@ def test_application_context_missing_dependency_expect_structured_diagnostic() -
     assert path_node.pod_type_name == "SamplePod"
     assert path_node.dependency_parameter_name == "missing_dep"
     assert path_node.requested_type_name == "MissingDependency"
-    assert ("dependency_parameter", "missing_dep") in diagnostic.as_detail_pairs()
+    assert diagnostic.as_detail_pairs() == (
+        ("failed_pod", "sample_pod"),
+        ("failed_pod_type", "SamplePod"),
+        ("dependency_path", "SamplePod.missing_dep:MissingDependency"),
+        ("dependency_parameter", "missing_dep"),
+        ("requested_type", "MissingDependency"),
+    )
 
 
 def test_set_singleton_cache_with_non_singleton_pod() -> None:

--- a/core/spakky/tests/application/test_application_scan.py
+++ b/core/spakky/tests/application/test_application_scan.py
@@ -177,6 +177,34 @@ def test_scan_discovery_manifest_stale_exclude_expect_fresh_discovery(
     assert len(app.container.pods) > 0
 
 
+def test_scan_discovery_manifest_stale_source_expect_fresh_discovery(
+    tmp_path: Path,
+) -> None:
+    """source fingerprint가 바뀌면 stale_input으로 기록하고 fresh discovery를 수행한다."""
+    from tests.dummy import dummy_package
+
+    manifest_path = tmp_path / "discovery-manifest.json"
+    SpakkyApplication(ApplicationContext()).enable_discovery_manifest(
+        manifest_path
+    ).scan(dummy_package)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    first_source = payload["fingerprint"]["sources"][0]
+    first_source["size"] += 1
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .enable_startup_diagnostics()
+        .enable_discovery_manifest(manifest_path)
+    )
+
+    app.scan(dummy_package)
+
+    assert (
+        _manifest_decision(_scan_record(app)) == DiscoveryManifestDecision.STALE_INPUT
+    )
+    assert len(app.container.pods) > 0
+
+
 def test_scan_discovery_manifest_invalid_json_expect_miss_recorded(
     tmp_path: Path,
 ) -> None:

--- a/core/spakky/tests/application/test_startup_diagnostics.py
+++ b/core/spakky/tests/application/test_startup_diagnostics.py
@@ -6,8 +6,19 @@ import pytest
 from typing_extensions import override
 
 import spakky.core.application.application_context as application_context_module
-from spakky.core.application.application import SpakkyApplication
-from spakky.core.application.application_context import ApplicationContext
+from spakky.core.application.application import (
+    STARTUP_PHASE_LOAD_PLUGINS,
+    STARTUP_PHASE_REGISTRATION,
+    STARTUP_PHASE_SCAN,
+    SpakkyApplication,
+)
+from spakky.core.application.application_context import (
+    STARTUP_PHASE_INSTANTIATION,
+    STARTUP_PHASE_POST_PROCESSING,
+    STARTUP_PHASE_POST_PROCESSOR_REGISTRATION,
+    STARTUP_PHASE_SERVICE_START,
+    ApplicationContext,
+)
 from spakky.core.application.startup_diagnostics import (
     ActiveStartupPhaseRecorder,
     NoOpStartupPhaseRecorder,
@@ -227,6 +238,47 @@ def test_spakky_application_startup_pipeline_diagnostics_expect_phase_records() 
             record.status is StartupPhaseStatus.SUCCESS
             for record in app.startup_report.records
         )
+    finally:
+        app.stop()
+
+
+def test_spakky_application_startup_diagnostics_regression_gate_expect_report_shape() -> (
+    None
+):
+    """startup diagnostics report가 phase 순서, count, status 의미를 구조적으로 고정한다."""
+    from tests.dummy import dummy_package
+
+    expected_phase_order = (
+        STARTUP_PHASE_LOAD_PLUGINS,
+        STARTUP_PHASE_SCAN,
+        STARTUP_PHASE_REGISTRATION,
+        STARTUP_PHASE_POST_PROCESSOR_REGISTRATION,
+        STARTUP_PHASE_INSTANTIATION,
+        STARTUP_PHASE_POST_PROCESSING,
+        STARTUP_PHASE_SERVICE_START,
+    )
+    app = SpakkyApplication(ApplicationContext()).enable_startup_diagnostics()
+
+    app.load_plugins(include=set()).scan(dummy_package).start()
+
+    try:
+        records = app.startup_report.records
+        records_by_phase = {record.phase_name: record for record in records}
+
+        assert tuple(record.phase_name for record in records) == expected_phase_order
+        assert all(record.elapsed_seconds >= 0.0 for record in records)
+        assert all(record.status is StartupPhaseStatus.SUCCESS for record in records)
+        assert all(record.failure_summary is None for record in records)
+        assert records_by_phase[STARTUP_PHASE_LOAD_PLUGINS].processed_count == 0
+        assert records_by_phase[STARTUP_PHASE_SCAN].processed_count == 3
+        assert records_by_phase[STARTUP_PHASE_REGISTRATION].processed_count == 4
+        assert (
+            records_by_phase[STARTUP_PHASE_POST_PROCESSOR_REGISTRATION].processed_count
+            == 3
+        )
+        assert records_by_phase[STARTUP_PHASE_INSTANTIATION].processed_count == 4
+        assert records_by_phase[STARTUP_PHASE_POST_PROCESSING].processed_count == 12
+        assert records_by_phase[STARTUP_PHASE_SERVICE_START].processed_count == 0
     finally:
         app.stop()
 

--- a/docs/di-container.md
+++ b/docs/di-container.md
@@ -223,7 +223,9 @@ class UserService:
 누락되거나 순환된 의존성은 기존 예외 의미를 유지하면서 구조화된
 dependency diagnostic을 함께 제공합니다. 이 진단은 별도 graph cache가
 아니라 등록된 `Pod.dependencies` 메타데이터에서 실패 Pod, 파라미터,
-요청 타입, 의존성 경로를 구성합니다.
+요청 타입, 의존성 경로를 구성합니다. Adapter는
+`dependency_diagnostic.as_detail_pairs()`로 안정적인 key/value 형태를 얻을
+수 있습니다.
 
 컨테이너는 의존성 체인에서 순환 참조를 감지합니다.
 
@@ -414,6 +416,34 @@ manifest_decision = scan_record.diagnostic_details[0].value
 ```
 
 `manifest_decision`은 `miss`, `hit`, `stale_schema`, `stale_input` 중 하나입니다.
+`hit`은 저장된 후보를 기존 등록 경로로 재생하고, `miss`와 stale decision은
+fresh discovery를 수행합니다. 이 기능은 actuator endpoint, exporter, 또는
+플러그인별 튜닝을 자동으로 제공하지 않습니다.
+
+### Startup diagnostics
+
+Startup diagnostics는 기본적으로 비활성화되어 있으며
+`enable_startup_diagnostics()`로 명시적으로 켭니다. 활성화된 앱은 하나의
+startup attempt에 대한 `StartupReport`를 노출합니다.
+
+```python
+app = (
+    SpakkyApplication(ApplicationContext())
+    .enable_startup_diagnostics()
+    .load_plugins(include=set())
+    .scan(apps)
+    .start()
+)
+
+for record in app.startup_report.records:
+    print(record.phase_name, record.processed_count, record.status)
+```
+
+기록되는 phase는 실행 순서대로 `load_plugins`, `scan`, `registration`,
+`post_processor_registration`, `instantiation`, `post_processing`,
+`service_start`입니다. 각 record는 elapsed seconds, processed count,
+success/failure status, diagnostic details, failure summary를 담습니다. 실패한
+phase도 report에 남긴 뒤 기존 예외를 그대로 전파합니다.
 
 ---
 

--- a/docs/guides/dependency-injection.md
+++ b/docs/guides/dependency-injection.md
@@ -119,6 +119,34 @@ app = (
 )
 ```
 
+### Startup diagnostics와 manifest 재사용
+
+Startup diagnostics는 opt-in입니다. 활성화하면 `load_plugins`, `scan`,
+`registration`, `post_processor_registration`, `instantiation`,
+`post_processing`, `service_start` phase의 처리 개수와 성공/실패 상태를
+`StartupReport`에서 읽을 수 있습니다.
+
+```python
+from pathlib import Path
+
+app = (
+    SpakkyApplication(ApplicationContext())
+    .enable_startup_diagnostics()
+    .enable_discovery_manifest(Path(".spakky/cache/discovery-manifest.json"))
+    .load_plugins(include=set())
+    .scan(apps)
+    .start()
+)
+
+scan_record = app.startup_report.records[1]
+manifest_decision = scan_record.diagnostic_details[0].value
+```
+
+DiscoveryManifest decision은 `miss`, `hit`, `stale_schema`, `stale_input` 중
+하나입니다. `hit`은 저장된 scan 후보를 기존 등록 경로로 재사용하고, stale
+또는 miss는 fresh discovery로 돌아갑니다. 이 기능은 container cache가 아니며
+actuator endpoint나 exporter 연동을 자동으로 만들지 않습니다.
+
 ---
 
 ## 싱글톤


### PR DESCRIPTION
## Summary
- Add deterministic regression coverage for startup diagnostics report shape, phase order, DI diagnostic detail pairs, and DiscoveryManifest stale source decisions.
- Sync core README, architecture docs, and DI user guide for startup diagnostics and DiscoveryManifest behavior.
- Avoid new feature behavior; this PR fixes the regression/docs gate for FR-007.

## Acceptance Criteria (자가 grep)

- acceptance_check: missing — issue #148 contains no executable grep/find/rg acceptance lines.

## Checks

- `cd core/spakky && uv run ruff format .`
- `cd core/spakky && rg -n "from spakky\.plugins|import spakky\.plugins" src tests` → 0 matches
- `cd core/spakky && uv run ruff check .`
- `cd core/spakky && uv run pyrefly check src tests --use-ignore-files=false`
- `cd core/spakky && uv run pytest` → 344 passed, 100% coverage
- `uv run python scripts/run_coverage.py --package spakky` → passed, 100% line/branch coverage

notes: project-status-update-failed: In Progress Status option not found for In Progress