### PR TITLE
feat(typer): add actuator CLI commands (#152)

### DIFF
--- a/plugins/spakky-typer/README.md
+++ b/plugins/spakky-typer/README.md
@@ -21,6 +21,7 @@ pip install spakky[typer]
 - **Command grouping**: Organize commands into logical groups
 - **Dependency injection**: Services are automatically injected into controllers
 - **Rich integration**: Leverages Typer's rich console output
+- **Actuator command**: Registers `actuator` status commands when `spakky-actuator` is loaded
 
 ## Usage
 
@@ -113,6 +114,31 @@ typer_app = application.container.get(Typer)
 # Run the CLI
 if __name__ == "__main__":
     typer_app()
+```
+
+### Actuator Commands
+
+When both `spakky-typer` and `spakky-actuator` are loaded, the plugin registers an `actuator` command group:
+
+```bash
+python main.py actuator health
+python main.py actuator readiness
+python main.py actuator liveness
+python main.py actuator info
+```
+
+Each command prints deterministic JSON from the transport-neutral actuator core result model.
+
+Disable command registration with:
+
+```bash
+export SPAKKY_TYPER_ACTUATOR_COMMAND_ENABLED=false
+```
+
+Customize the command group name with:
+
+```bash
+export SPAKKY_TYPER_ACTUATOR_COMMAND_NAME=status
 ```
 
 ### Application Setup

--- a/plugins/spakky-typer/pyproject.toml
+++ b/plugins/spakky-typer/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
-dependencies = ["spakky>=6.3.1", "typer>=0.24.1"]
+dependencies = ["spakky>=6.3.1", "spakky-actuator>=6.3.1", "typer>=0.24.1"]
 
 [project.entry-points."spakky.plugins"]
 spakky-typer = "spakky.plugins.typer.main:initialize"
@@ -65,3 +65,7 @@ exclude_lines = [
   "\\.\\.\\.\\.",
   "pass",
 ]
+
+[tool.uv.sources]
+spakky = { workspace = true }
+spakky-actuator = { workspace = true }

--- a/plugins/spakky-typer/src/spakky/plugins/typer/__init__.py
+++ b/plugins/spakky-typer/src/spakky/plugins/typer/__init__.py
@@ -19,6 +19,12 @@ Example:
 """
 
 from spakky.core.application.plugin import Plugin
+from spakky.plugins.typer.actuator import ActuatorTyperConfig
 
 PLUGIN_NAME = Plugin(name="spakky-typer")
 """Plugin identifier for the Typer CLI integration."""
+
+__all__ = [
+    "ActuatorTyperConfig",
+    "PLUGIN_NAME",
+]

--- a/plugins/spakky-typer/src/spakky/plugins/typer/actuator.py
+++ b/plugins/spakky-typer/src/spakky/plugins/typer/actuator.py
@@ -1,0 +1,153 @@
+"""Typer command adapter for actuator status output."""
+
+from json import dumps
+from os import getenv
+
+from spakky.actuator.result import (
+    ActuatorHealthResult,
+    ActuatorInfoResult,
+    ComponentHealthResult,
+)
+from spakky.actuator.service import ActuatorAggregationService
+from spakky.core.pod.annotations.order import Order
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.aware.application_context_aware import (
+    IApplicationContextAware,
+)
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.core.pod.interfaces.post_processor import IPostProcessor
+from spakky.core.stereotype.configuration import Configuration
+from typer import Typer, echo
+from typing_extensions import override
+
+ACTUATOR_COMMAND_ENABLED_ENV = "SPAKKY_TYPER_ACTUATOR_COMMAND_ENABLED"
+ACTUATOR_COMMAND_NAME_ENV = "SPAKKY_TYPER_ACTUATOR_COMMAND_NAME"
+
+
+@Configuration()
+class ActuatorTyperConfig:
+    """Configuration for Typer actuator command exposure."""
+
+    command_enabled: bool
+    command_name: str
+
+    def __init__(
+        self,
+        command_enabled: bool | None = None,
+        command_name: str | None = None,
+    ) -> None:
+        """Initialize Typer actuator command configuration."""
+        self.command_enabled = (
+            _env_bool(ACTUATOR_COMMAND_ENABLED_ENV, default=True)
+            if command_enabled is None
+            else command_enabled
+        )
+        self.command_name = (
+            getenv(ACTUATOR_COMMAND_NAME_ENV, "actuator")
+            if command_name is None
+            else command_name
+        )
+
+
+@Order(1)
+@Pod()
+class ActuatorTyperCommandPostProcessor(
+    IPostProcessor,
+    IContainerAware,
+    IApplicationContextAware,
+):
+    """Register actuator commands when the actuator core service is loaded."""
+
+    __app: Typer
+    __config: ActuatorTyperConfig
+    __container: IContainer
+    __application_context: IApplicationContext
+    __registered: bool
+
+    def __init__(self, app: Typer, config: ActuatorTyperConfig) -> None:
+        """Initialize with Typer app and actuator command configuration."""
+        self.__app = app
+        self.__config = config
+        self.__registered = False
+
+    @override
+    def set_container(self, container: IContainer) -> None:
+        """Set the DI container used by command invocations."""
+        self.__container = container
+
+    @override
+    def set_application_context(self, application_context: IApplicationContext) -> None:
+        """Set the application context used to clear CLI invocation scope."""
+        self.__application_context = application_context
+
+    @override
+    def post_process(self, pod: object) -> object:
+        """Register actuator command group after actuator service is available."""
+        if self.__registered:
+            return pod
+        if not self.__config.command_enabled:
+            return pod
+        if not isinstance(pod, ActuatorAggregationService):
+            return pod
+        self.__app.add_typer(self.__command_group())
+        self.__registered = True
+        return pod
+
+    def __command_group(self) -> Typer:
+        command_group = Typer(name=self.__config.command_name)
+
+        @command_group.command("health")
+        def health() -> None:
+            self.__print_health(self.__service().evaluate_health())
+
+        @command_group.command("readiness")
+        def readiness() -> None:
+            self.__print_health(self.__service().evaluate_readiness())
+
+        @command_group.command("liveness")
+        def liveness() -> None:
+            self.__print_health(self.__service().evaluate_liveness())
+
+        @command_group.command("info")
+        def info() -> None:
+            self.__print_info(self.__service().evaluate_info())
+
+        return command_group
+
+    def __service(self) -> ActuatorAggregationService:
+        self.__application_context.clear_context()
+        return self.__container.get(ActuatorAggregationService)
+
+    def __print_health(self, result: ActuatorHealthResult) -> None:
+        echo(dumps(_health_payload(result), sort_keys=True))
+
+    def __print_info(self, result: ActuatorInfoResult) -> None:
+        echo(dumps({"info": dict(result.info)}, sort_keys=True))
+
+
+def _health_payload(result: ActuatorHealthResult) -> dict[str, object]:
+    return {
+        "components": [
+            _component_payload(component) for component in result.components
+        ],
+        "endpoint": result.endpoint.value,
+        "status": result.status.value,
+    }
+
+
+def _component_payload(result: ComponentHealthResult) -> dict[str, object]:
+    return {
+        "details": dict(result.details),
+        "name": result.name,
+        "required": result.required,
+        "status": result.status.value,
+    }
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    value = getenv(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}

--- a/plugins/spakky-typer/src/spakky/plugins/typer/main.py
+++ b/plugins/spakky-typer/src/spakky/plugins/typer/main.py
@@ -6,6 +6,10 @@ Registers post-processor for automatic CLI command registration from
 
 from spakky.core.application.application import SpakkyApplication
 
+from spakky.plugins.typer.actuator import (
+    ActuatorTyperCommandPostProcessor,
+    ActuatorTyperConfig,
+)
 from spakky.plugins.typer.post_processor import TyperCLIPostProcessor
 
 
@@ -19,4 +23,6 @@ def initialize(app: SpakkyApplication) -> None:
     Args:
         app: The Spakky application instance.
     """
+    app.add(ActuatorTyperConfig)
+    app.add(ActuatorTyperCommandPostProcessor)
     app.add(TyperCLIPostProcessor)

--- a/plugins/spakky-typer/tests/test_actuator_command.py
+++ b/plugins/spakky-typer/tests/test_actuator_command.py
@@ -1,0 +1,133 @@
+"""Tests for Typer actuator command registration."""
+
+from collections.abc import Generator
+from contextlib import contextmanager
+import json
+
+from click.testing import Result
+from pytest import MonkeyPatch
+from collections.abc import Mapping
+
+from spakky.actuator.interfaces.contributor import AbstractInfoContributor
+from spakky.actuator.interfaces.probe import AbstractHealthProbe
+from spakky.actuator.result import ComponentHealthResult
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.application.plugin import Plugin
+from spakky.core.pod.annotations.pod import Pod
+from typer import Typer
+from typer.testing import CliRunner
+
+import spakky.plugins.typer
+
+
+@Pod()
+class _CliProbe(AbstractHealthProbe):
+    @property
+    def name(self) -> str:
+        return "cli"
+
+    def check(self) -> ComponentHealthResult:
+        return ComponentHealthResult.healthy(
+            self.name,
+            details={"a": 1, "z": 2},
+        )
+
+
+@Pod()
+class _CliInfoContributor(AbstractInfoContributor):
+    @property
+    def name(self) -> str:
+        return "cli-info"
+
+    def contribute_info(self) -> Mapping[str, object]:
+        return {"app": "typer", "version": "test"}
+
+
+@Pod(name="cli")
+def _get_cli() -> Typer:
+    return Typer()
+
+
+def test_actuator_command_registered_when_actuator_plugin_loaded() -> None:
+    """actuator plugin 로드 시 actuator command group이 등록되는지 검증한다."""
+    with _actuator_cli() as cli:
+        result = CliRunner().invoke(cli, ["actuator", "health"])
+
+    assert result.exit_code == 0
+
+
+def test_actuator_health_command_outputs_core_status_model() -> None:
+    """actuator health command가 core status model을 JSON으로 출력하는지 검증한다."""
+    with _actuator_cli() as cli:
+        result: Result = CliRunner().invoke(cli, ["actuator", "health"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "components": [
+            {
+                "details": {"a": 1, "z": 2},
+                "name": "cli",
+                "required": True,
+                "status": "healthy",
+            }
+        ],
+        "endpoint": "health",
+        "status": "healthy",
+    }
+
+
+def test_actuator_probe_commands_output_endpoint_statuses() -> None:
+    """readiness/liveness command가 endpoint별 core status model을 출력하는지 검증한다."""
+    with _actuator_cli() as cli:
+        readiness = CliRunner().invoke(cli, ["actuator", "readiness"])
+        liveness = CliRunner().invoke(cli, ["actuator", "liveness"])
+
+    assert json.loads(readiness.output)["endpoint"] == "readiness"
+    assert json.loads(liveness.output)["endpoint"] == "liveness"
+
+
+def test_actuator_info_command_outputs_core_info_model() -> None:
+    """actuator info command가 core info model을 JSON으로 출력하는지 검증한다."""
+    with _actuator_cli() as cli:
+        result = CliRunner().invoke(cli, ["actuator", "info"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "info": {
+            "app": "typer",
+            "version": "test",
+        }
+    }
+
+
+def test_actuator_command_absent_when_config_disabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """config로 비활성화하면 actuator command group이 등록되지 않는지 검증한다."""
+    monkeypatch.setenv("SPAKKY_TYPER_ACTUATOR_COMMAND_ENABLED", "false")
+    with _actuator_cli() as cli:
+        group_names = [group.name for group in cli.registered_groups]
+
+    assert "actuator" not in group_names
+
+
+@contextmanager
+def _actuator_cli() -> Generator[Typer, None, None]:
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .load_plugins(
+            include={
+                spakky.plugins.typer.PLUGIN_NAME,
+                Plugin(name="spakky-actuator"),
+            }
+        )
+        .add(_get_cli)
+        .add(_CliProbe)
+        .add(_CliInfoContributor)
+    )
+    app.start()
+    try:
+        yield app.container.get(type_=Typer)
+    finally:
+        app.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -3219,12 +3219,14 @@ version = "6.3.1"
 source = { editable = "plugins/spakky-typer" }
 dependencies = [
     { name = "spakky" },
+    { name = "spakky-actuator" },
     { name = "typer" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "spakky", editable = "core/spakky" },
+    { name = "spakky-actuator", editable = "core/spakky-actuator" },
     { name = "typer", specifier = ">=0.24.1" },
 ]
 


### PR DESCRIPTION
## Summary
- Register a Typer `actuator` command group when `spakky-actuator` is loaded.
- Add deterministic JSON output for health, readiness, liveness, and info core result models.
- Add Typer actuator config for command enablement/name plus README usage notes.

## Acceptance Criteria (자가 grep)

- acceptance_check: missing (issue body has no grep/find/rg lines)
- [x] Given actuator Typer integration enabled, When CLI app is built, Then actuator command is registered. (`test_actuator_command_registered_when_actuator_plugin_loaded`)
- [x] Given actuator command runs, Then output reflects actuator core status model. (`test_actuator_health_command_outputs_core_status_model`, `test_actuator_probe_commands_output_endpoint_statuses`, `test_actuator_info_command_outputs_core_info_model`)
- [x] Given command disabled by config, When CLI app is built, Then command is absent. (`test_actuator_command_absent_when_config_disabled`)
- [x] lint + type check + tests pass from package directory.

## Verification
- `cd plugins/spakky-typer && uv run --with ruff ruff format .`
- `cd plugins/spakky-typer && uv run --with ruff ruff check .`
- `cd plugins/spakky-typer && uv run --with pyrefly --with pytest pyrefly check src tests`
- `cd plugins/spakky-typer && uv run --with pytest --with pytest-asyncio --with pytest-cov --with pytest-spec --with pytest-xdist pytest`
- `uv run python scripts/run_coverage.py --package spakky-typer`

Closes #152
