### PR TITLE
feat(agent): define state signal evidence contracts (#221)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -16,6 +16,7 @@
 - `AgentState`: long-running agent execution의 materialized lifecycle state
 - `AgentSignal`: 실행 중 들어오는 user message, approval, cancel 같은 inbound stimulus
 - `AgentEvidence`: tool/model/context 판단 근거를 위한 append-only artifact
+- `IAgentStateRepository`, `IAgentSignalRepository`, `IAgentEvidenceRepository`: persistence provider가 구현하는 core port
 - `IAgentModel`: vLLM 등 model backend가 구현하는 outbound port
 
 ## 의존성 경계
@@ -23,6 +24,8 @@
 Core package는 `spakky` core에만 의존합니다. vLLM, SQLAlchemy, FastAPI, Typer 같은 infrastructure dependency를 직접 import하지 않습니다.
 
 Production persistence fallback도 제공하지 않습니다. State, signal, evidence repository 구현은 SQLAlchemy 등 provider plugin의 feature contribution으로 등록되어야 하며, 누락 시 bootstrap 단계에서 custom error로 실패해야 합니다.
+
+`AgentEvidenceRepository`의 agent-facing interface는 append/read 계열만 노출합니다. Redaction, correction, context digest 갱신은 기존 evidence를 수정하지 않고 새 evidence를 append하는 방식으로 표현합니다.
 
 ## 사용 예시
 

--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -17,6 +17,11 @@ from spakky.agent.execution import (
     RecoveryStrategy,
     StreamingExposureMode,
 )
+from spakky.agent.interfaces.repository import (
+    IAgentEvidenceRepository,
+    IAgentSignalRepository,
+    IAgentStateRepository,
+)
 from spakky.agent.interfaces.model import (
     IAgentModel,
     JsonSchemaConstraint,
@@ -31,7 +36,12 @@ from spakky.agent.interfaces.model import (
     StructuredOutputSpec,
 )
 from spakky.agent.signal import AgentSignal, ApprovalDecision
-from spakky.agent.state import AgentState, AgentStatus
+from spakky.agent.state import (
+    AgentState,
+    AgentStateReason,
+    AgentStateTransition,
+    AgentStatus,
+)
 from spakky.agent.types import JsonObject, JsonPrimitive, JsonValue
 from spakky.agent.yield_ import (
     AgentYield,
@@ -50,6 +60,9 @@ PLUGIN_NAME = Plugin(name="spakky-agent")
 
 __all__ = [
     "IAgentModel",
+    "IAgentEvidenceRepository",
+    "IAgentSignalRepository",
+    "IAgentStateRepository",
     "AbstractSpakkyAgentError",
     "Agent",
     "AgentBootstrapError",
@@ -61,6 +74,8 @@ __all__ = [
     "AgentPersistenceConfigurationError",
     "AgentSignal",
     "AgentSignalKind",
+    "AgentStateReason",
+    "AgentStateTransition",
     "AgentState",
     "AgentStatus",
     "AgentYield",

--- a/core/spakky-agent/src/spakky/agent/evidence.py
+++ b/core/spakky-agent/src/spakky/agent/evidence.py
@@ -12,8 +12,10 @@ class AgentEvidenceKind(StrEnum):
 
     MODEL = "model"
     TOOL = "tool"
+    CONTEXT = "context"
     CONTEXT_MANIFEST = "context_manifest"
     CONTEXT_DIGEST = "context_digest"
+    EVALUATION = "evaluation"
     APPROVAL = "approval"
     DELEGATION = "delegation"
     OUTPUT_GUARD = "output_guard"
@@ -28,5 +30,7 @@ class AgentEvidence:
     kind: AgentEvidenceKind
     payload: JsonObject = field(default_factory=dict)
     summary: str | None = None
+    digest: str | None = None
+    manifest_ref: str | None = None
     reference: str | None = None
     created_at: datetime | None = None

--- a/core/spakky-agent/src/spakky/agent/interfaces/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/interfaces/__init__.py
@@ -1,4 +1,4 @@
-"""Agent public interfaces."""
+"""Agent public interface ports."""
 
 from spakky.agent.interfaces.model import (
     IAgentModel,
@@ -13,9 +13,17 @@ from spakky.agent.interfaces.model import (
     SamplingOptions,
     StructuredOutputSpec,
 )
+from spakky.agent.interfaces.repository import (
+    IAgentEvidenceRepository,
+    IAgentSignalRepository,
+    IAgentStateRepository,
+)
 
 __all__ = [
+    "IAgentEvidenceRepository",
     "IAgentModel",
+    "IAgentSignalRepository",
+    "IAgentStateRepository",
     "JsonSchemaConstraint",
     "ModelMessage",
     "ModelMessageRole",

--- a/core/spakky-agent/src/spakky/agent/interfaces/repository.py
+++ b/core/spakky-agent/src/spakky/agent/interfaces/repository.py
@@ -1,0 +1,80 @@
+"""Persistence ports for durable agent state, signal, and evidence."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from spakky.agent.evidence import AgentEvidence
+from spakky.agent.signal import AgentSignal
+from spakky.agent.state import AgentState, AgentStatus
+
+
+class IAgentStateRepository(ABC):
+    """Materialized state repository for long-running agent executions."""
+
+    @abstractmethod
+    def get(self, state_id: str) -> AgentState:
+        """Return a persisted agent state by id."""
+        ...
+
+    @abstractmethod
+    def get_or_none(self, state_id: str) -> AgentState | None:
+        """Return a persisted agent state by id, or None when absent."""
+        ...
+
+    @abstractmethod
+    def save(self, state: AgentState) -> AgentState:
+        """Persist the materialized state and return the saved snapshot."""
+        ...
+
+    @abstractmethod
+    def list_by_status(self, status: AgentStatus) -> Sequence[AgentState]:
+        """Return states matching an externally observable lifecycle status."""
+        ...
+
+    @abstractmethod
+    def list_resume_candidates(self) -> Sequence[AgentState]:
+        """Return active or interrupted states that may resume after restart."""
+        ...
+
+
+class IAgentSignalRepository(ABC):
+    """Durable inbound queue repository for agent signals."""
+
+    @abstractmethod
+    def append(self, signal: AgentSignal) -> AgentSignal:
+        """Append a signal to the inbound queue and return the stored entry."""
+        ...
+
+    @abstractmethod
+    def list_pending(self, state_id: str) -> Sequence[AgentSignal]:
+        """Return unconsumed signals for an agent state in queue order."""
+        ...
+
+    @abstractmethod
+    def mark_consumed(self, signal_id: str) -> AgentSignal:
+        """Mark a queued signal as consumed at a safe action boundary."""
+        ...
+
+
+class IAgentEvidenceRepository(ABC):
+    """Append-only evidence repository exposed to agent-facing code."""
+
+    @abstractmethod
+    def append(self, evidence: AgentEvidence) -> AgentEvidence:
+        """Append immutable evidence and return the stored artifact."""
+        ...
+
+    @abstractmethod
+    def get(self, evidence_id: str) -> AgentEvidence:
+        """Return one evidence artifact by id."""
+        ...
+
+    @abstractmethod
+    def list_by_state(self, state_id: str) -> Sequence[AgentEvidence]:
+        """Return evidence artifacts captured for an agent state."""
+        ...
+
+    @abstractmethod
+    def list_by_manifest_ref(self, manifest_ref: str) -> Sequence[AgentEvidence]:
+        """Return evidence artifacts associated with a context manifest."""
+        ...

--- a/core/spakky-agent/src/spakky/agent/state.py
+++ b/core/spakky-agent/src/spakky/agent/state.py
@@ -20,6 +20,31 @@ class AgentStatus(StrEnum):
     CANCELLED = "cancelled"
 
 
+class AgentStateTransition(StrEnum):
+    """State transition vocabulary accepted by durable agent orchestration."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    WAITING_APPROVAL = "waiting_approval"
+    CANCELLING = "cancelling"
+    CANCELLED = "cancelled"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    TIMED_OUT = "timed_out"
+    INTERRUPTED = "interrupted"
+
+
+class AgentStateReason(StrEnum):
+    """Structured reason that refines an externally observable lifecycle state."""
+
+    APPROVAL_REQUIRED = "approval_required"
+    USER_INTERRUPTED = "user_interrupted"
+    TIMEOUT = "timeout"
+    CANCELLATION_REQUESTED = "cancellation_requested"
+    CANCELLATION_CLEANUP_FAILED = "cancellation_cleanup_failed"
+    RECOVERY_REQUIRES_HITL = "recovery_requires_hitl"
+
+
 @dataclass(frozen=True, slots=True)
 class AgentState:
     """Materialized state for a long-running agent execution."""
@@ -27,6 +52,8 @@ class AgentState:
     id: str
     agent_type: str
     status: AgentStatus
+    transition: AgentStateTransition | None = None
+    reason: AgentStateReason | None = None
     current_activity: str | None = None
     input_ref: str | None = None
     output_ref: str | None = None

--- a/core/spakky-agent/tests/unit/interfaces/test_repository.py
+++ b/core/spakky-agent/tests/unit/interfaces/test_repository.py
@@ -1,0 +1,49 @@
+"""Tests for agent persistence repository interfaces."""
+
+from abc import ABCMeta
+
+from spakky.agent import (
+    IAgentEvidenceRepository,
+    IAgentSignalRepository,
+    IAgentStateRepository,
+)
+
+
+def test_agent_state_repository_expect_exposes_materialized_state_methods() -> None:
+    """state repository가 저장, 조회, resume 후보 조회를 노출한다."""
+    methods = IAgentStateRepository.__abstractmethods__
+
+    assert methods == {
+        "get",
+        "get_or_none",
+        "save",
+        "list_by_status",
+        "list_resume_candidates",
+    }
+    assert isinstance(IAgentStateRepository, ABCMeta)
+
+
+def test_agent_signal_repository_expect_exposes_queue_methods() -> None:
+    """signal repository가 durable inbound queue append/consume을 노출한다."""
+    methods = IAgentSignalRepository.__abstractmethods__
+
+    assert methods == {
+        "append",
+        "list_pending",
+        "mark_consumed",
+    }
+    assert isinstance(IAgentSignalRepository, ABCMeta)
+
+
+def test_agent_evidence_repository_expect_exposes_append_read_only_methods() -> None:
+    """evidence repository가 update/delete를 agent-facing interface에 노출하지 않는다."""
+    methods = IAgentEvidenceRepository.__abstractmethods__
+
+    assert methods == {
+        "append",
+        "get",
+        "list_by_state",
+        "list_by_manifest_ref",
+    }
+    assert "update" not in methods
+    assert "delete" not in methods

--- a/core/spakky-agent/tests/unit/test_public_api.py
+++ b/core/spakky-agent/tests/unit/test_public_api.py
@@ -8,8 +8,11 @@ from spakky.agent import (
     AgentDefinitionError,
     AgentEvidence,
     AgentExecutionSpec,
+    IAgentEvidenceRepository,
     AgentSignal,
     AgentState,
+    IAgentSignalRepository,
+    IAgentStateRepository,
     AgentYield,
     ModelRequest,
     ModelResponse,
@@ -29,6 +32,9 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
         "AgentState",
         "AgentSignal",
         "AgentEvidence",
+        "IAgentStateRepository",
+        "IAgentSignalRepository",
+        "IAgentEvidenceRepository",
         "IAgentModel",
     }
 
@@ -41,6 +47,9 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
     assert AgentState is agent_api.AgentState
     assert AgentSignal is agent_api.AgentSignal
     assert AgentEvidence is agent_api.AgentEvidence
+    assert IAgentStateRepository is agent_api.IAgentStateRepository
+    assert IAgentSignalRepository is agent_api.IAgentSignalRepository
+    assert IAgentEvidenceRepository is agent_api.IAgentEvidenceRepository
     assert IAgentModel is agent_api.IAgentModel
 
 

--- a/core/spakky-agent/tests/unit/test_state_signal_evidence_yield.py
+++ b/core/spakky-agent/tests/unit/test_state_signal_evidence_yield.py
@@ -9,6 +9,8 @@ from spakky.agent import (
     AgentSignal,
     AgentSignalKind,
     AgentState,
+    AgentStateReason,
+    AgentStateTransition,
     AgentStatus,
     AgentYield,
     AgentYieldKind,
@@ -37,6 +39,48 @@ def test_agent_state_expect_uses_adr_lifecycle_statuses() -> None:
     assert state.current_activity == "approval required"
 
 
+def test_agent_state_expect_expresses_issue_transition_vocabulary() -> None:
+    """이슈 #221의 전이 어휘를 ADR top-level status와 분리해 표현한다."""
+    approval_state = AgentState(
+        id="run-1",
+        agent_type="CodeAssistant",
+        status=AgentStatus.INTERRUPTED,
+        transition=AgentStateTransition.WAITING_APPROVAL,
+        reason=AgentStateReason.APPROVAL_REQUIRED,
+    )
+    timeout_state = AgentState(
+        id="run-2",
+        agent_type="CodeAssistant",
+        status=AgentStatus.FAILED,
+        transition=AgentStateTransition.TIMED_OUT,
+        reason=AgentStateReason.TIMEOUT,
+    )
+
+    assert approval_state.status == AgentStatus.INTERRUPTED
+    assert approval_state.transition == AgentStateTransition.WAITING_APPROVAL
+    assert approval_state.reason == AgentStateReason.APPROVAL_REQUIRED
+    assert timeout_state.status == AgentStatus.FAILED
+    assert timeout_state.transition == AgentStateTransition.TIMED_OUT
+    assert timeout_state.reason == AgentStateReason.TIMEOUT
+
+
+def test_agent_state_transition_expect_covers_durable_execution_flow() -> None:
+    """pending부터 terminal state까지 durable execution 전이를 열거한다."""
+    transitions = {transition.value for transition in AgentStateTransition}
+
+    assert transitions == {
+        "pending",
+        "running",
+        "waiting_approval",
+        "cancelling",
+        "cancelled",
+        "completed",
+        "failed",
+        "timed_out",
+        "interrupted",
+    }
+
+
 def test_agent_state_expect_rejects_negative_pending_signal_count() -> None:
     """state snapshot이 불가능한 signal count를 custom error로 거부한다."""
     with pytest.raises(AgentDefinitionError):
@@ -61,6 +105,18 @@ def test_agent_signal_expect_carries_inbound_stimulus_payload() -> None:
     assert signal.payload == {"decision": "approve"}
 
 
+def test_agent_signal_expect_covers_durable_inbound_queue_vocabulary() -> None:
+    """user message, approval decision, cancel, resume 신호를 표현한다."""
+    signal_kinds = {kind.value for kind in AgentSignalKind}
+
+    assert {
+        "user_message",
+        "approval_decision",
+        "cancel",
+        "resume",
+    } <= signal_kinds
+
+
 def test_agent_evidence_expect_append_only_artifact_shape() -> None:
     """AgentEvidence가 update/delete 없이 append artifact shape만 제공한다."""
     evidence = AgentEvidence(
@@ -69,11 +125,29 @@ def test_agent_evidence_expect_append_only_artifact_shape() -> None:
         kind=AgentEvidenceKind.CONTEXT_DIGEST,
         payload={"digest": "abc"},
         summary="compressed context",
+        digest="sha256:abc",
+        manifest_ref="manifest-1",
     )
 
     assert evidence.kind == AgentEvidenceKind.CONTEXT_DIGEST
     assert evidence.payload == {"digest": "abc"}
     assert evidence.summary == "compressed context"
+    assert evidence.digest == "sha256:abc"
+    assert evidence.manifest_ref == "manifest-1"
+
+
+def test_agent_evidence_kind_expect_covers_required_evidence_sources() -> None:
+    """tool/model/context/evaluation evidence와 digest/manifest를 표현한다."""
+    evidence_kinds = {kind.value for kind in AgentEvidenceKind}
+
+    assert {
+        "tool",
+        "model",
+        "context",
+        "context_digest",
+        "context_manifest",
+        "evaluation",
+    } <= evidence_kinds
 
 
 def test_agent_yield_expect_supports_canonical_stream_vocabulary() -> None:


### PR DESCRIPTION
## Summary
- Add durable agent state transition and reason vocabulary for issue #221 lifecycle requirements.
- Add signal/state/evidence repository ports, including append/read-only evidence access.
- Export the new public contracts and document provider contribution expectations.

## Validation
- cd core/spakky-agent && uv run ruff format .
- cd core/spakky-agent && uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .
- cd core/spakky-agent && uv run ruff check .
- cd core/spakky-agent && uv run pyrefly check --disable-project-excludes-heuristics
- cd core/spakky-agent && uv run pytest
- uv run mkdocs build --strict

Closes #221