### PR TITLE
feat(agent): add typed context pack contracts (#233)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -16,6 +16,7 @@
 - `AgentState`: long-running agent execution의 materialized lifecycle state
 - `AgentSignal`: 실행 중 들어오는 user message, approval, cancel 같은 inbound stimulus
 - `AgentEvidence`: tool/model/context 판단 근거를 위한 append-only artifact
+- `ContextPack`, `ContextManifest`, `ContextDigest`: model input context와 audit/digest evidence를 위한 typed contract
 - `IAgentStateRepository`, `IAgentSignalRepository`, `IAgentEvidenceRepository`: persistence provider가 구현하는 core port
 - `IAgentModel`: vLLM 등 model backend가 구현하는 outbound port
 - `ModelRequest`, `ModelResponse`, `ModelStreamEvent`: provider-neutral model 호출/응답/stream 계약
@@ -89,3 +90,9 @@ class CodeAssistant:
 `@Agent`는 `@Pod` 계열 stereotype이므로 application scan과 constructor DI에 참여합니다. `execute()`는 `Generator` 또는 `AsyncGenerator`로 `AgentYield[...]`를 yield해야 하며, 잘못된 signature나 지원하지 않는 metadata는 definition/bootstrap 단계에서 `AgentDefinitionError` 또는 `AgentBootstrapError`로 드러납니다.
 
 `IAgentModel.stream()`은 model adapter가 token delta, tool-call candidate, structured output, error, done을 `ModelStreamEventKind`로 구분해 내보내는 계약입니다. 실제 vLLM/OpenAI-compatible HTTP 연결은 `plugins/spakky-vllm` 같은 outbound adapter가 담당하며, core package에는 production model implementation을 넣지 않습니다.
+
+## Context contract
+
+Model input context는 raw 문자열을 이어 붙인 prompt snapshot이 아니라 `ContextPack` sequence로 전달합니다. 각 pack은 source, role, freshness, relevance, token budget, sensitivity metadata를 보존하고, `ContextManifest`는 pack 구성과 origin/evidence reference를 audit 단위로 남깁니다. 압축이나 요약은 원본 evidence를 대체하지 않고 `ContextDigest` derived evidence로 표현합니다.
+
+`ModelRequest.assemble_messages()`는 기존 `messages`와 `context` packs를 provider-neutral `ModelMessage` tuple로 조립하는 hook입니다. Adapter는 이 hook을 사용해 context metadata를 잃지 않고 provider payload로 변환할 수 있습니다.

--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -9,6 +9,16 @@ from spakky.agent.error import (
     AgentModelConfigurationError,
     AgentPersistenceConfigurationError,
 )
+from spakky.agent.context import (
+    ContextDigest,
+    ContextFreshness,
+    ContextManifest,
+    ContextManifestEntry,
+    ContextPack,
+    ContextPackRole,
+    ContextSensitivity,
+    ContextTokenBudget,
+)
 from spakky.agent.evidence import AgentEvidence, AgentEvidenceKind
 from spakky.agent.execution import (
     Agent,
@@ -92,6 +102,14 @@ __all__ = [
     "Approval",
     "ApprovalDecision",
     "Checkpoint",
+    "ContextDigest",
+    "ContextFreshness",
+    "ContextManifest",
+    "ContextManifestEntry",
+    "ContextPack",
+    "ContextPackRole",
+    "ContextSensitivity",
+    "ContextTokenBudget",
     "Evidence",
     "Final",
     "JsonObject",

--- a/core/spakky-agent/src/spakky/agent/context.py
+++ b/core/spakky-agent/src/spakky/agent/context.py
@@ -1,0 +1,122 @@
+"""Typed context contracts for agent model input assembly."""
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+
+from spakky.agent.types import JsonObject, JsonValue
+
+
+class ContextPackRole(StrEnum):
+    """Semantic role of a context pack inside a model request."""
+
+    SYSTEM = "system"
+    INSTRUCTION = "instruction"
+    TASK = "task"
+    STATE = "state"
+    EVIDENCE = "evidence"
+    TOOL_RESULT = "tool_result"
+    DELEGATION = "delegation"
+    MEMORY = "memory"
+
+
+class ContextFreshness(StrEnum):
+    """Freshness classification for context rot and budget decisions."""
+
+    CURRENT = "current"
+    RECENT = "recent"
+    STALE = "stale"
+    UNKNOWN = "unknown"
+
+
+class ContextSensitivity(StrEnum):
+    """Deterministic sensitivity metadata carried before model input."""
+
+    PUBLIC = "public"
+    INTERNAL = "internal"
+    CONFIDENTIAL = "confidential"
+    SENSITIVE = "sensitive"
+    REDACTED = "redacted"
+
+
+@dataclass(frozen=True, slots=True)
+class ContextTokenBudget:
+    """Token budget allocated to one context pack."""
+
+    max_tokens: int | None = None
+    estimated_tokens: int | None = None
+    reserved_output_tokens: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ContextPack:
+    """LLM-facing context unit derived from state, signal, or evidence."""
+
+    id: str
+    content: str
+    source: str
+    role: ContextPackRole
+    freshness: ContextFreshness = ContextFreshness.UNKNOWN
+    relevance: float | None = None
+    token_budget: ContextTokenBudget = field(default_factory=ContextTokenBudget)
+    sensitivity: ContextSensitivity = ContextSensitivity.INTERNAL
+    metadata: JsonObject = field(default_factory=dict)
+
+    def message_metadata(self) -> Mapping[str, JsonValue]:
+        """Return non-content metadata for provider-neutral model messages."""
+        return {
+            "context_pack_id": self.id,
+            "source": self.source,
+            "role": self.role.value,
+            "freshness": self.freshness.value,
+            "relevance": self.relevance,
+            "token_budget": {
+                "max_tokens": self.token_budget.max_tokens,
+                "estimated_tokens": self.token_budget.estimated_tokens,
+                "reserved_output_tokens": self.token_budget.reserved_output_tokens,
+            },
+            "sensitivity": self.sensitivity.value,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ContextManifestEntry:
+    """One audited pack entry inside a context manifest."""
+
+    pack_id: str
+    source: str
+    role: ContextPackRole
+    origin_ref: str
+    evidence_ref: str | None = None
+    digest_ref: str | None = None
+    metadata: JsonObject = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ContextManifest:
+    """Auditable composition record for model input context packs."""
+
+    id: str
+    entries: Sequence[ContextManifestEntry]
+    origin_ref: str | None = None
+    evidence_refs: Sequence[str] = field(default_factory=tuple)
+    created_at: datetime | None = None
+    metadata: JsonObject = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ContextDigest:
+    """Derived compression evidence for a context identity."""
+
+    id: str
+    context_identity: str
+    source_manifest_ref: str
+    digest: str
+    derived_from_pack_ids: Sequence[str] = field(default_factory=tuple)
+    compression_evidence_ref: str | None = None
+    algorithm: str | None = None
+    summary: str | None = None
+    created_at: datetime | None = None
+    metadata: JsonObject = field(default_factory=dict)

--- a/core/spakky-agent/src/spakky/agent/interfaces/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/interfaces/__init__.py
@@ -1,5 +1,15 @@
 """Agent public interface ports."""
 
+from spakky.agent.context import (
+    ContextDigest,
+    ContextFreshness,
+    ContextManifest,
+    ContextManifestEntry,
+    ContextPack,
+    ContextPackRole,
+    ContextSensitivity,
+    ContextTokenBudget,
+)
 from spakky.agent.interfaces.model import (
     IAgentModel,
     JsonSchemaConstraint,
@@ -31,6 +41,14 @@ __all__ = [
     "IAgentSignalRepository",
     "IAgentStateRepository",
     "JsonSchemaConstraint",
+    "ContextDigest",
+    "ContextFreshness",
+    "ContextManifest",
+    "ContextManifestEntry",
+    "ContextPack",
+    "ContextPackRole",
+    "ContextSensitivity",
+    "ContextTokenBudget",
     "ModelError",
     "ModelMessage",
     "ModelMessageRole",

--- a/core/spakky-agent/src/spakky/agent/interfaces/model.py
+++ b/core/spakky-agent/src/spakky/agent/interfaces/model.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 
+from spakky.agent.context import ContextDigest, ContextManifest, ContextPack
 from spakky.agent.types import JsonObject, JsonValue
 
 
@@ -91,11 +92,26 @@ class ModelRequest:
     """Provider-neutral request passed to an agent model adapter."""
 
     messages: Sequence[ModelMessage]
+    context: Sequence[ContextPack] = field(default_factory=tuple)
+    context_manifest: ContextManifest | None = None
+    context_digest: ContextDigest | None = None
     structured_output: StructuredOutputSpec | None = None
     tool_calling: ToolCallingSpec | None = None
     sampling: SamplingOptions = field(default_factory=SamplingOptions)
     streaming: StreamingOptions = field(default_factory=StreamingOptions)
     metadata: JsonObject = field(default_factory=dict)
+
+    def assemble_messages(self) -> tuple[ModelMessage, ...]:
+        """Assemble prompt messages from typed context packs without concatenation."""
+        context_messages = tuple(
+            ModelMessage(
+                role=ModelMessageRole.EVIDENCE,
+                content=pack.content,
+                metadata=pack.message_metadata(),
+            )
+            for pack in self.context
+        )
+        return (*self.messages, *context_messages)
 
 
 @dataclass(frozen=True, slots=True)

--- a/core/spakky-agent/tests/unit/interfaces/test_model.py
+++ b/core/spakky-agent/tests/unit/interfaces/test_model.py
@@ -5,6 +5,14 @@ from collections.abc import AsyncIterator
 import pytest
 
 from spakky.agent import (
+    ContextDigest,
+    ContextFreshness,
+    ContextManifest,
+    ContextManifestEntry,
+    ContextPack,
+    ContextPackRole,
+    ContextSensitivity,
+    ContextTokenBudget,
     IAgentModel,
     JsonSchemaConstraint,
     ModelError,
@@ -87,6 +95,76 @@ def test_model_request_expect_provider_neutral_structured_output_contract() -> N
     assert request.sampling.max_tokens == 64
     assert request.streaming.include_usage is True
     assert request.streaming.include_progress is False
+
+
+def test_model_request_expect_assembles_typed_context_packs_as_messages() -> None:
+    """ModelRequest는 raw 문자열 결합 대신 ContextPack 기반 메시지를 조립한다."""
+    pack = ContextPack(
+        id="pack-1",
+        content="ticket context",
+        source="issue:#233",
+        role=ContextPackRole.EVIDENCE,
+        freshness=ContextFreshness.CURRENT,
+        relevance=0.92,
+        token_budget=ContextTokenBudget(max_tokens=512, estimated_tokens=128),
+        sensitivity=ContextSensitivity.CONFIDENTIAL,
+        metadata={"origin": "github"},
+    )
+    manifest = ContextManifest(
+        id="manifest-1",
+        entries=(
+            ContextManifestEntry(
+                pack_id="pack-1",
+                source="issue:#233",
+                role=ContextPackRole.EVIDENCE,
+                origin_ref="github:issue:233",
+                evidence_ref="evidence-1",
+            ),
+        ),
+        evidence_refs=("evidence-1",),
+    )
+    digest = ContextDigest(
+        id="digest-1",
+        context_identity="agent-run:state-1:model-call-1",
+        source_manifest_ref="manifest-1",
+        digest="sha256:abc123",
+        derived_from_pack_ids=("pack-1",),
+        compression_evidence_ref="evidence-2",
+        algorithm="summary-v1",
+    )
+
+    request = ModelRequest(
+        messages=(ModelMessage(ModelMessageRole.USER, "summarize"),),
+        context=(pack,),
+        context_manifest=manifest,
+        context_digest=digest,
+    )
+
+    assembled = request.assemble_messages()
+
+    assert assembled == (
+        ModelMessage(ModelMessageRole.USER, "summarize"),
+        ModelMessage(
+            role=ModelMessageRole.EVIDENCE,
+            content="ticket context",
+            metadata={
+                "context_pack_id": "pack-1",
+                "source": "issue:#233",
+                "role": "evidence",
+                "freshness": "current",
+                "relevance": 0.92,
+                "token_budget": {
+                    "max_tokens": 512,
+                    "estimated_tokens": 128,
+                    "reserved_output_tokens": None,
+                },
+                "sensitivity": "confidential",
+                "metadata": {"origin": "github"},
+            },
+        ),
+    )
+    assert request.context_manifest is manifest
+    assert request.context_digest is digest
 
 
 @pytest.mark.asyncio

--- a/core/spakky-agent/tests/unit/test_public_api.py
+++ b/core/spakky-agent/tests/unit/test_public_api.py
@@ -16,6 +16,9 @@ from spakky.agent import (
     AgentSignal,
     AgentState,
     AgentYield,
+    ContextDigest,
+    ContextManifest,
+    ContextPack,
     Final,
     IAgentEvidenceRepository,
     IAgentSignalRepository,
@@ -45,6 +48,9 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
         "AgentState",
         "AgentSignal",
         "AgentEvidence",
+        "ContextPack",
+        "ContextManifest",
+        "ContextDigest",
         "IAgentStateRepository",
         "IAgentSignalRepository",
         "IAgentEvidenceRepository",
@@ -61,6 +67,9 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
     assert AgentState is agent_api.AgentState
     assert AgentSignal is agent_api.AgentSignal
     assert AgentEvidence is agent_api.AgentEvidence
+    assert ContextPack is agent_api.ContextPack
+    assert ContextManifest is agent_api.ContextManifest
+    assert ContextDigest is agent_api.ContextDigest
     assert IAgentStateRepository is agent_api.IAgentStateRepository
     assert IAgentSignalRepository is agent_api.IAgentSignalRepository
     assert IAgentEvidenceRepository is agent_api.IAgentEvidenceRepository


### PR DESCRIPTION
## Summary

- Add `ContextPack`, `ContextManifest`, and `ContextDigest` core contracts for deterministic model input context.
- Expose context contracts through `spakky.agent` and `spakky.agent.interfaces` public surfaces.
- Add `ModelRequest.context` metadata plus `assemble_messages()` so adapters can build provider messages from typed context packs instead of raw string concatenation.
- Document the context contract in `core/spakky-agent/README.md`.

## Acceptance Criteria

- [x] ContextPack includes source, role, freshness, relevance, token budget, and sensitivity metadata.
- [x] ContextManifest preserves pack composition plus origin/evidence references.
- [x] ContextDigest represents context identity and derived compression evidence.
- [x] Model request assembly has a ContextPack-based hook via `ModelRequest.assemble_messages()`.

## Acceptance Criteria (자가 grep)

- [x] No executable grep/find/rg lines in issue body -> acceptance_check: missing

## Validation

- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run pytest` (46 passed, 100% coverage)
- [x] `uv run pyrefly check src tests`

Closes #233
