### PR TITLE
docs: document DI multi-implementation resolution (#179)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -413,7 +413,7 @@ class TimingAspect(IAsyncAspect):
 spakky-data = "spakky.data.main:initialize"
 ```
 
-`SpakkyApplication.load_plugins()`는 `importlib.metadata.entry_points(group="spakky.plugins")`로 등록된 플러그인을 발견하고, 각 플러그인의 `initialize(app: SpakkyApplication)` 함수를 호출합니다.
+`SpakkyApplication.load_plugins()`는 `importlib.metadata.entry_points(group="spakky.plugins")`로 등록된 플러그인을 발견하고, 각 플러그인의 `initialize(app: SpakkyApplication)` 함수를 호출합니다. 복수 구현체 DI resolution은 이 자동 활성화 모델을 유지합니다. 여러 플러그인이 같은 port 후보를 등록해도 플러그인은 그대로 초기화되고, 단수 주입 지점에서만 Qualifier/name/binding/`@Primary`/legacy parameter name 순서로 하나를 선택합니다.
 
 ### 플러그인 등록 요약
 

--- a/docs/di-container.md
+++ b/docs/di-container.md
@@ -153,6 +153,46 @@ class NotificationService:
         self.sms_sender = sms_sender
 ```
 
+### Collection 의존성
+
+같은 인터페이스를 구현하는 모든 Pod가 필요하면 단수 의존성 대신 collection
+타입을 선언합니다. Collection 주입은 `NoUniquePodError`를 발생시키지 않고
+매칭되는 모든 후보를 Pod name 기준의 안정적인 순서로 주입합니다.
+
+지원되는 형태는 다음과 같습니다.
+
+| 타입 힌트 | 주입 값 |
+|-----------|---------|
+| `list[T]` | 매칭 Pod 인스턴스 목록 |
+| `tuple[T, ...]` | 매칭 Pod 인스턴스 튜플 |
+| `dict[str, T]` | Pod name → 인스턴스 매핑 |
+
+```python
+@Pod(name="email")
+class EmailNotifier(INotifier):
+    ...
+
+@Pod(name="slack")
+class SlackNotifier(INotifier):
+    ...
+
+@Pod()
+class NotificationService:
+    def __init__(
+        self,
+        notifiers: list[INotifier],
+        notifier_by_name: dict[str, INotifier],
+    ) -> None:
+        self.notifiers = notifiers
+        self.email = notifier_by_name["email"]
+```
+
+`Annotated[list[T], Qualifier(...)]`, `Annotated[tuple[T, ...], Qualifier(...)]`,
+`Annotated[dict[str, T], Qualifier(...)]`처럼 Qualifier를 붙이면 collection에
+들어갈 후보 전체를 필터링합니다. `list`, `tuple`, `dict`의 element type은
+프레임워크가 관리하는 Pod 타입이어야 하며, `set[T]`, bare `list`, `tuple[T]`,
+`dict[int, T]` 같은 형태는 지원하지 않습니다.
+
 ---
 
 ## 의존성 해결 우선순위
@@ -197,6 +237,8 @@ class UserService:
 애플리케이션 또는 feature config가 `ApplicationContext`에 binding policy를
 등록하면, 같은 interface를 구현하는 후보 중 하나를 명시적으로 선택합니다.
 이 선택은 Qualifier/name보다 낮고 `@Primary`보다 높은 우선순위로 동작합니다.
+Binding은 단수 의존성 선택 정책입니다. Collection 의존성은 binding으로
+하나를 고르지 않고, Qualifier를 통과한 모든 후보를 주입합니다.
 
 ```python
 from spakky.core.application.application_context import ApplicationContext
@@ -228,6 +270,9 @@ adapter = context.get(IAgentAdapter)  # PydanticAiAgentAdapter
 `context.bind_to_type(IAgentAdapter, PydanticAiAgentAdapter)`를 사용할 수
 있습니다. binding은 Pod 등록 전에도 설정할 수 있으므로 plugin 자동 활성화
 모델을 유지하면서 application config에서 선택 정책을 먼저 선언할 수 있습니다.
+즉 `load_plugins()`로 설치된 플러그인을 모두 자동 활성화한 뒤, 특정 port의
+단수 주입 지점에서만 application config가 선택한 구현체를 사용하게 만들 수
+있습니다.
 binding이 type과 name을 동시에 지정하거나 둘 다 생략하면
 `InvalidPodBindingError`가 발생합니다. 지정한 target이 후보 Pod와 일치하지
 않으면 `NoSuchPodBindingTargetError`가 발생합니다.

--- a/docs/guides/dependency-injection.md
+++ b/docs/guides/dependency-injection.md
@@ -187,6 +187,85 @@ def get_engine(database_url: str) -> Engine:
 
 ## 고급 기능
 
+### 복수 구현체 선택
+
+같은 interface나 port를 구현하는 Pod가 여러 개 등록되면 단수 주입은
+명시적인 선택 정책을 따릅니다. 우선순위는 `Qualifier`, 명시 name,
+`ApplicationContext.bind(PodBinding(...))`, `@Primary`, legacy parameter name
+fallback 순서입니다. 이 순서로도 하나를 고를 수 없으면 컨테이너는 임의의
+후보를 선택하지 않고 `NoUniquePodError`를 발생시킵니다.
+
+Application config에서 선택 정책을 관리하려면 binding을 등록합니다.
+
+```python
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.binding import PodBinding
+
+class IEmailSender:
+    def send(self, to: str, body: str) -> None: ...
+
+@Pod(name="smtp")
+class SmtpEmailSender(IEmailSender):
+    def send(self, to: str, body: str) -> None: ...
+
+@Pod(name="console")
+class ConsoleEmailSender(IEmailSender):
+    def send(self, to: str, body: str) -> None: ...
+
+context = ApplicationContext()
+context.bind(PodBinding(interface=IEmailSender, implementation_name="smtp"))
+
+app = SpakkyApplication(context).scan(apps).start()
+sender = app.container.get(IEmailSender)  # SmtpEmailSender
+```
+
+간단한 경우에는 `context.bind_to_name(IEmailSender, "smtp")` 또는
+`context.bind_to_type(IEmailSender, SmtpEmailSender)`를 사용할 수 있습니다.
+Binding은 Pod 등록 전에도 선언할 수 있으므로, 플러그인 자동 로딩 흐름을
+유지하면서 application config만으로 단수 구현체 선택을 제어할 수 있습니다.
+
+### Collection 주입
+
+여러 구현체를 모두 사용해야 하면 단수 타입 대신 collection 타입을 선언합니다.
+Collection 주입은 단수 선택 정책을 적용하지 않고, 매칭되는 모든 후보를 Pod
+name 기준의 안정적인 순서로 주입합니다.
+
+```python
+@Pod()
+class NotificationFanout:
+    def __init__(
+        self,
+        senders: list[IEmailSender],
+        sender_by_name: dict[str, IEmailSender],
+    ) -> None:
+        self.senders = senders
+        self.smtp = sender_by_name["smtp"]
+```
+
+지원 타입은 `list[T]`, `tuple[T, ...]`, `dict[str, T]`입니다. Qualifier를
+붙이면 collection에 들어갈 후보 전체를 필터링할 수 있습니다.
+
+```python
+from typing import Annotated
+from spakky.core.pod.annotations.qualifier import Qualifier
+
+@Pod()
+class PrimaryFanout:
+    def __init__(
+        self,
+        senders: Annotated[
+            list[IEmailSender],
+            Qualifier(lambda p: p.name.startswith("smtp")),
+        ],
+    ) -> None:
+        self.senders = senders
+```
+
+`contains(type_)`는 해당 타입 후보가 등록되어 있는지만 확인합니다. 후보가
+둘 이상이라 단수 resolution이 모호해도 `contains(type_)`는 `True`일 수
+있으며, 실제 단수 선택 가능성은 `get(type_)` 또는 생성자 주입 시점에
+판정됩니다.
+
 ### @Qualifier — 같은 타입의 Pod 구분
 
 같은 인터페이스를 구현하는 Pod가 여러 개 있을 때, `Annotated` 타입 힌트에 `Qualifier`를 넣어 선택 조건을 지정합니다.

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -28,6 +28,11 @@ app.scan()
 app.start()
 ```
 
+`load_plugins()`의 기본 동작은 설치된 entry point를 자동 발견하고 모두
+초기화하는 것입니다. 복수 구현체 DI 지원은 이 자동 활성화 모델을 바꾸지
+않습니다. 여러 플러그인이 같은 interface나 port 구현체를 등록해도 플러그인은
+그대로 로드되며, 단수 주입 지점에서만 DI 컨테이너의 선택 정책이 적용됩니다.
+
 ### 선택적 플러그인 로드
 
 ```python
@@ -40,6 +45,49 @@ app.load_plugins(include={
     spakky.plugins.sqlalchemy.PLUGIN_NAME,
 })
 ```
+
+### 복수 구현체 선택
+
+서로 다른 플러그인이 같은 port를 구현할 수 있습니다. 예를 들어 여러
+execution adapter 플러그인이 같은 `IAgentAdapter`를 제공하는 경우,
+플러그인을 opt-out하지 않고 application config에서 단수 선택 정책을 등록합니다.
+
+```python
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.binding import PodBinding
+
+context = ApplicationContext()
+context.bind(PodBinding(interface=IAgentAdapter, implementation_name="langgraph"))
+
+app = (
+    SpakkyApplication(context)
+    .load_plugins()
+    .scan()
+    .start()
+)
+```
+
+Binding은 Pod 등록 전에도 선언할 수 있으므로 `load_plugins()` 자동 활성화를
+유지한 채 단수 주입의 기본 구현체만 선택할 수 있습니다. 우선순위는
+`Qualifier`, 명시 name, binding, `@Primary`, legacy parameter name fallback
+순서입니다. Binding target은 concrete type 또는 Pod name 중 정확히 하나만
+지정해야 합니다.
+
+모든 구현체가 필요한 확장 포인트는 단수 port 대신 collection 의존성을
+선언합니다. `list[T]`, `tuple[T, ...]`, `dict[str, T]`는 매칭되는 모든 Pod를
+Pod name 기준의 안정적인 순서로 주입하며, binding으로 하나를 고르지 않습니다.
+
+```python
+@Pod()
+class AgentAdapterRegistry:
+    def __init__(self, adapters: dict[str, IAgentAdapter]) -> None:
+        self.adapters = adapters
+```
+
+`contains(type_)`는 후보 존재 여부만 의미합니다. 여러 플러그인이 같은 port
+후보를 등록해 단수 선택이 모호해도, 후보가 하나 이상이면 `True`입니다. 실제
+단수 resolution 가능성은 `get(type_)` 또는 생성자 주입 시점에 판정됩니다.
 
 ---
 


### PR DESCRIPTION
## Summary

- Document DI multi-implementation resolution priority and `contains(type_)` semantics.
- Add collection injection docs for `list[T]`, `tuple[T, ...]`, and `dict[str, T]`.
- Clarify plugin auto-activation remains intact and binding selects only single injection points.

## Verification

- `uv run mkdocs build --strict`
- acceptance grep for collection injection, binding policy, `contains(type_)`, legacy fallback, and plugin auto-activation terms

Closes #179
