### PR TITLE
feat(core): add DI binding policy API (#177)

### DIFF
--- a/core/spakky/README.md
+++ b/core/spakky/README.md
@@ -142,11 +142,13 @@ class ContextScopedService:
     pass
 ```
 
-## Qualifier
+## Qualifier, Primary, Binding
 
 ```python
+from spakky.core.application.application_context import ApplicationContext
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.annotations.primary import Primary
+from spakky.core.pod.binding import PodBinding
 
 # 이름 기반 qualifier
 @Pod(name="mysql")
@@ -162,6 +164,15 @@ class PostgresRepository(IRepository):
 @Pod()
 class DefaultRepository(IRepository):
     pass
+
+# application config 기반 binding: Primary보다 우선
+context = ApplicationContext()
+context.bind(PodBinding(interface=IRepository, implementation_name="postgres"))
+context.add(MySQLRepository)
+context.add(PostgresRepository)
+context.add(DefaultRepository)
+
+repository = context.get(IRepository)  # PostgresRepository
 ```
 
 ## Stereotype

--- a/core/spakky/src/spakky/core/application/application_context.py
+++ b/core/spakky/src/spakky/core/application/application_context.py
@@ -29,6 +29,7 @@ from spakky.core.pod.annotations.pod import (
 )
 from spakky.core.pod.annotations.qualifier import Qualifier
 from spakky.core.pod.annotations.tag import Tag
+from spakky.core.pod.binding import PodBinding
 from spakky.core.pod.diagnostics import (
     PodCandidateDiagnostic,
     PodDependencyPathNode,
@@ -44,7 +45,9 @@ from spakky.core.pod.interfaces.application_context import (
 from spakky.core.pod.interfaces.container import (
     CannotRegisterNonPodObjectError,
     CircularDependencyGraphDetectedError,
+    InvalidPodBindingError,
     NoSuchPodError,
+    NoSuchPodBindingTargetError,
     NoUniquePodError,
     PodNameAlreadyExistsError,
 )
@@ -103,6 +106,9 @@ class ApplicationContext(IApplicationContext):
     __type_cache: dict[type, set[Pod]]
     """Cache mapping types to Pods for O(1) lookup."""
 
+    __bindings: dict[type, PodBinding]
+    """Explicit interface-to-implementation binding policies."""
+
     __forward_type_map: dict[str, type]
     """Map for resolving forward reference types."""
 
@@ -139,6 +145,7 @@ class ApplicationContext(IApplicationContext):
         self.__pods = {}
         self.__tags = set()
         self.__type_cache = {}
+        self.__bindings = {}
         self.__singleton_cache = {}
         self.__singleton_lock = RLock()
         self.__shutdown_lock = RLock()
@@ -219,6 +226,7 @@ class ApplicationContext(IApplicationContext):
         """Return resolution hints for a single dependency ambiguity."""
         hints = (
             "add Annotated[T, Qualifier(...)] to select one candidate",
+            "register ApplicationContext.bind(PodBinding(...)) from application config",
             "mark exactly one candidate with @Primary",
         )
         if dependency_parameter_name is None:
@@ -248,6 +256,39 @@ class ApplicationContext(IApplicationContext):
             resolution_hints=resolution_hints,
         )
 
+    def __binding_target_count(self, binding: PodBinding) -> int:
+        """Return how many target selectors a binding specifies."""
+        count = 0
+        if binding.implementation_type is not None:
+            count += 1
+        if binding.implementation_name is not None:
+            count += 1
+        return count
+
+    def __validate_binding(self, binding: PodBinding) -> None:
+        """Validate binding shape without requiring Pods to be registered yet."""
+        if self.__binding_target_count(binding) != 1:
+            raise InvalidPodBindingError
+
+    def __resolve_binding_candidate(
+        self,
+        type_: type,
+        pods: set[Pod],
+    ) -> Pod | None:
+        """Resolve an explicit binding for this requested type, when configured."""
+        binding = self.__bindings.get(type_)
+        if binding is None:
+            return None
+        if binding.implementation_name is not None:
+            named = {pod for pod in pods if pod.name == binding.implementation_name}
+            if len(named) == 1:
+                return named.pop()
+            raise NoSuchPodBindingTargetError(binding)
+        typed = {pod for pod in pods if pod.type_ == binding.implementation_type}
+        if len(typed) == 1:
+            return typed.pop()
+        raise NoSuchPodBindingTargetError(binding)
+
     def __resolve_candidate(
         self,
         type_: type,
@@ -275,10 +316,6 @@ class ApplicationContext(IApplicationContext):
         pods = self.__type_cache.get(type_, set()).copy()
         if not pods:
             return None
-
-        # Fast path: single candidate - no need to filter
-        if len(pods) == 1:
-            return next(iter(pods))
 
         if qualifiers:
             qualified = {
@@ -312,6 +349,13 @@ class ApplicationContext(IApplicationContext):
                 return named.pop()
             if not named:
                 return None
+
+        if binding_candidate := self.__resolve_binding_candidate(type_, pods):
+            return binding_candidate
+
+        # Fast path after explicit selectors and binding policy are honored.
+        if len(pods) == 1:
+            return next(iter(pods))
 
         primary = {pod for pod in pods if pod.is_primary}
         if len(primary) == 1:
@@ -525,6 +569,7 @@ class ApplicationContext(IApplicationContext):
     def __clear_all(self) -> None:
         self.__pods.clear()
         self.__type_cache.clear()
+        self.__bindings.clear()
         self.__forward_type_map.clear()
         with self.__singleton_lock:
             self.__singleton_cache.clear()
@@ -787,6 +832,22 @@ class ApplicationContext(IApplicationContext):
             if base_type not in self.__type_cache:
                 self.__type_cache[base_type] = set()
             self.__type_cache[base_type].add(pod)
+
+    @override
+    def bind(self, binding: PodBinding) -> None:
+        """Register an explicit interface-to-implementation binding policy."""
+        self.__validate_binding(binding)
+        self.__bindings[binding.interface] = binding
+
+    @override
+    def bind_to_type(self, interface: type, implementation: type) -> None:
+        """Bind an interface to a concrete implementation type."""
+        self.bind(PodBinding(interface=interface, implementation_type=implementation))
+
+    @override
+    def bind_to_name(self, interface: type, name: str) -> None:
+        """Bind an interface to a registered Pod name."""
+        self.bind(PodBinding(interface=interface, implementation_name=name))
 
     @override
     def add_service(self, service: IService | IAsyncService) -> None:

--- a/core/spakky/src/spakky/core/pod/binding.py
+++ b/core/spakky/src/spakky/core/pod/binding.py
@@ -1,0 +1,22 @@
+"""Binding policy values for dependency injection candidate selection."""
+
+from spakky.core.common.mutability import immutable
+
+
+@immutable
+class PodBinding:
+    """Explicit interface-to-implementation binding policy.
+
+    Application or feature configuration can register this value with
+    ApplicationContext to select one implementation when multiple Pods provide
+    the same interface.
+    """
+
+    interface: type
+    """Requested interface or port type."""
+
+    implementation_type: type | None = None
+    """Concrete implementation type to select."""
+
+    implementation_name: str | None = None
+    """Registered Pod name to select."""

--- a/core/spakky/src/spakky/core/pod/interfaces/container.py
+++ b/core/spakky/src/spakky/core/pod/interfaces/container.py
@@ -10,6 +10,7 @@ from typing import Callable, overload
 from spakky.core.common.interfaces.representable import IRepresentable
 from spakky.core.common.types import ObjectT
 from spakky.core.pod.annotations.pod import Pod, PodType
+from spakky.core.pod.binding import PodBinding
 from spakky.core.pod.diagnostics import (
     PodCandidateDiagnostic,
     PodDependencyResolutionDiagnostic,
@@ -110,6 +111,31 @@ class NoUniquePodError(AbstractSpakkyPodError):
         )
 
 
+class InvalidPodBindingError(AbstractSpakkyPodError):
+    """Raised when a binding policy does not identify exactly one target kind."""
+
+    message = "Pod binding must specify exactly one implementation target"
+
+
+class NoSuchPodBindingTargetError(AbstractSpakkyPodError):
+    """Raised when an explicit binding does not match any candidate Pod."""
+
+    message = "Pod binding target does not match a registered candidate"
+
+    binding: PodBinding
+
+    def __init__(self, binding: PodBinding) -> None:
+        """Initialize binding target details."""
+        self.binding = binding
+        super().__init__(self.message)
+
+
+class PodBindingNotSupportedError(AbstractSpakkyPodError):
+    """Raised when a container does not implement explicit binding policies."""
+
+    message = "Pod binding policy is not supported by this container"
+
+
 class CannotRegisterNonPodObjectError(AbstractSpakkyPodError):
     """Raised when attempting to register object without @Pod annotation."""
 
@@ -143,6 +169,22 @@ class IContainer(ABC):
             obj: The Pod-annotated class or function to register.
         """
         ...
+
+    def bind(self, binding: PodBinding) -> None:
+        """Register an explicit interface-to-implementation binding policy.
+
+        Args:
+            binding: Binding value supplied by application or feature config.
+        """
+        raise PodBindingNotSupportedError
+
+    def bind_to_type(self, interface: type, implementation: type) -> None:
+        """Bind an interface to a concrete implementation type."""
+        raise PodBindingNotSupportedError
+
+    def bind_to_name(self, interface: type, name: str) -> None:
+        """Bind an interface to a registered Pod name."""
+        raise PodBindingNotSupportedError
 
     @overload
     @abstractmethod

--- a/core/spakky/tests/application/test_application_context.py
+++ b/core/spakky/tests/application/test_application_context.py
@@ -18,7 +18,12 @@ from spakky.core.pod.annotations.lazy import Lazy
 from spakky.core.pod.annotations.pod import Pod, PodInstantiationFailedError
 from spakky.core.pod.annotations.primary import Primary
 from spakky.core.pod.annotations.qualifier import Qualifier
-from spakky.core.pod.interfaces.container import CannotRegisterNonPodObjectError
+from spakky.core.pod.binding import PodBinding
+from spakky.core.pod.interfaces.container import (
+    CannotRegisterNonPodObjectError,
+    InvalidPodBindingError,
+    NoSuchPodBindingTargetError,
+)
 from spakky.core.pod.interfaces.post_processor import IPostProcessor
 
 
@@ -459,6 +464,234 @@ def test_application_context_primary_precedes_legacy_parameter_name_expect_prima
     context.start()
 
     assert context.get(type_=SampleService).do() == "primary"
+
+
+def test_application_context_binding_to_type_precedes_primary_expect_bound_type() -> (
+    None
+):
+    """설정 기반 type binding이 Primary보다 높은 우선순위로 주입됨을 검증한다."""
+
+    class ISamplePod:
+        @abstractmethod
+        def do(self) -> str: ...
+
+    @Primary()
+    @Pod(name="langgraph")
+    class LangGraphSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "langgraph"
+
+    @Pod(name="pydantic_ai")
+    class PydanticAiSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "pydantic-ai"
+
+    context: ApplicationContext = ApplicationContext()
+    context.bind_to_type(ISamplePod, PydanticAiSamplePod)
+    context.add(LangGraphSamplePod)
+    context.add(PydanticAiSamplePod)
+
+    assert context.get(type_=ISamplePod).do() == "pydantic-ai"
+
+
+def test_application_context_binding_to_name_precedes_legacy_parameter_name_expect_bound_name() -> (
+    None
+):
+    """설정 기반 name binding이 legacy parameter name보다 높은 우선순위로 주입됨을 검증한다."""
+
+    class IAgentAdapter:
+        @abstractmethod
+        def engine(self) -> str: ...
+
+    @Pod(name="langgraph")
+    class LangGraphAgentAdapter(IAgentAdapter):
+        def engine(self) -> str:
+            return "langgraph"
+
+    @Pod(name="pydantic_ai")
+    class PydanticAiAgentAdapter(IAgentAdapter):
+        def engine(self) -> str:
+            return "pydantic-ai"
+
+    @Pod()
+    class AgentRunner:
+        __adapter: IAgentAdapter
+
+        def __init__(self, langgraph: IAgentAdapter) -> None:
+            self.__adapter = langgraph
+
+        def engine(self) -> str:
+            return self.__adapter.engine()
+
+    context: ApplicationContext = ApplicationContext()
+    context.bind(PodBinding(interface=IAgentAdapter, implementation_name="pydantic_ai"))
+    context.add(LangGraphAgentAdapter)
+    context.add(PydanticAiAgentAdapter)
+    context.add(AgentRunner)
+    context.start()
+
+    assert context.get(type_=AgentRunner).engine() == "pydantic-ai"
+
+
+def test_application_context_qualifier_precedes_binding_expect_qualified_candidate() -> (
+    None
+):
+    """Qualifier가 설정 기반 binding보다 높은 우선순위로 주입됨을 검증한다."""
+
+    class ISamplePod:
+        @abstractmethod
+        def do(self) -> str: ...
+
+    @Pod(name="bound")
+    class BoundSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "bound"
+
+    @Pod(name="qualified")
+    class QualifiedSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "qualified"
+
+    @Pod()
+    class SampleService:
+        __pod: ISamplePod
+
+        def __init__(
+            self,
+            pod: Annotated[ISamplePod, Qualifier(lambda pod: pod.name == "qualified")],
+        ) -> None:
+            self.__pod = pod
+
+        def do(self) -> str:
+            return self.__pod.do()
+
+    context: ApplicationContext = ApplicationContext()
+    context.bind_to_name(ISamplePod, "bound")
+    context.add(BoundSamplePod)
+    context.add(QualifiedSamplePod)
+    context.add(SampleService)
+    context.start()
+
+    assert context.get(type_=SampleService).do() == "qualified"
+
+
+def test_application_context_explicit_name_precedes_binding_expect_named_candidate() -> (
+    None
+):
+    """명시 name 조회가 설정 기반 binding보다 높은 우선순위임을 검증한다."""
+
+    class ISamplePod:
+        @abstractmethod
+        def do(self) -> str: ...
+
+    @Pod(name="bound")
+    class BoundSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "bound"
+
+    @Pod(name="named")
+    class NamedSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "named"
+
+    context: ApplicationContext = ApplicationContext()
+    context.bind_to_name(ISamplePod, "bound")
+    context.add(BoundSamplePod)
+    context.add(NamedSamplePod)
+
+    assert context.get(type_=ISamplePod, name="named").do() == "named"
+
+
+def test_application_context_binding_missing_target_expect_binding_error() -> None:
+    """명시 binding 대상이 후보에 없으면 binding target 오류가 발생함을 검증한다."""
+
+    class ISamplePod:
+        @abstractmethod
+        def do(self) -> str: ...
+
+    @Pod(name="available")
+    class AvailableSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "available"
+
+    context: ApplicationContext = ApplicationContext()
+    context.bind_to_name(ISamplePod, "missing")
+    context.add(AvailableSamplePod)
+
+    with pytest.raises(NoSuchPodBindingTargetError):
+        context.get(type_=ISamplePod)
+
+
+def test_application_context_binding_missing_type_target_expect_binding_error() -> None:
+    """명시 type binding 대상이 후보에 없으면 binding target 오류가 발생함을 검증한다."""
+
+    class ISamplePod:
+        @abstractmethod
+        def do(self) -> str: ...
+
+    class MissingSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "missing"
+
+    @Pod(name="available")
+    class AvailableSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "available"
+
+    context: ApplicationContext = ApplicationContext()
+    context.bind_to_type(ISamplePod, MissingSamplePod)
+    context.add(AvailableSamplePod)
+
+    with pytest.raises(NoSuchPodBindingTargetError):
+        context.get(type_=ISamplePod)
+
+
+def test_application_context_invalid_binding_expect_error() -> None:
+    """binding은 type 또는 name 대상 중 하나만 지정해야 함을 검증한다."""
+
+    class ISamplePod: ...
+
+    class SamplePod(ISamplePod): ...
+
+    context: ApplicationContext = ApplicationContext()
+
+    with pytest.raises(InvalidPodBindingError):
+        context.bind(
+            PodBinding(
+                interface=ISamplePod,
+                implementation_type=SamplePod,
+                implementation_name="sample",
+            )
+        )
+
+
+def test_application_context_ambiguity_hints_include_binding_policy() -> None:
+    """ambiguity diagnostic이 명시 binding 해결 방법을 제시함을 검증한다."""
+
+    class ISamplePod:
+        @abstractmethod
+        def do(self) -> str: ...
+
+    @Pod(name="first")
+    class FirstSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "first"
+
+    @Pod(name="second")
+    class SecondSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "second"
+
+    context: ApplicationContext = ApplicationContext()
+    context.add(FirstSamplePod)
+    context.add(SecondSamplePod)
+
+    with pytest.raises(NoUniquePodError) as error:
+        context.get(type_=ISamplePod)
+
+    assert any(
+        "ApplicationContext.bind" in hint for hint in error.value.resolution_hints
+    )
 
 
 def test_application_context_get_dependency_recursive_by_type() -> None:

--- a/core/spakky/tests/core/interfaces/test_container_errors.py
+++ b/core/spakky/tests/core/interfaces/test_container_errors.py
@@ -1,4 +1,15 @@
-from spakky.core.pod.interfaces.container import CircularDependencyGraphDetectedError
+from typing import Callable, overload
+
+import pytest
+
+from spakky.core.common.types import ObjectT
+from spakky.core.pod.annotations.pod import Pod, PodType
+from spakky.core.pod.binding import PodBinding
+from spakky.core.pod.interfaces.container import (
+    CircularDependencyGraphDetectedError,
+    IContainer,
+    PodBindingNotSupportedError,
+)
 
 
 class DummyA:
@@ -7,6 +18,49 @@ class DummyA:
 
 class DummyB:
     """테스트용 더미 클래스 B."""
+
+
+class LegacyContainerDouble(IContainer):
+    """기존 커스텀 컨테이너 구현체와 같은 최소 test double."""
+
+    @property
+    def pods(self) -> dict[str, Pod]:
+        return {}
+
+    def add(self, obj: PodType) -> None:
+        return
+
+    @overload
+    def get(self, type_: type[ObjectT]) -> ObjectT: ...
+
+    @overload
+    def get(self, type_: type[ObjectT], name: str) -> ObjectT: ...
+
+    def get(self, type_: type[ObjectT], name: str | None = None) -> ObjectT | object:
+        return object()
+
+    @overload
+    def get_or_none(self, type_: type[ObjectT]) -> ObjectT | None: ...
+
+    @overload
+    def get_or_none(self, type_: type[ObjectT], name: str) -> ObjectT | None: ...
+
+    def get_or_none(
+        self, type_: type[ObjectT], name: str | None = None
+    ) -> ObjectT | None:
+        return None
+
+    @overload
+    def contains(self, type_: type) -> bool: ...
+
+    @overload
+    def contains(self, type_: type, name: str) -> bool: ...
+
+    def contains(self, type_: type, name: str | None = None) -> bool:
+        return False
+
+    def find(self, selector: Callable[[Pod], bool]) -> set[object]:
+        return set()
 
 
 def test_circular_dependency_error_empty_chain_expect_message_only() -> None:
@@ -33,3 +87,17 @@ def test_circular_dependency_error_single_element_expect_circular_marker() -> No
     error = CircularDependencyGraphDetectedError(dependency_chain=[DummyA])
     result = str(error)
     assert "DummyA (CIRCULAR!)" in result
+
+
+def test_container_binding_default_methods_expect_not_supported_error() -> None:
+    """기존 IContainer 구현체가 binding 메서드 없이도 인스턴스화됨을 검증한다."""
+    container = LegacyContainerDouble()
+
+    with pytest.raises(PodBindingNotSupportedError):
+        container.bind(PodBinding(interface=DummyA, implementation_type=DummyB))
+
+    with pytest.raises(PodBindingNotSupportedError):
+        container.bind_to_type(DummyA, DummyB)
+
+    with pytest.raises(PodBindingNotSupportedError):
+        container.bind_to_name(DummyA, "dummy_b")

--- a/docs/api/core/spakky.md
+++ b/docs/api/core/spakky.md
@@ -48,6 +48,10 @@ show_root_heading: false
 options:
 show_root_heading: false
 
+::: spakky.core.pod.binding
+options:
+show_root_heading: false
+
 ::: spakky.core.pod.inject
 options:
 show_root_heading: false

--- a/docs/di-container.md
+++ b/docs/di-container.md
@@ -194,9 +194,43 @@ class UserService:
 
 ### 3. 설정 기반 binding
 
-인터페이스별 binding policy는 DI multi-implementation 마일스톤의 후속
-작업에서 추가됩니다. 추가 후에는 Qualifier/name보다 낮고 `@Primary`보다
-높은 우선순위로 동작합니다.
+애플리케이션 또는 feature config가 `ApplicationContext`에 binding policy를
+등록하면, 같은 interface를 구현하는 후보 중 하나를 명시적으로 선택합니다.
+이 선택은 Qualifier/name보다 낮고 `@Primary`보다 높은 우선순위로 동작합니다.
+
+```python
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.binding import PodBinding
+
+class IAgentAdapter:
+    def engine(self) -> str: ...
+
+@Pod(name="langgraph")
+class LangGraphAgentAdapter(IAgentAdapter):
+    def engine(self) -> str:
+        return "langgraph"
+
+@Pod(name="pydantic_ai")
+class PydanticAiAgentAdapter(IAgentAdapter):
+    def engine(self) -> str:
+        return "pydantic-ai"
+
+context = ApplicationContext()
+context.bind(PodBinding(interface=IAgentAdapter, implementation_name="pydantic_ai"))
+context.add(LangGraphAgentAdapter)
+context.add(PydanticAiAgentAdapter)
+
+adapter = context.get(IAgentAdapter)  # PydanticAiAgentAdapter
+```
+
+간단한 등록에는 `context.bind_to_name(IAgentAdapter, "pydantic_ai")` 또는
+`context.bind_to_type(IAgentAdapter, PydanticAiAgentAdapter)`를 사용할 수
+있습니다. binding은 Pod 등록 전에도 설정할 수 있으므로 plugin 자동 활성화
+모델을 유지하면서 application config에서 선택 정책을 먼저 선언할 수 있습니다.
+binding이 type과 name을 동시에 지정하거나 둘 다 생략하면
+`InvalidPodBindingError`가 발생합니다. 지정한 target이 후보 Pod와 일치하지
+않으면 `NoSuchPodBindingTargetError`가 발생합니다.
 
 ### 4. Primary 지정
 

--- a/docs/error-hierarchy.md
+++ b/docs/error-hierarchy.md
@@ -129,7 +129,10 @@ from spakky.core.pod.error import AbstractSpakkyPodError
 from spakky.core.pod.interfaces.container import (
     CircularDependencyGraphDetectedError,
     NoSuchPodError,
+    NoSuchPodBindingTargetError,
     NoUniquePodError,
+    InvalidPodBindingError,
+    PodBindingNotSupportedError,
     CannotRegisterNonPodObjectError,
     PodNameAlreadyExistsError,
 )
@@ -139,7 +142,10 @@ from spakky.core.pod.interfaces.container import (
 | -------------------------------------- | -------------------------- |
 | `CircularDependencyGraphDetectedError` | 순환 의존성 감지           |
 | `NoSuchPodError`                       | 요청한 Pod를 찾을 수 없음  |
+| `NoSuchPodBindingTargetError`          | 명시 binding 대상 없음     |
 | `NoUniquePodError`                     | 여러 후보 Pod 중 선택 불가 |
+| `InvalidPodBindingError`               | 잘못된 binding policy      |
+| `PodBindingNotSupportedError`          | 컨테이너가 binding 미지원  |
 | `CannotRegisterNonPodObjectError`      | @Pod 없는 객체 등록 시도   |
 | `PodNameAlreadyExistsError`            | Pod 이름 중복              |
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -871,6 +871,19 @@ class UserService:
         ...
 ```
 
+### PodBinding
+
+같은 interface를 구현하는 Pod 후보가 여러 개일 때 application config가
+선택할 구현체를 명시하는 binding policy 값입니다. `ApplicationContext.bind()`,
+`bind_to_name()`, `bind_to_type()`으로 등록하며, Qualifier/name보다 낮고
+`@Primary`보다 높은 우선순위로 단수 의존성을 선택합니다.
+
+```python
+from spakky.core.pod.binding import PodBinding
+
+context.bind(PodBinding(interface=IRepository, implementation_name="postgres"))
+```
+
 ### @Lazy
 
 Pod 인스턴스화를 첫 사용 시점까지 지연.


### PR DESCRIPTION
## Summary
- Add `PodBinding` plus `ApplicationContext.bind()`, `bind_to_name()`, and `bind_to_type()` for explicit interface-to-implementation policy registration.
- Apply binding resolution after qualifier/explicit name and before `@Primary` / legacy parameter-name fallback.
- Extend ambiguity hints and docs for binding policy, errors, and DI resolution semantics.
- Update downstream `IContainer` test stub in `spakky-event` for the expanded interface.

Closes #177

## Verification
- `core/spakky`: `uv run ruff format .`, `uv run ruff check .`, harness validation, `uv run --with pyrefly --with pytest pyrefly check src tests`, `uv run --with pytest --with pytest-asyncio --with pytest-cov --with pytest-spec --with pytest-xdist pytest` (356 passed, 100% coverage)
- `core/spakky-event`: `uv run ruff format .`, `uv run ruff check .`, harness validation, `uv run pyrefly check src tests`, `uv run pytest` (49 passed, 12 skipped, 100% coverage)
- Pre-commit hook: passed across 19 projects
- Pre-push hook: passed across 21 projects