### PR TITLE
test: lock actuator regressions and docs (#155)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -83,6 +83,7 @@ graph TD
     event --> tracing
     task_pkg --> core
     tracing --> core
+    actuator --> core
     outbox --> event
     outbox --> tracing
     saga --> core
@@ -102,7 +103,9 @@ graph TD
     otel -.->|optional| logging_pkg
     fastapi --> core
     fastapi --> tracing
+    fastapi -. actuator endpoints .-> actuator
     typer --> core
+    typer -. actuator commands .-> actuator
     security --> core
     grpc --> core
     grpc --> tracing
@@ -405,8 +408,8 @@ spakky-data = "spakky.data.main:initialize"
 | `spakky-domain` | (없음 — 모델만 제공) |
 | `spakky-data` | `AsyncTransactionalAspect`, `TransactionalAspect`, `AggregateCollector` |
 | `spakky-event` | `EventMediator`, `EventPublisher` (sync+async), `DirectEventBus` (sync+async), `TransactionalEventPublishingAspect` (sync+async), `EventHandlerRegistrationPostProcessor` |
-| `spakky-fastapi` | `BindLifespanPostProcessor`, `AddBuiltInMiddlewaresPostProcessor`, `RegisterRoutesPostProcessor` |
-| `spakky-typer` | `TyperCLIPostProcessor` |
+| `spakky-fastapi` | `BindLifespanPostProcessor`, `AddBuiltInMiddlewaresPostProcessor`, `RegisterRoutesPostProcessor`, `RegisterActuatorPostProcessor` |
+| `spakky-typer` | `TyperCLIPostProcessor`, `ActuatorTyperCommandPostProcessor` |
 | `spakky-security` | (없음 — 유틸리티 함수만 제공) |
 | `spakky-rabbitmq` | `RabbitMQConnectionConfig`, Consumer/`RabbitMQEventTransport` (sync+async), `RabbitMQPostProcessor` |
 | `spakky-kafka` | `KafkaConnectionConfig`, Consumer/`KafkaEventTransport` (sync+async), `KafkaPostProcessor` |

--- a/core/spakky-actuator/README.md
+++ b/core/spakky-actuator/README.md
@@ -16,6 +16,18 @@ pip install spakky-actuator
 - **Exception handling**: Probe exceptions become unhealthy component results with structured error details
 - **Transport-neutral core**: No FastAPI, Typer, or plugin adapter dependency
 
+## Endpoint Semantics
+
+| Surface | Meaning | Default behavior |
+|---------|---------|------------------|
+| `health` | Aggregate application health for operator-facing status checks | Evaluates probes whose `endpoints` include `ActuatorEndpoint.HEALTH` |
+| `readiness` | Whether the app is ready to serve traffic or work | Evaluates readiness probes; required unhealthy probes make the result unhealthy |
+| `liveness` | Whether the process/framework is alive | Separate from external dependency readiness; no custom liveness probes returns a healthy baseline |
+| `info` | Deterministic application metadata | Merges registered info contributors by contributor name |
+
+By default, health probes participate in `health` and `readiness`, not `liveness`.
+Use `ActuatorEndpoint.LIVENESS` only for process-local checks that should not fail because an external dependency is unavailable.
+
 ## Quick Start
 
 ```python
@@ -43,6 +55,46 @@ service = ActuatorAggregationService(registry)
 health = service.evaluate_health()
 readiness = service.evaluate_readiness()
 ```
+
+## Extension Points
+
+Register `AbstractHealthProbe` or `AbstractAsyncHealthProbe` Pods to contribute component health.
+Register `AbstractInfoContributor` or `AbstractAsyncInfoContributor` Pods to contribute metadata to `info`.
+The actuator plugin adds `ActuatorExtensionPostProcessor`, which discovers those Pods and stores them in `ActuatorExtensionRegistry`.
+
+```python
+from spakky.actuator import (
+    AbstractHealthProbe,
+    AbstractInfoContributor,
+    ActuatorEndpoint,
+    ComponentHealthResult,
+)
+
+
+class ProcessProbe(AbstractHealthProbe):
+    @property
+    def name(self) -> str:
+        return "process"
+
+    @property
+    def endpoints(self) -> tuple[ActuatorEndpoint, ...]:
+        return (ActuatorEndpoint.LIVENESS,)
+
+    def check(self) -> ComponentHealthResult:
+        return ComponentHealthResult.healthy(self.name)
+
+
+class BuildInfo(AbstractInfoContributor):
+    @property
+    def name(self) -> str:
+        return "build"
+
+    def contribute_info(self) -> dict[str, object]:
+        return {"version": "1.0.0"}
+```
+
+Plugin-specific deep checks for SQLAlchemy, Kafka, RabbitMQ, Celery, or other integrations are intentionally not included in this milestone.
+Applications can add those checks as first-party probes without changing the transport adapters.
 
 ## License
 

--- a/core/spakky-actuator/tests/unit/test_service.py
+++ b/core/spakky-actuator/tests/unit/test_service.py
@@ -140,6 +140,42 @@ def test_required_unhealthy_probe_expect_health_and_readiness_unhealthy() -> Non
     assert readiness.components[0].name == "db"
 
 
+def test_health_result_public_shape_expect_sorted_components_and_optional_status() -> (
+    None
+):
+    """health result 공개 shape와 optional component 집계 규칙을 고정한다."""
+    registry = ActuatorExtensionRegistry()
+    registry.register_health_probe(
+        _Probe(
+            "database",
+            ComponentHealthResult.healthy("database", details={"z": 2, "a": 1}),
+        )
+    )
+    registry.register_health_probe(
+        _Probe(
+            "cache",
+            ComponentHealthResult.unhealthy(
+                "cache",
+                required=False,
+                details={"reason": "warming"},
+            ),
+        )
+    )
+    service = ActuatorAggregationService(registry)
+
+    result = service.evaluate_health()
+
+    assert result.endpoint is ActuatorEndpoint.HEALTH
+    assert result.status is HealthStatus.HEALTHY
+    assert tuple(component.name for component in result.components) == (
+        "cache",
+        "database",
+    )
+    assert result.components[0].required is False
+    assert result.components[0].details == {"reason": "warming"}
+    assert result.components[1].details == {"a": 1, "z": 2}
+
+
 def test_liveness_uses_only_liveness_probes_expect_readiness_isolated() -> None:
     """liveness가 readiness 전용 probe 실패와 분리되는지 검증한다."""
     registry = ActuatorExtensionRegistry()

--- a/docs/api/core/spakky-actuator.md
+++ b/docs/api/core/spakky-actuator.md
@@ -1,0 +1,55 @@
+# spakky-actuator
+
+Actuator 상태/정보 계약 — Health, Readiness, Liveness, Info
+
+## Result Contracts
+
+::: spakky.actuator.result
+    options:
+      show_root_heading: false
+
+## Service
+
+::: spakky.actuator.service
+    options:
+      show_root_heading: false
+
+## Registry
+
+::: spakky.actuator.registry
+    options:
+      show_root_heading: false
+
+## Extension Interfaces
+
+::: spakky.actuator.interfaces.probe
+    options:
+      show_root_heading: false
+
+::: spakky.actuator.interfaces.contributor
+    options:
+      show_root_heading: false
+
+## Configuration
+
+::: spakky.actuator.config
+    options:
+      show_root_heading: false
+
+## Post Processor
+
+::: spakky.actuator.post_processor
+    options:
+      show_root_heading: false
+
+## Plugin Entry Point
+
+::: spakky.actuator.main
+    options:
+      show_root_heading: false
+
+## Errors
+
+::: spakky.actuator.error
+    options:
+      show_root_heading: false

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -14,6 +14,7 @@
 - [spakky-tracing](core/spakky-tracing.md) — 분산 트레이싱 추상화
 - [spakky-outbox](core/spakky-outbox.md) — Outbox 패턴
 - [spakky-saga](core/spakky-saga.md) — 사가 오케스트레이션
+- [spakky-actuator](core/spakky-actuator.md) — Actuator 상태/정보 계약
 
 ## Plugins
 

--- a/docs/api/plugins/spakky-fastapi.md
+++ b/docs/api/plugins/spakky-fastapi.md
@@ -70,6 +70,16 @@ show_root_heading: false
 options:
 show_root_heading: false
 
+::: spakky.plugins.fastapi.post_processors.register_actuator
+options:
+show_root_heading: false
+
+## Actuator
+
+::: spakky.plugins.fastapi.actuator
+options:
+show_root_heading: false
+
 ## Errors
 
 ::: spakky.plugins.fastapi.error

--- a/docs/api/plugins/spakky-typer.md
+++ b/docs/api/plugins/spakky-typer.md
@@ -20,6 +20,10 @@ show_root_heading: false
 options:
 show_root_heading: false
 
+::: spakky.plugins.typer.actuator
+options:
+show_root_heading: false
+
 ## Utilities
 
 ::: spakky.plugins.typer.utils.asyncio

--- a/docs/guides/actuator.md
+++ b/docs/guides/actuator.md
@@ -1,0 +1,137 @@
+# Actuator 상태 확인
+
+`spakky-actuator`는 애플리케이션 상태를 transport-neutral 모델로 집계합니다.
+FastAPI와 Typer 플러그인은 같은 core result를 HTTP endpoint나 CLI command로 노출합니다.
+
+## 의미 구분
+
+| Surface | 용도 | 실패 기준 |
+|---------|------|-----------|
+| `health` | 운영자가 보는 전체 상태 | required probe 중 하나라도 unhealthy이면 unhealthy |
+| `readiness` | 트래픽이나 작업을 받을 준비 여부 | 외부 의존성 등 준비 상태 probe 실패를 반영 |
+| `liveness` | 프로세스와 프레임워크 기본 생존 여부 | readiness와 분리되며 기본 probe가 없으면 healthy baseline |
+| `info` | 앱 버전, 빌드, 런타임 metadata | 등록된 contributor payload를 deterministic merge |
+
+기본 health probe는 `health`와 `readiness`에만 참여합니다.
+`liveness`는 데이터베이스, 브로커, 외부 API 같은 dependency readiness와 분리해야 합니다.
+
+## Core 사용
+
+```python
+from spakky.actuator import (
+    AbstractHealthProbe,
+    ActuatorAggregationService,
+    ActuatorEndpoint,
+    ActuatorExtensionRegistry,
+    ComponentHealthResult,
+)
+
+
+class DatabaseProbe(AbstractHealthProbe):
+    @property
+    def name(self) -> str:
+        return "database"
+
+    def check(self) -> ComponentHealthResult:
+        return ComponentHealthResult.healthy(self.name)
+
+
+class ProcessProbe(AbstractHealthProbe):
+    @property
+    def name(self) -> str:
+        return "process"
+
+    @property
+    def endpoints(self) -> tuple[ActuatorEndpoint, ...]:
+        return (ActuatorEndpoint.LIVENESS,)
+
+    def check(self) -> ComponentHealthResult:
+        return ComponentHealthResult.healthy(self.name)
+
+
+registry = ActuatorExtensionRegistry()
+registry.register_health_probe(DatabaseProbe())
+registry.register_health_probe(ProcessProbe())
+
+service = ActuatorAggregationService(registry)
+readiness = service.evaluate_readiness()
+liveness = service.evaluate_liveness()
+```
+
+`ComponentHealthResult.unhealthy(..., required=False)`는 component 자체는 unhealthy로 보존하지만 aggregate status를 실패시키지 않습니다.
+`ActuatorConfig(include_details=False)`를 등록하면 component details 노출을 제한합니다.
+
+## DI 확장
+
+애플리케이션에서는 probe와 info contributor를 Pod로 등록하면 됩니다.
+`spakky-actuator` plugin이 `ActuatorExtensionPostProcessor`를 등록하고, DI-managed extension을 `ActuatorExtensionRegistry`에 모읍니다.
+
+```python
+from collections.abc import Mapping
+
+from spakky.actuator import AbstractInfoContributor
+from spakky.core.pod.annotations.pod import Pod
+
+
+@Pod()
+class BuildInfo(AbstractInfoContributor):
+    @property
+    def name(self) -> str:
+        return "build"
+
+    def contribute_info(self) -> Mapping[str, object]:
+        return {"version": "1.0.0"}
+```
+
+Async probe와 async info contributor도 지원합니다.
+동기 평가 메서드에서 async extension이 발견되면 명시적 actuator error가 발생하므로, async transport에서는 `evaluate_*_async()`를 사용하세요.
+
+## FastAPI 노출
+
+`spakky-actuator`와 `spakky-fastapi`를 함께 로드하면 다음 route가 등록됩니다.
+
+| Route | Healthy | Unhealthy |
+|-------|---------|-----------|
+| `GET /actuator/health` | `200 OK` | `503 Service Unavailable` |
+| `GET /actuator/readiness` | `200 OK` | `503 Service Unavailable` |
+| `GET /actuator/liveness` | `200 OK` | `503 Service Unavailable` |
+| `GET /actuator/info` | `200 OK` | N/A |
+
+`FastAPIActuatorConfig`로 base path와 endpoint별 노출 여부를 조정합니다.
+
+```python
+from spakky.core.pod.annotations.pod import Pod
+from spakky.plugins.fastapi.actuator import FastAPIActuatorConfig
+
+
+@Pod()
+def fastapi_actuator_config() -> FastAPIActuatorConfig:
+    return FastAPIActuatorConfig(
+        base_path="/internal/actuator",
+        readiness_enabled=False,
+    )
+```
+
+## Typer 노출
+
+`spakky-actuator`와 `spakky-typer`를 함께 로드하면 `actuator` command group이 등록됩니다.
+
+```bash
+python main.py actuator health
+python main.py actuator readiness
+python main.py actuator liveness
+python main.py actuator info
+```
+
+다음 환경변수로 command 노출을 제어합니다.
+
+```bash
+export SPAKKY_TYPER_ACTUATOR_COMMAND_ENABLED=false
+export SPAKKY_TYPER_ACTUATOR_COMMAND_NAME=status
+```
+
+## 범위 밖
+
+이번 actuator MVP는 plugin-specific deep health checks를 제공하지 않습니다.
+SQLAlchemy 연결, Kafka/RabbitMQ broker, Celery worker 같은 깊은 통합 상태는 각 앱이 `AbstractHealthProbe`로 추가합니다.
+Metrics exporter나 Prometheus/OpenTelemetry exporter 약속도 이 milestone 범위가 아닙니다.

--- a/docs/index.md
+++ b/docs/index.md
@@ -209,6 +209,7 @@ app = (
 | [Transactional Outbox](guides/outbox.md)   | at-least-once 전달, Relay, OutboxEventBus               |
 | [분산 트레이싱](guides/tracing.md)         | TraceContext, Propagator, W3C traceparent              |
 | [OpenTelemetry 통합](guides/opentelemetry.md) | OTel SDK 브릿지, OTLP exporter, Propagator 자동 교체 |
+| [Actuator 상태 확인](guides/actuator.md) | Health, Readiness, Liveness, Info, probe 확장 |
 | [사가 오케스트레이션](guides/saga.md) | SagaFlow, SagaStep, 보상 기반 롤백, ErrorStrategy |
 | [gRPC 통합](guides/grpc.md) | `@GrpcController`, `@rpc`, code-first 프로토콜 생성 |
 
@@ -228,6 +229,7 @@ app = (
 | [spakky-tracing](api/core/spakky-tracing.md) | 분산 트레이싱 추상화              |
 | [spakky-outbox](api/core/spakky-outbox.md) | Outbox 패턴                        |
 | [spakky-saga](api/core/spakky-saga.md)     | 사가 오케스트레이션                |
+| [spakky-actuator](api/core/spakky-actuator.md) | Actuator 상태/정보 계약        |
 
 ### Plugins
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ plugins:
             - core/spakky-tracing/src
             - core/spakky-outbox/src
             - core/spakky-saga/src
+            - core/spakky-actuator/src
             - plugins/spakky-logging/src
             - plugins/spakky-fastapi/src
             - plugins/spakky-rabbitmq/src
@@ -119,6 +120,7 @@ nav:
       - Transactional Outbox: guides/outbox.md
       - 분산 트레이싱: guides/tracing.md
       - OpenTelemetry 통합: guides/opentelemetry.md
+      - Actuator 상태 확인: guides/actuator.md
       - 사가 오케스트레이션: guides/saga.md
       - gRPC 통합: guides/grpc.md
   - 심화 가이드:
@@ -140,6 +142,7 @@ nav:
           - spakky-tracing: api/core/spakky-tracing.md
           - spakky-outbox: api/core/spakky-outbox.md
           - spakky-saga: api/core/spakky-saga.md
+          - spakky-actuator: api/core/spakky-actuator.md
       - Plugins:
           - spakky-logging: api/plugins/spakky-logging.md
           - spakky-fastapi: api/plugins/spakky-fastapi.md

--- a/plugins/spakky-fastapi/README.md
+++ b/plugins/spakky-fastapi/README.md
@@ -118,6 +118,7 @@ def test_get_user(application: SpakkyApplication) -> None:
 ## Actuator Endpoints
 
 `spakky-actuator` 플러그인을 함께 로드하면 FastAPI 앱에 표준 actuator route가 등록됩니다.
+HTTP payload는 transport-neutral core result shape를 그대로 반영합니다.
 
 | Endpoint | Success | Unhealthy |
 |----------|---------|-----------|
@@ -128,6 +129,7 @@ def test_get_user(application: SpakkyApplication) -> None:
 
 Endpoint exposure and base path are configured with `FastAPIActuatorConfig`.
 Component detail exposure is controlled by `spakky.actuator.ActuatorConfig`.
+`readiness` is for traffic/work readiness, while `liveness` should stay process-local and independent from external dependency failures.
 
 ```python
 from spakky.core.pod.annotations.pod import Pod
@@ -140,6 +142,9 @@ def fastapi_actuator_config() -> FastAPIActuatorConfig:
         readiness_enabled=False,
     )
 ```
+
+Plugin-specific deep checks are not registered automatically by the FastAPI adapter.
+Register `spakky.actuator.AbstractHealthProbe` Pods in the application when database, broker, or worker readiness should affect actuator output.
 
 ## Components
 

--- a/plugins/spakky-fastapi/tests/test_actuator.py
+++ b/plugins/spakky-fastapi/tests/test_actuator.py
@@ -1,9 +1,11 @@
 """Actuator endpoint registration tests."""
 
+from collections.abc import Mapping
 from http import HTTPStatus
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from spakky.actuator.interfaces.contributor import AbstractInfoContributor
 from spakky.actuator.interfaces.probe import AbstractHealthProbe
 from spakky.actuator.result import ActuatorEndpoint, ComponentHealthResult
 from spakky.actuator.service import ActuatorAggregationService
@@ -68,6 +70,72 @@ def test_actuator_routes_registered_when_plugins_loaded() -> None:
     assert info.status_code == HTTPStatus.OK
     assert health.json()["status"] == "healthy"
     assert info.json() == {"info": {}}
+
+
+def test_actuator_endpoints_output_core_public_result_shape() -> None:
+    """FastAPI actuator endpoint가 core result shape를 HTTP payload로 노출한다."""
+
+    @Pod()
+    class HttpProbe(AbstractHealthProbe):
+        @property
+        @override
+        def name(self) -> str:
+            return "http"
+
+        @override
+        def check(self) -> ComponentHealthResult:
+            return ComponentHealthResult.healthy(
+                self.name,
+                details={"a": 1, "z": 2},
+            )
+
+    @Pod()
+    class HttpInfoContributor(AbstractInfoContributor):
+        @property
+        @override
+        def name(self) -> str:
+            return "http-info"
+
+        @override
+        def contribute_info(self) -> Mapping[str, object]:
+            return {"app": "fastapi", "version": "test"}
+
+    @Pod(name="api")
+    def get_api() -> FastAPI:
+        return FastAPI(debug=True)
+
+    app = (
+        SpakkyApplication(ApplicationContext())
+        .load_plugins(
+            include={
+                ACTUATOR_PLUGIN_NAME,
+                spakky.plugins.fastapi.PLUGIN_NAME,
+            }
+        )
+        .add(get_api)
+        .add(HttpProbe)
+        .add(HttpInfoContributor)
+    )
+    app.start()
+    api = app.container.get(type_=FastAPI)
+
+    with TestClient(api) as client:
+        health = client.get("/actuator/health")
+        info = client.get("/actuator/info")
+
+    assert health.json() == {
+        "endpoint": "health",
+        "status": "healthy",
+        "components": [
+            {
+                "name": "http",
+                "status": "healthy",
+                "required": True,
+                "details": {"a": 1, "z": 2},
+            }
+        ],
+    }
+    assert info.json() == {"info": {"app": "fastapi", "version": "test"}}
 
 
 def test_disabled_actuator_endpoint_is_not_registered() -> None:

--- a/plugins/spakky-typer/README.md
+++ b/plugins/spakky-typer/README.md
@@ -128,6 +128,7 @@ python main.py actuator info
 ```
 
 Each command prints deterministic JSON from the transport-neutral actuator core result model.
+`readiness` reports whether the app is ready to accept work; `liveness` should remain a process-local check and should not fail just because an external dependency is unavailable.
 
 Disable command registration with:
 
@@ -140,6 +141,9 @@ Customize the command group name with:
 ```bash
 export SPAKKY_TYPER_ACTUATOR_COMMAND_NAME=status
 ```
+
+Plugin-specific deep checks are not registered automatically by the Typer adapter.
+Register `spakky.actuator.AbstractHealthProbe` Pods in the application when database, broker, or worker readiness should affect command output.
 
 ### Application Setup
 

--- a/plugins/spakky-typer/tests/test_actuator_command.py
+++ b/plugins/spakky-typer/tests/test_actuator_command.py
@@ -112,6 +112,18 @@ def test_actuator_command_absent_when_config_disabled(
     assert "actuator" not in group_names
 
 
+def test_actuator_command_uses_configured_group_name(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """config로 지정한 actuator command group 이름을 사용한다."""
+    monkeypatch.setenv("SPAKKY_TYPER_ACTUATOR_COMMAND_NAME", "status")
+    with _actuator_cli() as cli:
+        result = CliRunner().invoke(cli, ["status", "health"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["endpoint"] == "health"
+
+
 @contextmanager
 def _actuator_cli() -> Generator[Typer, None, None]:
     app = (


### PR DESCRIPTION
## Summary

- Add actuator regression coverage for core aggregate result shape, FastAPI HTTP payload shape, and Typer configured command group behavior.
- Add actuator user guide and API reference page, including mkdocs nav and mkdocstrings path coverage.
- Sync actuator semantics across package READMEs and ARCHITECTURE.md, especially readiness vs liveness and plugin-specific deep-check scope.

## Acceptance Criteria (자가 grep)

- acceptance_check: missing — issue #155 has no explicit grep/rg/find acceptance lines.

## Validation

- `core/spakky-actuator`: `uv run --with ruff ruff check .`
- `core/spakky-actuator`: `uv run --with pyrefly --with pytest pyrefly check --use-ignore-files=false --disable-project-excludes-heuristics=true --project-excludes '**/__pycache__' --project-excludes '**/*.pyc'`
- `core/spakky-actuator`: `uv run --with pytest --with pytest-asyncio --with pytest-cov --with pytest-spec --with pytest-xdist pytest`
- `plugins/spakky-fastapi`: `uv run --with ruff ruff check .`
- `plugins/spakky-fastapi`: `uv run --with pyrefly --with pytest pyrefly check --use-ignore-files=false --disable-project-excludes-heuristics=true --project-excludes '**/__pycache__' --project-excludes '**/*.pyc'`
- `plugins/spakky-fastapi`: `uv run --with pytest --with pytest-asyncio --with pytest-cov --with pytest-spec --with pytest-xdist pytest`
- `plugins/spakky-typer`: `uv run --with ruff ruff check .`
- `plugins/spakky-typer`: `uv run --with pyrefly --with pytest pyrefly check --use-ignore-files=false --disable-project-excludes-heuristics=true --project-excludes '**/__pycache__' --project-excludes '**/*.pyc'`
- `plugins/spakky-typer`: `uv run --with pytest --with pytest-asyncio --with pytest-cov --with pytest-spec --with pytest-xdist pytest`
- `uv run --group dev mkdocs build --strict`

Closes #155
