### PR TITLE
docs(adr): reconcile contribution metadata semantics (#204)

### DIFF
--- a/docs/adr/0005-merge-outbox-sqlalchemy-into-sqlalchemy.md
+++ b/docs/adr/0005-merge-outbox-sqlalchemy-into-sqlalchemy.md
@@ -12,7 +12,7 @@
 
 1. **조합 폭발은 브릿지 분리로 해결되지 않는다**: DB 백엔드 N개 × 추상화 M개 = N×M 브릿지 패키지. 오히려 패키지 수가 선형 이상으로 증가한다.
 2. **Outbox 저장은 본질적으로 DB 작업이다**: `OutboxMessageTable`, `SqlAlchemyOutboxStorage`의 모든 코드가 SQLAlchemy API를 사용한다. 개념적으로 SQLAlchemy 플러그인에 속하는 코드다.
-3. **런타임 감지 패턴이 이미 프레임워크에 존재한다**: `spakky-opentelemetry`가 `spakky-logging` 설치 여부를 런타임에 감지하여 브릿지하는 패턴(ADR-0004)이 확립되었다. 동일한 패턴으로 `spakky-sqlalchemy`가 `spakky-outbox` 설치 여부를 감지할 수 있다.
+3. **명시적 feature contribution이 런타임 감지를 대체한다**: ADR-0010 이후 `spakky-sqlalchemy`는 `spakky-outbox` 설치 여부를 `_HAS_OUTBOX` 같은 import guard로 감지하지 않는다. 대신 Python entry point metadata의 `spakky.contributions.spakky.outbox` group으로 outbox 구현을 선언하고, framework loader가 active feature/provider 조합에 따라 호출한다.
 
 ### 현재 구조 vs 제안 구조
 
@@ -23,11 +23,11 @@ spakky-outbox-sqlalchemy (브릿지) → spakky-outbox + spakky-sqlalchemy
 spakky-outbox-mongodb (향후 브릿지) → spakky-outbox + motor
 spakky-outbox-dynamodb (향후 브릿지) → spakky-outbox + boto3
 
-# 제안
+# 제안 (ADR-0010 이후 구현 형태)
 spakky-outbox (추상화)
-spakky-sqlalchemy (기존 + outbox 설치 시 자동 확장)
-spakky-mongodb (향후, 기존 + outbox 설치 시 자동 확장)
-spakky-dynamodb (향후, 기존 + outbox 설치 시 자동 확장)
+spakky-sqlalchemy (기존 + spakky-outbox contribution)
+spakky-mongodb (향후, 기존 + spakky-outbox contribution)
+spakky-dynamodb (향후, 기존 + spakky-outbox contribution)
 ```
 
 **DB 백엔드 하나를 추가하면 그 DB로 할 수 있는 모든 것이 하나의 플러그인에서 제공된다.** 브릿지 패키지 0개.
@@ -36,7 +36,7 @@ spakky-dynamodb (향후, 기존 + outbox 설치 시 자동 확장)
 
 - **패키지 수 최소화**: 사용자가 설치할 패키지 수 감소 (`spakky-outbox` + `spakky-sqlalchemy`만으로 충분)
 - **DB 백엔드 = 단일 플러그인 원칙**: 하나의 DB 기술에 대한 모든 구현이 하나의 플러그인에 위치
-- **런타임 감지 패턴 일관성**: ADR-0004에서 확립된 선택적 의존 패턴 재사용
+- **명시적 metadata 기반 활성화**: optional import guard 대신 ADR-0010의 feature contribution entry point 모델 사용
 - **관리 비용 감소**: 버전 호환성 관리 대상 패키지 1개 감소
 
 ## 고려한 대안 (Considered Options)
@@ -48,11 +48,11 @@ ADR-0002 그대로. `spakky-outbox-sqlalchemy`를 독립 패키지로 유지.
 - **장점**: 기존 사용자 코드 변경 없음
 - **단점**: 브릿지 패키지 수 선형 증가, 사용자 설치 불편, DB 백엔드 추가 시 항상 2개 패키지 생성
 
-### 대안 B: spakky-sqlalchemy에 통합 + 런타임 감지 ✅
+### 대안 B: spakky-sqlalchemy에 통합 + feature contribution ✅
 
-`spakky-outbox-sqlalchemy`의 코드를 `spakky-sqlalchemy`로 이동. `spakky-outbox` 설치 여부를 런타임에 감지하여 outbox 관련 Pod를 조건부 등록.
+`spakky-outbox-sqlalchemy`의 코드를 `spakky-sqlalchemy`로 이동. `spakky-sqlalchemy` base plugin은 SQLAlchemy substrate만 등록하고, outbox 관련 Pod는 `spakky.contributions.spakky.outbox` entry point가 별도 contribution으로 등록한다.
 
-- **장점**: 패키지 1개 감소, DB 백엔드 = 단일 플러그인 원칙, ADR-0004 패턴과 일관성
+- **장점**: 패키지 1개 감소, DB 백엔드 = 단일 플러그인 원칙, ADR-0010 contribution policy와 일관성
 - **단점**: `spakky-sqlalchemy`의 코드 약간 증가 (파일 3개 추가), breaking change
 
 ### 대안 C: spakky-outbox에 통합
@@ -73,39 +73,42 @@ ADR-0002 그대로. `spakky-outbox-sqlalchemy`를 독립 패키지로 유지.
    ```
    plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/
    ├── ... (기존)
-   └── outbox/                    # 신규 (outbox 설치 시에만 활성화)
+   ├── contributions/
+   │   └── outbox.py              # spakky-outbox contribution initialize()
+   └── outbox/
        ├── __init__.py
        ├── storage.py             # SqlAlchemyOutboxStorage, AsyncSqlAlchemyOutboxStorage
        └── table.py               # OutboxMessageTable
    ```
 
-2. **조건부 등록**: `spakky-sqlalchemy`의 `main.py`에서 런타임 감지
+2. **Contribution 등록**: `spakky-sqlalchemy`의 base plugin은 outbox를 감지하지 않는다. 패키지 metadata가 `spakky.contributions.spakky.outbox` group을 선언하고, loader가 `spakky-outbox` feature와 `spakky-sqlalchemy` provider가 모두 active일 때 contribution을 호출한다.
 
-   ```python
-   try:
-       from spakky.plugins.outbox import PLUGIN_NAME as _OUTBOX_PLUGIN  # noqa: F401
+   ```toml
+   [project.entry-points."spakky.plugins"]
+   spakky-sqlalchemy = "spakky.plugins.sqlalchemy.main:initialize"
 
-       from spakky.plugins.sqlalchemy.outbox.storage import (
-           AsyncSqlAlchemyOutboxStorage,
-           SqlAlchemyOutboxStorage,
-       )
-       from spakky.plugins.sqlalchemy.outbox.table import OutboxMessageTable
-
-       _HAS_OUTBOX = True
-   except ImportError:
-       _HAS_OUTBOX = False
-
-   def initialize(app: SpakkyApplication) -> None:
-       # ... 기존 코드 ...
-       if _HAS_OUTBOX:
-           app.add(SqlAlchemyOutboxStorage)
-           app.add(AsyncSqlAlchemyOutboxStorage)
-           app.add(OutboxMessageTable)
+   [project.entry-points."spakky.contributions.spakky.outbox"]
+   spakky-sqlalchemy = "spakky.plugins.sqlalchemy.contributions.outbox:initialize"
    ```
 
-3. **패키지 제거**: `spakky-outbox-sqlalchemy` 패키지 삭제, 워크스페이스에서 제거
+   `spakky-outbox`의 plugin name은 Python entry point group segment에서 `spakky.outbox`로 정규화되므로 canonical contribution group은 `spakky.contributions.spakky.outbox`다.
 
-4. **에러 계층**: `AbstractSpakkyOutboxSqlAlchemyError` → `AbstractSpakkySqlAlchemyError`를 상속하도록 변경 (outbox 에러도 SQLAlchemy 에러로 통합)
+3. **Contribution initialize**: outbox Pod 등록은 contribution module에만 위치한다.
+
+   ```python
+   def initialize(app: SpakkyApplication) -> None:
+       config = SQLAlchemyConnectionConfig()
+
+       app.add(OutboxMessageTable)
+       app.add(SqlAlchemyOutboxStorage)
+
+       if config.support_async_mode:
+           app.add(AsyncSqlAlchemyOutboxStorage)
+   ```
+
+4. **패키지 제거**: `spakky-outbox-sqlalchemy` 패키지 삭제, 워크스페이스에서 제거
+
+5. **에러 계층**: `AbstractSpakkyOutboxSqlAlchemyError` → `AbstractSpakkySqlAlchemyError`를 상속하도록 변경 (outbox 에러도 SQLAlchemy 에러로 통합)
 
 ### ADR-0002와의 관계
 
@@ -116,9 +119,9 @@ ADR-0002의 핵심 결정(추상화/구현체 분리)은 유효하다. `IOutboxS
 ### 긍정적
 
 - **패키지 수 감소**: `spakky-outbox-sqlalchemy` 제거 (모노레포 패키지 -1)
-- **사용자 설치 단순화**: `spakky-outbox` + `spakky-sqlalchemy`만 설치하면 outbox 자동 활성화
+- **사용자 설치 단순화**: `spakky-outbox` + `spakky-sqlalchemy`만 설치하면 outbox contribution이 feature/provider 활성 조합에서 로드됨
 - **DB 백엔드 확장 시**: 새 DB 플러그인 하나만 만들면 data + outbox 모두 지원
-- **ADR-0004 패턴과 일관성**: 런타임 감지 → 조건부 등록 패턴 재사용
+- **ADR-0010 패턴과 일관성**: entry point metadata → contribution loading 패턴 재사용
 
 ### 부정적
 
@@ -128,9 +131,9 @@ ADR-0002의 핵심 결정(추상화/구현체 분리)은 유효하다. `IOutboxS
 ### 중립적
 
 - `spakky-outbox`의 추상화(`IOutboxStorage`, `OutboxMessage`, Bus, Relay)는 변경 없음
-- `spakky-sqlalchemy`에 `spakky-outbox` 의존성이 **추가되지 않음** — 런타임 감지이므로 pyproject.toml 변경 없음
+- `spakky-sqlalchemy`는 outbox contribution module이 feature core contract를 import하므로 `spakky-outbox`를 명시 의존성으로 가진다. 활성화 여부는 import guard가 아니라 base plugin과 contribution provider가 모두 active인지, 그리고 `load_plugins(include=...)` 필터가 양쪽을 포함하는지로 결정된다.
 
 ## 참고 자료
 
 - [ADR-0002: Outbox 플러그인 아키텍처](0002-outbox-plugin-architecture.md)
-- [ADR-0004: 분산 트레이싱 아키텍처](0004-distributed-tracing-architecture.md) — 런타임 감지 패턴 선례
+- [ADR-0010: Feature Contribution Policy](0010-feature-contribution-policy.md) — contribution entry point 활성화 정책

--- a/docs/adr/0010-feature-contribution-policy.md
+++ b/docs/adr/0010-feature-contribution-policy.md
@@ -82,7 +82,7 @@ sqlalchemy-agent-state = "spakky.plugins.sqlalchemy.contributions.agent_state:in
 - `spakky-sqlalchemy` 패키지는 하나로 유지된다.
 - feature별 구현 기여는 명시적 entry point로 분리된다.
 - plugin 본체가 다른 core feature 설치 여부를 감지하지 않는다.
-- loader가 누락 contribution을 구조적으로 진단할 수 있다.
+- loader가 로드/스킵/실패한 contribution을 구조적으로 진단할 수 있다.
 - 향후 Redis, Kafka, SQLAlchemy 같은 인프라 plugin이 여러 core feature에 같은 방식으로 기여할 수 있다.
 
 단점:
@@ -100,8 +100,9 @@ Spakky Framework는 **Feature Contribution Policy**를 도입한다. plugin pack
 정책:
 
 - base plugin entry point group은 기존처럼 `spakky.plugins`를 사용한다.
-- feature contribution entry point group은 `spakky.contributions.<feature-plugin-name>` 형식을 사용한다.
-- `<feature-plugin-name>`은 core feature의 plugin name과 동일해야 한다. 예: `spakky-agent`, `spakky-outbox`.
+- feature contribution entry point group은 `spakky.contributions.<normalized-feature-plugin-name>` 형식을 사용한다.
+- `<normalized-feature-plugin-name>`은 core feature plugin name을 Python entry point group segment에 안전한 형태로 정규화한 값이다. 현재 규칙은 plugin name의 `-`를 `.`로 바꾸는 것이다.
+- 예를 들어 `spakky-outbox` feature plugin의 contribution group은 `spakky.contributions.spakky.outbox`이고, `spakky-agent`는 `spakky.contributions.spakky.agent`다.
 - contribution entry point name은 같은 group 안에서 고유해야 한다.
 - contribution module은 해당 feature core package의 public contract를 import할 수 있다.
 - base plugin `initialize()`는 다른 feature 설치 여부를 감지하지 않는다.
@@ -110,7 +111,7 @@ Spakky Framework는 **Feature Contribution Policy**를 도입한다. plugin pack
 - `include`가 지정된 plugin loading에서는 base plugin과 contribution provider/plugin filtering semantics를 명시적으로 정의한다.
 - `include`가 지정되면 target feature plugin과 contribution provider base plugin이 모두 `include`에 있고 실제 base plugin으로 로드된 경우에만 contribution을 로드한다.
 - contribution provider base plugin은 contribution entry point name 파싱이 아니라 해당 entry point distribution의 `spakky.plugins` metadata로 식별한다.
-- diagnostics는 로드된 contribution, skipped contribution, missing required contribution을 startup report에 기록할 수 있어야 한다.
+- diagnostics는 현재 구현된 로드/스킵/실패 contribution 결과를 startup report에 기록한다. 스킵 사유는 `inactive_feature`, `inactive_provider`, `include_filter`로 구분한다.
 
 ## Canonical Loading Model
 
@@ -118,7 +119,7 @@ Spakky Framework는 **Feature Contribution Policy**를 도입한다. plugin pack
 Installed packages
   -> spakky.plugins entry points
   -> active core feature set
-  -> spakky.contributions.<feature> entry points
+  -> spakky.contributions.<normalized-feature> entry points
   -> Pod/Tag registration
   -> ApplicationContext.start()
 ```
@@ -130,6 +131,23 @@ Installed packages
 - 향후 loader API가 feature activation을 별도로 선언한다.
 
 Contribution은 base plugin을 대체하지 않는다. base plugin은 인프라 substrate의 기본 설정과 공통 구현을 등록하고, contribution은 특정 core feature port 구현만 추가 등록한다.
+
+`spakky-outbox`의 SQLAlchemy 구현은 이 모델의 canonical 사례다. `spakky-sqlalchemy`는 base plugin entry point와 별도로 다음 metadata를 선언한다.
+
+```toml
+[project.entry-points."spakky.contributions.spakky.outbox"]
+spakky-sqlalchemy = "spakky.plugins.sqlalchemy.contributions.outbox:initialize"
+```
+
+Loader는 base plugin loading 이후 active feature 이름순으로 contribution group을 조회하고, group 내부 entry point 이름순으로 contribution을 호출한다. Provider base plugin은 같은 distribution의 `spakky.plugins` metadata에서 식별되므로 contribution entry point name 자체가 provider 이름을 암시할 필요는 없다.
+
+Startup diagnostics가 활성화되어 있으면 `load_plugins` phase detail에 다음 summary key와 item detail이 기록된다.
+
+- `contributions.loaded`, `contributions.skipped`, `contributions.failed`
+- `contributions.skipped.inactive_feature`, `contributions.skipped.inactive_provider`, `contributions.skipped.include_filter`
+- `contributions.loaded.item`, `contributions.skipped.item`, `contributions.failed.item`
+
+Required contribution absence는 현재 loader diagnostics의 구현 범위가 아니다. feature core가 특정 contribution을 필수로 선언하는 API는 아래 미결정 사항으로 남기며, 그 전까지 구현체 부재는 일반 DI resolution 또는 feature별 검증 단계에서 드러난다.
 
 ## Consequences
 
@@ -176,6 +194,4 @@ ADR-0009의 `spakky-agent`는 checkpoint/evidence/artifact persistence가 필수
 
 ## 미결정 사항
 
-- contribution entry point가 base plugin보다 먼저 로드될 수 없도록 보장하는 구체 순서
 - contribution이 required인지 optional인지 feature core가 선언하는 API
-- contribution diagnostics의 정확한 public model


### PR DESCRIPTION
## 요약

- ADR-0005의 outbox SQLAlchemy 통합 설명을 runtime import guard 모델에서 ADR-0010 contribution entry point 모델로 정정했습니다.
- ADR-0010의 contribution group naming을 Python entry point metadata 제약에 맞춰 `-` -> `.` 정규화로 명확히 했습니다.
- 현재 diagnostics 범위를 loaded/skipped/failed와 `inactive_feature`, `inactive_provider`, `include_filter`로 한정하고 required contribution 부재 진단은 미결정 API로 분리했습니다.

## Acceptance Criteria (자가 grep)

- [x] 이슈 본문에 실행 가능한 grep/find/rg 라인이 없어 `acceptance_check: missing`으로 분류했습니다.
- [x] ADR-0005 reader가 runtime detection이 아니라 contribution entry point 모델임을 알 수 있습니다.
- [x] ADR-0010 reader가 `spakky-outbox` group이 `spakky.contributions.spakky.outbox`로 정규화됨을 알 수 있습니다.
- [x] startup diagnostics 설명이 현재 구현된 loaded/skipped/failed 및 skip reason으로 제한됩니다.

## 검증

- `uv run mkdocs build --strict` 통과
- pre-commit `python-harness-rules` 통과
- pre-commit `monorepo-pre-commit` 통과
- pre-push `monorepo-pre-push-tests` 통과 (workspace projects affected 없음)

Closes #204
