### PR TITLE
docs(cache): sync milestone 13 cache docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -114,6 +114,7 @@ graph TD
     security --> core
     grpc --> core
     grpc --> tracing
+    redis --> cache
 
     style core fill:#e1f5ff,stroke:#42a5f5,stroke-width:2px,color:#0d47a1
     style domain fill:#fff4e1,stroke:#ffa726,stroke-width:2px,color:#e65100

--- a/core/spakky-cache/README.md
+++ b/core/spakky-cache/README.md
@@ -58,7 +58,7 @@ class ProfileService:
         ...
 ```
 
-The default key is derived from the method module, qualified name, positional arguments, and sorted keyword arguments. Explicit `key` values are Python format strings evaluated against method call arguments. Backend failures are not swallowed; cache errors propagate loudly.
+The default key is derived from the method module, qualified name, positional arguments, and sorted keyword arguments. Explicit `key` values are Python format strings evaluated against method call arguments. Invalid key formatting raises `CacheKeyGenerationError`. Backend failures are not swallowed; cache errors propagate loudly.
 
 `@cache_evict()` deletes the matching entry only after the annotated method succeeds. Failed method calls leave existing entries untouched so a failed refresh does not erase the last known cached value.
 

--- a/docs/error-hierarchy.md
+++ b/docs/error-hierarchy.md
@@ -47,6 +47,10 @@ flowchart TD
   AbstractSpakkySagaError --> SagaEngineNotConnectedError
 
   AbstractSpakkyCacheError --> InvalidCacheTTLError
+  AbstractSpakkyCacheError --> CacheKeyGenerationError
+  AbstractSpakkyCacheError --> AbstractSpakkyRedisError
+  AbstractSpakkyRedisError --> RedisCacheOperationError
+  AbstractSpakkyRedisError --> RedisCacheSerializationError
 
   AbstractSpakkySqlAlchemyError --> AbstractSpakkySqlAlchemyORMError
   AbstractSpakkySqlAlchemyError --> AbstractSpakkySqlAlchemyPersistencyError
@@ -257,13 +261,15 @@ from spakky.task.error import (
 ```python
 from spakky.cache.error import (
     AbstractSpakkyCacheError,
+    CacheKeyGenerationError,
     InvalidCacheTTLError,
 )
 ```
 
-| 에러                   | 설명                     |
-| ---------------------- | ------------------------ |
-| `InvalidCacheTTLError` | 0 이하 TTL 값 지정 시도 |
+| 에러                      | 설명                           |
+| ------------------------- | ------------------------------ |
+| `InvalidCacheTTLError`    | 0 이하 TTL 값 지정 시도        |
+| `CacheKeyGenerationError` | cache annotation key 생성 실패 |
 
 ---
 
@@ -450,6 +456,24 @@ from spakky.plugins.logging.error import (
 | ---------------------------- | ---------------------------- |
 | `AbstractSpakkyLoggingError` | 로깅 에러 기반 클래스        |
 | `UnknownLogFormatError`      | 인식할 수 없는 로그 포맷     |
+
+### spakky-redis
+
+Redis cache backend 관련 에러입니다.
+
+```python
+from spakky.plugins.redis.error import (
+    AbstractSpakkyRedisError,
+    RedisCacheOperationError,
+    RedisCacheSerializationError,
+)
+```
+
+| 에러                           | 설명                                 |
+| ------------------------------ | ------------------------------------ |
+| `AbstractSpakkyRedisError`     | Redis cache backend 에러 기반 클래스 |
+| `RedisCacheOperationError`     | Redis 명령 실행 또는 응답 변환 실패  |
+| `RedisCacheSerializationError` | cache 값 직렬화 또는 역직렬화 실패   |
 
 ### spakky-saga
 

--- a/docs/guides/cache.md
+++ b/docs/guides/cache.md
@@ -45,7 +45,7 @@ class ProfileService:
         ...
 ```
 
-The default key is deterministic for the method module, qualified name, positional arguments, and sorted keyword arguments. Explicit `key` values are Python format strings evaluated against call arguments.
+The default key is deterministic for the method module, qualified name, positional arguments, and sorted keyword arguments. Explicit `key` values are Python format strings evaluated against call arguments. Invalid key formatting raises `CacheKeyGenerationError`.
 
 `@cacheable()` reads the cache before invoking the method and stores the result on a miss. `@cache_evict()` deletes the matching entry only after the annotated method succeeds. Backend failures propagate as Spakky cache errors and are not silently converted to misses.
 
@@ -62,7 +62,7 @@ cache = RedisCache[str]()
 cache.set("profile:42", "Ada", ttl=timedelta(minutes=5))
 ```
 
-`RedisCacheConfig` reads `SPAKKY_REDIS__HOST`, `SPAKKY_REDIS__PORT`, `SPAKKY_REDIS__DB`, `SPAKKY_REDIS__USERNAME`, `SPAKKY_REDIS__PASSWORD`, `SPAKKY_REDIS__USE_SSL`, and `SPAKKY_REDIS__KEY_PREFIX`. `clear()` and `clear_async()` delete only keys under the configured prefix.
+`RedisCacheConfig` reads `SPAKKY_REDIS__HOST`, `SPAKKY_REDIS__PORT`, `SPAKKY_REDIS__DB`, `SPAKKY_REDIS__USERNAME`, `SPAKKY_REDIS__PASSWORD`, `SPAKKY_REDIS__USE_SSL`, `SPAKKY_REDIS__KEY_PREFIX`, and `SPAKKY_REDIS__SOCKET_TIMEOUT`. `clear()` and `clear_async()` delete only keys under the configured prefix.
 
 ## Non-goals
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -279,6 +279,7 @@ flowchart LR
     domain --> core[spakky]
     task[spakky-task] --> core
     tracing_dep --> core
+    cache[spakky-cache] --> core
     saga[spakky-saga] --> domain
     saga --> core
   end
@@ -301,4 +302,5 @@ flowchart LR
   opentelemetry -. logging .-> logging
   grpc -. gRPC .-> core
   grpc -- tracing --> tracing_dep
+  redis -. Redis .-> cache
 ```

--- a/plugins/spakky-redis/README.md
+++ b/plugins/spakky-redis/README.md
@@ -45,6 +45,7 @@ if isinstance(result, CacheHit):
 | `SPAKKY_REDIS__PASSWORD` | unset |
 | `SPAKKY_REDIS__USE_SSL` | `false` |
 | `SPAKKY_REDIS__KEY_PREFIX` | `spakky:cache:` |
+| `SPAKKY_REDIS__SOCKET_TIMEOUT` | `5.0` |
 
 ## Async Usage
 


### PR DESCRIPTION
## Summary
- sync cache and Redis docs after milestone 13 implementation
- document cache key generation errors, Redis socket timeout, and Redis/cache dependency edges
- update error hierarchy and docs index diagrams

## Verification
- uv run --project . --group dev mkdocs build --strict
- pre-commit monorepo-pre-commit
- pre-push monorepo-pre-push-tests