### PR TITLE
feat(fastapi): add actuator HTTP endpoints (#149)

### DIFF
--- a/plugins/spakky-fastapi/README.md
+++ b/plugins/spakky-fastapi/README.md
@@ -21,6 +21,7 @@ pip install spakky[fastapi]
 - **OpenAPI integration**: Tags and documentation automatically configured
 - **Error handling middleware**: Built-in exception handling with debug mode
 - **Context management**: Request-scoped dependency injection support
+- **Actuator endpoints**: Optional `/actuator/*` HTTP endpoints when `spakky-actuator` is loaded
 
 ## Usage
 
@@ -114,6 +115,32 @@ def test_get_user(application: SpakkyApplication) -> None:
 - 헤더가 없으면 새로운 루트 트레이스를 시작합니다
 - 요청 완료 후 `TraceContext`를 자동으로 정리합니다
 
+## Actuator Endpoints
+
+`spakky-actuator` 플러그인을 함께 로드하면 FastAPI 앱에 표준 actuator route가 등록됩니다.
+
+| Endpoint | Success | Unhealthy |
+|----------|---------|-----------|
+| `GET /actuator/health` | `200 OK` | `503 Service Unavailable` |
+| `GET /actuator/readiness` | `200 OK` | `503 Service Unavailable` |
+| `GET /actuator/liveness` | `200 OK` | `503 Service Unavailable` |
+| `GET /actuator/info` | `200 OK` | N/A |
+
+Endpoint exposure and base path are configured with `FastAPIActuatorConfig`.
+Component detail exposure is controlled by `spakky.actuator.ActuatorConfig`.
+
+```python
+from spakky.core.pod.annotations.pod import Pod
+from spakky.plugins.fastapi.actuator import FastAPIActuatorConfig
+
+@Pod()
+def fastapi_actuator_config() -> FastAPIActuatorConfig:
+    return FastAPIActuatorConfig(
+        base_path="/internal/actuator",
+        readiness_enabled=False,
+    )
+```
+
 ## Components
 
 | Component | Description |
@@ -123,6 +150,8 @@ def test_get_user(application: SpakkyApplication) -> None:
 | `websocket` | WebSocket endpoint decorator |
 | `ErrorHandlingMiddleware` | Built-in exception handling middleware |
 | `TracingMiddleware` | Trace context propagation middleware (`spakky-tracing` 필수 의존) |
+| `FastAPIActuatorConfig` | FastAPI actuator endpoint exposure configuration |
+| `RegisterActuatorPostProcessor` | Automatic actuator endpoint registration post-processor |
 | `RegisterRoutesPostProcessor` | Automatic route registration post-processor |
 
 ## Configuration

--- a/plugins/spakky-fastapi/pyproject.toml
+++ b/plugins/spakky-fastapi/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "fastapi[standard]>=0.135.3",
     "orjson>=3.11.8",
     "spakky>=6.3.1",
+    "spakky-actuator>=6.3.1",
     "spakky-tracing>=6.3.1",
     "websockets>=16.0",
 ]

--- a/plugins/spakky-fastapi/src/spakky/plugins/fastapi/actuator.py
+++ b/plugins/spakky-fastapi/src/spakky/plugins/fastapi/actuator.py
@@ -1,0 +1,39 @@
+"""FastAPI configuration for actuator HTTP endpoints."""
+
+from spakky.core.stereotype.configuration import Configuration
+
+
+@Configuration()
+class FastAPIActuatorConfig:
+    """Configuration for FastAPI actuator endpoint exposure."""
+
+    enabled: bool
+    base_path: str
+    health_enabled: bool
+    readiness_enabled: bool
+    liveness_enabled: bool
+    info_enabled: bool
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        base_path: str = "/actuator",
+        health_enabled: bool = True,
+        readiness_enabled: bool = True,
+        liveness_enabled: bool = True,
+        info_enabled: bool = True,
+    ) -> None:
+        """Initialize actuator endpoint exposure configuration."""
+        self.enabled = enabled
+        self.base_path = self._normalize_base_path(base_path)
+        self.health_enabled = health_enabled
+        self.readiness_enabled = readiness_enabled
+        self.liveness_enabled = liveness_enabled
+        self.info_enabled = info_enabled
+
+    def _normalize_base_path(self, base_path: str) -> str:
+        stripped = base_path.strip("/")
+        if not stripped:
+            return ""
+        return f"/{stripped}"

--- a/plugins/spakky-fastapi/src/spakky/plugins/fastapi/main.py
+++ b/plugins/spakky-fastapi/src/spakky/plugins/fastapi/main.py
@@ -12,6 +12,9 @@ from spakky.plugins.fastapi.post_processors.add_builtin_middlewares import (
 from spakky.plugins.fastapi.post_processors.bind_lifespan import (
     BindLifespanPostProcessor,
 )
+from spakky.plugins.fastapi.post_processors.register_actuator import (
+    RegisterActuatorPostProcessor,
+)
 from spakky.plugins.fastapi.post_processors.register_routes import (
     RegisterRoutesPostProcessor,
 )
@@ -29,4 +32,5 @@ def initialize(app: SpakkyApplication) -> None:
     """
     app.add(BindLifespanPostProcessor)
     app.add(AddBuiltInMiddlewaresPostProcessor)
+    app.add(RegisterActuatorPostProcessor)
     app.add(RegisterRoutesPostProcessor)

--- a/plugins/spakky-fastapi/src/spakky/plugins/fastapi/post_processors/register_actuator.py
+++ b/plugins/spakky-fastapi/src/spakky/plugins/fastapi/post_processors/register_actuator.py
@@ -1,0 +1,138 @@
+"""Post-processor for registering actuator HTTP endpoints."""
+
+from collections.abc import Awaitable, Callable, Mapping
+from http import HTTPStatus
+
+from spakky.actuator.result import (
+    ActuatorHealthResult,
+    ActuatorInfoResult,
+    HealthStatus,
+)
+from spakky.actuator.service import ActuatorAggregationService
+from spakky.core.pod.annotations.order import Order
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.core.pod.interfaces.post_processor import IPostProcessor
+from typing_extensions import override
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from spakky.plugins.fastapi.actuator import FastAPIActuatorConfig
+
+
+@Order(0)
+@Pod()
+class RegisterActuatorPostProcessor(IPostProcessor, IContainerAware):
+    """Register actuator endpoints when the actuator service is available."""
+
+    __container: IContainer
+
+    @override
+    def set_container(self, container: IContainer) -> None:
+        """Set the container used to resolve actuator dependencies."""
+        self.__container = container
+
+    @override
+    def post_process(self, pod: object) -> object:
+        """Register actuator routes on FastAPI instances."""
+        if not isinstance(pod, FastAPI):
+            return pod
+
+        service = self.__container.get_or_none(ActuatorAggregationService)
+        if service is None:
+            return pod
+
+        config = self.__container.get_or_none(FastAPIActuatorConfig)
+        if config is None:
+            config = FastAPIActuatorConfig()
+        if not config.enabled:
+            return pod
+
+        self._register_routes(pod, service, config)
+        return pod
+
+    def _register_routes(
+        self,
+        fast_api: FastAPI,
+        service: ActuatorAggregationService,
+        config: FastAPIActuatorConfig,
+    ) -> None:
+        if config.health_enabled:
+            self._add_health_route(
+                fast_api,
+                f"{config.base_path}/health",
+                service.evaluate_health_async,
+            )
+        if config.readiness_enabled:
+            self._add_health_route(
+                fast_api,
+                f"{config.base_path}/readiness",
+                service.evaluate_readiness_async,
+            )
+        if config.liveness_enabled:
+            self._add_health_route(
+                fast_api,
+                f"{config.base_path}/liveness",
+                service.evaluate_liveness_async,
+            )
+        if config.info_enabled:
+            self._add_info_route(
+                fast_api,
+                f"{config.base_path}/info",
+                service.evaluate_info_async,
+            )
+
+    def _add_health_route(
+        self,
+        fast_api: FastAPI,
+        path: str,
+        evaluator: Callable[[], Awaitable[ActuatorHealthResult]],
+    ) -> None:
+        async def endpoint() -> JSONResponse:
+            result = await evaluator()
+            return self._health_response(result)
+
+        fast_api.add_api_route(path=path, endpoint=endpoint, methods=["GET"])
+
+    def _add_info_route(
+        self,
+        fast_api: FastAPI,
+        path: str,
+        evaluator: Callable[[], Awaitable[ActuatorInfoResult]],
+    ) -> None:
+        async def endpoint() -> dict[str, object]:
+            result = await evaluator()
+            return self._info_payload(result)
+
+        fast_api.add_api_route(path=path, endpoint=endpoint, methods=["GET"])
+
+    def _health_response(self, health_result: ActuatorHealthResult) -> JSONResponse:
+        status_code = HTTPStatus.OK
+        if health_result.status is HealthStatus.UNHEALTHY:
+            status_code = HTTPStatus.SERVICE_UNAVAILABLE
+        return JSONResponse(
+            content=self._health_payload(health_result),
+            status_code=status_code,
+        )
+
+    def _health_payload(self, result: ActuatorHealthResult) -> dict[str, object]:
+        return {
+            "endpoint": result.endpoint.value,
+            "status": result.status.value,
+            "components": [
+                {
+                    "name": component.name,
+                    "status": component.status.value,
+                    "required": component.required,
+                    "details": self._mapping_payload(component.details),
+                }
+                for component in result.components
+            ],
+        }
+
+    def _info_payload(self, result: ActuatorInfoResult) -> dict[str, object]:
+        return {"info": self._mapping_payload(result.info)}
+
+    def _mapping_payload(self, value: Mapping[str, object]) -> dict[str, object]:
+        return {key: value[key] for key in sorted(value)}

--- a/plugins/spakky-fastapi/tests/test_actuator.py
+++ b/plugins/spakky-fastapi/tests/test_actuator.py
@@ -1,0 +1,190 @@
+"""Actuator endpoint registration tests."""
+
+from http import HTTPStatus
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from spakky.actuator.interfaces.probe import AbstractHealthProbe
+from spakky.actuator.result import ActuatorEndpoint, ComponentHealthResult
+from spakky.actuator.service import ActuatorAggregationService
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.application.plugin import Plugin
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.plugins.fastapi.post_processors.register_actuator import (
+    RegisterActuatorPostProcessor,
+)
+from typing import cast
+from typing_extensions import override
+from unittest.mock import Mock
+
+import spakky.plugins.fastapi
+from spakky.plugins.fastapi.actuator import FastAPIActuatorConfig
+
+ACTUATOR_PLUGIN_NAME = Plugin(name="spakky-actuator")
+
+
+def _start_app(config: FastAPIActuatorConfig | None = None) -> FastAPI:
+    @Pod(name="api")
+    def get_api() -> FastAPI:
+        return FastAPI(debug=True)
+
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .load_plugins(
+            include={
+                ACTUATOR_PLUGIN_NAME,
+                spakky.plugins.fastapi.PLUGIN_NAME,
+            }
+        )
+        .add(get_api)
+    )
+    if config is not None:
+
+        @Pod(name="fastapi_actuator_config")
+        def get_actuator_config() -> FastAPIActuatorConfig:
+            return config
+
+        app.add(get_actuator_config)
+
+    app.start()
+    return app.container.get(type_=FastAPI)
+
+
+def test_actuator_routes_registered_when_plugins_loaded() -> None:
+    """actuator와 FastAPI 플러그인이 로드되면 표준 actuator route가 등록된다."""
+    api = _start_app()
+
+    with TestClient(api) as client:
+        health = client.get("/actuator/health")
+        readiness = client.get("/actuator/readiness")
+        liveness = client.get("/actuator/liveness")
+        info = client.get("/actuator/info")
+
+    assert health.status_code == HTTPStatus.OK
+    assert readiness.status_code == HTTPStatus.OK
+    assert liveness.status_code == HTTPStatus.OK
+    assert info.status_code == HTTPStatus.OK
+    assert health.json()["status"] == "healthy"
+    assert info.json() == {"info": {}}
+
+
+def test_disabled_actuator_endpoint_is_not_registered() -> None:
+    """비활성화된 actuator endpoint는 FastAPI route로 노출되지 않는다."""
+    api = _start_app(FastAPIActuatorConfig(readiness_enabled=False))
+
+    with TestClient(api) as client:
+        readiness = client.get("/actuator/readiness")
+        health = client.get("/actuator/health")
+
+    assert readiness.status_code == HTTPStatus.NOT_FOUND
+    assert health.status_code == HTTPStatus.OK
+
+
+def test_disabled_actuator_endpoint_group_uses_configured_base_path() -> None:
+    """config가 비활성화한 endpoint 묶음은 등록되지 않고 base path는 정규화된다."""
+    api = _start_app(
+        FastAPIActuatorConfig(
+            base_path="/",
+            health_enabled=False,
+            liveness_enabled=False,
+            info_enabled=False,
+        )
+    )
+
+    with TestClient(api) as client:
+        readiness = client.get("/readiness")
+        health = client.get("/health")
+        liveness = client.get("/liveness")
+        info = client.get("/info")
+
+    assert readiness.status_code == HTTPStatus.OK
+    assert health.status_code == HTTPStatus.NOT_FOUND
+    assert liveness.status_code == HTTPStatus.NOT_FOUND
+    assert info.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_disabled_actuator_integration_registers_no_routes() -> None:
+    """actuator HTTP exposure가 꺼져 있으면 표준 route가 등록되지 않는다."""
+    api = _start_app(FastAPIActuatorConfig(enabled=False))
+
+    with TestClient(api) as client:
+        health = client.get("/actuator/health")
+
+    assert health.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_actuator_post_processor_ignores_non_fastapi_pods() -> None:
+    """FastAPI 인스턴스가 아닌 pod는 actuator 등록 대상이 아니다."""
+    processor = _make_processor(None)
+    pod = object()
+
+    assert processor.post_process(pod) is pod
+
+
+def test_actuator_post_processor_ignores_fastapi_without_actuator_service() -> None:
+    """actuator service가 없으면 FastAPI route를 등록하지 않는다."""
+    processor = _make_processor(None)
+    api = FastAPI()
+
+    assert processor.post_process(api) is api
+    with TestClient(api) as client:
+        response = client.get("/actuator/health")
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_unhealthy_readiness_returns_service_unavailable() -> None:
+    """readiness 결과가 unhealthy이면 HTTP 실패 상태로 응답한다."""
+
+    @Pod()
+    class UnhealthyReadinessProbe(AbstractHealthProbe):
+        @property
+        @override
+        def name(self) -> str:
+            return "database"
+
+        @property
+        @override
+        def endpoints(self) -> tuple[ActuatorEndpoint, ...]:
+            return (ActuatorEndpoint.READINESS,)
+
+        @override
+        def check(self) -> ComponentHealthResult:
+            return ComponentHealthResult.unhealthy(self.name)
+
+    @Pod(name="api")
+    def get_api() -> FastAPI:
+        return FastAPI(debug=True)
+
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .load_plugins(
+            include={
+                ACTUATOR_PLUGIN_NAME,
+                spakky.plugins.fastapi.PLUGIN_NAME,
+            }
+        )
+        .add(get_api)
+        .add(UnhealthyReadinessProbe)
+    )
+    app.start()
+    api = app.container.get(type_=FastAPI)
+
+    with TestClient(api) as client:
+        response = client.get("/actuator/readiness")
+
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert response.json()["status"] == "unhealthy"
+    assert response.json()["components"][0]["name"] == "database"
+
+
+def _make_processor(
+    service: ActuatorAggregationService | None,
+) -> RegisterActuatorPostProcessor:
+    container = Mock(spec=IContainer)
+    container.get_or_none.return_value = service
+    processor = RegisterActuatorPostProcessor()
+    processor.set_container(cast(IContainer, container))
+    return processor

--- a/uv.lock
+++ b/uv.lock
@@ -2879,6 +2879,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "orjson" },
     { name = "spakky" },
+    { name = "spakky-actuator" },
     { name = "spakky-tracing" },
     { name = "websockets" },
 ]
@@ -2888,6 +2889,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "orjson", specifier = ">=3.11.8" },
     { name = "spakky", editable = "core/spakky" },
+    { name = "spakky-actuator", editable = "core/spakky-actuator" },
     { name = "spakky-tracing", editable = "core/spakky-tracing" },
     { name = "websockets", specifier = ">=16.0" },
 ]


### PR DESCRIPTION
## Summary
- register FastAPI actuator health/readiness/liveness/info endpoints when spakky-actuator is loaded
- add FastAPIActuatorConfig for base path and endpoint exposure controls
- document actuator HTTP behavior and cover endpoint registration/status mapping tests

## Verification
- cd plugins/spakky-fastapi && uv run --project ../.. ruff format .
- cd plugins/spakky-fastapi && uv run --project ../.. ruff check .
- cd plugins/spakky-fastapi && uv run --project ../.. pyrefly check src tests --use-ignore-files=false
- cd plugins/spakky-fastapi && uv run --project ../.. pytest

Closes #149