### PR TITLE
test(cache): add cache regression coverage and docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -432,6 +432,12 @@ spakky-data = "spakky.data.main:initialize"
 | `spakky-grpc` | `RegisterServicesPostProcessor`, `AddInterceptorsPostProcessor`, `BindServerPostProcessor` |
 | `spakky-redis` | `RedisCacheConfig`, `RedisCache` |
 
+### 애플리케이션 데이터 캐시
+
+`spakky-cache`는 서비스·유스케이스 코드가 backend에 묶이지 않고 `CacheHit`/`CacheMiss`와 sync/async `AbstractCache` 계약으로 애플리케이션 데이터를 캐시하기 위한 코어 패키지입니다. 이 캐시는 `ApplicationContext`의 type/singleton/context 내부 캐시와 별개이며 DI 컨테이너 lookup 동작을 변경하지 않습니다.
+
+`spakky-cache` 플러그인은 기본 `InMemoryCache`를 등록하고, `@cacheable`/`@cache_evict` 메서드를 `CacheAspect`와 `AsyncCacheAspect`로 처리합니다. `spakky-redis`는 같은 계약을 Redis에 연결하는 backend plugin이며, configured key prefix 하위 항목만 clear합니다. distributed lock, cache stampede protection, tag invalidation, write-through/write-behind, metrics/exporter integration은 현재 범위 밖입니다.
+
 ---
 
 ## 도메인 레이어 (spakky-domain)

--- a/core/spakky-cache/README.md
+++ b/core/spakky-cache/README.md
@@ -60,6 +60,8 @@ class ProfileService:
 
 The default key is derived from the method module, qualified name, positional arguments, and sorted keyword arguments. Explicit `key` values are Python format strings evaluated against method call arguments. Backend failures are not swallowed; cache errors propagate loudly.
 
+`@cache_evict()` deletes the matching entry only after the annotated method succeeds. Failed method calls leave existing entries untouched so a failed refresh does not erase the last known cached value.
+
 ## Async Usage
 
 ```python
@@ -80,6 +82,10 @@ if isinstance(result, CacheHit):
 The in-memory backend deletes expired entries when they are observed. It is deterministic for one process and does not provide distributed invalidation, stampede protection, or tag-based eviction.
 
 Cache eviction annotations remove a single matching entry only after the annotated method succeeds.
+
+## Scope
+
+`spakky-cache` is an application data cache abstraction. It is separate from `ApplicationContext` internal type, singleton, and context caches. Distributed locks, cache stampede protection, tag invalidation, write-through/write-behind policies, and metrics exporters are outside the current contract.
 
 ## License
 

--- a/core/spakky-cache/tests/unit/test_cache_aspect.py
+++ b/core/spakky-cache/tests/unit/test_cache_aspect.py
@@ -24,6 +24,10 @@ class CacheBackendUnavailableError(AbstractSpakkyCacheError):
     message = "Cache backend unavailable"
 
 
+class ServiceExecutionError(Exception):
+    """Raised by the test service before eviction."""
+
+
 class FailingCache(AbstractCache[object]):
     def get(self, key: str) -> CacheResult[object]:
         raise CacheBackendUnavailableError()
@@ -59,6 +63,11 @@ class CounterService:
         self.calls += 1
         return f"sync:{value}:{self.calls}"
 
+    @cacheable()
+    def compute_with_kwargs(self, *, prefix: str, value: int) -> str:
+        self.calls += 1
+        return f"{prefix}:{value}:{self.calls}"
+
     @cacheable(key="manual:{0}", ttl=timedelta(seconds=5))
     def compute_with_manual_key(self, value: int) -> str:
         self.calls += 1
@@ -68,6 +77,11 @@ class CounterService:
     def evict_manual_key(self, value: int) -> str:
         self.calls += 1
         return f"evict:{value}:{self.calls}"
+
+    @cache_evict(key="manual:{0}")
+    def fail_before_evicting_manual_key(self, value: int) -> str:
+        self.calls += 1
+        raise ServiceExecutionError
 
     @cacheable(key="{missing}")
     def bad_key(self) -> str:
@@ -97,6 +111,19 @@ def test_cacheable_sync_method_expect_second_call_uses_cached_value() -> None:
     assert first == second == "sync:7:1"
     assert service.calls == 1
     assert Aspect.get(aspect).matches(service.compute) is True
+
+
+def test_cacheable_default_key_expect_keyword_order_is_deterministic() -> None:
+    """default key generation이 kwargs 순서와 무관하게 deterministic한지 검증한다."""
+    cache = InMemoryCache[object]()
+    aspect = CacheAspect(cache)
+    service = CounterService()
+
+    first = aspect.around(service.compute_with_kwargs, prefix="user", value=7)
+    second = aspect.around(service.compute_with_kwargs, value=7, prefix="user")
+
+    assert first == second == "user:7:1"
+    assert service.calls == 1
 
 
 async def test_cacheable_async_method_expect_second_call_uses_cached_value() -> None:
@@ -129,6 +156,23 @@ def test_cache_evict_method_expect_matching_entry_removed_after_success() -> Non
     assert isinstance(cache.get("manual:3"), CacheMiss)
 
 
+def test_cache_evict_method_failure_expect_matching_entry_preserved() -> None:
+    """eviction annotation이 method 실패 시 matching cache entry를 보존하는지 검증한다."""
+    cache = InMemoryCache[object]()
+    aspect = CacheAspect(cache)
+    service = CounterService()
+
+    cached = aspect.around(service.compute_with_manual_key, 3)
+    assert cached == "manual:3:1"
+
+    with pytest.raises(ServiceExecutionError):
+        aspect.around(service.fail_before_evicting_manual_key, 3)
+
+    result = cache.get("manual:3")
+    assert isinstance(result, CacheHit)
+    assert result.value == "manual:3:1"
+
+
 async def test_cache_evict_async_method_expect_matching_entry_removed_after_success() -> (
     None
 ):
@@ -155,6 +199,15 @@ def test_backend_failure_expect_cache_error_fails_loudly() -> None:
 
     with pytest.raises(CacheBackendUnavailableError):
         aspect.around(service.compute, 1)
+
+
+async def test_async_backend_failure_expect_cache_error_fails_loudly() -> None:
+    """async backend failure가 cache aspect에서 숨겨지지 않고 전파되는지 검증한다."""
+    aspect = AsyncCacheAspect(FailingCache())
+    service = CounterService()
+
+    with pytest.raises(CacheBackendUnavailableError):
+        await aspect.around_async(service.compute_async, 1)
 
 
 def test_bad_key_template_expect_cache_key_generation_error() -> None:

--- a/docs/guides/cache.md
+++ b/docs/guides/cache.md
@@ -1,0 +1,69 @@
+# Application Data Cache
+
+Spakky cache is a backend-neutral application data cache for service and use-case code. It is separate from `ApplicationContext` internal type, singleton, and context caches; it does not change how pods are discovered or injected.
+
+Use `spakky-cache` when application code needs a consistent hit/miss contract for repeated reads, external calls, or expensive calculations. Use `spakky-redis` when those entries must be shared across process instances.
+
+## Core Contract
+
+`AbstractCache[T]` provides sync and async paths for `get`, `set`, `delete`, and `clear`. A missing key returns `CacheMiss`; it is not a framework error. A stored value returns `CacheHit[T]`.
+
+```python
+from datetime import timedelta
+
+from spakky.cache import CacheHit, InMemoryCache
+
+cache = InMemoryCache[str]()
+cache.set("profile:42", "Ada", ttl=timedelta(minutes=5))
+
+result = cache.get("profile:42")
+if isinstance(result, CacheHit):
+    print(result.value)
+```
+
+`ttl=None` stores an entry until explicit deletion or clear. Positive `int`, `float`, and `datetime.timedelta` values expire entries after that duration. Zero or negative TTL values raise `InvalidCacheTTLError`.
+
+## Method Annotations
+
+Load the `spakky-cache` plugin to register `InMemoryCache`, `CacheAspect`, and `AsyncCacheAspect`. Then annotate service methods with `@cacheable()` or `@cache_evict()`.
+
+```python
+from datetime import timedelta
+
+from spakky.cache import cache_evict, cacheable
+from spakky.core.stereotype.usecase import UseCase
+
+
+@UseCase()
+class ProfileService:
+    @cacheable(key="profile:{0}", ttl=timedelta(minutes=5))
+    def load_profile(self, user_id: str) -> str:
+        return f"profile:{user_id}"
+
+    @cache_evict(key="profile:{0}")
+    def refresh_profile(self, user_id: str) -> None:
+        ...
+```
+
+The default key is deterministic for the method module, qualified name, positional arguments, and sorted keyword arguments. Explicit `key` values are Python format strings evaluated against call arguments.
+
+`@cacheable()` reads the cache before invoking the method and stores the result on a miss. `@cache_evict()` deletes the matching entry only after the annotated method succeeds. Backend failures propagate as Spakky cache errors and are not silently converted to misses.
+
+## Redis Backend
+
+`spakky-redis` provides `RedisCache[T]`, a `spakky-cache` backend that stores pickled values in Redis. Business code can depend on `AbstractCache[T]` and switch from `InMemoryCache` to `RedisCache` without changing hit/miss handling.
+
+```python
+from datetime import timedelta
+
+from spakky.plugins.redis import RedisCache
+
+cache = RedisCache[str]()
+cache.set("profile:42", "Ada", ttl=timedelta(minutes=5))
+```
+
+`RedisCacheConfig` reads `SPAKKY_REDIS__HOST`, `SPAKKY_REDIS__PORT`, `SPAKKY_REDIS__DB`, `SPAKKY_REDIS__USERNAME`, `SPAKKY_REDIS__PASSWORD`, `SPAKKY_REDIS__USE_SSL`, and `SPAKKY_REDIS__KEY_PREFIX`. `clear()` and `clear_async()` delete only keys under the configured prefix.
+
+## Non-goals
+
+The current cache milestone does not provide distributed locks, cache stampede protection, tag or group invalidation, write-through/write-behind policies, or metrics/exporter integration.

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,6 +211,7 @@ app = (
 | [OpenTelemetry 통합](guides/opentelemetry.md) | OTel SDK 브릿지, OTLP exporter, Propagator 자동 교체 |
 | [Actuator 상태 확인](guides/actuator.md) | Health, Readiness, Liveness, Info, probe 확장 |
 | [사가 오케스트레이션](guides/saga.md) | SagaFlow, SagaStep, 보상 기반 롤백, ErrorStrategy |
+| [애플리케이션 데이터 캐시](guides/cache.md) | `CacheHit`, `CacheMiss`, `@cacheable`, Redis backend |
 | [gRPC 통합](guides/grpc.md) | `@GrpcController`, `@rpc`, code-first 프로토콜 생성 |
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
       - OpenTelemetry 통합: guides/opentelemetry.md
       - Actuator 상태 확인: guides/actuator.md
       - 사가 오케스트레이션: guides/saga.md
+      - 애플리케이션 데이터 캐시: guides/cache.md
       - gRPC 통합: guides/grpc.md
   - 심화 가이드:
       - DI/IoC 컨테이너: di-container.md

--- a/plugins/spakky-redis/README.md
+++ b/plugins/spakky-redis/README.md
@@ -60,6 +60,14 @@ if isinstance(result, CacheHit):
     assert result.value == 42
 ```
 
+## Contract Notes
+
+`RedisCache` is a backend implementation of the `spakky-cache` application data cache contract. Business code should depend on `AbstractCache[T]` and can switch between `InMemoryCache` and `RedisCache` without changing cache hit/miss handling.
+
+Values are serialized with pickle and stored under `SPAKKY_REDIS__KEY_PREFIX`. `clear()` and `clear_async()` delete only keys under that prefix. Redis failures, unexpected response types, and serialization failures are raised as Spakky cache errors instead of being treated as cache misses.
+
+This plugin does not add distributed locks, cache stampede protection, tag invalidation, write-through/write-behind policies, or metrics exporters.
+
 ## License
 
 MIT License

--- a/plugins/spakky-redis/pyproject.toml
+++ b/plugins/spakky-redis/pyproject.toml
@@ -30,7 +30,7 @@ module-name = "spakky.plugins.redis"
 
 [tool.pyrefly]
 python-version = "3.11"
-search_path = ["src", "."]
+search_path = ["src", ".", "../../core/spakky/src", "../../core/spakky-cache/src"]
 project_excludes = ["**/__pycache__", "**/*.pyc"]
 
 [tool.ruff]
@@ -38,7 +38,7 @@ builtins = ["_"]
 cache-dir = "~/.cache/ruff"
 
 [tool.pytest.ini_options]
-pythonpath = "src/spakky/plugins/redis"
+pythonpath = ["src", "../../core/spakky/src", "../../core/spakky-cache/src"]
 testpaths = "tests"
 python_files = ["test_*.py"]
 asyncio_mode = "auto"

--- a/plugins/spakky-redis/tests/unit/test_redis_cache.py
+++ b/plugins/spakky-redis/tests/unit/test_redis_cache.py
@@ -130,6 +130,19 @@ def test_missing_and_ttl_expiry_expect_typed_miss() -> None:
     assert isinstance(cache.get("short"), CacheMiss)
 
 
+def test_ttl_float_expect_redis_millisecond_expiry() -> None:
+    """float TTL이 Redis millisecond expiry로 변환되는지 검증한다."""
+    server = fakeredis.FakeServer()
+    cache = _cache(server)
+    raw_client = fakeredis.FakeRedis(server=server)
+
+    cache.set("short", "value", ttl=1.25)
+
+    ttl_ms = raw_client.pttl("spakky:cache:short")
+    assert isinstance(ttl_ms, int)
+    assert 0 < ttl_ms <= 1250
+
+
 def test_delete_and_clear_expect_only_configured_prefix_removed() -> None:
     """delete와 clear가 configured prefix 범위만 삭제하는지 검증한다."""
     server = fakeredis.FakeServer()
@@ -172,6 +185,25 @@ async def test_async_contract_expect_shared_value_and_async_clear() -> None:
     assert isinstance(await cache.get_async("session"), CacheMiss)
 
     await cache.clear_async()
+
+
+async def test_async_clear_expect_only_configured_prefix_removed() -> None:
+    """async clear가 configured prefix 범위만 삭제하는지 검증한다."""
+    server = fakeredis.FakeServer()
+    cache = _cache(server, prefix="app:")
+    other = _cache(server, prefix="other:")
+
+    await cache.set_async("a", "1")
+    await cache.set_async("b", "2")
+    await other.set_async("a", "keep")
+
+    await cache.clear_async()
+
+    assert isinstance(await cache.get_async("a"), CacheMiss)
+    assert isinstance(await cache.get_async("b"), CacheMiss)
+    other_result = await other.get_async("a")
+    assert isinstance(other_result, CacheHit)
+    assert other_result.value == "keep"
 
 
 def test_invalid_ttl_expect_core_cache_error() -> None:


### PR DESCRIPTION
## Summary

- Add deterministic cache AOP regression tests for keyword-order key generation, failed eviction preservation, and async backend failure propagation.
- Add Redis regression tests for float TTL millisecond expiry and async prefix-scoped clear behavior.
- Add an application data cache user guide and sync cache/Redis package docs plus architecture/index navigation.
- Fix `spakky-redis` package validation paths so package-local pyrefly/pytest resolve core and cache sources.

## Acceptance Criteria

- Cache core deterministic regression tests: covered in `core/spakky-cache/tests/unit/test_cache_aspect.py`.
- Cache AOP hit/miss/eviction deterministic regression tests: covered in `test_cache_aspect.py`.
- Redis adapter contract compatibility regression tests: covered in `plugins/spakky-redis/tests/unit/test_redis_cache.py`.
- Docs explain backend-neutral use, annotations, TTL, Redis adapter, and non-goals: covered in `docs/guides/cache.md`, package READMEs, and `ARCHITECTURE.md`.
- package-level lint + type check + tests pass from package directories: see validation below.

Acceptance grep: missing (issue has no grep/find/rg command lines).

## Validation

- `uv run --project ../.. --group dev ruff check .` from `core/spakky-cache`: passed
- `uv run --project ../.. --group dev pyrefly check .` from `core/spakky-cache`: passed, 0 errors
- `uv run --project ../.. --group dev pytest .` from `core/spakky-cache`: passed, 16 tests, 100% coverage
- `uv run --project ../.. --group dev ruff check .` from `plugins/spakky-redis`: passed
- `uv run --project ../.. --group dev pyrefly check .` from `plugins/spakky-redis`: passed, 0 errors
- `uv run --project ../.. --group dev pytest .` from `plugins/spakky-redis`: passed, 16 tests, 100% coverage
- `uv run --project . --group dev mkdocs build --strict`: passed
- `git diff --check`: passed

Closes #151