### PR TITLE
feat(cache): add cache annotation aspects (#154)

### DIFF
--- a/core/spakky-cache/README.md
+++ b/core/spakky-cache/README.md
@@ -14,6 +14,7 @@ pip install spakky-cache
 - **Sync and async contracts**: `AbstractCache[T]` defines `get`, `set`, `delete`, `clear` and async equivalents.
 - **TTL semantics**: Positive TTL values expire entries deterministically; missing and expired entries are misses.
 - **In-memory backend**: `InMemoryCache[T]` is suitable for local development, tests, and single-process usage.
+- **AOP method caching**: `@cacheable()` and `@cache_evict()` apply cache hit/miss and eviction behavior without manual plumbing.
 - **Application data scope**: This package does not expose or mutate `ApplicationContext` internal caches.
 
 ## Quick Start
@@ -30,6 +31,34 @@ result = cache.get("profile:42")
 if isinstance(result, CacheHit):
     print(result.value)
 ```
+
+## Annotation Usage
+
+Load the `spakky-cache` plugin, then annotate service methods. The plugin registers `InMemoryCache`, `CacheAspect`, and `AsyncCacheAspect` so sync and async methods are handled through Spakky AOP.
+
+```python
+from datetime import timedelta
+
+from spakky.cache import cache_evict, cacheable
+from spakky.core.stereotype.usecase import UseCase
+
+
+@UseCase()
+class ProfileService:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    @cacheable(key="profile:{0}", ttl=timedelta(minutes=5))
+    def load_profile(self, user_id: str) -> str:
+        self.calls += 1
+        return f"profile:{user_id}"
+
+    @cache_evict(key="profile:{0}")
+    def refresh_profile(self, user_id: str) -> None:
+        ...
+```
+
+The default key is derived from the method module, qualified name, positional arguments, and sorted keyword arguments. Explicit `key` values are Python format strings evaluated against method call arguments. Backend failures are not swallowed; cache errors propagate loudly.
 
 ## Async Usage
 
@@ -49,6 +78,8 @@ if isinstance(result, CacheHit):
 `ttl=None` stores an entry until explicit deletion or clear. Positive `float`, `int`, or `datetime.timedelta` values expire entries after that duration. Zero or negative TTL values raise `InvalidCacheTTLError`.
 
 The in-memory backend deletes expired entries when they are observed. It is deterministic for one process and does not provide distributed invalidation, stampede protection, or tag-based eviction.
+
+Cache eviction annotations remove a single matching entry only after the annotated method succeeds.
 
 ## License
 

--- a/core/spakky-cache/pyproject.toml
+++ b/core/spakky-cache/pyproject.toml
@@ -21,7 +21,7 @@ module-name = "spakky.cache"
 
 [tool.pyrefly]
 python-version = "3.11"
-search_path = ["src", "."]
+search_path = ["src", ".", "../spakky/src"]
 project_excludes = ["**/__pycache__", "**/*.pyc"]
 
 [tool.ruff]
@@ -29,7 +29,7 @@ builtins = ["_"]
 cache-dir = "~/.cache/ruff"
 
 [tool.pytest.ini_options]
-pythonpath = "src/spakky/cache"
+pythonpath = ["src", "../spakky/src"]
 testpaths = "tests"
 python_files = ["test_*.py"]
 asyncio_mode = "auto"

--- a/core/spakky-cache/src/spakky/cache/__init__.py
+++ b/core/spakky-cache/src/spakky/cache/__init__.py
@@ -2,8 +2,14 @@
 
 from spakky.core.application.plugin import Plugin
 
+from spakky.cache.annotation import CacheEvict, Cacheable, cache_evict, cacheable
+from spakky.cache.aspects.cache_aspect import AsyncCacheAspect, CacheAspect
 from spakky.cache.backends.memory import InMemoryCache
-from spakky.cache.error import AbstractSpakkyCacheError, InvalidCacheTTLError
+from spakky.cache.error import (
+    AbstractSpakkyCacheError,
+    CacheKeyGenerationError,
+    InvalidCacheTTLError,
+)
 from spakky.cache.interfaces.cache import AbstractCache, CacheTTL
 from spakky.cache.result import CacheHit, CacheMiss, CacheResult
 
@@ -13,11 +19,18 @@ PLUGIN_NAME = Plugin(name="spakky-cache")
 __all__ = [
     "AbstractCache",
     "AbstractSpakkyCacheError",
+    "AsyncCacheAspect",
+    "CacheEvict",
     "CacheHit",
+    "CacheKeyGenerationError",
     "CacheMiss",
     "CacheResult",
     "CacheTTL",
+    "CacheAspect",
+    "Cacheable",
     "InMemoryCache",
     "InvalidCacheTTLError",
     "PLUGIN_NAME",
+    "cache_evict",
+    "cacheable",
 ]

--- a/core/spakky-cache/src/spakky/cache/annotation.py
+++ b/core/spakky-cache/src/spakky/cache/annotation.py
@@ -1,0 +1,54 @@
+"""Cache method annotations."""
+
+from dataclasses import dataclass
+from typing import Callable, ParamSpec, TypeVar
+
+from spakky.core.common.annotation import FunctionAnnotation
+
+from spakky.cache.interfaces.cache import CacheTTL
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+@dataclass
+class Cacheable(FunctionAnnotation):
+    """Annotation for caching method return values."""
+
+    key: str | None = None
+    """Optional format string used as the cache key."""
+
+    ttl: CacheTTL = None
+    """Optional cache entry TTL."""
+
+
+@dataclass
+class CacheEvict(FunctionAnnotation):
+    """Annotation for evicting a cache entry after successful method execution."""
+
+    key: str | None = None
+    """Optional format string used as the cache key."""
+
+
+def cacheable(
+    key: str | None = None,
+    *,
+    ttl: CacheTTL = None,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Decorate a method so its return value is cached by AOP."""
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        return Cacheable(key=key, ttl=ttl)(func)
+
+    return decorator
+
+
+def cache_evict(
+    key: str | None = None,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Decorate a method so its cache entry is evicted after success."""
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        return CacheEvict(key=key)(func)
+
+    return decorator

--- a/core/spakky-cache/src/spakky/cache/aspects/__init__.py
+++ b/core/spakky-cache/src/spakky/cache/aspects/__init__.py
@@ -1,0 +1,5 @@
+"""Cache AOP aspects."""
+
+from spakky.cache.aspects.cache_aspect import AsyncCacheAspect, CacheAspect
+
+__all__ = ["AsyncCacheAspect", "CacheAspect"]

--- a/core/spakky-cache/src/spakky/cache/aspects/cache_aspect.py
+++ b/core/spakky-cache/src/spakky/cache/aspects/cache_aspect.py
@@ -1,0 +1,114 @@
+"""AOP aspects for cache annotations."""
+
+from inspect import iscoroutinefunction
+
+from spakky.core.aop.aspect import Aspect, AsyncAspect
+from spakky.core.aop.interfaces.aspect import IAspect, IAsyncAspect
+from spakky.core.aop.pointcut import Around
+from spakky.core.common.types import AsyncFunc, Func
+from spakky.core.pod.annotations.order import Order
+
+from spakky.cache.annotation import CacheEvict, Cacheable
+from spakky.cache.error import CacheKeyGenerationError
+from spakky.cache.interfaces.cache import AbstractCache
+from spakky.cache.result import CacheHit
+
+
+def _matches_sync(method: Func) -> bool:
+    return (
+        Cacheable.exists(method) or CacheEvict.exists(method)
+    ) and not iscoroutinefunction(method)
+
+
+def _matches_async(method: Func) -> bool:
+    return (
+        Cacheable.exists(method) or CacheEvict.exists(method)
+    ) and iscoroutinefunction(method)
+
+
+def _key_from_call(
+    joinpoint: Func,
+    configured_key: str | None,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> str:
+    try:
+        if configured_key is not None:
+            return configured_key.format(*args, **kwargs)
+        ordered_kwargs = tuple(sorted(kwargs.items(), key=lambda item: item[0]))
+        return (
+            f"{joinpoint.__module__}.{joinpoint.__qualname__}:"
+            f"args={args!r}:kwargs={ordered_kwargs!r}"
+        )
+    except Exception as error:
+        raise CacheKeyGenerationError() from error
+
+
+@Order(0)
+@Aspect()
+class CacheAspect(IAspect):
+    """Aspect that applies cacheable and cache eviction annotations."""
+
+    _cache: AbstractCache[object]
+
+    def __init__(self, cache: AbstractCache[object]) -> None:
+        self._cache = cache
+
+    @Around(_matches_sync)
+    def around(
+        self,
+        joinpoint: Func,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        evict = CacheEvict.get_or_none(joinpoint)
+        if evict is not None:
+            result = joinpoint(*args, **kwargs)
+            self._cache.delete(_key_from_call(joinpoint, evict.key, args, kwargs))
+            return result
+
+        cacheable = Cacheable.get(joinpoint)
+        key = _key_from_call(joinpoint, cacheable.key, args, kwargs)
+        cached = self._cache.get(key)
+        if isinstance(cached, CacheHit):
+            return cached.value
+
+        result = joinpoint(*args, **kwargs)
+        self._cache.set(key, result, ttl=cacheable.ttl)
+        return result
+
+
+@Order(0)
+@AsyncAspect()
+class AsyncCacheAspect(IAsyncAspect):
+    """Async aspect that applies cacheable and cache eviction annotations."""
+
+    _cache: AbstractCache[object]
+
+    def __init__(self, cache: AbstractCache[object]) -> None:
+        self._cache = cache
+
+    @Around(_matches_async)
+    async def around_async(
+        self,
+        joinpoint: AsyncFunc,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        evict = CacheEvict.get_or_none(joinpoint)
+        if evict is not None:
+            result = await joinpoint(*args, **kwargs)
+            await self._cache.delete_async(
+                _key_from_call(joinpoint, evict.key, args, kwargs)
+            )
+            return result
+
+        cacheable = Cacheable.get(joinpoint)
+        key = _key_from_call(joinpoint, cacheable.key, args, kwargs)
+        cached = await self._cache.get_async(key)
+        if isinstance(cached, CacheHit):
+            return cached.value
+
+        result = await joinpoint(*args, **kwargs)
+        await self._cache.set_async(key, result, ttl=cacheable.ttl)
+        return result

--- a/core/spakky-cache/src/spakky/cache/error.py
+++ b/core/spakky-cache/src/spakky/cache/error.py
@@ -15,3 +15,9 @@ class InvalidCacheTTLError(AbstractSpakkyCacheError):
     """Raised when a cache entry is written with an invalid TTL."""
 
     message = "Cache TTL must be positive"
+
+
+class CacheKeyGenerationError(AbstractSpakkyCacheError):
+    """Raised when a cache annotation cannot produce a deterministic key."""
+
+    message = "Cache key generation failed"

--- a/core/spakky-cache/src/spakky/cache/main.py
+++ b/core/spakky-cache/src/spakky/cache/main.py
@@ -2,6 +2,7 @@
 
 from spakky.core.application.application import SpakkyApplication
 
+from spakky.cache.aspects.cache_aspect import AsyncCacheAspect, CacheAspect
 from spakky.cache.backends.memory import InMemoryCache
 
 
@@ -12,3 +13,5 @@ def initialize(app: SpakkyApplication) -> None:
         app: The SpakkyApplication instance.
     """
     app.add(InMemoryCache)
+    app.add(CacheAspect)
+    app.add(AsyncCacheAspect)

--- a/core/spakky-cache/tests/unit/test_cache_aspect.py
+++ b/core/spakky-cache/tests/unit/test_cache_aspect.py
@@ -1,0 +1,166 @@
+"""Tests for cache annotations and AOP aspects."""
+
+from datetime import timedelta
+
+import pytest
+
+from spakky.cache import (
+    AbstractCache,
+    AbstractSpakkyCacheError,
+    CacheHit,
+    CacheKeyGenerationError,
+    CacheMiss,
+    CacheResult,
+    InMemoryCache,
+    cache_evict,
+    cacheable,
+)
+from spakky.cache.aspects.cache_aspect import AsyncCacheAspect, CacheAspect
+from spakky.cache.interfaces.cache import CacheTTL
+from spakky.core.aop.aspect import Aspect, AsyncAspect
+
+
+class CacheBackendUnavailableError(AbstractSpakkyCacheError):
+    message = "Cache backend unavailable"
+
+
+class FailingCache(AbstractCache[object]):
+    def get(self, key: str) -> CacheResult[object]:
+        raise CacheBackendUnavailableError()
+
+    def set(self, key: str, value: object, *, ttl: CacheTTL = None) -> None:
+        raise CacheBackendUnavailableError()
+
+    def delete(self, key: str) -> bool:
+        raise CacheBackendUnavailableError()
+
+    def clear(self) -> None:
+        raise CacheBackendUnavailableError()
+
+    async def get_async(self, key: str) -> CacheResult[object]:
+        raise CacheBackendUnavailableError()
+
+    async def set_async(self, key: str, value: object, *, ttl: CacheTTL = None) -> None:
+        raise CacheBackendUnavailableError()
+
+    async def delete_async(self, key: str) -> bool:
+        raise CacheBackendUnavailableError()
+
+    async def clear_async(self) -> None:
+        raise CacheBackendUnavailableError()
+
+
+class CounterService:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    @cacheable()
+    def compute(self, value: int) -> str:
+        self.calls += 1
+        return f"sync:{value}:{self.calls}"
+
+    @cacheable(key="manual:{0}", ttl=timedelta(seconds=5))
+    def compute_with_manual_key(self, value: int) -> str:
+        self.calls += 1
+        return f"manual:{value}:{self.calls}"
+
+    @cache_evict(key="manual:{0}")
+    def evict_manual_key(self, value: int) -> str:
+        self.calls += 1
+        return f"evict:{value}:{self.calls}"
+
+    @cacheable(key="{missing}")
+    def bad_key(self) -> str:
+        self.calls += 1
+        return "bad"
+
+    @cacheable()
+    async def compute_async(self, value: int) -> str:
+        self.calls += 1
+        return f"async:{value}:{self.calls}"
+
+    @cache_evict(key="manual:{0}")
+    async def evict_manual_key_async(self, value: int) -> str:
+        self.calls += 1
+        return f"async-evict:{value}:{self.calls}"
+
+
+def test_cacheable_sync_method_expect_second_call_uses_cached_value() -> None:
+    """cacheable sync method가 같은 입력에서 method 실행을 1회로 줄이는지 검증한다."""
+    cache = InMemoryCache[object]()
+    aspect = CacheAspect(cache)
+    service = CounterService()
+
+    first = aspect.around(service.compute, 7)
+    second = aspect.around(service.compute, 7)
+
+    assert first == second == "sync:7:1"
+    assert service.calls == 1
+    assert Aspect.get(aspect).matches(service.compute) is True
+
+
+async def test_cacheable_async_method_expect_second_call_uses_cached_value() -> None:
+    """cacheable async method가 같은 입력에서 async method 실행을 1회로 줄이는지 검증한다."""
+    cache = InMemoryCache[object]()
+    aspect = AsyncCacheAspect(cache)
+    service = CounterService()
+
+    first = await aspect.around_async(service.compute_async, 9)
+    second = await aspect.around_async(service.compute_async, 9)
+
+    assert first == second == "async:9:1"
+    assert service.calls == 1
+    assert AsyncAspect.get(aspect).matches(service.compute_async) is True
+
+
+def test_cache_evict_method_expect_matching_entry_removed_after_success() -> None:
+    """eviction annotation이 성공 후 matching cache entry를 제거하는지 검증한다."""
+    cache = InMemoryCache[object]()
+    aspect = CacheAspect(cache)
+    service = CounterService()
+
+    cached = aspect.around(service.compute_with_manual_key, 3)
+    assert cached == "manual:3:1"
+    assert isinstance(cache.get("manual:3"), CacheHit)
+
+    evicted = aspect.around(service.evict_manual_key, 3)
+
+    assert evicted == "evict:3:2"
+    assert isinstance(cache.get("manual:3"), CacheMiss)
+
+
+async def test_cache_evict_async_method_expect_matching_entry_removed_after_success() -> (
+    None
+):
+    """async eviction annotation이 성공 후 matching cache entry를 제거하는지 검증한다."""
+    cache = InMemoryCache[object]()
+    sync_aspect = CacheAspect(cache)
+    async_aspect = AsyncCacheAspect(cache)
+    service = CounterService()
+
+    cached = sync_aspect.around(service.compute_with_manual_key, 5)
+    assert cached == "manual:5:1"
+    assert isinstance(cache.get("manual:5"), CacheHit)
+
+    evicted = await async_aspect.around_async(service.evict_manual_key_async, 5)
+
+    assert evicted == "async-evict:5:2"
+    assert isinstance(cache.get("manual:5"), CacheMiss)
+
+
+def test_backend_failure_expect_cache_error_fails_loudly() -> None:
+    """backend failure가 cache aspect에서 숨겨지지 않고 전파되는지 검증한다."""
+    aspect = CacheAspect(FailingCache())
+    service = CounterService()
+
+    with pytest.raises(CacheBackendUnavailableError):
+        aspect.around(service.compute, 1)
+
+
+def test_bad_key_template_expect_cache_key_generation_error() -> None:
+    """key template이 입력과 맞지 않으면 cache key error로 실패하는지 검증한다."""
+    aspect = CacheAspect(InMemoryCache[object]())
+    service = CounterService()
+
+    with pytest.raises(CacheKeyGenerationError):
+        aspect.around(service.bad_key)

--- a/core/spakky-cache/tests/unit/test_main.py
+++ b/core/spakky-cache/tests/unit/test_main.py
@@ -1,6 +1,7 @@
 """Tests for cache plugin initialization."""
 
 from spakky.cache.backends.memory import InMemoryCache
+from spakky.cache.aspects.cache_aspect import AsyncCacheAspect, CacheAspect
 from spakky.cache.main import initialize
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
@@ -14,3 +15,5 @@ def test_initialize_expect_registers_cache_backend() -> None:
 
     pod_types = {pod.type_ for pod in app.container.pods.values()}
     assert InMemoryCache in pod_types
+    assert CacheAspect in pod_types
+    assert AsyncCacheAspect in pod_types

--- a/docs/api/core/spakky-cache.md
+++ b/docs/api/core/spakky-cache.md
@@ -2,6 +2,18 @@
 
 Application data cache contract and in-memory backend.
 
+## Annotations
+
+::: spakky.cache.annotation
+    options:
+      show_root_heading: false
+
+## AOP Aspects
+
+::: spakky.cache.aspects.cache_aspect
+    options:
+      show_root_heading: false
+
 ## Result Contracts
 
 ::: spakky.cache.result

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -15,7 +15,7 @@
 - [spakky-outbox](core/spakky-outbox.md) — Outbox 패턴
 - [spakky-saga](core/spakky-saga.md) — 사가 오케스트레이션
 - [spakky-actuator](core/spakky-actuator.md) — Actuator 상태/정보 계약
-- [spakky-cache](core/spakky-cache.md) — 애플리케이션 데이터 캐시 계약
+- [spakky-cache](core/spakky-cache.md) — 애플리케이션 데이터 캐시 계약과 AOP annotation
 
 ## Plugins
 


### PR DESCRIPTION
## Summary
- Add `@cacheable()` and `@cache_evict()` method annotations.
- Add sync and async cache AOP aspects with deterministic key generation, TTL pass-through, eviction-after-success, and loud backend error propagation.
- Register cache aspects in the `spakky-cache` plugin and document the public API.

## Validation
- `uv run --project ../.. --group dev ruff check .` from `core/spakky-cache`
- `uv run --project ../.. --group dev pyrefly check .` from `core/spakky-cache`
- `uv run --project ../.. --group dev pytest .` from `core/spakky-cache` (13 passed, 100% coverage)
- `uv run --project . --group dev mkdocs build --strict`

Closes #154