### PR TITLE
feat(agent): add Agent pod stereotype (#214)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -11,7 +11,7 @@
 
 ## 제공하는 public surface
 
-- `Agent`, `AgentExecutionSpec`: agent definition metadata와 실행 의미
+- `Agent`, `AgentExecutionSpec`, `AgentExecutionLimits`: `@UseCase`와 동격인 Pod stereotype과 보조 실행 의미
 - `AgentYield`: `execute()`가 caller에게 흘려보내는 typed stream item
 - `AgentState`: long-running agent execution의 materialized lifecycle state
 - `AgentSignal`: 실행 중 들어오는 user message, approval, cancel 같은 inbound stimulus
@@ -35,9 +35,13 @@ Production persistence fallback도 제공하지 않습니다. State, signal, evi
 from collections.abc import AsyncGenerator
 
 from spakky.agent import (
+    Agent,
+    AgentExecutionLimits,
     AgentExecutionSpec,
     AgentSignalKind,
     AgentYield,
+    AgentYieldKind,
+    Final,
     IAgentModel,
     ModelMessage,
     ModelMessageRole,
@@ -46,26 +50,42 @@ from spakky.agent import (
 )
 
 
+@Agent(
+    spec=AgentExecutionSpec(
+        name="code_assistant",
+        objective="inspect and edit a workspace",
+        accepted_signals=(
+            AgentSignalKind.USER_MESSAGE,
+            AgentSignalKind.APPROVAL_DECISION,
+            AgentSignalKind.CANCEL,
+        ),
+        limits=AgentExecutionLimits(timeout_seconds=300),
+    )
+)
 class CodeAssistant:
     def __init__(self, model: IAgentModel) -> None:
         self.model = model
 
-    async def execute(self, command: str) -> AsyncGenerator[AgentYield[str], None]:
+    async def execute(
+        self,
+        command: str,
+    ) -> AsyncGenerator[AgentYield[Final[str]], None]:
         request = ModelRequest(
             messages=(ModelMessage(ModelMessageRole.USER, command),),
         )
         async for event in self.model.stream(request):
             if event.kind == ModelStreamEventKind.TOKEN_DELTA:
-                ...
+                yield AgentYield(
+                    kind=AgentYieldKind.TEXT_DELTA,
+                    payload=event.token_delta or "",
+                )
 
-
-spec = AgentExecutionSpec(
-    accepted_signals=(
-        AgentSignalKind.USER_MESSAGE,
-        AgentSignalKind.APPROVAL_DECISION,
-        AgentSignalKind.CANCEL,
-    )
-)
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(output=command, metadata={}),
+        )
 ```
+
+`@Agent`는 `@Pod` 계열 stereotype이므로 application scan과 constructor DI에 참여합니다. `execute()`는 `Generator` 또는 `AsyncGenerator`로 `AgentYield[...]`를 yield해야 하며, 잘못된 signature나 지원하지 않는 metadata는 definition/bootstrap 단계에서 `AgentDefinitionError` 또는 `AgentBootstrapError`로 드러납니다.
 
 `IAgentModel.stream()`은 model adapter가 token delta, tool-call candidate, structured output, error, done을 `ModelStreamEventKind`로 구분해 내보내는 계약입니다. 실제 vLLM/OpenAI-compatible HTTP 연결은 `plugins/spakky-vllm` 같은 outbound adapter가 담당하며, core package에는 production model implementation을 넣지 않습니다.

--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -12,6 +12,7 @@ from spakky.agent.error import (
 from spakky.agent.evidence import AgentEvidence, AgentEvidenceKind
 from spakky.agent.execution import (
     Agent,
+    AgentExecutionLimits,
     AgentExecutionSpec,
     AgentSignalKind,
     RecoveryStrategy,
@@ -75,6 +76,7 @@ __all__ = [
     "AgentDefinitionError",
     "AgentEvidence",
     "AgentEvidenceKind",
+    "AgentExecutionLimits",
     "AgentExecutionSpec",
     "AgentModelConfigurationError",
     "AgentPersistenceConfigurationError",

--- a/core/spakky-agent/src/spakky/agent/execution.py
+++ b/core/spakky-agent/src/spakky/agent/execution.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncGenerator, Generator
 from dataclasses import dataclass, field
 from enum import StrEnum
 from inspect import Parameter, Signature, getattr_static, isclass, signature
-from typing import get_args, get_origin
+from typing import get_args, get_origin, get_type_hints
 
 from spakky.agent.error import AgentDefinitionError
 from spakky.core.pod.annotations.pod import Pod, PodType
@@ -108,7 +108,11 @@ class Agent(Pod):
             raise AgentDefinitionError("@Agent class must define execute()")
         execute_signature = signature(execute)
         self._validate_execute_parameters(execute_signature)
-        self._validate_execute_return_type(execute_signature)
+        return_annotation = self._resolve_execute_return_annotation(
+            execute,
+            execute_signature,
+        )
+        self._validate_execute_return_type(return_annotation)
 
     def _validate_execute_parameters(self, execute_signature: Signature) -> None:
         parameters = list(execute_signature.parameters.values())
@@ -128,8 +132,28 @@ class Agent(Pod):
                     "@Agent.execute() parameters must be type annotated"
                 )
 
-    def _validate_execute_return_type(self, execute_signature: Signature) -> None:
+    def _resolve_execute_return_annotation(
+        self,
+        execute: object,
+        execute_signature: Signature,
+    ) -> object:
         return_annotation = execute_signature.return_annotation
+        if return_annotation == Signature.empty:
+            return return_annotation
+        hint_target = (
+            execute.__func__
+            if isinstance(execute, (staticmethod, classmethod))
+            else execute
+        )
+        try:
+            type_hints = get_type_hints(hint_target, include_extras=True)
+        except (NameError, TypeError) as e:
+            raise AgentDefinitionError(
+                "@Agent.execute() return type annotation cannot be resolved"
+            ) from e
+        return type_hints.get("return", return_annotation)
+
+    def _validate_execute_return_type(self, return_annotation: object) -> None:
         if return_annotation == Signature.empty:
             raise AgentDefinitionError("@Agent.execute() return type is required")
         return_origin = get_origin(return_annotation)

--- a/core/spakky-agent/src/spakky/agent/execution.py
+++ b/core/spakky-agent/src/spakky/agent/execution.py
@@ -1,9 +1,14 @@
 """Agent execution metadata contracts."""
 
+from collections.abc import AsyncGenerator, Generator
 from dataclasses import dataclass, field
 from enum import StrEnum
+from inspect import Parameter, Signature, getattr_static, isclass, signature
+from typing import get_args, get_origin
 
 from spakky.agent.error import AgentDefinitionError
+from spakky.core.pod.annotations.pod import Pod, PodType
+from spakky.core.pod.error import AbstractSpakkyPodError
 
 
 class RecoveryStrategy(StrEnum):
@@ -36,24 +41,113 @@ class AgentSignalKind(StrEnum):
 
 
 @dataclass(frozen=True, slots=True)
+class AgentExecutionLimits:
+    """Bounded execution limits declared outside infrastructure capabilities."""
+
+    timeout_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        """Reject limits that would fail later at bootstrap."""
+        if self.timeout_seconds is not None and self.timeout_seconds <= 0:
+            raise AgentDefinitionError("Agent timeout limit must be positive")
+
+
+@dataclass(frozen=True, slots=True)
 class AgentExecutionSpec:
     """Declarative execution semantics that cannot be inferred from DI alone."""
 
+    name: str | None = None
+    objective: str | None = None
     accepted_signals: tuple[AgentSignalKind, ...] = ()
     recovery: RecoveryStrategy = RecoveryStrategy.NONE
     streaming_exposure_mode: StreamingExposureMode = StreamingExposureMode.BALANCED
     timeout_seconds: float | None = None
+    limits: AgentExecutionLimits = field(default_factory=AgentExecutionLimits)
     delegation_allowed: bool = False
     metadata: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Reject execution specs that would fail later at bootstrap."""
+        if self.name is not None and not self.name.strip():
+            raise AgentDefinitionError("Agent name cannot be blank")
+        if self.objective is not None and not self.objective.strip():
+            raise AgentDefinitionError("Agent objective cannot be blank")
         if self.timeout_seconds is not None and self.timeout_seconds <= 0:
             raise AgentDefinitionError("Agent timeout must be positive")
+        if (
+            self.timeout_seconds is not None
+            and self.limits.timeout_seconds is not None
+            and self.timeout_seconds != self.limits.timeout_seconds
+        ):
+            raise AgentDefinitionError("Agent timeout declarations must match")
 
 
-@dataclass(frozen=True, slots=True)
-class Agent:
-    """Public agent definition metadata exported by the core package."""
+@dataclass(eq=False)
+class Agent(Pod):
+    """UseCase-equivalent Pod stereotype for agentic workflow components."""
 
     spec: AgentExecutionSpec = field(default_factory=AgentExecutionSpec)
+
+    def _initialize(self, obj: PodType) -> None:
+        """Initialize Pod metadata and validate the Agent execute contract."""
+        try:
+            super()._initialize(obj)
+        except AbstractSpakkyPodError as e:
+            raise AgentDefinitionError("Agent Pod metadata is invalid") from e
+        self._validate_execute_contract(obj)
+
+    def validate_bootstrap(self) -> None:
+        """Re-run definition validation during application bootstrap."""
+        self._validate_execute_contract(self.target)
+
+    def _validate_execute_contract(self, obj: PodType) -> None:
+        if not isclass(obj):
+            raise AgentDefinitionError("@Agent can only annotate classes")
+        execute = getattr_static(obj, "execute", None)
+        if execute is None:
+            raise AgentDefinitionError("@Agent class must define execute()")
+        execute_signature = signature(execute)
+        self._validate_execute_parameters(execute_signature)
+        self._validate_execute_return_type(execute_signature)
+
+    def _validate_execute_parameters(self, execute_signature: Signature) -> None:
+        parameters = list(execute_signature.parameters.values())
+        if not parameters or parameters[0].name != "self":
+            raise AgentDefinitionError("@Agent.execute() must be an instance method")
+        for parameter in parameters[1:]:
+            if parameter.kind == Parameter.POSITIONAL_ONLY:
+                raise AgentDefinitionError(
+                    "@Agent.execute() cannot use positional-only parameters"
+                )
+            if parameter.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD):
+                raise AgentDefinitionError(
+                    "@Agent.execute() cannot use variable arguments"
+                )
+            if parameter.annotation == Parameter.empty:
+                raise AgentDefinitionError(
+                    "@Agent.execute() parameters must be type annotated"
+                )
+
+    def _validate_execute_return_type(self, execute_signature: Signature) -> None:
+        return_annotation = execute_signature.return_annotation
+        if return_annotation == Signature.empty:
+            raise AgentDefinitionError("@Agent.execute() return type is required")
+        return_origin = get_origin(return_annotation)
+        if return_origin is None and return_annotation in (AsyncGenerator, Generator):
+            return_origin = return_annotation
+        if return_origin not in (AsyncGenerator, Generator):
+            raise AgentDefinitionError(
+                "@Agent.execute() must return Generator or AsyncGenerator"
+            )
+        return_args = get_args(return_annotation)
+        if not return_args:
+            raise AgentDefinitionError("@Agent.execute() yield type is required")
+        yield_type = return_args[0]
+        yield_origin = get_origin(yield_type)
+        yield_candidate = yield_type if yield_origin is None else yield_origin
+        if (
+            not isclass(yield_candidate)
+            or yield_candidate.__module__ != "spakky.agent.yield_"
+            or yield_candidate.__name__ != "AgentYield"
+        ):
+            raise AgentDefinitionError("@Agent.execute() must yield AgentYield items")

--- a/core/spakky-agent/src/spakky/agent/main.py
+++ b/core/spakky-agent/src/spakky/agent/main.py
@@ -2,6 +2,8 @@
 
 from spakky.core.application.application import SpakkyApplication
 
+from spakky.agent.post_processor import AgentBootstrapValidationPostProcessor
+
 
 def initialize(app: SpakkyApplication) -> None:
     """Initialize spakky-agent core contracts.
@@ -9,4 +11,4 @@ def initialize(app: SpakkyApplication) -> None:
     The package intentionally registers no persistence implementation; production
     repositories must arrive through feature contributions.
     """
-    return
+    app.add(AgentBootstrapValidationPostProcessor)

--- a/core/spakky-agent/src/spakky/agent/post_processor.py
+++ b/core/spakky-agent/src/spakky/agent/post_processor.py
@@ -1,0 +1,26 @@
+"""Bootstrap validation for Agent Pod instances."""
+
+from typing import override
+
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.post_processor import IPostProcessor
+
+from spakky.agent.error import AgentBootstrapError, AgentDefinitionError
+from spakky.agent.execution import Agent
+
+
+@Pod()
+class AgentBootstrapValidationPostProcessor(IPostProcessor):
+    """Validate Agent metadata during application bootstrap."""
+
+    @override
+    def post_process(self, pod: object) -> object:
+        """Fail startup when an Agent contract is no longer valid."""
+        agent = Agent.get_or_none(type(pod))
+        if agent is None:
+            return pod
+        try:
+            agent.validate_bootstrap()
+        except AgentDefinitionError as e:
+            raise AgentBootstrapError("Agent bootstrap contract is invalid") from e
+        return pod

--- a/core/spakky-agent/tests/fixtures/__init__.py
+++ b/core/spakky-agent/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Fixture modules for spakky-agent tests."""

--- a/core/spakky-agent/tests/fixtures/agent_app.py
+++ b/core/spakky-agent/tests/fixtures/agent_app.py
@@ -1,0 +1,35 @@
+"""Scannable application module containing an Agent Pod."""
+
+from collections.abc import AsyncGenerator
+
+from spakky.core.pod.annotations.pod import Pod
+
+from spakky.agent import Agent, AgentExecutionSpec, AgentYield, AgentYieldKind, Final
+
+
+@Pod()
+class AnswerTools:
+    """Simple constructor dependency resolved through the Spakky container."""
+
+    def answer(self, command: str) -> str:
+        """Return a deterministic answer for direct invocation tests."""
+        return f"handled:{command}"
+
+
+@Agent(spec=AgentExecutionSpec(name="code_assistant", objective="handle commands"))
+class CodeAssistant:
+    """Agent fixture shaped like a UseCase with constructor DI."""
+
+    def __init__(self, tools: AnswerTools) -> None:
+        """Receive outbound capability through constructor DI."""
+        self._tools = tools
+
+    async def execute(
+        self,
+        command: str,
+    ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+        """Yield a final item so inbound adapters can consume the stream directly."""
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(output=self._tools.answer(command), metadata={}),
+        )

--- a/core/spakky-agent/tests/fixtures/future_agent_app.py
+++ b/core/spakky-agent/tests/fixtures/future_agent_app.py
@@ -1,0 +1,22 @@
+"""Scannable Agent fixture using postponed annotations."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+from spakky.agent import Agent, AgentYield, AgentYieldKind, Final
+
+
+@Agent()
+class FutureAnnotatedAgent:
+    """Agent fixture whose execute return annotation is stored as a string."""
+
+    async def execute(
+        self,
+        command: str,
+    ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+        """Yield a final item after postponed annotations are resolved."""
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(output=command, metadata={}),
+        )

--- a/core/spakky-agent/tests/unit/test_execution.py
+++ b/core/spakky-agent/tests/unit/test_execution.py
@@ -1,11 +1,19 @@
 """Tests for agent execution contracts."""
 
+from collections.abc import AsyncGenerator
+
 import pytest
+
+from spakky.core.pod.annotations.pod import Pod
 
 from spakky.agent import (
     Agent,
     AgentDefinitionError,
+    AgentExecutionLimits,
     AgentExecutionSpec,
+    AgentYield,
+    AgentYieldKind,
+    Final,
     AgentSignalKind,
     RecoveryStrategy,
     StreamingExposureMode,
@@ -17,11 +25,27 @@ def test_agent_execution_spec_expect_defaults_are_non_durable_and_balanced() -> 
     spec = AgentExecutionSpec()
 
     assert spec.accepted_signals == ()
+    assert spec.name is None
+    assert spec.objective is None
     assert spec.recovery == RecoveryStrategy.NONE
     assert spec.streaming_exposure_mode == StreamingExposureMode.BALANCED
     assert spec.timeout_seconds is None
+    assert spec.limits == AgentExecutionLimits()
     assert spec.delegation_allowed is False
     assert spec.metadata == {}
+
+
+def test_agent_execution_spec_expect_declares_business_semantics() -> None:
+    """실행 spec이 DI로 정해지는 infra capability가 아닌 보조 의미를 담는다."""
+    spec = AgentExecutionSpec(
+        name="support_agent",
+        objective="resolve support tickets",
+        limits=AgentExecutionLimits(timeout_seconds=30),
+    )
+
+    assert spec.name == "support_agent"
+    assert spec.objective == "resolve support tickets"
+    assert spec.limits.timeout_seconds == 30
 
 
 def test_agent_execution_spec_expect_accepts_adr_signal_vocabulary() -> None:
@@ -49,10 +73,217 @@ def test_agent_execution_spec_expect_rejects_non_positive_timeout() -> None:
         AgentExecutionSpec(timeout_seconds=0)
 
 
-def test_agent_expect_wraps_execution_spec_metadata() -> None:
-    """Agent public metadata가 execution spec을 보존한다."""
+def test_agent_execution_limits_expect_rejects_non_positive_timeout() -> None:
+    """limits가 잘못된 실행 경계를 custom error로 거부한다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentExecutionLimits(timeout_seconds=0)
+
+
+def test_agent_expect_is_pod_stereotype_with_execution_spec_metadata() -> None:
+    """Agent stereotype이 Pod metadata와 execution spec을 함께 보존한다."""
     spec = AgentExecutionSpec(delegation_allowed=True)
 
-    agent = Agent(spec=spec)
+    @Agent(spec=spec)
+    class SampleAgent:
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    agent = Agent.get(SampleAgent)
 
     assert agent.spec is spec
+    assert agent.type_ is SampleAgent
+    assert agent.name == "sample_agent"
+
+
+def test_agent_expect_wraps_pod_constructor_di_metadata() -> None:
+    """Agent가 UseCase처럼 constructor DI dependency metadata를 가진다."""
+
+    @Pod()
+    class AgentTools: ...
+
+    @Agent()
+    class SampleAgent:
+        def __init__(self, tools: AgentTools) -> None:
+            self.tools = tools
+
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    agent = Agent.get(SampleAgent)
+
+    assert agent.dependencies["tools"].type_ is AgentTools
+
+
+def test_agent_expect_rejects_missing_execute_contract() -> None:
+    """execute가 없는 class는 definition 단계에서 custom error로 거부한다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class MissingExecute: ...
+
+
+def test_agent_expect_rejects_non_agent_yield_return_type() -> None:
+    """execute stream이 AgentYield를 내지 않으면 custom error로 거부한다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class InvalidReturnAgent:
+            async def execute(self, command: str) -> AsyncGenerator[str, None]:
+                yield command
+
+
+def test_agent_execution_spec_expect_rejects_blank_name() -> None:
+    """name은 공백 문자열일 수 없다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentExecutionSpec(name=" ")
+
+
+def test_agent_execution_spec_expect_rejects_blank_objective() -> None:
+    """objective는 공백 문자열일 수 없다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentExecutionSpec(objective=" ")
+
+
+def test_agent_execution_spec_expect_rejects_conflicting_timeout_declarations() -> None:
+    """legacy timeout과 limits timeout이 동시에 다르면 거부한다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentExecutionSpec(
+            timeout_seconds=10,
+            limits=AgentExecutionLimits(timeout_seconds=20),
+        )
+
+
+def test_agent_expect_rejects_non_class_target() -> None:
+    """Agent stereotype은 class target에만 적용된다."""
+
+    def factory() -> str:
+        return "agent"
+
+    with pytest.raises(AgentDefinitionError):
+        Agent()(factory)
+
+
+def test_agent_expect_wraps_invalid_pod_metadata_as_definition_error() -> None:
+    """Pod metadata 분석 실패도 agent definition custom error로 감싼다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class UntypedConstructorAgent:
+            def __init__(self, dependency) -> None:
+                self.dependency = dependency
+
+            async def execute(
+                self,
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+
+def test_agent_expect_rejects_static_execute() -> None:
+    """execute는 self를 받는 instance method여야 한다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class StaticExecuteAgent:
+            @staticmethod
+            async def execute(
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+
+def test_agent_expect_rejects_positional_only_execute_parameter() -> None:
+    """execute 인자는 positional-only를 사용할 수 없다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class PositionalOnlyAgent:
+            async def execute(
+                self,
+                command: str,
+                /,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+
+def test_agent_expect_rejects_varargs_execute_parameter() -> None:
+    """execute는 variable arguments를 사용할 수 없다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class VarargsAgent:
+            async def execute(
+                self,
+                *commands: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=commands[0], metadata={}),
+                )
+
+
+def test_agent_expect_rejects_untyped_execute_parameter() -> None:
+    """execute 인자는 타입 어노테이션을 가져야 한다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class UntypedExecuteParameterAgent:
+            async def execute(
+                self,
+                command,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+
+def test_agent_expect_rejects_missing_execute_return_type() -> None:
+    """execute return annotation은 필수다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class MissingReturnTypeAgent:
+            async def execute(self, command: str):
+                yield command
+
+
+def test_agent_expect_rejects_non_generator_execute_return_type() -> None:
+    """execute는 Generator 또는 AsyncGenerator stream을 반환해야 한다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class NonGeneratorAgent:
+            async def execute(self, command: str) -> str:
+                return command
+
+
+def test_agent_expect_rejects_unparameterized_generator_return_type() -> None:
+    """execute stream은 yield type을 명시해야 한다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class UnparameterizedGeneratorAgent:
+            async def execute(self, command: str) -> AsyncGenerator:
+                yield command

--- a/core/spakky-agent/tests/unit/test_execution.py
+++ b/core/spakky-agent/tests/unit/test_execution.py
@@ -3,6 +3,8 @@
 from collections.abc import AsyncGenerator
 
 import pytest
+import tests.fixtures.future_agent_app as future_agent_app
+import spakky.agent.execution as execution_module
 
 from spakky.core.pod.annotations.pod import Pod
 
@@ -287,3 +289,37 @@ def test_agent_expect_rejects_unparameterized_generator_return_type() -> None:
         class UnparameterizedGeneratorAgent:
             async def execute(self, command: str) -> AsyncGenerator:
                 yield command
+
+
+def test_agent_expect_resolves_postponed_execute_return_annotation() -> None:
+    """future annotations 스타일의 execute 반환 타입도 해석해 검증한다."""
+    agent = Agent.get(future_agent_app.FutureAnnotatedAgent)
+
+    assert agent.type_ is future_agent_app.FutureAnnotatedAgent
+
+
+def test_agent_expect_rejects_unresolvable_execute_return_annotation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """해석 불가능한 지연 반환 타입은 custom definition error로 드러난다."""
+
+    def unresolved_type_hints(
+        target: object,
+        include_extras: bool = False,
+    ) -> dict[str, object]:
+        raise NameError(target, include_extras)
+
+    monkeypatch.setattr(execution_module, "get_type_hints", unresolved_type_hints)
+
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class UnknownReturnAnnotationAgent:
+            async def execute(
+                self,
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )

--- a/core/spakky-agent/tests/unit/test_public_api.py
+++ b/core/spakky-agent/tests/unit/test_public_api.py
@@ -1,19 +1,25 @@
 """Tests for spakky-agent public API exports."""
 
+from collections.abc import AsyncGenerator
+
+import pytest
 import spakky.agent as agent_api
+import tests.fixtures.agent_app as agent_app
 from spakky.agent import (
     IAgentModel,
     Agent,
     AgentBootstrapError,
     AgentDefinitionError,
     AgentEvidence,
+    AgentExecutionLimits,
     AgentExecutionSpec,
-    IAgentEvidenceRepository,
     AgentSignal,
     AgentState,
+    AgentYield,
+    Final,
+    IAgentEvidenceRepository,
     IAgentSignalRepository,
     IAgentStateRepository,
-    AgentYield,
     ModelError,
     ModelRequest,
     ModelResponse,
@@ -24,6 +30,7 @@ from spakky.agent import (
     ToolCallingSpec,
 )
 from spakky.agent.main import initialize
+from spakky.agent.post_processor import AgentBootstrapValidationPostProcessor
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
 
@@ -32,6 +39,7 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
     """이슈 #213이 요구한 public import surface를 노출하는지 검증한다."""
     required_exports = {
         "Agent",
+        "AgentExecutionLimits",
         "AgentExecutionSpec",
         "AgentYield",
         "AgentState",
@@ -47,6 +55,7 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
 
     assert required_exports <= exported
     assert Agent is agent_api.Agent
+    assert AgentExecutionLimits is agent_api.AgentExecutionLimits
     assert AgentExecutionSpec is agent_api.AgentExecutionSpec
     assert AgentYield is agent_api.AgentYield
     assert AgentState is agent_api.AgentState
@@ -76,11 +85,54 @@ def test_public_api_expect_exports_custom_error_hierarchy() -> None:
     assert issubclass(AgentBootstrapError, agent_api.AbstractSpakkyAgentError)
 
 
-def test_initialize_expect_registers_no_production_fallbacks() -> None:
-    """core package 초기화가 persistence/model fallback 구현을 등록하지 않는다."""
+def test_initialize_expect_registers_only_bootstrap_validation() -> None:
+    """core package 초기화가 persistence/model fallback 없이 검증기만 등록한다."""
     app = SpakkyApplication(ApplicationContext())
 
-    before = dict(app.container.pods)
     initialize(app)
 
-    assert app.container.pods == before
+    assert app.container.contains(AgentBootstrapValidationPostProcessor) is True
+    assert app.container.contains(IAgentModel) is False
+
+
+async def test_agent_expect_scans_resolves_and_invokes_like_usecase() -> None:
+    """@Agent class가 scan, constructor DI, 직접 execute 호출에 참여한다."""
+    app = SpakkyApplication(ApplicationContext())
+    initialize(app)
+
+    app.scan(agent_app).start()
+
+    agent = app.container.get(agent_app.CodeAssistant)
+    items: list[AgentYield[Final[str]]] = []
+    async for item in agent.execute("ticket-214"):
+        items.append(item)
+
+    assert len(items) == 1
+    assert items[0].payload.output == "handled:ticket-214"
+
+
+def test_agent_bootstrap_expect_surfaces_execute_contract_as_custom_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """bootstrap 재검증에서 execute 계약 손상이 custom error로 드러난다."""
+
+    @Agent()
+    class ValidAtDefinition:
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=agent_api.AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    agent = Agent.get(ValidAtDefinition)
+    monkeypatch.setattr(agent.target, "execute", _invalid_execute)
+
+    with pytest.raises(AgentBootstrapError):
+        AgentBootstrapValidationPostProcessor().post_process(ValidAtDefinition())
+
+
+async def _invalid_execute(command: str) -> AsyncGenerator[str, None]:
+    yield command


### PR DESCRIPTION
## Summary
- Implement `@Agent` as a `@Pod`-derived stereotype so agent classes participate in scan, constructor DI, and direct `execute()` invocation like UseCase-shaped business components.
- Add `AgentExecutionLimits` plus name/objective validation to keep `AgentExecutionSpec` focused on auxiliary execution semantics, not infrastructure capability flags.
- Register an agent bootstrap validation post-processor that surfaces broken `execute()` contracts as custom bootstrap errors without adding model or persistence fallbacks.
- Sync `core/spakky-agent/README.md` with the new authoring surface.

## Validation
- `cd core/spakky-agent && uv run ruff format .`
- `cd core/spakky-agent && uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- `cd core/spakky-agent && uv run ruff check .`
- `cd core/spakky-agent && uv run pyrefly check src tests --python-interpreter-path ../../.venv/bin/python`
- `cd core/spakky-agent && uv run pytest` (35 passed, 100% coverage)
- `uv run mkdocs build --strict`

## Acceptance Criteria (self grep)
- [x] Issue #214 has no explicit grep/find/rg acceptance lines -> `acceptance_check: missing`

Closes #214
