### PR TITLE
feat(core): resolve DI collection candidates (#176)

### DIFF
--- a/core/spakky/src/spakky/core/application/application_context.py
+++ b/core/spakky/src/spakky/core/application/application_context.py
@@ -23,6 +23,8 @@ from spakky.core.common.types import ObjectT, is_optional, remove_none
 from spakky.core.pod.annotations.lazy import Lazy
 from spakky.core.pod.annotations.order import Order
 from spakky.core.pod.annotations.pod import (
+    DependencyCollectionKind,
+    DependencyInfo,
     Pod,
     PodType,
     UnexpectedDependencyTypeInjectedError,
@@ -289,6 +291,21 @@ class ApplicationContext(IApplicationContext):
             return typed.pop()
         raise NoSuchPodBindingTargetError(binding)
 
+    def __resolve_collection_candidates(
+        self,
+        type_: type,
+        qualifiers: list[Qualifier],
+    ) -> tuple[Pod, ...]:
+        """Resolve all collection dependency candidates in stable Pod name order."""
+        pods = self.__type_cache.get(type_, set()).copy()
+        if qualifiers:
+            pods = {
+                pod
+                for pod in pods
+                if all(qualifier.selector(pod) for qualifier in qualifiers)
+            }
+        return tuple(sorted(pods, key=lambda pod: pod.name))
+
     def __resolve_candidate(
         self,
         type_: type,
@@ -328,7 +345,7 @@ class ApplicationContext(IApplicationContext):
             if not qualified:
                 return None
             candidates = self.__candidate_diagnostics(qualified)
-            resolution_hints = self.__ambiguity_hints(None)
+            resolution_hints = self.__ambiguity_hints(name)
             raise NoUniquePodError(
                 type_,
                 candidates,
@@ -447,17 +464,24 @@ class ApplicationContext(IApplicationContext):
                     requested_type=requested_type,
                 ),
             )
-            resolved_dependency = self.__get_internal(
-                type_=remove_none(dependency.type_)
-                if is_optional(dependency.type_)
-                else dependency.type_,
-                name=name,
-                dependency_hierarchy=new_hierarchy,
-                dependency_path=current_path,
-                qualifiers=dependency.qualifiers,
-                name_is_dependency_parameter=True,
-                requester_pod=pod,
-            )
+            if dependency.collection_kind is None:
+                resolved_dependency = self.__get_internal(
+                    type_=remove_none(dependency.type_)
+                    if is_optional(dependency.type_)
+                    else dependency.type_,
+                    name=name,
+                    dependency_hierarchy=new_hierarchy,
+                    dependency_path=current_path,
+                    qualifiers=dependency.qualifiers,
+                    name_is_dependency_parameter=True,
+                    requester_pod=pod,
+                )
+            else:
+                resolved_dependency = self.__resolve_collection_dependency(
+                    dependency=dependency,
+                    dependency_hierarchy=new_hierarchy,
+                    dependency_path=current_path,
+                )
             if (
                 resolved_dependency is None
                 and not dependency.has_default
@@ -487,6 +511,77 @@ class ApplicationContext(IApplicationContext):
         self.__record_instantiation_attempt(perf_counter() - started_at)
         post_processed: object = self.__post_process_pod(instance)
         return post_processed
+
+    def __get_pod_instance(
+        self,
+        pod: Pod,
+        dependency_hierarchy: tuple[type, ...],
+        dependency_path: tuple[PodDependencyPathNode, ...],
+    ) -> object:
+        """Get or create an instance for an already resolved Pod candidate."""
+        match pod.scope:
+            case Pod.Scope.SINGLETON:
+                if (cached := self.__get_singleton_cache(pod)) is not None:
+                    return cached
+                with self.__singleton_lock:
+                    if (cached := self.__singleton_cache.get(pod.name)) is not None:
+                        return cached
+                    instance = self.__instantiate_pod(
+                        pod,
+                        dependency_hierarchy,
+                        dependency_path,
+                    )
+                    self.__set_singleton_cache(pod, instance)
+                    return instance
+            case Pod.Scope.CONTEXT:
+                if (cached := self.__get_context_cache(pod)) is not None:
+                    return cached
+
+        instance = self.__instantiate_pod(
+            pod,
+            dependency_hierarchy,
+            dependency_path,
+        )
+
+        match pod.scope:
+            case Pod.Scope.CONTEXT:
+                self.__set_context_cache(pod, instance)
+
+        return instance
+
+    def __resolve_collection_dependency(
+        self,
+        dependency: DependencyInfo,
+        dependency_hierarchy: tuple[type, ...],
+        dependency_path: tuple[PodDependencyPathNode, ...],
+    ) -> object | None:
+        """Resolve list/tuple/dict dependency injection without single ambiguity."""
+        pods = self.__resolve_collection_candidates(
+            type_=dependency.type_,
+            qualifiers=dependency.qualifiers,
+        )
+        if not pods:
+            return None
+
+        instances = [
+            self.__get_pod_instance(
+                pod=pod,
+                dependency_hierarchy=dependency_hierarchy,
+                dependency_path=dependency_path,
+            )
+            for pod in pods
+        ]
+        match dependency.collection_kind:
+            case DependencyCollectionKind.LIST:
+                return instances
+            case DependencyCollectionKind.TUPLE:
+                return tuple(instances)
+            case DependencyCollectionKind.DICT:
+                return {
+                    pod.name: instance
+                    for pod, instance in zip(pods, instances, strict=True)
+                }
+        return None
 
     def __record_instantiation_attempt(self, elapsed_seconds: float) -> None:
         if self.__startup_metrics is None:
@@ -645,39 +740,14 @@ class ApplicationContext(IApplicationContext):
         if pod is None:
             return None
 
-        # Try to hit the cache by scope type of pod
-        match pod.scope:
-            case Pod.Scope.SINGLETON:
-                if (cached := self.__get_singleton_cache(pod)) is not None:
-                    return cast(ObjectT, cached)
-                # Double-checked locking for thread-safe lazy singleton creation
-                with self.__singleton_lock:
-                    # Re-check cache after acquiring lock
-                    if (cached := self.__singleton_cache.get(pod.name)) is not None:
-                        return cast(ObjectT, cached)
-                    instance = self.__instantiate_pod(
-                        pod,
-                        dependency_hierarchy,
-                        dependency_path,
-                    )
-                    self.__set_singleton_cache(pod, instance)
-                    return cast(ObjectT, instance)
-            case Pod.Scope.CONTEXT:
-                if (cached := self.__get_context_cache(pod)) is not None:
-                    return cast(ObjectT, cached)
-
-        instance = self.__instantiate_pod(
-            pod,
-            dependency_hierarchy,
-            dependency_path,
+        return cast(
+            ObjectT,
+            self.__get_pod_instance(
+                pod=pod,
+                dependency_hierarchy=dependency_hierarchy,
+                dependency_path=dependency_path,
+            ),
         )
-
-        # Cache the instance based on pod scope
-        match pod.scope:
-            case Pod.Scope.CONTEXT:
-                self.__set_context_cache(pod, instance)
-
-        return cast(ObjectT, instance)
 
     def __add_post_processor(self, post_processor: IPostProcessor) -> None:
         self.__post_processors.append(post_processor)

--- a/core/spakky/tests/application/test_application_context.py
+++ b/core/spakky/tests/application/test_application_context.py
@@ -1042,6 +1042,95 @@ def test_application_context_with_multiple_children_list_not_exists() -> None:
         context.start()
 
 
+def test_application_context_with_multiple_children_list_expect_stable_order() -> None:
+    """list collection 의존성이 모든 후보를 Pod name 순서로 주입함을 검증한다."""
+
+    class IRepository:
+        @abstractmethod
+        def name(self) -> str: ...
+
+    @Pod(name="z_repository")
+    class LastRepository(IRepository):
+        def name(self) -> str:
+            return "last"
+
+    @Pod(name="a_repository")
+    class FirstRepository(IRepository):
+        def name(self) -> str:
+            return "first"
+
+    @Pod()
+    class SampleService:
+        __repositories: list[IRepository]
+
+        def __init__(self, repositories: list[IRepository]) -> None:
+            self.__repositories = repositories
+
+        def names(self) -> list[str]:
+            return [repository.name() for repository in self.__repositories]
+
+    context: ApplicationContext = ApplicationContext()
+    context.add(LastRepository)
+    context.add(FirstRepository)
+    context.add(SampleService)
+    context.start()
+
+    assert context.get(type_=SampleService).names() == ["first", "last"]
+
+
+def test_application_context_with_multiple_children_tuple_expect_qualified_order() -> (
+    None
+):
+    """tuple collection 의존성이 qualifier에 맞는 후보만 안정적 순서로 주입함을 검증한다."""
+
+    class IRepository:
+        @abstractmethod
+        def name(self) -> str: ...
+
+    @Pod(name="primary_second")
+    class PrimarySecondRepository(IRepository):
+        def name(self) -> str:
+            return "primary-second"
+
+    @Pod(name="other")
+    class OtherRepository(IRepository):
+        def name(self) -> str:
+            return "other"
+
+    @Pod(name="primary_first")
+    class PrimaryFirstRepository(IRepository):
+        def name(self) -> str:
+            return "primary-first"
+
+    @Pod()
+    class SampleService:
+        __repositories: tuple[IRepository, ...]
+
+        def __init__(
+            self,
+            repositories: Annotated[
+                tuple[IRepository, ...],
+                Qualifier(lambda pod: pod.name.startswith("primary")),
+            ],
+        ) -> None:
+            self.__repositories = repositories
+
+        def names(self) -> tuple[str, ...]:
+            return tuple(repository.name() for repository in self.__repositories)
+
+    context: ApplicationContext = ApplicationContext()
+    context.add(PrimarySecondRepository)
+    context.add(OtherRepository)
+    context.add(PrimaryFirstRepository)
+    context.add(SampleService)
+    context.start()
+
+    assert context.get(type_=SampleService).names() == (
+        "primary-first",
+        "primary-second",
+    )
+
+
 def test_application_context_with_multiple_children_set_not_exists() -> None:
     """지원하지 않는 set collection 의존성은 Pod metadata 생성 시 실패함을 검증한다."""
 
@@ -1085,6 +1174,48 @@ def test_application_context_with_multiple_children_dict_not_exists() -> None:
         context.start()
 
 
+def test_application_context_with_multiple_children_dict_expect_name_keys() -> None:
+    """dict collection 의존성이 Pod name을 key로 모든 후보를 주입함을 검증한다."""
+
+    class IRepository:
+        @abstractmethod
+        def name(self) -> str: ...
+
+    @Pod(name="second")
+    class SecondRepository(IRepository):
+        def name(self) -> str:
+            return "second"
+
+    @Pod(name="first")
+    class FirstRepository(IRepository):
+        def name(self) -> str:
+            return "first"
+
+    @Pod()
+    class SampleService:
+        __repositories: dict[str, IRepository]
+
+        def __init__(self, repositories: dict[str, IRepository]) -> None:
+            self.__repositories = repositories
+
+        def names(self) -> dict[str, str]:
+            return {
+                name: repository.name()
+                for name, repository in self.__repositories.items()
+            }
+
+    context: ApplicationContext = ApplicationContext()
+    context.add(SecondRepository)
+    context.add(FirstRepository)
+    context.add(SampleService)
+    context.start()
+
+    assert context.get(type_=SampleService).names() == {
+        "first": "first",
+        "second": "second",
+    }
+
+
 def test_application_context_with_optional_dependency() -> None:
     """Optional 타입 의존성이 없을 때 None이 주입됨을 검증한다."""
 
@@ -1108,6 +1239,39 @@ def test_application_context_with_optional_dependency() -> None:
 
     service = context.get(type_=SampleService)
     assert service.do() == "default"
+
+
+def test_application_context_with_optional_ambiguous_dependency_expect_error() -> None:
+    """Optional 단수 의존성의 ambiguity는 None fallback으로 숨기지 않음을 검증한다."""
+
+    class IDependency:
+        @abstractmethod
+        def do(self) -> str: ...
+
+    @Pod(name="first")
+    class FirstDependency(IDependency):
+        def do(self) -> str:
+            return "first"
+
+    @Pod(name="second")
+    class SecondDependency(IDependency):
+        def do(self) -> str:
+            return "second"
+
+    @Pod()
+    class SampleService:
+        __service: IDependency | None
+
+        def __init__(self, service: IDependency | None) -> None:
+            self.__service = service
+
+    context = ApplicationContext()
+    context.add(FirstDependency)
+    context.add(SecondDependency)
+    context.add(SampleService)
+
+    with pytest.raises(NoUniquePodError):
+        context.start()
 
 
 def test_application_context_with_multiple_qualifiers() -> None:


### PR DESCRIPTION
## Summary
- split ApplicationContext dependency resolution so collection injection bypasses single-candidate ambiguity selection
- preserve deterministic collection ordering by Pod name for list/tuple/dict injection
- cover list, tuple, dict, qualifier-filtered collection injection, and Optional ambiguity behavior

## Verification
- cd core/spakky && uv run ruff format .
- cd core/spakky && uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .
- cd core/spakky && uv run ruff check .
- cd core/spakky && uv run pyrefly check src tests
- cd core/spakky && uv run pytest
- uv run python scripts/run_coverage.py --package spakky

Closes #176