### PR TITLE
feat(di): add ambiguity diagnostics (#174)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -276,8 +276,15 @@ class UserService:
 
 1. `__type_cache`에서 타입으로 후보 조회 (O(1))
 2. 후보가 1개 → 즉시 반환
-3. 복수 → Qualifier → name → `@Primary` 순으로 필터링
-4. 여전히 모호 → `NoUniquePodError`
+3. 복수 → Qualifier → 명시 name → 설정 binding → `@Primary` → legacy parameter name 순으로 필터링
+4. 여전히 모호 → 후보 Pod와 해결 힌트가 포함된 `NoUniquePodError`
+
+`contains(type_)`는 타입 후보 존재 여부만 나타냅니다. 후보가 둘 이상이고
+단수 resolution이 모호해도 후보가 등록되어 있으면 `True`이며, 실제 단수
+선택 가능성은 `get(type_)` 또는 의존성 주입 시점에 판정합니다.
+
+`NoUniquePodError`는 요청 타입, 후보 Pod name/type, `@Primary` 여부,
+dependency path, 해결 힌트를 구조화된 diagnostic으로 제공합니다.
 
 **인스턴스화 시 순환 참조 감지:**
 

--- a/core/spakky/src/spakky/core/application/application_context.py
+++ b/core/spakky/src/spakky/core/application/application_context.py
@@ -30,6 +30,7 @@ from spakky.core.pod.annotations.pod import (
 from spakky.core.pod.annotations.qualifier import Qualifier
 from spakky.core.pod.annotations.tag import Tag
 from spakky.core.pod.diagnostics import (
+    PodCandidateDiagnostic,
     PodDependencyPathNode,
     PodDependencyResolutionDiagnostic,
 )
@@ -181,6 +182,8 @@ class ApplicationContext(IApplicationContext):
         dependency_parameter_name: str | None,
         requested_type: object | None,
         dependency_path: tuple[PodDependencyPathNode, ...],
+        candidates: tuple[PodCandidateDiagnostic, ...] = (),
+        resolution_hints: tuple[str, ...] = (),
     ) -> PodDependencyResolutionDiagnostic:
         """Build structured diagnostics from the active Pod dependency path."""
         requested_type_name = (
@@ -192,6 +195,57 @@ class ApplicationContext(IApplicationContext):
             dependency_parameter_name=dependency_parameter_name,
             requested_type_name=requested_type_name,
             path=dependency_path,
+            candidates=candidates,
+            resolution_hints=resolution_hints,
+        )
+
+    def __candidate_diagnostics(
+        self,
+        pods: set[Pod],
+    ) -> tuple[PodCandidateDiagnostic, ...]:
+        """Return stable ambiguity diagnostics for candidate Pods."""
+        return tuple(
+            PodCandidateDiagnostic(
+                pod_name=pod.name,
+                pod_type_name=self.__type_name(pod.type_),
+                is_primary=pod.is_primary,
+            )
+            for pod in sorted(pods, key=lambda candidate: candidate.name)
+        )
+
+    def __ambiguity_hints(
+        self, dependency_parameter_name: str | None
+    ) -> tuple[str, ...]:
+        """Return resolution hints for a single dependency ambiguity."""
+        hints = (
+            "add Annotated[T, Qualifier(...)] to select one candidate",
+            "mark exactly one candidate with @Primary",
+        )
+        if dependency_parameter_name is None:
+            return hints + ("call get(type_, name=...) for an explicit Pod name",)
+        return hints + (
+            "rename the dependency parameter to one candidate Pod name as legacy fallback",
+        )
+
+    def __ambiguity_diagnostic(
+        self,
+        requester_pod: Pod | None,
+        dependency_parameter_name: str | None,
+        requested_type: type,
+        dependency_path: tuple[PodDependencyPathNode, ...],
+        candidates: tuple[PodCandidateDiagnostic, ...],
+        resolution_hints: tuple[str, ...],
+    ) -> PodDependencyResolutionDiagnostic | None:
+        """Build dependency diagnostics when ambiguity occurs during injection."""
+        if requester_pod is None:
+            return None
+        return self.__dependency_diagnostic(
+            pod=requester_pod,
+            dependency_parameter_name=dependency_parameter_name,
+            requested_type=requested_type,
+            dependency_path=dependency_path,
+            candidates=candidates,
+            resolution_hints=resolution_hints,
         )
 
     def __resolve_candidate(
@@ -199,6 +253,9 @@ class ApplicationContext(IApplicationContext):
         type_: type,
         name: str | None,
         qualifiers: list[Qualifier],
+        name_is_dependency_parameter: bool,
+        requester_pod: Pod | None,
+        dependency_path: tuple[PodDependencyPathNode, ...],
     ) -> Pod | None:
         """Resolve a Pod candidate matching type, name, and qualifiers.
 
@@ -214,13 +271,6 @@ class ApplicationContext(IApplicationContext):
             NoUniquePodError: If multiple Pods match without clear qualification.
         """
 
-        def qualify_pod(pod: Pod) -> bool:
-            if any(qualifiers):
-                return all(qualifier.selector(pod) for qualifier in qualifiers)
-            if name is not None:
-                return pod.name == name
-            return pod.is_primary
-
         # Use type index for O(1) lookup instead of O(n) iteration
         pods = self.__type_cache.get(type_, set()).copy()
         if not pods:
@@ -230,13 +280,79 @@ class ApplicationContext(IApplicationContext):
         if len(pods) == 1:
             return next(iter(pods))
 
-        # Multiple candidates: filter by qualifier/name/primary
-        qualified = {pod for pod in pods if qualify_pod(pod)}
-        if len(qualified) == 1:
-            return qualified.pop()
-        if not qualified:
-            return None
-        raise NoUniquePodError(type_, [p.name for p in qualified])
+        if qualifiers:
+            qualified = {
+                pod
+                for pod in pods
+                if all(qualifier.selector(pod) for qualifier in qualifiers)
+            }
+            if len(qualified) == 1:
+                return qualified.pop()
+            if not qualified:
+                return None
+            candidates = self.__candidate_diagnostics(qualified)
+            resolution_hints = self.__ambiguity_hints(None)
+            raise NoUniquePodError(
+                type_,
+                candidates,
+                self.__ambiguity_diagnostic(
+                    requester_pod=requester_pod,
+                    dependency_parameter_name=name,
+                    requested_type=type_,
+                    dependency_path=dependency_path,
+                    candidates=candidates,
+                    resolution_hints=resolution_hints,
+                ),
+                resolution_hints,
+            )
+
+        if name is not None and not name_is_dependency_parameter:
+            named = {pod for pod in pods if pod.name == name}
+            if len(named) == 1:
+                return named.pop()
+            if not named:
+                return None
+
+        primary = {pod for pod in pods if pod.is_primary}
+        if len(primary) == 1:
+            return primary.pop()
+        if len(primary) > 1:
+            candidates = self.__candidate_diagnostics(primary)
+            resolution_hints = self.__ambiguity_hints(name)
+            raise NoUniquePodError(
+                type_,
+                candidates,
+                self.__ambiguity_diagnostic(
+                    requester_pod=requester_pod,
+                    dependency_parameter_name=name,
+                    requested_type=type_,
+                    dependency_path=dependency_path,
+                    candidates=candidates,
+                    resolution_hints=resolution_hints,
+                ),
+                resolution_hints,
+            )
+
+        if name is not None and name_is_dependency_parameter:
+            legacy_named = {pod for pod in pods if pod.name == name}
+            if len(legacy_named) == 1:
+                return legacy_named.pop()
+
+        candidates = self.__candidate_diagnostics(pods)
+        resolution_hints = self.__ambiguity_hints(name)
+        raise NoUniquePodError(
+            type_,
+            candidates,
+            self.__ambiguity_diagnostic(
+                requester_pod=requester_pod,
+                dependency_parameter_name=name,
+                requested_type=type_,
+                dependency_path=dependency_path,
+                candidates=candidates,
+                resolution_hints=resolution_hints,
+            ),
+            resolution_hints,
+        )
 
     def __instantiate_pod(
         self,
@@ -295,6 +411,8 @@ class ApplicationContext(IApplicationContext):
                 dependency_hierarchy=new_hierarchy,
                 dependency_path=current_path,
                 qualifiers=dependency.qualifiers,
+                name_is_dependency_parameter=True,
+                requester_pod=pod,
             )
             if (
                 resolved_dependency is None
@@ -437,6 +555,8 @@ class ApplicationContext(IApplicationContext):
         dependency_hierarchy: tuple[type, ...] | None = None,
         dependency_path: tuple[PodDependencyPathNode, ...] | None = None,
         qualifiers: list[Qualifier] | None = None,
+        name_is_dependency_parameter: bool = False,
+        requester_pod: Pod | None = None,
     ) -> ObjectT | None:
         """Internal method to get or create a Pod instance.
 
@@ -469,7 +589,14 @@ class ApplicationContext(IApplicationContext):
                 type_
             ]  # pragma: no cover - coverage boundary
 
-        pod = self.__resolve_candidate(type_=type_, name=name, qualifiers=qualifiers)
+        pod = self.__resolve_candidate(
+            type_=type_,
+            name=name,
+            qualifiers=qualifiers,
+            name_is_dependency_parameter=name_is_dependency_parameter,
+            requester_pod=requester_pod,
+            dependency_path=dependency_path,
+        )
         if pod is None:
             return None
 

--- a/core/spakky/src/spakky/core/pod/diagnostics.py
+++ b/core/spakky/src/spakky/core/pod/diagnostics.py
@@ -4,6 +4,20 @@ from spakky.core.common.mutability import immutable
 
 
 @immutable
+class PodCandidateDiagnostic:
+    """One candidate Pod observed during dependency resolution."""
+
+    pod_name: str
+    """Registered Pod name for the candidate."""
+
+    pod_type_name: str
+    """Registered Pod type name for the candidate."""
+
+    is_primary: bool
+    """Whether the candidate is marked with @Primary."""
+
+
+@immutable
 class PodDependencyPathNode:
     """One Pod dependency graph edge observed during resolution."""
 
@@ -39,6 +53,12 @@ class PodDependencyResolutionDiagnostic:
     path: tuple[PodDependencyPathNode, ...]
     """Dependency path from the root Pod to the failure point."""
 
+    candidates: tuple[PodCandidateDiagnostic, ...] = ()
+    """Candidate Pods involved in an ambiguity, when applicable."""
+
+    resolution_hints: tuple[str, ...] = ()
+    """Stable human-readable actions that can resolve the failure."""
+
     def as_detail_pairs(self) -> tuple[tuple[str, str], ...]:
         """Return stable key/value details for report adapters."""
         path_value = " -> ".join(
@@ -56,8 +76,21 @@ class PodDependencyResolutionDiagnostic:
             ("dependency_path", path_value),
         )
         if self.dependency_parameter_name is None:
-            return details
-        return details + (
-            ("dependency_parameter", self.dependency_parameter_name),
-            ("requested_type", self.requested_type_name or ""),
+            dependency_details = details
+        else:
+            dependency_details = details + (
+                ("dependency_parameter", self.dependency_parameter_name),
+                ("requested_type", self.requested_type_name or ""),
+            )
+        if not self.candidates:
+            return dependency_details
+        candidate_value = ", ".join(
+            f"{candidate.pod_name}:{candidate.pod_type_name}"
+            f":primary={candidate.is_primary}"
+            for candidate in self.candidates
+        )
+        hint_value = "; ".join(self.resolution_hints)
+        return dependency_details + (
+            ("candidates", candidate_value),
+            ("resolution_hints", hint_value),
         )

--- a/core/spakky/src/spakky/core/pod/interfaces/container.py
+++ b/core/spakky/src/spakky/core/pod/interfaces/container.py
@@ -10,7 +10,10 @@ from typing import Callable, overload
 from spakky.core.common.interfaces.representable import IRepresentable
 from spakky.core.common.types import ObjectT
 from spakky.core.pod.annotations.pod import Pod, PodType
-from spakky.core.pod.diagnostics import PodDependencyResolutionDiagnostic
+from spakky.core.pod.diagnostics import (
+    PodCandidateDiagnostic,
+    PodDependencyResolutionDiagnostic,
+)
 from spakky.core.pod.error import AbstractSpakkyPodError
 
 
@@ -70,6 +73,41 @@ class NoUniquePodError(AbstractSpakkyPodError):
     """Raised when multiple Pods match criteria without clear qualification."""
 
     message = "No unique pod found; multiple candidates exist"
+    requested_type: type
+    candidates: tuple[PodCandidateDiagnostic, ...]
+    dependency_diagnostic: PodDependencyResolutionDiagnostic | None
+    resolution_hints: tuple[str, ...]
+
+    def __init__(
+        self,
+        requested_type: type,
+        candidates: tuple[PodCandidateDiagnostic, ...],
+        dependency_diagnostic: PodDependencyResolutionDiagnostic | None = None,
+        resolution_hints: tuple[str, ...] = (),
+    ) -> None:
+        """Initialize ambiguity details.
+
+        Args:
+            requested_type: Dependency type requested by the caller.
+            candidates: Candidate Pods that matched the requested type.
+            dependency_diagnostic: Optional structured dependency path.
+            resolution_hints: Actions that can make the selection explicit.
+        """
+        self.requested_type = requested_type
+        self.candidates = candidates
+        self.dependency_diagnostic = dependency_diagnostic
+        self.resolution_hints = resolution_hints
+        candidate_names = ", ".join(candidate.pod_name for candidate in candidates)
+        super().__init__(
+            "\n".join(
+                (
+                    self.message,
+                    "Requested type: " + requested_type.__name__,
+                    "Candidates: " + candidate_names,
+                    "Resolution: " + "; ".join(resolution_hints),
+                )
+            )
+        )
 
 
 class CannotRegisterNonPodObjectError(AbstractSpakkyPodError):

--- a/core/spakky/tests/application/test_application_context.py
+++ b/core/spakky/tests/application/test_application_context.py
@@ -301,6 +301,166 @@ def test_application_context_get_primary_expect_no_unique_error() -> None:
         context.get(type_=ISamplePod)
 
 
+def test_application_context_get_multiple_unqualified_candidates_expect_ambiguity_diagnostic() -> (
+    None
+):
+    """단수 조회 후보가 여러 개이고 선택 정책이 없으면 후보 진단이 포함된 ambiguity error가 발생함을 검증한다."""
+
+    class ISamplePod:
+        @abstractmethod
+        def do(self) -> str: ...
+
+    @Pod(name="first")
+    class FirstSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "first"
+
+    @Pod(name="second")
+    class SecondSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "second"
+
+    context: ApplicationContext = ApplicationContext()
+    context.add(FirstSamplePod)
+    context.add(SecondSamplePod)
+
+    with pytest.raises(NoUniquePodError) as error:
+        context.get(type_=ISamplePod)
+
+    assert [candidate.pod_name for candidate in error.value.candidates] == [
+        "first",
+        "second",
+    ]
+    assert "add Annotated[T, Qualifier(...)]" in error.value.resolution_hints[0]
+    assert error.value.dependency_diagnostic is None
+    assert context.contains(type_=ISamplePod) is True
+
+
+def test_application_context_start_with_ambiguous_dependency_expect_dependency_diagnostic() -> (
+    None
+):
+    """단수 의존성 후보가 모호하면 dependency path와 후보 목록이 포함된 ambiguity error가 발생함을 검증한다."""
+
+    class ISamplePod:
+        @abstractmethod
+        def do(self) -> str: ...
+
+    @Pod(name="first")
+    class FirstSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "first"
+
+    @Pod(name="second")
+    class SecondSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "second"
+
+    @Pod()
+    class SampleService:
+        def __init__(self, pod: ISamplePod) -> None:
+            self.pod = pod
+
+    context: ApplicationContext = ApplicationContext()
+    context.add(FirstSamplePod)
+    context.add(SecondSamplePod)
+    context.add(SampleService)
+
+    with pytest.raises(NoUniquePodError) as error:
+        context.start()
+
+    diagnostic = error.value.dependency_diagnostic
+    assert diagnostic is not None
+    assert diagnostic.failed_pod_name == "sample_service"
+    assert diagnostic.dependency_parameter_name == "pod"
+    assert diagnostic.requested_type_name == "ISamplePod"
+    assert [candidate.pod_name for candidate in diagnostic.candidates] == [
+        "first",
+        "second",
+    ]
+    assert ("dependency_parameter", "pod") in diagnostic.as_detail_pairs()
+    assert any(key == "candidates" for key, _value in diagnostic.as_detail_pairs())
+
+
+def test_application_context_get_multiple_primary_candidates_expect_primary_diagnostic() -> (
+    None
+):
+    """Primary 후보가 둘 이상이면 primary 후보만 포함한 ambiguity diagnostic이 발생함을 검증한다."""
+
+    class ISamplePod:
+        @abstractmethod
+        def do(self) -> str: ...
+
+    @Primary()
+    @Pod(name="first")
+    class FirstSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "first"
+
+    @Primary()
+    @Pod(name="second")
+    class SecondSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "second"
+
+    @Pod(name="third")
+    class ThirdSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "third"
+
+    context: ApplicationContext = ApplicationContext()
+    context.add(FirstSamplePod)
+    context.add(SecondSamplePod)
+    context.add(ThirdSamplePod)
+
+    with pytest.raises(NoUniquePodError) as error:
+        context.get(type_=ISamplePod)
+
+    assert [candidate.pod_name for candidate in error.value.candidates] == [
+        "first",
+        "second",
+    ]
+    assert all(candidate.is_primary for candidate in error.value.candidates)
+
+
+def test_application_context_primary_precedes_legacy_parameter_name_expect_primary_injected() -> (
+    None
+):
+    """Primary가 legacy parameter name 자동 매칭보다 높은 우선순위로 주입됨을 검증한다."""
+
+    class ISamplePod:
+        @abstractmethod
+        def do(self) -> str: ...
+
+    @Pod(name="pod")
+    class ParameterNamedSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "parameter"
+
+    @Primary()
+    @Pod(name="primary")
+    class PrimarySamplePod(ISamplePod):
+        def do(self) -> str:
+            return "primary"
+
+    @Pod()
+    class SampleService:
+        __pod: ISamplePod
+
+        def __init__(self, pod: ISamplePod) -> None:
+            self.__pod = pod
+
+        def do(self) -> str:
+            return self.__pod.do()
+
+    context: ApplicationContext = ApplicationContext()
+    context.add(ParameterNamedSamplePod)
+    context.add(PrimarySamplePod)
+    context.add(SampleService)
+    context.start()
+
+    assert context.get(type_=SampleService).do() == "primary"
+
+
 def test_application_context_get_dependency_recursive_by_type() -> None:
     """의존성이 있는 Pod가 재귀적으로 주입됨을 검증한다."""
 

--- a/docs/di-container.md
+++ b/docs/di-container.md
@@ -157,11 +157,13 @@ class NotificationService:
 
 ## 의존성 해결 우선순위
 
-동일 타입의 여러 Pod가 있을 때, 다음 순서로 해결됩니다:
+단수 의존성 또는 `get(type_)` 조회에서 동일 타입의 여러 Pod 후보가 있으면
+컨테이너는 다음 순서로 정확히 하나의 후보를 선택합니다.
 
 ### 1. Qualifier로 명시적 지정
 
-`Annotated`와 `Qualifier`를 사용하여 이름으로 특정 Pod를 지정합니다.
+`Annotated`와 `Qualifier`를 사용하여 특정 Pod를 지정합니다. Qualifier는
+가장 높은 우선순위의 명시 선택 정책입니다.
 
 ```python
 from typing import Annotated
@@ -184,7 +186,19 @@ class UserService:
         self.repository = repository
 ```
 
-### 2. Primary 지정
+### 2. 명시 name 조회
+
+`context.get(IUserRepository, name="cache")`처럼 호출자가 name을 명시하면
+해당 Pod name 후보를 선택합니다. 생성자 파라미터 이름 자동 매칭은
+하위 호환용 fallback이므로 이 단계에 포함되지 않습니다.
+
+### 3. 설정 기반 binding
+
+인터페이스별 binding policy는 DI multi-implementation 마일스톤의 후속
+작업에서 추가됩니다. 추가 후에는 Qualifier/name보다 낮고 `@Primary`보다
+높은 우선순위로 동작합니다.
+
+### 4. Primary 지정
 
 `@Primary`로 기본 선택 대상을 지정합니다.
 
@@ -207,25 +221,46 @@ class UserService:
         self.repository = repository  # DefaultUserRepository
 ```
 
-### 3. 단일 후보
+`@Primary` 후보가 둘 이상이면 컨테이너는 임의로 선택하지 않고
+`NoUniquePodError`를 발생시킵니다.
+
+### 5. Legacy parameter name 자동 매칭
+
+생성자 또는 factory 함수 파라미터 이름이 Pod name과 일치하면 해당 후보를
+선택합니다. 이 동작은 기존 편의를 유지하기 위한 fallback이며, Qualifier,
+명시 name, binding, `@Primary`보다 낮은 우선순위입니다.
+
+### 6. 단일 후보
 
 타입에 해당하는 Pod가 하나뿐이면 자동 선택됩니다.
 
-### 4. 해결 실패
+### 7. 해결 실패
 
 - `NoSuchPodError` — 해당 타입의 Pod가 없음
 - `NoUniquePodError` — 여러 후보가 있으나 구분 불가
 
+`NoUniquePodError`는 요청 타입, 후보 Pod name/type, `@Primary` 여부,
+dependency path, 해결 힌트를 구조화된 diagnostic으로 제공합니다.
+
+### `contains(type_)` 의미
+
+`contains(type_)`는 후보 존재 여부만 확인합니다. 후보가 둘 이상이라 단수
+resolution이 모호해도, 해당 타입 후보가 하나 이상 등록되어 있으면 `True`를
+반환합니다. 실제 단수 선택 가능성은 `get(type_)` 또는 의존성 주입 시점에
+위 우선순위로 판정됩니다.
+
 ---
 
-## 순환 참조 감지
+## Dependency diagnostic
 
-누락되거나 순환된 의존성은 기존 예외 의미를 유지하면서 구조화된
+누락, 순환 참조, ambiguity는 기존 예외 의미를 유지하면서 구조화된
 dependency diagnostic을 함께 제공합니다. 이 진단은 별도 graph cache가
 아니라 등록된 `Pod.dependencies` 메타데이터에서 실패 Pod, 파라미터,
-요청 타입, 의존성 경로를 구성합니다. Adapter는
+요청 타입, 의존성 경로, 후보 Pod, 해결 힌트를 구성합니다. Adapter는
 `dependency_diagnostic.as_detail_pairs()`로 안정적인 key/value 형태를 얻을
 수 있습니다.
+
+## 순환 참조 감지
 
 컨테이너는 의존성 체인에서 순환 참조를 감지합니다.
 

--- a/docs/planning/di-multi-implementation-resolution.md
+++ b/docs/planning/di-multi-implementation-resolution.md
@@ -38,26 +38,26 @@ Agent runtime 논의에서 이 문제가 명확히 드러났다. 예를 들어 `
 
 ### US-1: 복수 구현체를 설치해도 애플리케이션이 예측 가능하게 시작된다
 
-Given 사용자가 같은 interface를 구현하는 여러 plugin을 설치했다.  
-When 애플리케이션이 `load_plugins().scan().start()` 순서로 시작된다.  
+Given 사용자가 같은 interface를 구현하는 여러 plugin을 설치했다.
+When 애플리케이션이 `load_plugins().scan().start()` 순서로 시작된다.
 Then DI 컨테이너는 명시 선택이 있으면 해당 구현체를 주입하고, 없으면 후보와 해결 방법이 포함된 오류로 시작을 중단한다.
 
 ### US-2: 단수 구현체가 필요한 의존성은 명시적으로 하나만 선택된다
 
-Given `IRepository` 구현체가 둘 이상 등록되어 있다.  
-When 어떤 Pod가 `IRepository`를 단수로 주입받는다.  
+Given `IRepository` 구현체가 둘 이상 등록되어 있다.
+When 어떤 Pod가 `IRepository`를 단수로 주입받는다.
 Then `Qualifier`, 명시 name, 설정 binding, `@Primary`, 단일 후보 중 하나로 정확히 하나가 선택되어야 한다.
 
 ### US-3: 여러 구현체를 의도적으로 모두 받을 수 있다
 
-Given `IHealthContributor` 또는 `IAgentExecutionEngine` 구현체가 여러 개 등록되어 있다.  
-When 어떤 Pod가 collection 형태로 해당 구현체들을 주입받는다.  
+Given `IHealthContributor` 또는 `IAgentExecutionEngine` 구현체가 여러 개 등록되어 있다.
+When 어떤 Pod가 collection 형태로 해당 구현체들을 주입받는다.
 Then 컨테이너는 후보 전체를 안정적인 순서와 이름으로 제공한다.
 
 ### US-4: 플러그인 adapter 선택은 설치 여부가 아니라 binding policy로 결정된다
 
-Given `spakky-langgraph`와 `spakky-pydantic-ai`가 모두 설치되어 있다.  
-When 어떤 agent definition이 `engine="langgraph"`를 지정하거나 application config가 default engine을 지정한다.  
+Given `spakky-langgraph`와 `spakky-pydantic-ai`가 모두 설치되어 있다.
+When 어떤 agent definition이 `engine="langgraph"`를 지정하거나 application config가 default engine을 지정한다.
 Then 해당 이름의 execution engine이 선택된다.
 
 ## 4. 기능 요구사항
@@ -165,7 +165,7 @@ Agent 마일스톤과의 상호작용:
 
 ### T1. DI resolution semantics 확정 및 오류 진단 설계
 
-담당 요구사항: FR-1, FR-2, FR-7, FR-8  
+담당 요구사항: FR-1, FR-2, FR-7, FR-8
 산출물:
 
 - 단수/복수 resolution decision table
@@ -177,7 +177,7 @@ Agent 마일스톤과의 상호작용:
 
 ### T2. Collection injection 타입 파싱
 
-담당 요구사항: FR-4  
+담당 요구사항: FR-4
 산출물:
 
 - `list[T]`, `tuple[T, ...]`, `dict[str, T]` dependency type parsing
@@ -188,7 +188,7 @@ Agent 마일스톤과의 상호작용:
 
 ### T3. ApplicationContext candidate resolution 리팩터링
 
-담당 요구사항: FR-1, FR-2, FR-3, FR-4, FR-5  
+담당 요구사항: FR-1, FR-2, FR-3, FR-4, FR-5
 산출물:
 
 - single resolution path
@@ -200,7 +200,7 @@ Agent 마일스톤과의 상호작용:
 
 ### T4. Binding policy API 설계 및 구현
 
-담당 요구사항: FR-6  
+담당 요구사항: FR-6
 산출물:
 
 - interface-to-implementation binding 값 객체 또는 annotation
@@ -211,7 +211,7 @@ Agent 마일스톤과의 상호작용:
 
 ### T5. Regression and conformance tests
 
-담당 요구사항: 전체 FR/SC  
+담당 요구사항: 전체 FR/SC
 산출물:
 
 - 단수 ambiguity tests
@@ -224,7 +224,7 @@ Agent 마일스톤과의 상호작용:
 
 ### T6. 문서 동기화
 
-담당 요구사항: FR-8, FR-10  
+담당 요구사항: FR-8, FR-10
 산출물:
 
 - `docs/di-container.md` 업데이트


### PR DESCRIPTION
## Summary

- Defines structured candidate diagnostics for DI ambiguity errors.
- Updates single-candidate resolution semantics so ambiguous unqualified injections fail with `NoUniquePodError` instead of falling through as missing dependencies.
- Documents the decision table, `contains(type_)` semantics, and ambiguity diagnostics.

Closes #174

## Verification

- `uv run --project ../.. python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- `rg -n "from spakky\.(domain|data|event|outbox|task|tracing|saga|cache|actuator)|import spakky\.(domain|data|event|outbox|task|tracing|saga|cache|actuator)" src tests`
- `uv run --project ../.. --with-editable . ruff check .`
- `uv run --project ../.. --with-editable . pyrefly check src tests`
- `uv run --project ../.. --with-editable . pytest`
- `uv run --project ../.. python ../../scripts/run_coverage.py --package spakky`
