### PR TITLE
feat(core): parse collection dependency metadata (#175)

### DIFF
--- a/core/spakky/src/spakky/core/pod/annotations/pod.py
+++ b/core/spakky/src/spakky/core/pod/annotations/pod.py
@@ -9,13 +9,14 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from inspect import Parameter, isclass, isfunction
 from types import NoneType
-from typing import Annotated, TypeGuard, TypeVar, get_origin
+from typing import Annotated, TypeGuard, TypeVar, get_args, get_origin
 from uuid import UUID, uuid4
 
 from spakky.core.common.annotation import Annotation
 from spakky.core.common.interfaces.equatable import IEquatable
+from spakky.core.common.metadata import AnnotatedType
 from spakky.core.common.mro import generic_mro
-from spakky.core.common.types import Class, Func, is_optional
+from spakky.core.common.types import Class, Func, is_optional, remove_none
 from spakky.core.pod.diagnostics import PodDependencyResolutionDiagnostic
 from spakky.core.pod.annotations.primary import Primary
 from spakky.core.pod.annotations.qualifier import Qualifier
@@ -41,6 +42,21 @@ class DependencyInfo:
     has_default: bool = False
     is_optional: bool = False
     qualifiers: list[Qualifier] = field(default_factory=list[Qualifier])
+    collection_kind: "DependencyCollectionKind | None" = None
+    collection_key_type: Class | None = None
+
+
+class DependencyCollectionKind(Enum):
+    """Supported collection dependency injection shapes."""
+
+    LIST = auto()
+    """Inject all matching Pods as a stable list."""
+
+    TUPLE = auto()
+    """Inject all matching Pods as a stable tuple."""
+
+    DICT = auto()
+    """Inject matching Pods keyed by registered Pod name."""
 
 
 type DependencyMap = dict[str, DependencyInfo]
@@ -72,6 +88,12 @@ class CannotUseOptionalReturnTypeInPodError(PodAnnotationFailedError):
     """Raised when function Pod has Optional return type."""
 
     message = "Cannot use optional return type in pod"
+
+
+class UnsupportedCollectionDependencyTypeError(PodAnnotationFailedError):
+    """Raised when a collection dependency annotation is unsupported."""
+
+    message = "Unsupported collection dependency type"
 
 
 class UnexpectedDependencyNameInjectedError(PodInstantiationFailedError):
@@ -136,6 +158,102 @@ class Pod(Annotation, IEquatable):
     dependencies: DependencyMap = field(init=False, default_factory=dict)
     """Map of dependency names to their injection information."""
 
+    def __normalize_dependency_annotation(
+        self, annotation: object
+    ) -> tuple[object, list[Qualifier], bool]:
+        qualifiers: list[Qualifier] = []
+        actual_type = annotation
+        if self.__is_annotated_dependency(annotation):
+            actual_type = Qualifier.get_actual_type(annotation)
+            qualifiers = Qualifier.all(annotation)
+        optional = is_optional(actual_type)
+        if optional:
+            actual_type = remove_none(actual_type)
+        return actual_type, qualifiers, optional
+
+    def __is_annotated_dependency(self, annotation: object) -> TypeGuard[AnnotatedType]:
+        return get_origin(annotation) is Annotated
+
+    def __collection_dependency_info(
+        self,
+        name: str,
+        annotation: object,
+        has_default: bool,
+        is_optional_dependency: bool,
+        qualifiers: list[Qualifier],
+    ) -> DependencyInfo | None:
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+        if origin is list:
+            if len(args) != 1:
+                raise UnsupportedCollectionDependencyTypeError(name, annotation)
+            if self.__is_builtin_collection_element(args[0]):
+                return None
+            element_type = self.__collection_element_type(name, annotation, args[0])
+            return DependencyInfo(
+                name=name,
+                type_=element_type,
+                has_default=has_default,
+                is_optional=is_optional_dependency,
+                qualifiers=qualifiers,
+                collection_kind=DependencyCollectionKind.LIST,
+            )
+        if origin is tuple:
+            if len(args) != 2 or args[1] is not Ellipsis:
+                raise UnsupportedCollectionDependencyTypeError(name, annotation)
+            if self.__is_builtin_collection_element(args[0]):
+                return None
+            element_type = self.__collection_element_type(name, annotation, args[0])
+            return DependencyInfo(
+                name=name,
+                type_=element_type,
+                has_default=has_default,
+                is_optional=is_optional_dependency,
+                qualifiers=qualifiers,
+                collection_kind=DependencyCollectionKind.TUPLE,
+            )
+        if origin is dict:
+            if len(args) != 2 or args[0] is not str:
+                raise UnsupportedCollectionDependencyTypeError(name, annotation)
+            if self.__is_builtin_collection_element(args[1]):
+                return None
+            element_type = self.__collection_element_type(name, annotation, args[1])
+            return DependencyInfo(
+                name=name,
+                type_=element_type,
+                has_default=has_default,
+                is_optional=is_optional_dependency,
+                qualifiers=qualifiers,
+                collection_kind=DependencyCollectionKind.DICT,
+                collection_key_type=str,
+            )
+        if origin in (set, frozenset) or annotation in (
+            list,
+            tuple,
+            dict,
+            set,
+            frozenset,
+        ):
+            raise UnsupportedCollectionDependencyTypeError(name, annotation)
+        return None
+
+    def __is_builtin_collection_element(self, element_type: object) -> bool:
+        return isclass(element_type) and element_type.__module__ == "builtins"
+
+    def __collection_element_type(
+        self, name: str, annotation: object, element_type: object
+    ) -> Class:
+        if not isclass(element_type):
+            raise UnsupportedCollectionDependencyTypeError(name, annotation)
+        return element_type
+
+    def __is_dependency_type(self, annotation: object) -> TypeGuard[Class]:
+        return (
+            isclass(annotation)
+            or isinstance(annotation, str)
+            or get_origin(annotation) is not None
+        )
+
     def __get_dependencies(self, obj: PodType) -> DependencyMap:
         """Extract dependency information from constructor or function parameters.
 
@@ -169,23 +287,29 @@ class Pod(Annotation, IEquatable):
                 raise CannotUseVarArgsInPodError(obj, parameter.name)
             if parameter.annotation == Parameter.empty:
                 raise CannotDeterminePodTypeError(obj, parameter.name)
-            if get_origin(parameter.annotation) is Annotated:
-                type_ = Qualifier.get_actual_type(parameter.annotation)
-                qualifiers = Qualifier.all(parameter.annotation)
-                dependencies[parameter.name] = DependencyInfo(
-                    name=parameter.name,
-                    type_=type_,
-                    has_default=parameter.default != Parameter.empty,
-                    is_optional=is_optional(parameter.annotation),
-                    qualifiers=qualifiers,
-                )
-            else:
-                dependencies[parameter.name] = DependencyInfo(
-                    name=parameter.name,
-                    type_=parameter.annotation,
-                    is_optional=is_optional(parameter.annotation),
-                    has_default=parameter.default != Parameter.empty,
-                )
+            type_, qualifiers, is_optional_dependency = (
+                self.__normalize_dependency_annotation(parameter.annotation)
+            )
+            has_default = parameter.default != Parameter.empty
+            collection_dependency = self.__collection_dependency_info(
+                name=parameter.name,
+                annotation=type_,
+                has_default=has_default,
+                is_optional_dependency=is_optional_dependency,
+                qualifiers=qualifiers,
+            )
+            if collection_dependency is not None:
+                dependencies[parameter.name] = collection_dependency
+                continue
+            if not self.__is_dependency_type(type_):
+                raise CannotDeterminePodTypeError(obj, parameter.name)
+            dependencies[parameter.name] = DependencyInfo(
+                name=parameter.name,
+                type_=type_,
+                is_optional=is_optional_dependency,
+                has_default=has_default,
+                qualifiers=qualifiers,
+            )
 
         return dependencies
 

--- a/core/spakky/tests/application/test_application_context.py
+++ b/core/spakky/tests/application/test_application_context.py
@@ -15,7 +15,11 @@ from spakky.core.application.application_context import (
 from spakky.core.common.annotation import ClassAnnotation
 from spakky.core.common.constants import CONTEXT_ID
 from spakky.core.pod.annotations.lazy import Lazy
-from spakky.core.pod.annotations.pod import Pod, PodInstantiationFailedError
+from spakky.core.pod.annotations.pod import (
+    Pod,
+    PodInstantiationFailedError,
+    UnsupportedCollectionDependencyTypeError,
+)
 from spakky.core.pod.annotations.primary import Primary
 from spakky.core.pod.annotations.qualifier import Qualifier
 from spakky.core.pod.interfaces.container import CannotRegisterNonPodObjectError
@@ -806,26 +810,20 @@ def test_application_context_with_multiple_children_list_not_exists() -> None:
 
 
 def test_application_context_with_multiple_children_set_not_exists() -> None:
-    """set 타입 의존성에 해당하는 Pod가 없을 때 PodInstantiationFailedError가 발생함을 검증한다."""
+    """지원하지 않는 set collection 의존성은 Pod metadata 생성 시 실패함을 검증한다."""
 
     class IRepository:
         @abstractmethod
         def get(self, id: str) -> dict[str, Any]: ...
 
-    @Pod()
-    class SampleService:
-        __repositories: set[IRepository]
+    with pytest.raises(UnsupportedCollectionDependencyTypeError):
 
-        def __init__(self, repositories: set[IRepository]) -> None:
-            self.__repositories = repositories
+        @Pod()
+        class SampleService:
+            __repositories: set[IRepository]
 
-        def get(self, id: str) -> list[dict[str, Any]]:
-            return [repository.get(id) for repository in self.__repositories]
-
-    context: ApplicationContext = ApplicationContext()
-    context.add(SampleService)
-    with pytest.raises(PodInstantiationFailedError):
-        context.start()
+            def __init__(self, repositories: set[IRepository]) -> None:
+                self.__repositories = repositories
 
 
 def test_application_context_with_multiple_children_dict_not_exists() -> None:

--- a/core/spakky/tests/pod/test_pod.py
+++ b/core/spakky/tests/pod/test_pod.py
@@ -1,14 +1,18 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from types import GenericAlias
 from typing import Annotated, Any, Generic, TypeVar, cast
+from typing import List as LegacyList
 
 import pytest
 
 from spakky.core.pod.annotations.pod import (
     CannotDeterminePodTypeError,
     CannotUseVarArgsInPodError,
+    DependencyCollectionKind,
     DependencyInfo,
     Pod,
+    UnsupportedCollectionDependencyTypeError,
     is_class_pod,
     is_function_pod,
 )
@@ -288,6 +292,213 @@ def test_pod_with_qualifier() -> None:
         ),
         "job": DependencyInfo(name="job", type_=str),
     }
+
+
+def test_pod_with_list_collection_dependency_expect_metadata() -> None:
+    """list[T] 의존성이 모든 후보 주입용 metadata로 파싱됨을 검증한다."""
+
+    class IService: ...
+
+    @Pod()
+    class ServiceConsumer:
+        def __init__(self, services: list[IService]) -> None:
+            self.services = services
+
+    assert Pod.get(ServiceConsumer).dependencies == {
+        "services": DependencyInfo(
+            name="services",
+            type_=IService,
+            collection_kind=DependencyCollectionKind.LIST,
+        )
+    }
+
+
+def test_pod_with_tuple_collection_dependency_expect_metadata() -> None:
+    """tuple[T, ...] 의존성이 안정적 순서의 후보 metadata로 파싱됨을 검증한다."""
+
+    class IService: ...
+
+    @Pod()
+    class ServiceConsumer:
+        def __init__(self, services: tuple[IService, ...]) -> None:
+            self.services = services
+
+    assert Pod.get(ServiceConsumer).dependencies == {
+        "services": DependencyInfo(
+            name="services",
+            type_=IService,
+            collection_kind=DependencyCollectionKind.TUPLE,
+        )
+    }
+
+
+def test_pod_with_dict_collection_dependency_expect_name_key_metadata() -> None:
+    """dict[str, T] 의존성이 Pod name key metadata로 파싱됨을 검증한다."""
+
+    class IService: ...
+
+    @Pod()
+    class ServiceConsumer:
+        def __init__(self, services: dict[str, IService]) -> None:
+            self.services = services
+
+    assert Pod.get(ServiceConsumer).dependencies == {
+        "services": DependencyInfo(
+            name="services",
+            type_=IService,
+            collection_kind=DependencyCollectionKind.DICT,
+            collection_key_type=str,
+        )
+    }
+
+
+def test_pod_with_annotated_optional_collection_dependency_expect_metadata() -> None:
+    """Annotated/Optional 조합에서도 collection metadata와 qualifier가 보존됨을 검증한다."""
+
+    class IService: ...
+
+    def is_primary_pod(pod: Pod) -> bool:
+        return pod.is_primary
+
+    @Pod()
+    class ServiceConsumer:
+        def __init__(
+            self,
+            services: Annotated[
+                list[IService] | None,
+                Qualifier(is_primary_pod),
+            ],
+        ) -> None:
+            self.services = services
+
+    assert Pod.get(ServiceConsumer).dependencies == {
+        "services": DependencyInfo(
+            name="services",
+            type_=IService,
+            is_optional=True,
+            qualifiers=[Qualifier(is_primary_pod)],
+            collection_kind=DependencyCollectionKind.LIST,
+        )
+    }
+
+
+def test_pod_with_builtin_collection_dependency_expect_single_generic_metadata() -> (
+    None
+):
+    """builtin element collection은 기존 generic 단수 의존성 metadata로 보존됨을 검증한다."""
+
+    @Pod()
+    class BuiltinCollectionConsumer:
+        def __init__(
+            self,
+            names: list[str],
+            ages: tuple[int, ...],
+            lookup: dict[str, int],
+        ) -> None:
+            self.names = names
+            self.ages = ages
+            self.lookup = lookup
+
+    assert Pod.get(BuiltinCollectionConsumer).dependencies == {
+        "names": DependencyInfo(name="names", type_=list[str]),
+        "ages": DependencyInfo(name="ages", type_=tuple[int, ...]),
+        "lookup": DependencyInfo(name="lookup", type_=dict[str, int]),
+    }
+
+
+def test_pod_with_unsupported_collection_dependency_expect_error() -> None:
+    """지원하지 않는 collection 의존성 타입은 명시적 에러로 실패함을 검증한다."""
+
+    class IService: ...
+
+    with pytest.raises(UnsupportedCollectionDependencyTypeError):
+
+        @Pod()
+        class SetConsumer:
+            def __init__(self, services: set[IService]) -> None:
+                self.services = services
+
+
+def test_pod_with_legacy_bare_list_dependency_expect_error() -> None:
+    """element 타입이 없는 list collection 의존성은 지원하지 않음을 검증한다."""
+
+    with pytest.raises(UnsupportedCollectionDependencyTypeError):
+
+        @Pod()
+        class ListConsumer:
+            def __init__(self, services: LegacyList) -> None:
+                self.services = services
+
+
+def test_pod_with_collection_non_type_element_expect_error() -> None:
+    """element가 타입이 아닌 collection 의존성은 지원하지 않음을 검증한다."""
+    invalid_element = 42
+
+    def invalid_factory(services) -> object:
+        return services
+
+    invalid_factory.__annotations__["services"] = GenericAlias(list, (invalid_element,))
+    invalid_factory.__annotations__["return"] = object
+
+    with pytest.raises(UnsupportedCollectionDependencyTypeError):
+        Pod()(invalid_factory)
+
+
+def test_pod_with_dict_non_string_key_dependency_expect_error() -> None:
+    """dict[str, T] 외의 dict collection 의존성은 지원하지 않음을 검증한다."""
+
+    class IService: ...
+
+    with pytest.raises(UnsupportedCollectionDependencyTypeError):
+
+        @Pod()
+        class DictConsumer:
+            def __init__(self, services: dict[int, IService]) -> None:
+                self.services = services
+
+
+def test_pod_with_tuple_fixed_length_dependency_expect_error() -> None:
+    """tuple[T, ...] 외의 tuple collection 의존성은 지원하지 않음을 검증한다."""
+
+    class IService: ...
+
+    with pytest.raises(UnsupportedCollectionDependencyTypeError):
+
+        @Pod()
+        class TupleConsumer:
+            def __init__(self, services: tuple[IService, IService]) -> None:
+                self.services = services
+
+
+def test_pod_with_non_type_dependency_annotation_expect_error() -> None:
+    """타입이 아닌 의존성 annotation은 CannotDeterminePodTypeError로 실패함을 검증한다."""
+    invalid_annotation = 42
+
+    def invalid_factory(service) -> object:
+        return service
+
+    invalid_factory.__annotations__["service"] = invalid_annotation
+    invalid_factory.__annotations__["return"] = object
+
+    with pytest.raises(CannotDeterminePodTypeError):
+        Pod()(invalid_factory)
+
+
+def test_pod_with_string_dependency_annotation_expect_metadata() -> None:
+    """문자열 forward reference 의존성 annotation은 기존 metadata로 보존됨을 검증한다."""
+
+    def forward_factory(service) -> object:
+        return service
+
+    forward_factory.__annotations__["service"] = "ForwardService"
+    forward_factory.__annotations__["return"] = object
+
+    Pod()(forward_factory)
+
+    dependency = Pod.get(forward_factory).dependencies["service"]
+    assert dependency.name == "service"
+    assert dependency.type_ == "ForwardService"
+    assert dependency.collection_kind is None
 
 
 def test_pod_equality_with_different_type() -> None:


### PR DESCRIPTION
## Summary
- Add collection dependency metadata parsing for list[T], tuple[T, ...], and dict[str, T].
- Preserve qualifiers and optional wrapping through Annotated/Optional normalization.
- Add unsupported collection dependency diagnostics for set/frozenset, malformed tuple/dict/list, and non-type elements.

## Verification
- cd core/spakky && uv run --with ruff ruff format . && uv run --with ruff ruff check .
- cd core/spakky && uv run --with pyrefly --with pytest pyrefly check src tests
- cd core/spakky && uv run --with pytest --with pytest-cov --with pytest-asyncio --with pytest-spec --with pytest-xdist pytest
- cd plugins/spakky-logging && uv run --with pytest --with pytest-cov --with pytest-asyncio --with pytest-spec --with pytest-xdist pytest
- pre-commit hooks on commit and pre-push hooks on push

Closes #175