### PR TITLE
feat(core): load active feature contributions (#193)

### DIFF
--- a/core/spakky/src/spakky/core/application/application.py
+++ b/core/spakky/src/spakky/core/application/application.py
@@ -5,7 +5,7 @@ for configuring and starting a Spakky application with DI/IoC and AOP support.
 """
 
 import inspect
-from importlib.metadata import entry_points
+from importlib.metadata import EntryPoint, entry_points
 from pathlib import Path
 from types import FunctionType, ModuleType
 from typing import Callable, Self
@@ -28,7 +28,7 @@ from spakky.core.application.startup_diagnostics import (
     StartupDiagnosticDetail,
     StartupReport,
 )
-from spakky.core.common.constants import PLUGIN_PATH
+from spakky.core.common.constants import CONTRIBUTION_PATH_PREFIX, PLUGIN_PATH
 from spakky.core.common.importing import (
     Module,
     ensure_importable,
@@ -47,6 +47,8 @@ STARTUP_PHASE_LOAD_PLUGINS = "load_plugins"
 STARTUP_PHASE_SCAN = "scan"
 STARTUP_PHASE_REGISTRATION = "registration"
 
+_PLUGIN_MODULE_PREFIX = "spakky.plugins."
+
 
 @immutable
 class _DiscoveryManifestHit:
@@ -57,6 +59,11 @@ class _DiscoveryManifestHit:
 
     objects: tuple[PodType, ...]
     """Resolved Pod or Tag objects."""
+
+
+def _is_core_feature_entry_point(entry_point: EntryPoint) -> bool:
+    """Return whether a base plugin entry point represents a core feature."""
+    return not entry_point.value.startswith(_PLUGIN_MODULE_PREFIX)
 
 
 class CannotDetermineScanPathError(AbstractSpakkyApplicationError):
@@ -360,23 +367,41 @@ class SpakkyApplication:
             Self for method chaining.
         """
         loaded_count = 0
+        active_feature_plugins: set[Plugin] = set()
         with self._startup_phase_recorder.record_phase(
             phase_name=STARTUP_PHASE_LOAD_PLUGINS
         ) as plugin_phase:
-            for entry_point in entry_points(
-                group=PLUGIN_PATH
-            ):  # pragma: no cover - coverage boundary
-                if include is not None:  # pragma: no cover - coverage boundary
-                    if (
-                        Plugin(name=entry_point.name) not in include
-                    ):  # pragma: no cover - coverage boundary
-                        continue  # pragma: no cover - coverage boundary
+            base_entry_points = sorted(
+                entry_points(group=PLUGIN_PATH),
+                key=lambda entry_point: entry_point.name,
+            )
+            for entry_point in base_entry_points:
+                plugin = Plugin(name=entry_point.name)
+                if include is not None and plugin not in include:
+                    continue
                 entry_point_function: Callable[[SpakkyApplication], None] = (
                     entry_point.load()
                 )
                 loaded_count += 1
                 plugin_phase.set_processed_count(loaded_count)
-                entry_point_function(self)  # pragma: no cover - coverage boundary
+                entry_point_function(self)
+                if _is_core_feature_entry_point(entry_point):
+                    active_feature_plugins.add(plugin)
+            for feature_plugin in sorted(
+                active_feature_plugins,
+                key=lambda plugin: plugin.name,
+            ):
+                contribution_entry_points = sorted(
+                    entry_points(
+                        group=(f"{CONTRIBUTION_PATH_PREFIX}.{feature_plugin.name}")
+                    ),
+                    key=lambda entry_point: entry_point.name,
+                )
+                for contribution_entry_point in contribution_entry_points:
+                    entry_point_function = contribution_entry_point.load()
+                    loaded_count += 1
+                    plugin_phase.set_processed_count(loaded_count)
+                    entry_point_function(self)
         return self
 
     def start(self) -> Self:

--- a/core/spakky/src/spakky/core/common/constants.py
+++ b/core/spakky/src/spakky/core/common/constants.py
@@ -1,6 +1,7 @@
 """Core constants for Spakky framework."""
 
 PLUGIN_PATH = "spakky.plugins"
+CONTRIBUTION_PATH_PREFIX = "spakky.contributions"
 ANNOTATION_METADATA = "__spakky_annotation_metadata__"
 PATH = "__path__"
 ORIGIN_BASES = "__orig_bases__"

--- a/core/spakky/tests/application/test_application_methods.py
+++ b/core/spakky/tests/application/test_application_methods.py
@@ -1,5 +1,11 @@
 """Test application methods for complete coverage."""
 
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import pytest
+
+import spakky.core.application.application as application_module
 from spakky.core.aop.aspect import Aspect, AsyncAspect
 from spakky.core.aop.interfaces.aspect import IAspect, IAsyncAspect
 from spakky.core.application.application import SpakkyApplication
@@ -13,6 +19,26 @@ class StubAspect(IAspect): ...
 
 @AsyncAspect()
 class AsyncStubAspect(IAsyncAspect): ...
+
+
+@dataclass(frozen=True)
+class FakeEntryPoint:
+    name: str
+    value: str
+    initializer: Callable[[SpakkyApplication], None]
+
+    def load(self) -> Callable[[SpakkyApplication], None]:
+        return self.initializer
+
+
+def _recording_initializer(
+    calls: list[str],
+    label: str,
+) -> Callable[[SpakkyApplication], None]:
+    def initialize(_app: SpakkyApplication) -> None:
+        calls.append(label)
+
+    return initialize
 
 
 def test_add_aspect_expect_registered() -> None:
@@ -36,6 +62,191 @@ def test_load_plugins_with_include() -> None:
     app.load_plugins(include={Plugin(name="non_existent_plugin")})
     # Should complete without error
     assert app is not None
+
+
+def test_load_plugins_expect_contributions_after_base_plugins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """active core feature contribution이 base plugin 이후 로드됨을 검증한다."""
+    calls: list[str] = []
+
+    def fake_entry_points(group: str) -> tuple[FakeEntryPoint, ...]:
+        if group == "spakky.plugins":
+            return (
+                FakeEntryPoint(
+                    name="spakky-sqlalchemy",
+                    value="spakky.plugins.sqlalchemy.main:initialize",
+                    initializer=_recording_initializer(calls, "base:sqlalchemy"),
+                ),
+                FakeEntryPoint(
+                    name="spakky-outbox",
+                    value="spakky.outbox.main:initialize",
+                    initializer=_recording_initializer(calls, "base:outbox"),
+                ),
+            )
+        if group == "spakky.contributions.spakky-outbox":
+            return (
+                FakeEntryPoint(
+                    name="sqlalchemy-outbox",
+                    value=("spakky.plugins.sqlalchemy.contributions.outbox:initialize"),
+                    initializer=_recording_initializer(
+                        calls,
+                        "contribution:sqlalchemy-outbox",
+                    ),
+                ),
+            )
+        return ()
+
+    monkeypatch.setattr(application_module, "entry_points", fake_entry_points)
+
+    SpakkyApplication(ApplicationContext()).load_plugins()
+
+    assert calls == [
+        "base:outbox",
+        "base:sqlalchemy",
+        "contribution:sqlalchemy-outbox",
+    ]
+
+
+def test_load_plugins_without_active_feature_expect_no_contribution_loaded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """core feature가 active가 아니면 contribution lookup이 등록을 수행하지 않는다."""
+    calls: list[str] = []
+    requested_groups: list[str] = []
+
+    def fake_entry_points(group: str) -> tuple[FakeEntryPoint, ...]:
+        requested_groups.append(group)
+        if group == "spakky.plugins":
+            return (
+                FakeEntryPoint(
+                    name="spakky-sqlalchemy",
+                    value="spakky.plugins.sqlalchemy.main:initialize",
+                    initializer=_recording_initializer(calls, "base:sqlalchemy"),
+                ),
+            )
+        return (
+            FakeEntryPoint(
+                name="unexpected",
+                value="unexpected.module:initialize",
+                initializer=_recording_initializer(calls, "unexpected"),
+            ),
+        )
+
+    monkeypatch.setattr(application_module, "entry_points", fake_entry_points)
+
+    SpakkyApplication(ApplicationContext()).load_plugins()
+
+    assert calls == ["base:sqlalchemy"]
+    assert requested_groups == ["spakky.plugins"]
+
+
+def test_load_plugins_include_expect_skipped_feature_has_no_contributions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """include에서 제외된 core feature의 contribution을 조회하지 않음을 검증한다."""
+    calls: list[str] = []
+    requested_groups: list[str] = []
+
+    def fake_entry_points(group: str) -> tuple[FakeEntryPoint, ...]:
+        requested_groups.append(group)
+        if group == "spakky.plugins":
+            return (
+                FakeEntryPoint(
+                    name="spakky-outbox",
+                    value="spakky.outbox.main:initialize",
+                    initializer=_recording_initializer(calls, "base:outbox"),
+                ),
+                FakeEntryPoint(
+                    name="spakky-sqlalchemy",
+                    value="spakky.plugins.sqlalchemy.main:initialize",
+                    initializer=_recording_initializer(calls, "base:sqlalchemy"),
+                ),
+            )
+        return (
+            FakeEntryPoint(
+                name="unexpected",
+                value="unexpected.module:initialize",
+                initializer=_recording_initializer(calls, "unexpected"),
+            ),
+        )
+
+    monkeypatch.setattr(application_module, "entry_points", fake_entry_points)
+
+    SpakkyApplication(ApplicationContext()).load_plugins(
+        include={Plugin(name="spakky-sqlalchemy")}
+    )
+
+    assert calls == ["base:sqlalchemy"]
+    assert requested_groups == ["spakky.plugins"]
+
+
+def test_load_plugins_expect_deterministic_contribution_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """여러 feature/contribution 로딩 순서가 재현 가능함을 검증한다."""
+    calls: list[str] = []
+
+    def fake_entry_points(group: str) -> tuple[FakeEntryPoint, ...]:
+        if group == "spakky.plugins":
+            return (
+                FakeEntryPoint(
+                    name="spakky-outbox",
+                    value="spakky.outbox.main:initialize",
+                    initializer=_recording_initializer(calls, "base:outbox"),
+                ),
+                FakeEntryPoint(
+                    name="spakky-data",
+                    value="spakky.data.main:initialize",
+                    initializer=_recording_initializer(calls, "base:data"),
+                ),
+            )
+        if group == "spakky.contributions.spakky-data":
+            return (
+                FakeEntryPoint(
+                    name="z-data",
+                    value="example.z_data:initialize",
+                    initializer=_recording_initializer(calls, "contribution:z-data"),
+                ),
+                FakeEntryPoint(
+                    name="a-data",
+                    value="example.a_data:initialize",
+                    initializer=_recording_initializer(calls, "contribution:a-data"),
+                ),
+            )
+        if group == "spakky.contributions.spakky-outbox":
+            return (
+                FakeEntryPoint(
+                    name="z-outbox",
+                    value="example.z_outbox:initialize",
+                    initializer=_recording_initializer(
+                        calls,
+                        "contribution:z-outbox",
+                    ),
+                ),
+                FakeEntryPoint(
+                    name="a-outbox",
+                    value="example.a_outbox:initialize",
+                    initializer=_recording_initializer(
+                        calls,
+                        "contribution:a-outbox",
+                    ),
+                ),
+            )
+        return ()
+
+    monkeypatch.setattr(application_module, "entry_points", fake_entry_points)
+
+    SpakkyApplication(ApplicationContext()).load_plugins()
+
+    assert calls == [
+        "base:data",
+        "base:outbox",
+        "contribution:a-data",
+        "contribution:z-data",
+        "contribution:a-outbox",
+        "contribution:z-outbox",
+    ]
 
 
 def test_stop_application() -> None:


### PR DESCRIPTION
## 요약

- `load_plugins()`가 `spakky.plugins` base plugin을 먼저 로드한 뒤 active core feature별 contribution group을 조회하도록 확장했습니다.
- contribution group 이름은 `spakky.contributions.<feature-plugin-name>` 형식을 사용하고, feature name 및 contribution entry point name 기준으로 정렬해 재현 가능한 호출 순서를 보장합니다.
- core feature가 active가 아니거나 include에서 제외된 경우 contribution을 조회/호출하지 않는 회귀 테스트를 추가했습니다.

## 검증

- `cd core/spakky && uv run ruff format .` → pass
- `cd core/spakky && uv run ruff check .` → pass
- `cd core/spakky && uv run pytest tests/application/test_application_methods.py --no-cov` → 13 passed
- `cd core/spakky && uv run pyrefly check src tests` → 0 errors
- `cd core/spakky && uv run pytest` → 388 passed, coverage 100.00%
- pre-commit hook → pass
- pre-push hook → pass

## Acceptance Criteria (자가 grep)

- 수용 기준 섹션에 직접 실행 가능한 grep/find/rg 라인이 없어 `acceptance_check: missing`으로 분류했습니다.

Closes #193
