### PR TITLE
feat(sqlalchemy): add agent persistence contribution (#222)

### DIFF
--- a/plugins/spakky-sqlalchemy/README.md
+++ b/plugins/spakky-sqlalchemy/README.md
@@ -243,6 +243,34 @@ from spakky.plugins.sqlalchemy.outbox.storage import AsyncSqlAlchemyOutboxStorag
 storage = app.container.get(type_=AsyncSqlAlchemyOutboxStorage)
 ```
 
+## Agent Persistence Contribution
+
+`spakky-agent`의 durable state, signal, evidence repository는 production
+in-memory fallback을 두지 않고 provider contribution으로만 공급됩니다.
+SQLAlchemy 구현은 별도 `spakky-agent-sqlalchemy` 패키지를 만들지 않고 이
+패키지의 `agent` extra와 contribution entry point로 제공합니다.
+
+```bash
+pip install "spakky-sqlalchemy[agent]"
+```
+
+```toml
+[project.entry-points."spakky.contributions.spakky.agent"]
+spakky-sqlalchemy = "spakky.plugins.sqlalchemy.contributions.agent:initialize"
+```
+
+`spakky-agent`와 `spakky-sqlalchemy`가 모두 active이면 다음 Pod과 schema가
+등록됩니다.
+
+- `SqlAlchemyAgentStateRepository`
+- `SqlAlchemyAgentSignalRepository`
+- `SqlAlchemyAgentEvidenceRepository`
+- `spakky_agent_state`, `spakky_agent_signal`, `spakky_agent_evidence`
+
+각 repository는 현재 SQLAlchemy transactional session을 사용합니다. Signal은
+`consumed_at`으로 pending queue를 구분하고, Evidence repository는 append/read
+메서드만 노출해 agent-facing append-only 계약을 유지합니다.
+
 ## 주요 기능
 
 - **Domain-Table mapping**: domain model과 ORM table 간 양방향 변환

--- a/plugins/spakky-sqlalchemy/pyproject.toml
+++ b/plugins/spakky-sqlalchemy/pyproject.toml
@@ -13,9 +13,11 @@ dependencies = [
 
 [project.optional-dependencies]
 outbox = ["spakky-outbox>=6.5.0"]
+agent = ["spakky-agent>=6.5.0"]
 
 [dependency-groups]
 dev = [
+    "spakky-agent>=6.5.0",
     "spakky-outbox>=6.5.0",
     "testcontainers[postgres]>=4.14.2",
     "psycopg[binary]>=3.3.3",
@@ -29,6 +31,9 @@ spakky-sqlalchemy = "spakky.plugins.sqlalchemy.main:initialize"
 
 [project.entry-points."spakky.contributions.spakky.outbox"]
 spakky-sqlalchemy = "spakky.plugins.sqlalchemy.contributions.outbox:initialize"
+
+[project.entry-points."spakky.contributions.spakky.agent"]
+spakky-sqlalchemy = "spakky.plugins.sqlalchemy.contributions.agent:initialize"
 
 [build-system]
 requires = ["uv_build>=0.10.10,<0.11.0"]
@@ -48,7 +53,7 @@ builtins = ["_"]
 cache-dir = "~/.cache/ruff"
 
 [tool.pytest.ini_options]
-pythonpath = "src/spakky/plugins/sqlalchemy"
+pythonpath = ["src/spakky/plugins/sqlalchemy", "../../core/spakky-agent/src"]
 testpaths = "tests"
 python_files = ["test_*.py"]
 asyncio_mode = "auto"
@@ -92,3 +97,4 @@ exclude_lines = [
 [tool.uv.sources]
 spakky-data = { workspace = true }
 spakky-outbox = { workspace = true }
+spakky-agent = { workspace = true }

--- a/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/agent/__init__.py
+++ b/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/agent/__init__.py
@@ -1,0 +1,1 @@
+"""SQLAlchemy-backed persistence for spakky-agent contracts."""

--- a/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/agent/error.py
+++ b/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/agent/error.py
@@ -1,0 +1,11 @@
+"""Errors for SQLAlchemy-backed agent persistence."""
+
+from spakky.plugins.sqlalchemy.persistency.error import (
+    AbstractSpakkySqlAlchemyPersistencyError,
+)
+
+
+class AgentPersistenceRowNotFoundError(AbstractSpakkySqlAlchemyPersistencyError):
+    """Raised when an agent persistence row cannot be found."""
+
+    message = "Agent persistence row not found"

--- a/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/agent/repository.py
+++ b/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/agent/repository.py
@@ -1,0 +1,152 @@
+"""SQLAlchemy repository implementations for spakky-agent contracts."""
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import override
+
+from spakky.agent.evidence import AgentEvidence
+from spakky.agent.interfaces.repository import (
+    IAgentEvidenceRepository,
+    IAgentSignalRepository,
+    IAgentStateRepository,
+)
+from spakky.agent.signal import AgentSignal
+from spakky.agent.state import AgentState, AgentStatus
+from spakky.core.pod.annotations.pod import Pod
+from sqlalchemy import select
+
+from spakky.plugins.sqlalchemy.agent.error import AgentPersistenceRowNotFoundError
+from spakky.plugins.sqlalchemy.agent.table import (
+    AgentEvidenceTable,
+    AgentSignalTable,
+    AgentStateTable,
+)
+from spakky.plugins.sqlalchemy.persistency.session_manager import SessionManager
+
+
+@Pod()
+class SqlAlchemyAgentStateRepository(IAgentStateRepository):
+    """SQLAlchemy materialized state repository for agent executions."""
+
+    _session_manager: SessionManager
+
+    def __init__(self, session_manager: SessionManager) -> None:
+        self._session_manager = session_manager
+
+    @override
+    def get(self, state_id: str) -> AgentState:
+        state = self.get_or_none(state_id)
+        if state is None:
+            raise AgentPersistenceRowNotFoundError(state_id)
+        return state
+
+    @override
+    def get_or_none(self, state_id: str) -> AgentState | None:
+        row = self._session_manager.session.get(AgentStateTable, state_id)
+        return row.to_domain() if row else None
+
+    @override
+    def save(self, state: AgentState) -> AgentState:
+        row = self._session_manager.session.merge(AgentStateTable.from_domain(state))
+        self._session_manager.session.flush()
+        return row.to_domain()
+
+    @override
+    def list_by_status(self, status: AgentStatus) -> Sequence[AgentState]:
+        rows = self._session_manager.session.scalars(
+            select(AgentStateTable)
+            .where(AgentStateTable.status == status.value)
+            .order_by(AgentStateTable.updated_at, AgentStateTable.id)
+        ).all()
+        return [row.to_domain() for row in rows]
+
+    @override
+    def list_resume_candidates(self) -> Sequence[AgentState]:
+        rows = self._session_manager.session.scalars(
+            select(AgentStateTable)
+            .where(
+                AgentStateTable.status.in_(
+                    (AgentStatus.ACTIVE.value, AgentStatus.INTERRUPTED.value)
+                )
+            )
+            .order_by(AgentStateTable.updated_at, AgentStateTable.id)
+        ).all()
+        return [row.to_domain() for row in rows]
+
+
+@Pod()
+class SqlAlchemyAgentSignalRepository(IAgentSignalRepository):
+    """SQLAlchemy durable inbound queue repository for agent signals."""
+
+    _session_manager: SessionManager
+
+    def __init__(self, session_manager: SessionManager) -> None:
+        self._session_manager = session_manager
+
+    @override
+    def append(self, signal: AgentSignal) -> AgentSignal:
+        row = AgentSignalTable.from_domain(signal)
+        self._session_manager.session.add(row)
+        self._session_manager.session.flush()
+        return row.to_domain()
+
+    @override
+    def list_pending(self, state_id: str) -> Sequence[AgentSignal]:
+        rows = self._session_manager.session.scalars(
+            select(AgentSignalTable)
+            .where(AgentSignalTable.agent_state_id == state_id)
+            .where(AgentSignalTable.consumed_at.is_(None))
+            .order_by(AgentSignalTable.created_at, AgentSignalTable.id)
+        ).all()
+        return [row.to_domain() for row in rows]
+
+    @override
+    def mark_consumed(self, signal_id: str) -> AgentSignal:
+        row = self._session_manager.session.get(AgentSignalTable, signal_id)
+        if row is None:
+            raise AgentPersistenceRowNotFoundError(signal_id)
+        row.consumed_at = datetime.now(UTC)
+        self._session_manager.session.flush()
+        return row.to_domain()
+
+
+@Pod()
+class SqlAlchemyAgentEvidenceRepository(IAgentEvidenceRepository):
+    """SQLAlchemy append-only repository for agent evidence artifacts."""
+
+    _session_manager: SessionManager
+
+    def __init__(self, session_manager: SessionManager) -> None:
+        self._session_manager = session_manager
+
+    @override
+    def append(self, evidence: AgentEvidence) -> AgentEvidence:
+        row = AgentEvidenceTable.from_domain(evidence)
+        self._session_manager.session.add(row)
+        self._session_manager.session.flush()
+        return row.to_domain()
+
+    @override
+    def get(self, evidence_id: str) -> AgentEvidence:
+        row = self._session_manager.session.get(AgentEvidenceTable, evidence_id)
+        if row is None:
+            raise AgentPersistenceRowNotFoundError(evidence_id)
+        return row.to_domain()
+
+    @override
+    def list_by_state(self, state_id: str) -> Sequence[AgentEvidence]:
+        rows = self._session_manager.session.scalars(
+            select(AgentEvidenceTable)
+            .where(AgentEvidenceTable.agent_state_id == state_id)
+            .order_by(AgentEvidenceTable.created_at, AgentEvidenceTable.id)
+        ).all()
+        return [row.to_domain() for row in rows]
+
+    @override
+    def list_by_manifest_ref(self, manifest_ref: str) -> Sequence[AgentEvidence]:
+        rows = self._session_manager.session.scalars(
+            select(AgentEvidenceTable)
+            .where(AgentEvidenceTable.manifest_ref == manifest_ref)
+            .order_by(AgentEvidenceTable.created_at, AgentEvidenceTable.id)
+        ).all()
+        return [row.to_domain() for row in rows]

--- a/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/agent/table.py
+++ b/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/agent/table.py
@@ -1,0 +1,190 @@
+"""SQLAlchemy schema mappings for spakky-agent persistence contracts."""
+
+from datetime import datetime
+from typing import Self, cast
+
+from spakky.agent.evidence import AgentEvidence, AgentEvidenceKind
+from spakky.agent.execution import AgentSignalKind
+from spakky.agent.signal import AgentSignal
+from spakky.agent.state import (
+    AgentState,
+    AgentStateReason,
+    AgentStateTransition,
+    AgentStatus,
+)
+from spakky.agent.types import JsonObject
+from sqlalchemy import JSON, DateTime, Index, Integer, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from spakky.plugins.sqlalchemy.orm.table import AbstractMappableTable, Table
+
+
+@Table()
+class AgentStateTable(AbstractMappableTable[AgentState]):
+    """Materialized state table for durable agent executions."""
+
+    __tablename__ = "spakky_agent_state"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    agent_type: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    transition: Mapped[str | None] = mapped_column(Text, nullable=True)
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    current_activity: Mapped[str | None] = mapped_column(Text, nullable=True)
+    input_ref: Mapped[str | None] = mapped_column(Text, nullable=True)
+    output_ref: Mapped[str | None] = mapped_column(Text, nullable=True)
+    pending_signal_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0
+    )
+    last_event_cursor: Mapped[str | None] = mapped_column(Text, nullable=True)
+    recovery_marker: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metadata_json: Mapped[JsonObject] = mapped_column(
+        "metadata", JSON, nullable=False, default=dict
+    )
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    __table_args__ = (
+        Index("ix_spakky_agent_state_status", "status"),
+        Index("ix_spakky_agent_state_resume", "status", "updated_at"),
+    )
+
+    @classmethod
+    def from_domain(cls, domain: AgentState) -> Self:
+        return cls(
+            id=domain.id,
+            agent_type=domain.agent_type,
+            status=domain.status.value,
+            transition=domain.transition.value if domain.transition else None,
+            reason=domain.reason.value if domain.reason else None,
+            current_activity=domain.current_activity,
+            input_ref=domain.input_ref,
+            output_ref=domain.output_ref,
+            pending_signal_count=domain.pending_signal_count,
+            last_event_cursor=domain.last_event_cursor,
+            recovery_marker=domain.recovery_marker,
+            metadata_json=domain.metadata,
+            created_at=domain.created_at,
+            updated_at=domain.updated_at,
+        )
+
+    def to_domain(self) -> AgentState:
+        return AgentState(
+            id=self.id,
+            agent_type=self.agent_type,
+            status=AgentStatus(self.status),
+            transition=(
+                AgentStateTransition(self.transition) if self.transition else None
+            ),
+            reason=AgentStateReason(self.reason) if self.reason else None,
+            current_activity=self.current_activity,
+            input_ref=self.input_ref,
+            output_ref=self.output_ref,
+            pending_signal_count=self.pending_signal_count,
+            last_event_cursor=self.last_event_cursor,
+            recovery_marker=self.recovery_marker,
+            metadata=cast(JsonObject, self.metadata_json),
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
+
+
+@Table()
+class AgentSignalTable(AbstractMappableTable[AgentSignal]):
+    """Durable inbound signal queue table for agent executions."""
+
+    __tablename__ = "spakky_agent_signal"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    agent_state_id: Mapped[str] = mapped_column(Text, nullable=False)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[JsonObject] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    consumed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_spakky_agent_signal_pending",
+            "agent_state_id",
+            "consumed_at",
+            "created_at",
+        ),
+    )
+
+    @classmethod
+    def from_domain(cls, domain: AgentSignal) -> Self:
+        return cls(
+            id=domain.id,
+            agent_state_id=domain.agent_state_id,
+            kind=domain.kind.value,
+            payload=domain.payload,
+            created_at=domain.created_at,
+        )
+
+    def to_domain(self) -> AgentSignal:
+        return AgentSignal(
+            id=self.id,
+            agent_state_id=self.agent_state_id,
+            kind=AgentSignalKind(self.kind),
+            payload=cast(JsonObject, self.payload),
+            created_at=self.created_at,
+        )
+
+
+@Table()
+class AgentEvidenceTable(AbstractMappableTable[AgentEvidence]):
+    """Append-only evidence table for agent execution artifacts."""
+
+    __tablename__ = "spakky_agent_evidence"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    agent_state_id: Mapped[str] = mapped_column(Text, nullable=False)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[JsonObject] = mapped_column(JSON, nullable=False, default=dict)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    digest: Mapped[str | None] = mapped_column(Text, nullable=True)
+    manifest_ref: Mapped[str | None] = mapped_column(Text, nullable=True)
+    reference: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    __table_args__ = (
+        Index("ix_spakky_agent_evidence_state", "agent_state_id", "created_at"),
+        Index("ix_spakky_agent_evidence_manifest", "manifest_ref", "created_at"),
+    )
+
+    @classmethod
+    def from_domain(cls, domain: AgentEvidence) -> Self:
+        return cls(
+            id=domain.id,
+            agent_state_id=domain.agent_state_id,
+            kind=domain.kind.value,
+            payload=domain.payload,
+            summary=domain.summary,
+            digest=domain.digest,
+            manifest_ref=domain.manifest_ref,
+            reference=domain.reference,
+            created_at=domain.created_at,
+        )
+
+    def to_domain(self) -> AgentEvidence:
+        return AgentEvidence(
+            id=self.id,
+            agent_state_id=self.agent_state_id,
+            kind=AgentEvidenceKind(self.kind),
+            payload=cast(JsonObject, self.payload),
+            summary=self.summary,
+            digest=self.digest,
+            manifest_ref=self.manifest_ref,
+            reference=self.reference,
+            created_at=self.created_at,
+        )

--- a/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/contributions/agent.py
+++ b/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/contributions/agent.py
@@ -1,0 +1,24 @@
+"""SQLAlchemy contribution for the spakky-agent feature."""
+
+from spakky.core.application.application import SpakkyApplication
+
+from spakky.plugins.sqlalchemy.agent.repository import (
+    SqlAlchemyAgentEvidenceRepository,
+    SqlAlchemyAgentSignalRepository,
+    SqlAlchemyAgentStateRepository,
+)
+from spakky.plugins.sqlalchemy.agent.table import (
+    AgentEvidenceTable,
+    AgentSignalTable,
+    AgentStateTable,
+)
+
+
+def initialize(app: SpakkyApplication) -> None:
+    """Register SQLAlchemy-backed agent persistence infrastructure."""
+    app.add(AgentStateTable)
+    app.add(AgentSignalTable)
+    app.add(AgentEvidenceTable)
+    app.add(SqlAlchemyAgentStateRepository)
+    app.add(SqlAlchemyAgentSignalRepository)
+    app.add(SqlAlchemyAgentEvidenceRepository)

--- a/plugins/spakky-sqlalchemy/tests/unit/test_agent_contribution.py
+++ b/plugins/spakky-sqlalchemy/tests/unit/test_agent_contribution.py
@@ -1,0 +1,32 @@
+"""Unit tests for SQLAlchemy agent contribution initialization."""
+
+from unittest.mock import MagicMock
+
+from spakky.plugins.sqlalchemy.agent.repository import (
+    SqlAlchemyAgentEvidenceRepository,
+    SqlAlchemyAgentSignalRepository,
+    SqlAlchemyAgentStateRepository,
+)
+from spakky.plugins.sqlalchemy.agent.table import (
+    AgentEvidenceTable,
+    AgentSignalTable,
+    AgentStateTable,
+)
+from spakky.plugins.sqlalchemy.contributions.agent import initialize
+
+
+def test_agent_contribution_expect_tables_and_repositories_registered() -> None:
+    """agent contribution이 state/signal/evidence table과 repository를 등록한다."""
+    app = MagicMock()
+
+    initialize(app)
+
+    added_types = [call.args[0] for call in app.add.call_args_list]
+    assert added_types == [
+        AgentStateTable,
+        AgentSignalTable,
+        AgentEvidenceTable,
+        SqlAlchemyAgentStateRepository,
+        SqlAlchemyAgentSignalRepository,
+        SqlAlchemyAgentEvidenceRepository,
+    ]

--- a/plugins/spakky-sqlalchemy/tests/unit/test_agent_repository.py
+++ b/plugins/spakky-sqlalchemy/tests/unit/test_agent_repository.py
@@ -1,0 +1,177 @@
+"""Unit tests for SQLAlchemy-backed agent repositories."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Generator, cast
+
+import pytest
+from spakky.agent import (
+    AgentEvidence,
+    AgentEvidenceKind,
+    AgentSignal,
+    AgentSignalKind,
+    AgentState,
+    AgentStatus,
+)
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from spakky.plugins.sqlalchemy.agent.error import AgentPersistenceRowNotFoundError
+from spakky.plugins.sqlalchemy.agent.repository import (
+    SqlAlchemyAgentEvidenceRepository,
+    SqlAlchemyAgentSignalRepository,
+    SqlAlchemyAgentStateRepository,
+)
+from spakky.plugins.sqlalchemy.agent.table import (
+    AgentEvidenceTable,
+    AgentSignalTable,
+    AgentStateTable,
+)
+from spakky.plugins.sqlalchemy.persistency.session_manager import SessionManager
+
+
+@dataclass(slots=True)
+class SessionManagerStub:
+    """Minimal session manager shape used by repository unit tests."""
+
+    session: Session
+
+
+@pytest.fixture(name="session")
+def session_fixture() -> Generator[Session, None, None]:
+    """Create an isolated in-memory SQLAlchemy session."""
+    engine = create_engine("sqlite:///:memory:")
+    AgentStateTable.metadata.create_all(engine)
+    AgentSignalTable.metadata.create_all(engine)
+    AgentEvidenceTable.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+@pytest.fixture(name="session_manager")
+def session_manager_fixture(session: Session) -> SessionManager:
+    """Return a typed session manager stub for repository construction."""
+    return cast(SessionManager, SessionManagerStub(session=session))
+
+
+def test_agent_state_repository_expect_save_get_and_resume_queries(
+    session_manager: SessionManager,
+) -> None:
+    """state repository가 저장, 상태 조회, resume 후보 조회를 지원한다."""
+    repository = SqlAlchemyAgentStateRepository(session_manager)
+    active_state = AgentState(
+        id="state-1",
+        agent_type="CodeAssistant",
+        status=AgentStatus.ACTIVE,
+        current_activity="thinking",
+        metadata={"task": "inspect"},
+        created_at=datetime(2026, 5, 6),
+        updated_at=datetime(2026, 5, 6),
+    )
+    completed_state = AgentState(
+        id="state-2",
+        agent_type="CodeAssistant",
+        status=AgentStatus.COMPLETED,
+        updated_at=datetime(2026, 5, 7),
+    )
+
+    saved = repository.save(active_state)
+    repository.save(completed_state)
+
+    assert saved == active_state
+    assert repository.get("state-1") == active_state
+    assert repository.get_or_none("missing") is None
+    assert repository.list_by_status(AgentStatus.ACTIVE) == [active_state]
+    assert repository.list_resume_candidates() == [active_state]
+
+
+def test_agent_state_repository_get_missing_expect_custom_error(
+    session_manager: SessionManager,
+) -> None:
+    """없는 state 조회는 plugin custom error로 실패한다."""
+    repository = SqlAlchemyAgentStateRepository(session_manager)
+
+    with pytest.raises(AgentPersistenceRowNotFoundError):
+        repository.get("missing")
+
+
+def test_agent_signal_repository_expect_append_pending_and_mark_consumed(
+    session_manager: SessionManager,
+) -> None:
+    """signal repository가 pending queue와 consumed marker를 관리한다."""
+    repository = SqlAlchemyAgentSignalRepository(session_manager)
+    first_signal = AgentSignal(
+        id="signal-1",
+        agent_state_id="state-1",
+        kind=AgentSignalKind.USER_MESSAGE,
+        payload={"message": "continue"},
+        created_at=datetime(2026, 5, 6, 1),
+    )
+    second_signal = AgentSignal(
+        id="signal-2",
+        agent_state_id="state-1",
+        kind=AgentSignalKind.CANCEL,
+        created_at=datetime(2026, 5, 6, 2),
+    )
+
+    assert repository.append(first_signal) == first_signal
+    assert repository.append(second_signal) == second_signal
+    assert repository.list_pending("state-1") == [first_signal, second_signal]
+
+    consumed = repository.mark_consumed("signal-1")
+
+    assert consumed == first_signal
+    assert repository.list_pending("state-1") == [second_signal]
+
+
+def test_agent_signal_repository_mark_missing_expect_custom_error(
+    session_manager: SessionManager,
+) -> None:
+    """없는 signal consume은 plugin custom error로 실패한다."""
+    repository = SqlAlchemyAgentSignalRepository(session_manager)
+
+    with pytest.raises(AgentPersistenceRowNotFoundError):
+        repository.mark_consumed("missing")
+
+
+def test_agent_evidence_repository_expect_append_get_and_filter_queries(
+    session_manager: SessionManager,
+) -> None:
+    """evidence repository가 append/read 전용 조회를 지원한다."""
+    repository = SqlAlchemyAgentEvidenceRepository(session_manager)
+    manifest_evidence = AgentEvidence(
+        id="evidence-1",
+        agent_state_id="state-1",
+        kind=AgentEvidenceKind.CONTEXT_MANIFEST,
+        payload={"path": "manifest.json"},
+        manifest_ref="manifest-1",
+        created_at=datetime(2026, 5, 6, 1),
+    )
+    tool_evidence = AgentEvidence(
+        id="evidence-2",
+        agent_state_id="state-1",
+        kind=AgentEvidenceKind.TOOL,
+        summary="read file",
+        created_at=datetime(2026, 5, 6, 2),
+    )
+
+    assert repository.append(manifest_evidence) == manifest_evidence
+    assert repository.append(tool_evidence) == tool_evidence
+    assert repository.get("evidence-1") == manifest_evidence
+    assert repository.list_by_state("state-1") == [manifest_evidence, tool_evidence]
+    assert repository.list_by_manifest_ref("manifest-1") == [manifest_evidence]
+
+
+def test_agent_evidence_repository_get_missing_expect_custom_error(
+    session_manager: SessionManager,
+) -> None:
+    """없는 evidence 조회는 plugin custom error로 실패한다."""
+    repository = SqlAlchemyAgentEvidenceRepository(session_manager)
+
+    with pytest.raises(AgentPersistenceRowNotFoundError):
+        repository.get("missing")

--- a/plugins/spakky-sqlalchemy/tests/unit/test_entry_points.py
+++ b/plugins/spakky-sqlalchemy/tests/unit/test_entry_points.py
@@ -3,10 +3,21 @@
 from importlib.metadata import entry_points
 
 import pytest
+import spakky.agent
 import spakky.outbox
 import spakky.plugins.sqlalchemy
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
+from spakky.plugins.sqlalchemy.agent.repository import (
+    SqlAlchemyAgentEvidenceRepository,
+    SqlAlchemyAgentSignalRepository,
+    SqlAlchemyAgentStateRepository,
+)
+from spakky.plugins.sqlalchemy.agent.table import (
+    AgentEvidenceTable,
+    AgentSignalTable,
+    AgentStateTable,
+)
 from spakky.plugins.sqlalchemy.orm.table import Table
 from spakky.plugins.sqlalchemy.outbox.storage import (
     AsyncSqlAlchemyOutboxStorage,
@@ -23,6 +34,18 @@ def test_sqlalchemy_outbox_contribution_entry_point_is_declared() -> None:
         entry_point.name == "spakky-sqlalchemy"
         and entry_point.value
         == "spakky.plugins.sqlalchemy.contributions.outbox:initialize"
+        for entry_point in contribution_entry_points
+    )
+
+
+def test_sqlalchemy_agent_contribution_entry_point_is_declared() -> None:
+    """SQLAlchemy agent contribution entry point metadata를 검증한다."""
+    contribution_entry_points = entry_points(group="spakky.contributions.spakky.agent")
+
+    assert any(
+        entry_point.name == "spakky-sqlalchemy"
+        and entry_point.value
+        == "spakky.plugins.sqlalchemy.contributions.agent:initialize"
         for entry_point in contribution_entry_points
     )
 
@@ -66,3 +89,50 @@ def test_load_plugins_with_sqlalchemy_only_expect_outbox_contribution_skipped(
     assert not app.application_context.contains_tag(Table.get(OutboxMessageTable))
     assert SqlAlchemyOutboxStorage not in added_types
     assert AsyncSqlAlchemyOutboxStorage not in added_types
+
+
+def test_load_plugins_with_agent_and_sqlalchemy_expect_agent_contribution_registered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """spakky-agent active 조합에서 SQLAlchemy agent contribution 등록을 검증한다."""
+    monkeypatch.setenv(
+        "SPAKKY_SQLALCHEMY__CONNECTION_STRING",
+        "postgresql+psycopg://test:test@localhost/test",
+    )
+
+    app = SpakkyApplication(ApplicationContext()).load_plugins(
+        include={
+            spakky.agent.PLUGIN_NAME,
+            spakky.plugins.sqlalchemy.PLUGIN_NAME,
+        }
+    )
+    added_types = {pod.type_ for pod in app.container.pods.values()}
+
+    assert app.application_context.contains_tag(Table.get(AgentStateTable))
+    assert app.application_context.contains_tag(Table.get(AgentSignalTable))
+    assert app.application_context.contains_tag(Table.get(AgentEvidenceTable))
+    assert SqlAlchemyAgentStateRepository in added_types
+    assert SqlAlchemyAgentSignalRepository in added_types
+    assert SqlAlchemyAgentEvidenceRepository in added_types
+
+
+def test_load_plugins_with_sqlalchemy_only_expect_agent_contribution_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """spakky-agent 비활성 조합에서는 SQLAlchemy agent Pod을 등록하지 않는다."""
+    monkeypatch.setenv(
+        "SPAKKY_SQLALCHEMY__CONNECTION_STRING",
+        "postgresql+psycopg://test:test@localhost/test",
+    )
+
+    app = SpakkyApplication(ApplicationContext()).load_plugins(
+        include={spakky.plugins.sqlalchemy.PLUGIN_NAME}
+    )
+    added_types = {pod.type_ for pod in app.container.pods.values()}
+
+    assert not app.application_context.contains_tag(Table.get(AgentStateTable))
+    assert not app.application_context.contains_tag(Table.get(AgentSignalTable))
+    assert not app.application_context.contains_tag(Table.get(AgentEvidenceTable))
+    assert SqlAlchemyAgentStateRepository not in added_types
+    assert SqlAlchemyAgentSignalRepository not in added_types
+    assert SqlAlchemyAgentEvidenceRepository not in added_types

--- a/uv.lock
+++ b/uv.lock
@@ -3001,6 +3001,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+agent = [
+    { name = "spakky-agent" },
+]
 outbox = [
     { name = "spakky-outbox" },
 ]
@@ -3011,17 +3014,19 @@ dev = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest-asyncio" },
     { name = "pytest-integration-mark" },
+    { name = "spakky-agent" },
     { name = "spakky-outbox" },
     { name = "testcontainers" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "spakky-agent", marker = "extra == 'agent'", editable = "core/spakky-agent" },
     { name = "spakky-data", editable = "core/spakky-data" },
     { name = "spakky-outbox", marker = "extra == 'outbox'", editable = "core/spakky-outbox" },
     { name = "sqlalchemy", specifier = ">=2.0.49" },
 ]
-provides-extras = ["outbox"]
+provides-extras = ["outbox", "agent"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3029,6 +3034,7 @@ dev = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-integration-mark", specifier = ">=0.2.0" },
+    { name = "spakky-agent", editable = "core/spakky-agent" },
     { name = "spakky-outbox", editable = "core/spakky-outbox" },
     { name = "testcontainers", extras = ["postgres"], specifier = ">=4.14.2" },
 ]


### PR DESCRIPTION
## Summary
- Add SQLAlchemy-backed spakky-agent state, signal, and evidence tables/repositories inside plugins/spakky-sqlalchemy
- Register the provider via spakky.contributions.spakky.agent without creating an agent-specific SQLAlchemy package
- Document the agent extra and cover contribution loading plus repository round-trips

## Validation
- uv run --with ruff ruff check .
- uv run --with pyrefly pyrefly check src tests
- uv run --with pytest-cov --with pytest-xdist --with pytest-spec pytest
- uv run mkdocs build --strict

Closes #222