### PR TITLE
feat(core): filter contributions by active provider (#195)

### DIFF
--- a/core/spakky/src/spakky/core/application/application.py
+++ b/core/spakky/src/spakky/core/application/application.py
@@ -66,6 +66,38 @@ def _is_core_feature_entry_point(entry_point: EntryPoint) -> bool:
     return not entry_point.value.startswith(_PLUGIN_MODULE_PREFIX)
 
 
+def _provider_plugins_for_contribution(entry_point: EntryPoint) -> set[Plugin]:
+    """Return base plugin providers declared by the entry point distribution."""
+    distribution = entry_point.dist
+    if distribution is None:
+        return set()
+    return {
+        Plugin(name=provider_entry_point.name)
+        for provider_entry_point in distribution.entry_points
+        if provider_entry_point.group == PLUGIN_PATH
+    }
+
+
+def _should_load_contribution(
+    feature_plugin: Plugin,
+    contribution_entry_point: EntryPoint,
+    loaded_base_plugins: set[Plugin],
+    include: set[Plugin] | None,
+) -> bool:
+    """Return whether a contribution matches active feature/provider filters."""
+    if include is not None and feature_plugin not in include:
+        return False
+    active_provider_plugins = (
+        _provider_plugins_for_contribution(contribution_entry_point)
+        & loaded_base_plugins
+    )
+    if len(active_provider_plugins) == 0:
+        return False
+    if include is None:
+        return True
+    return len(active_provider_plugins & include) > 0
+
+
 class CannotDetermineScanPathError(AbstractSpakkyApplicationError):
     """Raised when the scan path cannot be automatically determined."""
 
@@ -367,6 +399,7 @@ class SpakkyApplication:
             Self for method chaining.
         """
         loaded_count = 0
+        loaded_base_plugins: set[Plugin] = set()
         active_feature_plugins: set[Plugin] = set()
         with self._startup_phase_recorder.record_phase(
             phase_name=STARTUP_PHASE_LOAD_PLUGINS
@@ -385,6 +418,7 @@ class SpakkyApplication:
                 loaded_count += 1
                 plugin_phase.set_processed_count(loaded_count)
                 entry_point_function(self)
+                loaded_base_plugins.add(plugin)
                 if _is_core_feature_entry_point(entry_point):
                     active_feature_plugins.add(plugin)
             for feature_plugin in sorted(
@@ -398,6 +432,13 @@ class SpakkyApplication:
                     key=lambda entry_point: entry_point.name,
                 )
                 for contribution_entry_point in contribution_entry_points:
+                    if not _should_load_contribution(
+                        feature_plugin=feature_plugin,
+                        contribution_entry_point=contribution_entry_point,
+                        loaded_base_plugins=loaded_base_plugins,
+                        include=include,
+                    ):
+                        continue
                     entry_point_function = contribution_entry_point.load()
                     loaded_count += 1
                     plugin_phase.set_processed_count(loaded_count)

--- a/core/spakky/tests/application/test_application_methods.py
+++ b/core/spakky/tests/application/test_application_methods.py
@@ -22,10 +22,22 @@ class AsyncStubAspect(IAsyncAspect): ...
 
 
 @dataclass(frozen=True)
+class FakeDistributionEntryPoint:
+    name: str
+    group: str
+
+
+@dataclass(frozen=True)
+class FakeDistribution:
+    entry_points: tuple[FakeDistributionEntryPoint, ...]
+
+
+@dataclass(frozen=True)
 class FakeEntryPoint:
     name: str
     value: str
     initializer: Callable[[SpakkyApplication], None]
+    dist: FakeDistribution | None = None
 
     def load(self) -> Callable[[SpakkyApplication], None]:
         return self.initializer
@@ -92,6 +104,14 @@ def test_load_plugins_expect_contributions_after_base_plugins(
                     initializer=_recording_initializer(
                         calls,
                         "contribution:sqlalchemy-outbox",
+                    ),
+                    dist=FakeDistribution(
+                        entry_points=(
+                            FakeDistributionEntryPoint(
+                                name="spakky-sqlalchemy",
+                                group="spakky.plugins",
+                            ),
+                        )
                     ),
                 ),
             )
@@ -181,6 +201,154 @@ def test_load_plugins_include_expect_skipped_feature_has_no_contributions(
     assert requested_groups == ["spakky.plugins"]
 
 
+def test_load_plugins_include_feature_and_provider_expect_contribution_loaded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """include가 feature와 provider를 모두 담으면 contribution을 로드한다."""
+    calls: list[str] = []
+
+    def fake_entry_points(group: str) -> tuple[FakeEntryPoint, ...]:
+        if group == "spakky.plugins":
+            return (
+                FakeEntryPoint(
+                    name="spakky-outbox",
+                    value="spakky.outbox.main:initialize",
+                    initializer=_recording_initializer(calls, "base:outbox"),
+                ),
+                FakeEntryPoint(
+                    name="spakky-sqlalchemy",
+                    value="spakky.plugins.sqlalchemy.main:initialize",
+                    initializer=_recording_initializer(calls, "base:sqlalchemy"),
+                ),
+            )
+        if group == "spakky.contributions.spakky-outbox":
+            return (
+                FakeEntryPoint(
+                    name="sqlalchemy-outbox",
+                    value=("spakky.plugins.sqlalchemy.contributions.outbox:initialize"),
+                    initializer=_recording_initializer(
+                        calls,
+                        "contribution:sqlalchemy-outbox",
+                    ),
+                    dist=FakeDistribution(
+                        entry_points=(
+                            FakeDistributionEntryPoint(
+                                name="spakky-sqlalchemy",
+                                group="spakky.plugins",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        return ()
+
+    monkeypatch.setattr(application_module, "entry_points", fake_entry_points)
+
+    SpakkyApplication(ApplicationContext()).load_plugins(
+        include={Plugin(name="spakky-outbox"), Plugin(name="spakky-sqlalchemy")}
+    )
+
+    assert calls == [
+        "base:outbox",
+        "base:sqlalchemy",
+        "contribution:sqlalchemy-outbox",
+    ]
+
+
+def test_load_plugins_include_feature_only_expect_provider_contribution_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """include에 provider가 없으면 feature contribution을 skip한다."""
+    calls: list[str] = []
+    requested_groups: list[str] = []
+
+    def fake_entry_points(group: str) -> tuple[FakeEntryPoint, ...]:
+        requested_groups.append(group)
+        if group == "spakky.plugins":
+            return (
+                FakeEntryPoint(
+                    name="spakky-outbox",
+                    value="spakky.outbox.main:initialize",
+                    initializer=_recording_initializer(calls, "base:outbox"),
+                ),
+                FakeEntryPoint(
+                    name="spakky-sqlalchemy",
+                    value="spakky.plugins.sqlalchemy.main:initialize",
+                    initializer=_recording_initializer(calls, "base:sqlalchemy"),
+                ),
+            )
+        if group == "spakky.contributions.spakky-outbox":
+            return (
+                FakeEntryPoint(
+                    name="sqlalchemy-outbox",
+                    value=("spakky.plugins.sqlalchemy.contributions.outbox:initialize"),
+                    initializer=_recording_initializer(
+                        calls,
+                        "contribution:sqlalchemy-outbox",
+                    ),
+                    dist=FakeDistribution(
+                        entry_points=(
+                            FakeDistributionEntryPoint(
+                                name="spakky-sqlalchemy",
+                                group="spakky.plugins",
+                            ),
+                        )
+                    ),
+                ),
+            )
+        return ()
+
+    monkeypatch.setattr(application_module, "entry_points", fake_entry_points)
+
+    SpakkyApplication(ApplicationContext()).load_plugins(
+        include={Plugin(name="spakky-outbox")}
+    )
+
+    assert calls == ["base:outbox"]
+    assert requested_groups == [
+        "spakky.plugins",
+        "spakky.contributions.spakky-outbox",
+    ]
+
+
+def test_load_plugins_include_empty_expect_no_base_or_contribution_loaded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """include가 빈 set이면 base plugin과 contribution을 모두 로드하지 않는다."""
+    calls: list[str] = []
+    requested_groups: list[str] = []
+
+    def fake_entry_points(group: str) -> tuple[FakeEntryPoint, ...]:
+        requested_groups.append(group)
+        if group == "spakky.plugins":
+            return (
+                FakeEntryPoint(
+                    name="spakky-outbox",
+                    value="spakky.outbox.main:initialize",
+                    initializer=_recording_initializer(calls, "base:outbox"),
+                ),
+                FakeEntryPoint(
+                    name="spakky-sqlalchemy",
+                    value="spakky.plugins.sqlalchemy.main:initialize",
+                    initializer=_recording_initializer(calls, "base:sqlalchemy"),
+                ),
+            )
+        return (
+            FakeEntryPoint(
+                name="unexpected",
+                value="unexpected.module:initialize",
+                initializer=_recording_initializer(calls, "unexpected"),
+            ),
+        )
+
+    monkeypatch.setattr(application_module, "entry_points", fake_entry_points)
+
+    SpakkyApplication(ApplicationContext()).load_plugins(include=set())
+
+    assert calls == []
+    assert requested_groups == ["spakky.plugins"]
+
+
 def test_load_plugins_expect_deterministic_contribution_order(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -200,6 +368,11 @@ def test_load_plugins_expect_deterministic_contribution_order(
                     value="spakky.data.main:initialize",
                     initializer=_recording_initializer(calls, "base:data"),
                 ),
+                FakeEntryPoint(
+                    name="spakky-sqlalchemy",
+                    value="spakky.plugins.sqlalchemy.main:initialize",
+                    initializer=_recording_initializer(calls, "base:sqlalchemy"),
+                ),
             )
         if group == "spakky.contributions.spakky-data":
             return (
@@ -207,11 +380,27 @@ def test_load_plugins_expect_deterministic_contribution_order(
                     name="z-data",
                     value="example.z_data:initialize",
                     initializer=_recording_initializer(calls, "contribution:z-data"),
+                    dist=FakeDistribution(
+                        entry_points=(
+                            FakeDistributionEntryPoint(
+                                name="spakky-sqlalchemy",
+                                group="spakky.plugins",
+                            ),
+                        )
+                    ),
                 ),
                 FakeEntryPoint(
                     name="a-data",
                     value="example.a_data:initialize",
                     initializer=_recording_initializer(calls, "contribution:a-data"),
+                    dist=FakeDistribution(
+                        entry_points=(
+                            FakeDistributionEntryPoint(
+                                name="spakky-sqlalchemy",
+                                group="spakky.plugins",
+                            ),
+                        )
+                    ),
                 ),
             )
         if group == "spakky.contributions.spakky-outbox":
@@ -223,6 +412,14 @@ def test_load_plugins_expect_deterministic_contribution_order(
                         calls,
                         "contribution:z-outbox",
                     ),
+                    dist=FakeDistribution(
+                        entry_points=(
+                            FakeDistributionEntryPoint(
+                                name="spakky-sqlalchemy",
+                                group="spakky.plugins",
+                            ),
+                        )
+                    ),
                 ),
                 FakeEntryPoint(
                     name="a-outbox",
@@ -230,6 +427,14 @@ def test_load_plugins_expect_deterministic_contribution_order(
                     initializer=_recording_initializer(
                         calls,
                         "contribution:a-outbox",
+                    ),
+                    dist=FakeDistribution(
+                        entry_points=(
+                            FakeDistributionEntryPoint(
+                                name="spakky-sqlalchemy",
+                                group="spakky.plugins",
+                            ),
+                        )
                     ),
                 ),
             )
@@ -242,6 +447,7 @@ def test_load_plugins_expect_deterministic_contribution_order(
     assert calls == [
         "base:data",
         "base:outbox",
+        "base:sqlalchemy",
         "contribution:a-data",
         "contribution:z-data",
         "contribution:a-outbox",

--- a/docs/adr/0010-feature-contribution-policy.md
+++ b/docs/adr/0010-feature-contribution-policy.md
@@ -108,6 +108,8 @@ Spakky Framework는 **Feature Contribution Policy**를 도입한다. plugin pack
 - contribution `initialize()`도 다른 plugin을 직접 import하지 않고, feature core contract와 자기 plugin 내부 구현만 import한다.
 - loader는 base plugin loading 이후 활성 feature contribution을 로드한다.
 - `include`가 지정된 plugin loading에서는 base plugin과 contribution provider/plugin filtering semantics를 명시적으로 정의한다.
+- `include`가 지정되면 target feature plugin과 contribution provider base plugin이 모두 `include`에 있고 실제 base plugin으로 로드된 경우에만 contribution을 로드한다.
+- contribution provider base plugin은 contribution entry point name 파싱이 아니라 해당 entry point distribution의 `spakky.plugins` metadata로 식별한다.
 - diagnostics는 로드된 contribution, skipped contribution, missing required contribution을 startup report에 기록할 수 있어야 한다.
 
 ## Canonical Loading Model
@@ -174,7 +176,6 @@ ADR-0009의 `spakky-agent`는 checkpoint/evidence/artifact persistence가 필수
 
 ## 미결정 사항
 
-- `include`가 provider plugin만 포함하고 feature plugin을 제외한 경우 contribution을 skip할지, 진단만 남길지
 - contribution entry point가 base plugin보다 먼저 로드될 수 없도록 보장하는 구체 순서
 - contribution이 required인지 optional인지 feature core가 선언하는 API
 - contribution diagnostics의 정확한 public model


### PR DESCRIPTION
## 요약
- contribution provider base plugin을 distribution의 `spakky.plugins` metadata로 식별하도록 loader를 확장했습니다.
- target feature와 provider base plugin이 모두 active/include 조건을 만족할 때만 contribution을 로드하도록 했습니다.
- include feature/provider/empty 조합 테스트와 ADR-0010 include semantics 결정을 동기화했습니다.

## 검증
- `cd core/spakky && uv run --with ruff ruff format --check src tests`
- `cd core/spakky && uv run --with ruff ruff check src tests`
- `cd core/spakky && uv run --with pyrefly --with pytest pyrefly check src tests`
- `cd core/spakky && uv run --with pytest --with pytest-asyncio --with pytest-cov --with pytest-spec --with pytest-xdist pytest`
- `uv run mkdocs build --strict`
- pre-commit / pre-push hooks passed

Closes #195