### PR TITLE
docs: document feature contributions (#196)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,7 +26,7 @@
 | **Plugin** | `spakky-security` | 암호화/해싱/JWT 유틸리티 |
 | **Plugin** | `spakky-rabbitmq` | RabbitMQ 이벤트 브로커 통합 |
 | **Plugin** | `spakky-kafka` | Apache Kafka 이벤트 브로커 통합 |
-| **Plugin** | `spakky-sqlalchemy` | SQLAlchemy ORM 통합 + Outbox 저장소 등록 |
+| **Plugin** | `spakky-sqlalchemy` | SQLAlchemy ORM 통합 + Outbox 저장소 contribution |
 | **Plugin** | `spakky-celery` | Celery 태스크 디스패치 및 스케줄 등록 |
 | **Plugin** | `spakky-logging` | 구조화 로깅, 컨텍스트 전파, @logged AOP Aspect |
 | **Plugin** | `spakky-opentelemetry` | OpenTelemetry SDK 브릿지 (TracerProvider, OTel Propagator) |
@@ -95,7 +95,7 @@ graph TD
     saga --> domain
 
     sqlalchemy --> data
-    sqlalchemy --> outbox
+    sqlalchemy -. outbox contribution .-> outbox
     rabbitmq --> event
     rabbitmq --> tracing
     kafka --> event
@@ -141,7 +141,7 @@ graph TD
 
 - **UI 플러그인** (fastapi, typer) → `spakky` 코어에만 의존. fastapi는 `spakky-tracing`에도 의존 (트레이싱 미들웨어)
 - **유틸리티 플러그인** (security) → `spakky` 코어에만 의존
-- **인프라 플러그인** (sqlalchemy) → `spakky-data` + `spakky-outbox`에 의존 (Outbox 저장소 등록)
+- **인프라 플러그인** (sqlalchemy) → `spakky-data` + `spakky-outbox`에 의존. Base plugin은 SQLAlchemy substrate를 등록하고, Outbox 저장소는 `spakky.contributions.spakky.outbox` contribution으로 등록
 - **트랜스포트 플러그인** (rabbitmq, kafka) → `spakky-event`까지 의존 (전체 코어 체인). `spakky-tracing`에도 의존 (컨텍스트 전파)
 - **Outbox 코어** (spakky-outbox) → `spakky-event` + `spakky-tracing`에 의존 (추상화 + 오케스트레이션)
 - **태스크 코어** (spakky-task) → `spakky` 코어에만 의존
@@ -346,7 +346,7 @@ app = (
 
 **`scan()` 자동 감지**: `inspect.stack()`으로 호출자의 패키지를 찾고, 하위 모듈을 재귀 순회하며 `Pod.exists()` 또는 `Tag.exists()`인 객체를 등록합니다.
 
-**Startup diagnostics**: `enable_startup_diagnostics()`는 no-op 기본 recorder를 활성 recorder로 교체합니다. 활성화된 앱은 startup attempt별 `StartupReport`를 생성하고 `load_plugins`, `scan`, `registration`, `post_processor_registration`, `instantiation`, `post_processing`, `service_start` phase를 실행 순서대로 기록합니다. 각 record는 phase name, elapsed seconds, processed count, success/failure status, optional diagnostic details, optional structured failure summary를 포함합니다. 실패 phase는 기록된 뒤 기존 예외를 그대로 전파합니다.
+**Startup diagnostics**: `enable_startup_diagnostics()`는 no-op 기본 recorder를 활성 recorder로 교체합니다. 활성화된 앱은 startup attempt별 `StartupReport`를 생성하고 `load_plugins`, `scan`, `registration`, `post_processor_registration`, `instantiation`, `post_processing`, `service_start` phase를 실행 순서대로 기록합니다. 각 record는 phase name, elapsed seconds, processed count, success/failure status, optional diagnostic details, optional structured failure summary를 포함합니다. `load_plugins` phase는 base plugin 이후 로드된 feature contribution의 loaded/skipped/failed count와 `inactive_feature`, `inactive_provider`, `include_filter` skip reason을 diagnostic detail로 기록합니다. 실패 phase는 기록된 뒤 기존 예외를 그대로 전파합니다.
 
 **DiscoveryManifest 재사용**: `enable_discovery_manifest(path=None)`을 `scan()` 전에 호출하면 scan discovery 결과를 JSON manifest로 저장합니다. manifest fingerprint는 schema version, Python major/minor version, scan 대상 module/package, exclude pattern, source file mtime/size로 구성됩니다. decision은 `miss`, `hit`, `stale_schema`, `stale_input` 중 하나이며 startup diagnostics의 scan phase diagnostic detail로 기록됩니다. `hit`은 저장된 Pod/Tag 후보를 기존 등록 경로로 재생하고, stale/miss는 기존 fresh discovery로 돌아갑니다. container lookup/type cache는 변경하지 않습니다.
 
@@ -432,7 +432,7 @@ class TimingAspect(IAsyncAspect):
 spakky-data = "spakky.data.main:initialize"
 ```
 
-`SpakkyApplication.load_plugins()`는 `importlib.metadata.entry_points(group="spakky.plugins")`로 등록된 플러그인을 발견하고, 각 플러그인의 `initialize(app: SpakkyApplication)` 함수를 호출합니다. 복수 구현체 DI resolution은 이 자동 활성화 모델을 유지합니다. 여러 플러그인이 같은 port 후보를 등록해도 플러그인은 그대로 초기화되고, 단수 주입 지점에서만 Qualifier/name/binding/`@Primary`/legacy parameter name 순서로 하나를 선택합니다.
+`SpakkyApplication.load_plugins()`는 `importlib.metadata.entry_points(group="spakky.plugins")`로 등록된 base 플러그인을 발견하고, 각 플러그인의 `initialize(app: SpakkyApplication)` 함수를 호출합니다. 그 뒤 active core feature마다 `spakky.contributions.<feature>` group을 조회해 feature contribution을 base plugin 이후, `scan()`/`start()` 이전에 호출합니다. Feature plugin 이름의 `-`는 entry point group에서 `.`로 정규화되므로 `spakky-outbox`의 group은 `spakky.contributions.spakky.outbox`입니다. 복수 구현체 DI resolution은 이 자동 활성화 모델을 유지합니다. 여러 플러그인이 같은 port 후보를 등록해도 플러그인은 그대로 초기화되고, 단수 주입 지점에서만 Qualifier/name/binding/`@Primary`/legacy parameter name 순서로 하나를 선택합니다.
 
 ### 플러그인 등록 요약
 
@@ -447,7 +447,8 @@ spakky-data = "spakky.data.main:initialize"
 | `spakky-security` | (없음 — 유틸리티 함수만 제공) |
 | `spakky-rabbitmq` | `RabbitMQConnectionConfig`, Consumer/`RabbitMQEventTransport` (sync+async), `RabbitMQPostProcessor` |
 | `spakky-kafka` | `KafkaConnectionConfig`, Consumer/`KafkaEventTransport` (sync+async), `KafkaPostProcessor` |
-| `spakky-sqlalchemy` | `SQLAlchemyConnectionConfig`, `SchemaRegistry`, Session/ConnectionManager, Transaction, `SqlAlchemyOutboxStorage` (sync+async), `OutboxMessageTable` |
+| `spakky-sqlalchemy` | `SQLAlchemyConnectionConfig`, `SchemaRegistry`, Session/ConnectionManager, Transaction |
+| `spakky-sqlalchemy` contribution for `spakky-outbox` | `SqlAlchemyOutboxStorage` (sync+async), `OutboxMessageTable` |
 | `spakky-outbox` | `OutboxConfig`, `OutboxEventBus` (sync+async), `OutboxRelayBackgroundService` (sync+async) |
 | `spakky-task` | `TaskRegistrationPostProcessor` |
 | `spakky-actuator` | `ActuatorConfig`, `ActuatorExtensionRegistry`, `ActuatorExtensionPostProcessor`, `ActuatorAggregationService` |
@@ -1042,7 +1043,7 @@ flowchart TD
 
 ### 저장소 구현
 
-`spakky-sqlalchemy`가 `spakky-outbox`를 감지하면 `SqlAlchemyOutboxStorage`를 자동 등록합니다. 커스텀 저장소는 `IAsyncOutboxStorage`를 구현합니다.
+`spakky-sqlalchemy`는 `spakky.contributions.spakky.outbox` entry point로 `SqlAlchemyOutboxStorage`와 `OutboxMessageTable`을 기여합니다. 이 contribution은 `spakky-outbox` feature와 `spakky-sqlalchemy` provider가 모두 active일 때 base plugin 이후 로드됩니다. 커스텀 저장소는 `IAsyncOutboxStorage`를 구현합니다.
 
 > **설계 배경**: [ADR-0002](docs/adr/0002-outbox-plugin-architecture.md), [ADR-0005](docs/adr/0005-merge-outbox-sqlalchemy-into-sqlalchemy.md), [ADR-0006](docs/adr/0006-move-outbox-to-core.md) 참조.
 
@@ -1191,7 +1192,7 @@ flowchart TD
 
 | 플러그인 | 등록 컴포넌트 | 외부 의존성 |
 |---------|-------------|-----------|
-| `spakky-sqlalchemy` | ConnectionConfig, SchemaRegistry, Session/ConnectionManager, Transaction, `SqlAlchemyOutboxStorage` (sync+async), `OutboxMessageTable` | `sqlalchemy`, `spakky-outbox` |
+| `spakky-sqlalchemy` | ConnectionConfig, SchemaRegistry, Session/ConnectionManager, Transaction; `spakky-outbox` contribution으로 `SqlAlchemyOutboxStorage` (sync+async), `OutboxMessageTable` | `sqlalchemy`, `spakky-outbox` |
 | `spakky-security` | (등록 없음 — 유틸리티 함수만) | `argon2-cffi`, `bcrypt`, `pycryptodome` |
 | `spakky-redis` | `RedisCacheConfig`, `RedisCache` (sync+async) | `redis`, `pydantic-settings`, `spakky-cache` |
 ### 태스크 플러그인

--- a/core/spakky/README.md
+++ b/core/spakky/README.md
@@ -387,6 +387,28 @@ def initialize(app: SpakkyApplication) -> None:
     pass
 ```
 
+### Feature contribution
+
+인프라 plugin이 특정 core feature의 port 구현을 제공해야 하면 base plugin 본체에서
+feature 설치 여부를 감지하지 않고 contribution entry point를 선언합니다. Base plugin은
+공통 substrate만 등록하고, contribution은 target feature와 provider base plugin이 모두
+active일 때 base plugin 이후, `scan()`/`start()` 이전에 호출됩니다.
+
+```toml
+[project.entry-points."spakky.plugins"]
+spakky-myinfra = "spakky.plugins.myinfra.main:initialize"
+
+[project.entry-points."spakky.contributions.spakky.outbox"]
+spakky-myinfra = "spakky.plugins.myinfra.contributions.outbox:initialize"
+```
+
+Feature plugin 이름의 `-`는 group 이름에서 `.`로 정규화됩니다. 예를 들어
+`Plugin(name="spakky-outbox")`의 contribution group은
+`spakky.contributions.spakky.outbox`입니다. `load_plugins(include=...)`를 사용할 때는
+feature plugin과 provider plugin이 모두 include set에 있어야 contribution이 로드됩니다.
+Startup diagnostics를 켜면 `load_plugins` phase에 contribution loaded/skipped/failed
+count와 skip reason이 기록됩니다.
+
 자세한 내용은 [기여 가이드](../../CONTRIBUTING.md#-plugin-development)를 참고하세요.
 
 ## 사용 가능한 플러그인

--- a/docs/api/plugins/spakky-sqlalchemy.md
+++ b/docs/api/plugins/spakky-sqlalchemy.md
@@ -1,11 +1,16 @@
 # spakky-sqlalchemy
 
-SQLAlchemy 통합 — ORM, Repository, Transaction, Outbox Storage
+SQLAlchemy 통합 - ORM, Repository, Transaction, Outbox Contribution
 
 `spakky-sqlalchemy`는 `spakky-data`의 Repository/Transaction 계약을 SQLAlchemy engine과
 session으로 구현하는 플러그인입니다. 처음 사용하는 경우에는
 [데이터베이스 가이드](../../guides/sqlalchemy.md)에서 도메인 Aggregate, ORM table,
 Repository, `@Transactional()` UseCase를 한 흐름으로 확인하세요.
+
+Outbox storage/table은 base plugin 본체가 아니라
+`spakky.contributions.spakky.outbox` contribution으로 등록됩니다. `load_plugins(include=...)`
+사용 시 `spakky-outbox`와 `spakky-sqlalchemy`가 모두 include set에 있어야 이
+contribution이 로드됩니다.
 
 ## 메인
 
@@ -56,6 +61,10 @@ options:
 show_root_heading: false
 
 ## Outbox
+
+::: spakky.plugins.sqlalchemy.contributions.outbox
+options:
+show_root_heading: false
 
 ::: spakky.plugins.sqlalchemy.outbox.storage
 options:

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -507,7 +507,9 @@ from spakky.outbox.common.message import OutboxMessage
 
 ### IOutboxStorage
 
-Outbox 메시지의 CRUD를 담당하는 포트 인터페이스. `spakky-sqlalchemy` 플러그인이 구현체를 제공합니다.
+Outbox 메시지의 CRUD를 담당하는 포트 인터페이스. `spakky-sqlalchemy`는
+`spakky.contributions.spakky.outbox` contribution으로 SQLAlchemy 구현체와 Outbox
+table을 제공합니다.
 
 ```python
 from spakky.outbox.ports.storage import IOutboxStorage, IAsyncOutboxStorage

--- a/docs/guides/outbox.md
+++ b/docs/guides/outbox.md
@@ -23,12 +23,14 @@ from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
 import spakky.outbox
 import spakky.plugins.rabbitmq  # 또는 spakky.plugins.kafka
+import spakky.plugins.sqlalchemy
 import apps
 
 app = (
     SpakkyApplication(ApplicationContext())
     .load_plugins(include={
         spakky.outbox.PLUGIN_NAME,
+        spakky.plugins.sqlalchemy.PLUGIN_NAME,  # Outbox storage provider
         spakky.plugins.rabbitmq.PLUGIN_NAME,  # Transport 플러그인 필수
     })
     .scan(apps)
@@ -77,7 +79,9 @@ from spakky.outbox.relay.relay import (
 
 ### IOutboxStorage
 
-Outbox 메시지의 저장/조회/상태 변경을 담당하는 포트 인터페이스입니다. `spakky-sqlalchemy` 플러그인이 구현체를 제공합니다.
+Outbox 메시지의 저장/조회/상태 변경을 담당하는 포트 인터페이스입니다.
+`spakky-sqlalchemy`는 `spakky.contributions.spakky.outbox` contribution으로
+SQLAlchemy 구현체와 Outbox table을 제공합니다.
 
 ```python
 from spakky.outbox.ports.storage import IOutboxStorage, IAsyncOutboxStorage

--- a/docs/guides/sqlalchemy.md
+++ b/docs/guides/sqlalchemy.md
@@ -326,11 +326,14 @@ class MigrationMetadataProvider:
 
 ---
 
-## Outbox Storage
+## Outbox Contribution
 
-`spakky-outbox`가 함께 설치되어 있으면 `spakky-sqlalchemy`가 SQLAlchemy 기반 Outbox storage를
-등록합니다. `save()`는 현재 transactional session을 사용하므로 비즈니스 데이터와 Outbox
-메시지가 같은 DB transaction 안에서 commit 또는 rollback됩니다.
+SQLAlchemy 기반 Outbox storage/table은 `spakky-sqlalchemy` base plugin 본체가 아니라
+`spakky.contributions.spakky.outbox` contribution에서 등록됩니다. 이 contribution은
+`spakky-outbox` feature와 `spakky-sqlalchemy` provider가 모두 active일 때 base plugin
+이후 로드됩니다. `load_plugins(include=...)`를 사용한다면 두 plugin을 모두 include set에
+넣어야 합니다. `save()`는 현재 transactional session을 사용하므로 비즈니스 데이터와
+Outbox 메시지가 같은 DB transaction 안에서 commit 또는 rollback됩니다.
 
 ```python
 from spakky.plugins.sqlalchemy.outbox.storage import AsyncSqlAlchemyOutboxStorage

--- a/docs/index.md
+++ b/docs/index.md
@@ -290,7 +290,7 @@ flowchart LR
   kafka -. Kafka .-> event
   kafka -- tracing --> tracing_dep
   sqlalchemy -. ORM .-> data
-  sqlalchemy -- Outbox --> outbox
+  sqlalchemy -. Outbox contribution .-> outbox
   fastapi -. FastAPI .-> core
   fastapi -- tracing --> tracing_dep
   typer -. Typer .-> core

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -10,7 +10,8 @@ Spakky 플러그인 시스템은 Python의 `entry_points` 메커니즘을 사용
 
 1. `pyproject.toml`에 `spakky.plugins` 그룹으로 entry point 등록
 2. `SpakkyApplication.load_plugins()`가 등록된 플러그인 탐색
-3. 각 플러그인의 `initialize(app: SpakkyApplication)` 함수 호출
+3. 각 base 플러그인의 `initialize(app: SpakkyApplication)` 함수 호출
+4. 활성 core feature에 대한 `spakky.contributions.*` entry point 탐색 및 호출
 
 ---
 
@@ -45,6 +46,53 @@ app.load_plugins(include={
     spakky.plugins.sqlalchemy.PLUGIN_NAME,
 })
 ```
+
+`include`가 지정되면 base plugin은 include set에 들어 있는 항목만 로드됩니다.
+Contribution도 같은 명시성 규칙을 따르며, target feature plugin과 provider base
+plugin이 모두 include set에 있고 실제 base plugin으로 로드된 경우에만 호출됩니다.
+
+### Feature Contribution
+
+Feature Contribution Policy는 인프라 plugin 하나가 여러 core feature에 구현을
+기여하기 위한 표준 경로입니다. Base plugin은 자기 substrate의 공통 컴포넌트만
+등록하고, feature-specific port 구현은 별도 contribution entry point로 선언합니다.
+예를 들어 `spakky-sqlalchemy`의 base plugin은 SQLAlchemy connection, session,
+transaction, schema registry를 등록하고, Outbox storage/table은
+`spakky.contributions.spakky.outbox` contribution에서 등록합니다.
+
+```toml
+[project.entry-points."spakky.plugins"]
+spakky-sqlalchemy = "spakky.plugins.sqlalchemy.main:initialize"
+
+[project.entry-points."spakky.contributions.spakky.outbox"]
+spakky-sqlalchemy = "spakky.plugins.sqlalchemy.contributions.outbox:initialize"
+```
+
+Contribution group 이름은 `spakky.contributions.<feature>` 형식입니다. Feature
+plugin 이름의 `-`는 Python package metadata group에서 안전하게 쓰기 위해 `.`로
+정규화됩니다. 따라서 `Plugin(name="spakky-outbox")`의 contribution group은
+`spakky.contributions.spakky.outbox`입니다.
+
+Loader 순서는 다음과 같습니다.
+
+1. `spakky.plugins` entry point를 이름순으로 로드합니다.
+2. 로드된 base plugin으로 active feature/provider set을 계산합니다.
+3. active feature 이름순으로 contribution group을 조회합니다.
+4. 각 group 안의 contribution entry point를 이름순으로 호출합니다.
+5. `scan()`과 `start()`는 contribution 로딩 이후 실행됩니다.
+
+Provider base plugin은 contribution entry point name을 파싱하지 않고, 같은
+distribution이 선언한 `spakky.plugins` metadata로 식별합니다. Contribution module은
+target feature core package의 public contract와 자기 plugin 내부 구현만 import할 수
+있으며, 다른 plugin public module을 직접 import하지 않습니다.
+
+Startup diagnostics가 활성화되어 있으면 `load_plugins` phase detail에 contribution
+결과가 함께 기록됩니다. Summary key는 `contributions.loaded`,
+`contributions.skipped`, `contributions.failed`이며, skip reason은
+`inactive_feature`, `inactive_provider`, `include_filter`로 구분됩니다. 개별 항목은
+`contributions.loaded.item`, `contributions.skipped.item`,
+`contributions.failed.item` detail로 feature, provider, group, entry point context를
+남깁니다.
 
 ### 복수 구현체 선택
 
@@ -142,6 +190,7 @@ flowchart TD
   Src --> Namespace[spakky/plugins/example]
   Namespace --> Init[__init__.py]
   Namespace --> Main[main.py<br/>initialize 진입점]
+  Namespace --> Contributions[contributions<br/>feature별 contribution]
   Namespace --> Error[error.py<br/>에러 클래스]
   Namespace --> PostProcessors[post_processors<br/>PostProcessor 구현]
 ```
@@ -179,6 +228,17 @@ spakky-myfeature = "spakky.plugins.myfeature.main:initialize"
 
 [tool.pyrefly]
 module-name = "spakky.plugins.myfeature"
+```
+
+기존 core feature에 구현을 기여하는 인프라 plugin이라면 base plugin entry point와
+contribution entry point를 함께 선언합니다.
+
+```toml
+[project.entry-points."spakky.plugins"]
+spakky-myinfra = "spakky.plugins.myinfra.main:initialize"
+
+[project.entry-points."spakky.contributions.spakky.myfeature"]
+spakky-myinfra = "spakky.plugins.myinfra.contributions.myfeature:initialize"
 ```
 
 ### 3. Plugin 식별자 정의
@@ -349,7 +409,9 @@ class RegisterRoutesPostProcessor(IPostProcessor):
 
 ## 플러그인 의존성
 
-플러그인 간 의존성은 `pyproject.toml`의 `dependencies`로 선언합니다:
+플러그인 간 의존성은 `pyproject.toml`의 `dependencies`로 선언합니다. Contribution은
+target core feature contract를 import할 수 있으므로, provider package는 해당 core
+feature package를 의존성에 포함해야 합니다:
 
 ```toml
 [project]

--- a/plugins/spakky-sqlalchemy/README.md
+++ b/plugins/spakky-sqlalchemy/README.md
@@ -213,6 +213,29 @@ class MigrationService:
         return self._schema_registry.metadata
 ```
 
+## Outbox Contribution
+
+`spakky-sqlalchemy` base plugin은 SQLAlchemy connection, session, transaction,
+schema registry만 등록합니다. SQLAlchemy 기반 Outbox storage/table은 별도 feature
+contribution으로 제공합니다.
+
+```toml
+[project.entry-points."spakky.contributions.spakky.outbox"]
+spakky-sqlalchemy = "spakky.plugins.sqlalchemy.contributions.outbox:initialize"
+```
+
+이 contribution은 `spakky-outbox` feature와 `spakky-sqlalchemy` provider가 모두
+active일 때 base plugin 이후 로드됩니다. `load_plugins(include=...)`를 사용한다면
+include set에 두 plugin을 모두 넣어야 합니다. `save()`는 현재 transactional session을
+사용하므로 비즈니스 데이터와 Outbox 메시지가 같은 DB transaction 안에서 commit 또는
+rollback됩니다.
+
+```python
+from spakky.plugins.sqlalchemy.outbox.storage import AsyncSqlAlchemyOutboxStorage
+
+storage = app.container.get(type_=AsyncSqlAlchemyOutboxStorage)
+```
+
 ## 주요 기능
 
 - **Domain-Table mapping**: domain model과 ORM table 간 양방향 변환


### PR DESCRIPTION
## 요약
- Feature Contribution Policy의 entry point 선언, loader order, include semantics, diagnostics를 plugin API와 core README에 문서화했습니다.
- Architecture, SQLAlchemy README/API, Outbox/SQLAlchemy guides, glossary, docs index의 Outbox storage 설명을 contribution 모델로 정정했습니다.
- ADR-0009가 ADR-0010을 선행 조건으로 명시하는지 확인했습니다.

## 검증
- rg -n 'spakky.contributions.spakky.outbox|Loader 순서|include set|contributions.loaded|inactive_feature|inactive_provider|include_filter' docs/plugin-api.md core/spakky/README.md plugins/spakky-sqlalchemy/README.md docs/guides/sqlalchemy.md docs/guides/outbox.md docs/glossary.md docs/api/plugins/spakky-sqlalchemy.md ARCHITECTURE.md
- rg -n '선행.*ADR-0010|ADR-0010.*선행|Feature Contribution Policy' docs/adr/0009-agentic-hexagonal-architecture.md docs/adr/0010-feature-contribution-policy.md docs/adr/README.md
- uv run mkdocs build --strict
- pre-commit changed sub-project hooks
- pre-push changed-project hooks

Closes #196