### PR TITLE
feat(agent): add non-blocking signal consumption (#229)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -15,6 +15,7 @@
 - `AgentYield`: `execute()`가 caller에게 흘려보내는 typed stream item
 - `AgentState`: long-running agent execution의 materialized lifecycle state
 - `AgentSignal`: 실행 중 들어오는 user message, approval, cancel 같은 inbound stimulus
+- `AgentSignalPollPoint`, `consume_pending_agent_signals`: safe boundary나 configured poll point에서 durable signal queue를 대기 없이 소비하는 helper
 - `AgentEvidence`: tool/model/context 판단 근거를 위한 append-only artifact
 - `ContextPack`, `ContextManifest`, `ContextDigest`: model input context와 audit/digest evidence를 위한 typed contract
 - `IAgentStateRepository`, `IAgentSignalRepository`, `IAgentEvidenceRepository`: persistence provider가 구현하는 core port
@@ -91,6 +92,8 @@ class CodeAssistant:
 `@Agent`는 `@Pod` 계열 stereotype이므로 application scan과 constructor DI에 참여합니다. `execute()`는 `Generator[AgentYield[T], None, None]` 또는 `AsyncGenerator[AgentYield[T], None]`로 typed stream item을 yield할 수 있고, non-generator 반환형은 streaming 없는 직접 결과 계약으로 취급됩니다. Inbound adapter가 SSE/WebSocket/CLI처럼 진행 상태를 즉시 내보내야 한다면 `AgentYield` generator 계약을 사용해야 합니다.
 
 `AgentYieldKind`의 public status vocabulary는 `token`, `progress`, `tool`, `evidence`, `approval`, `final`, `error`, `cancel`입니다. 각 item의 payload는 `Token`, `Progress`, `Tool`, `Evidence`, `Approval`, `Final[T]`, `Error`, `Cancel` value object로 구분되므로 inbound adapter는 별도 stream projector 없이 generator를 직접 순회해 transport별 이벤트로 바꿀 수 있습니다.
+
+실행 중 inbound adapter가 user message, approval decision, cancel, resume signal을 append하면 orchestration은 safe boundary, action boundary, model stream tick 같은 poll point에서 `consume_pending_agent_signals()`를 호출합니다. 이 helper는 sleep/poll loop 없이 현재 pending queue만 읽고 append order의 eligible prefix를 consumed 처리하므로 token streaming을 불필요하게 block하지 않습니다. Repository 구현은 `list_pending()` 결과를 append/queue order로 반환해야 하며, helper는 earlier unaccepted signal을 건너뛰어 later signal을 먼저 소비하지 않습니다.
 
 잘못된 signature나 지원하지 않는 metadata는 definition/bootstrap 단계에서 `AgentDefinitionError` 또는 `AgentBootstrapError`로 드러납니다.
 

--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -53,6 +53,11 @@ from spakky.agent.interfaces.model import (
     ToolCallingSpec,
 )
 from spakky.agent.signal import AgentSignal, ApprovalDecision
+from spakky.agent.signal_consumption import (
+    AgentSignalConsumptionBatch,
+    AgentSignalPollPoint,
+    consume_pending_agent_signals,
+)
 from spakky.agent.state import (
     AgentState,
     AgentStateReason,
@@ -114,7 +119,9 @@ __all__ = [
     "AgentModelConfigurationError",
     "AgentPersistenceConfigurationError",
     "AgentSignal",
+    "AgentSignalConsumptionBatch",
     "AgentSignalKind",
+    "AgentSignalPollPoint",
     "AgentToolCatalog",
     "AgentToolDefinition",
     "AgentToolDescriptor",
@@ -178,6 +185,7 @@ __all__ = [
     "ToolCallingSpec",
     "ToolEffects",
     "ToolPermission",
+    "consume_pending_agent_signals",
     "agent_tool",
     "discover_agent_tools",
 ]

--- a/core/spakky-agent/src/spakky/agent/interfaces/repository.py
+++ b/core/spakky-agent/src/spakky/agent/interfaces/repository.py
@@ -47,12 +47,12 @@ class IAgentSignalRepository(ABC):
 
     @abstractmethod
     def list_pending(self, state_id: str) -> Sequence[AgentSignal]:
-        """Return unconsumed signals for an agent state in queue order."""
+        """Return unconsumed signals for an agent state in append/queue order."""
         ...
 
     @abstractmethod
     def mark_consumed(self, signal_id: str) -> AgentSignal:
-        """Mark a queued signal as consumed at a safe action boundary."""
+        """Mark one queued signal as consumed after a non-blocking poll."""
         ...
 
 

--- a/core/spakky-agent/src/spakky/agent/signal_consumption.py
+++ b/core/spakky-agent/src/spakky/agent/signal_consumption.py
@@ -1,0 +1,86 @@
+"""Non-blocking consumption helpers for durable agent signals."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+
+from spakky.agent.error import AgentDefinitionError
+from spakky.agent.execution import AgentSignalKind
+from spakky.agent.interfaces.repository import IAgentSignalRepository
+from spakky.agent.signal import AgentSignal
+
+
+class AgentSignalPollPoint(StrEnum):
+    """Places where orchestration may poll durable signals without waiting."""
+
+    SAFE_BOUNDARY = "safe_boundary"
+    ACTION_BOUNDARY = "action_boundary"
+    MODEL_STREAM_TICK = "model_stream_tick"
+    TOOL_BOUNDARY = "tool_boundary"
+    APPROVAL_BOUNDARY = "approval_boundary"
+    CONFIGURED = "configured"
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSignalConsumptionBatch:
+    """Signals consumed during one non-blocking poll."""
+
+    state_id: str
+    poll_point: AgentSignalPollPoint
+    signals: tuple[AgentSignal, ...]
+
+    @property
+    def consumed_count(self) -> int:
+        """Return the number of signals consumed by this poll."""
+        return len(self.signals)
+
+
+def consume_pending_agent_signals(
+    repository: IAgentSignalRepository,
+    state_id: str,
+    *,
+    poll_point: AgentSignalPollPoint = AgentSignalPollPoint.SAFE_BOUNDARY,
+    accepted_signals: Sequence[AgentSignalKind] | None = None,
+    max_signals: int | None = None,
+) -> AgentSignalConsumptionBatch:
+    """Consume currently pending signals without sleeping or waiting for new input.
+
+    The repository remains responsible for durable queue ordering. This helper
+    consumes only the eligible prefix of the pending queue so later signals never
+    overtake an earlier unaccepted signal.
+    """
+    if not state_id.strip():
+        raise AgentDefinitionError("Agent signal state id cannot be blank")
+    if max_signals is not None and max_signals <= 0:
+        raise AgentDefinitionError("Agent signal max_signals must be positive")
+
+    accepted = frozenset(accepted_signals) if accepted_signals is not None else None
+    pending = tuple(repository.list_pending(state_id))
+    selected = _select_consumable_prefix(
+        pending,
+        accepted_signals=accepted,
+        max_signals=max_signals,
+    )
+    consumed = tuple(repository.mark_consumed(signal.id) for signal in selected)
+
+    return AgentSignalConsumptionBatch(
+        state_id=state_id,
+        poll_point=poll_point,
+        signals=consumed,
+    )
+
+
+def _select_consumable_prefix(
+    pending: tuple[AgentSignal, ...],
+    *,
+    accepted_signals: frozenset[AgentSignalKind] | None,
+    max_signals: int | None,
+) -> tuple[AgentSignal, ...]:
+    selected: list[AgentSignal] = []
+    for signal in pending:
+        if max_signals is not None and len(selected) >= max_signals:
+            break
+        if accepted_signals is not None and signal.kind not in accepted_signals:
+            break
+        selected.append(signal)
+    return tuple(selected)

--- a/core/spakky-agent/tests/unit/interfaces/test_repository.py
+++ b/core/spakky-agent/tests/unit/interfaces/test_repository.py
@@ -35,6 +35,13 @@ def test_agent_signal_repository_expect_exposes_queue_methods() -> None:
     assert isinstance(IAgentSignalRepository, ABCMeta)
 
 
+def test_agent_signal_repository_expect_list_pending_documents_queue_order() -> None:
+    """list_pending contract가 append/queue order 보존을 문서화한다."""
+    doc = IAgentSignalRepository.list_pending.__doc__ or ""
+
+    assert "append/queue order" in doc
+
+
 def test_agent_evidence_repository_expect_exposes_append_read_only_methods() -> None:
     """evidence repository가 update/delete를 agent-facing interface에 노출하지 않는다."""
     methods = IAgentEvidenceRepository.__abstractmethods__

--- a/core/spakky-agent/tests/unit/test_public_api.py
+++ b/core/spakky-agent/tests/unit/test_public_api.py
@@ -17,6 +17,7 @@ from spakky.agent import (
     AgentExecutionLimits,
     AgentExecutionSpec,
     AgentSignal,
+    AgentSignalConsumptionBatch,
     AgentState,
     AgentYield,
     Cancel,
@@ -28,6 +29,7 @@ from spakky.agent import (
     IAgentEvidenceRepository,
     IAgentSignalRepository,
     IAgentStateRepository,
+    AgentSignalPollPoint,
     ModelError,
     ModelRequest,
     ModelResponse,
@@ -42,6 +44,7 @@ from spakky.agent import (
     ToolPermission,
     ToolCallingSpec,
     agent_tool,
+    consume_pending_agent_signals,
 )
 from spakky.agent.main import initialize
 from spakky.agent.post_processor import AgentBootstrapValidationPostProcessor
@@ -60,6 +63,8 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
         "Error",
         "AgentState",
         "AgentSignal",
+        "AgentSignalConsumptionBatch",
+        "AgentSignalPollPoint",
         "AgentEvidence",
         "ContextPack",
         "ContextManifest",
@@ -75,6 +80,7 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
         "AgentToolCatalog",
         "AgentToolDescriptor",
         "AgentToolIdentity",
+        "consume_pending_agent_signals",
     }
 
     exported = set(agent_api.__all__)
@@ -88,6 +94,8 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
     assert Error is agent_api.Error
     assert AgentState is agent_api.AgentState
     assert AgentSignal is agent_api.AgentSignal
+    assert AgentSignalConsumptionBatch is agent_api.AgentSignalConsumptionBatch
+    assert AgentSignalPollPoint is agent_api.AgentSignalPollPoint
     assert AgentEvidence is agent_api.AgentEvidence
     assert ContextPack is agent_api.ContextPack
     assert ContextManifest is agent_api.ContextManifest
@@ -103,6 +111,7 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
     assert AgentToolCatalog is agent_api.AgentToolCatalog
     assert AgentToolDescriptor is agent_api.AgentToolDescriptor
     assert AgentToolIdentity is agent_api.AgentToolIdentity
+    assert consume_pending_agent_signals is agent_api.consume_pending_agent_signals
 
 
 def test_public_api_expect_exports_model_contract_types() -> None:

--- a/core/spakky-agent/tests/unit/test_signal_consumption.py
+++ b/core/spakky-agent/tests/unit/test_signal_consumption.py
@@ -1,0 +1,146 @@
+"""Tests for non-blocking agent signal consumption."""
+
+from collections.abc import AsyncGenerator, Sequence
+
+import pytest
+
+from spakky.agent import (
+    AgentDefinitionError,
+    AgentSignal,
+    AgentSignalKind,
+    AgentSignalPollPoint,
+    AgentYield,
+    AgentYieldKind,
+    Final,
+    IAgentSignalRepository,
+    Progress,
+    Token,
+    consume_pending_agent_signals,
+)
+
+
+class InboundSignalQueue(IAgentSignalRepository):
+    """Test double that behaves like an append-ordered inbound adapter queue."""
+
+    def __init__(self) -> None:
+        self._pending: list[AgentSignal] = []
+        self.consumed_ids: list[str] = []
+
+    def append(self, signal: AgentSignal) -> AgentSignal:
+        self._pending.append(signal)
+        return signal
+
+    def list_pending(self, state_id: str) -> Sequence[AgentSignal]:
+        return tuple(
+            signal for signal in self._pending if signal.agent_state_id == state_id
+        )
+
+    def mark_consumed(self, signal_id: str) -> AgentSignal:
+        for index, signal in enumerate(self._pending):
+            if signal.id == signal_id:
+                self.consumed_ids.append(signal_id)
+                return self._pending.pop(index)
+        raise AgentDefinitionError("Queued agent signal was not found")
+
+
+def test_consume_pending_agent_signals_expect_preserves_queue_order() -> None:
+    """user message, approval, cancel, resume 신호를 append 순서로 소비한다."""
+    queue = InboundSignalQueue()
+    for signal in (
+        AgentSignal("signal-1", "run-1", AgentSignalKind.USER_MESSAGE),
+        AgentSignal("signal-2", "run-1", AgentSignalKind.APPROVAL_DECISION),
+        AgentSignal("signal-3", "run-1", AgentSignalKind.CANCEL),
+        AgentSignal("signal-4", "run-1", AgentSignalKind.RESUME),
+    ):
+        queue.append(signal)
+
+    batch = consume_pending_agent_signals(
+        queue,
+        "run-1",
+        poll_point=AgentSignalPollPoint.ACTION_BOUNDARY,
+    )
+
+    assert batch.poll_point == AgentSignalPollPoint.ACTION_BOUNDARY
+    assert [signal.id for signal in batch.signals] == [
+        "signal-1",
+        "signal-2",
+        "signal-3",
+        "signal-4",
+    ]
+    assert queue.consumed_ids == ["signal-1", "signal-2", "signal-3", "signal-4"]
+
+
+def test_consume_pending_agent_signals_expect_does_not_overtake_unaccepted_signal() -> (
+    None
+):
+    """later accepted signal이 earlier unaccepted signal을 앞질러 소비되지 않는다."""
+    queue = InboundSignalQueue()
+    queue.append(AgentSignal("signal-1", "run-1", AgentSignalKind.EXTERNAL_EVENT))
+    queue.append(AgentSignal("signal-2", "run-1", AgentSignalKind.USER_MESSAGE))
+
+    batch = consume_pending_agent_signals(
+        queue,
+        "run-1",
+        accepted_signals=(AgentSignalKind.USER_MESSAGE,),
+    )
+
+    assert batch.consumed_count == 0
+    assert queue.consumed_ids == []
+    assert [signal.id for signal in queue.list_pending("run-1")] == [
+        "signal-1",
+        "signal-2",
+    ]
+
+
+async def test_inbound_adapter_append_expect_running_stream_polls_without_waiting() -> (
+    None
+):
+    """inbound adapter가 실행 중 append한 signal을 stream tick에서 소비한다."""
+    queue = InboundSignalQueue()
+
+    async def execute() -> AsyncGenerator[AgentYield[object], None]:
+        yield AgentYield(kind=AgentYieldKind.TOKEN, payload=Token("hel"))
+        queue.append(
+            AgentSignal(
+                id="signal-1",
+                agent_state_id="run-1",
+                kind=AgentSignalKind.USER_MESSAGE,
+                payload={"message": "continue"},
+            )
+        )
+        batch = consume_pending_agent_signals(
+            queue,
+            "run-1",
+            poll_point=AgentSignalPollPoint.MODEL_STREAM_TICK,
+            accepted_signals=(AgentSignalKind.USER_MESSAGE,),
+        )
+        for signal in batch.signals:
+            yield AgentYield(
+                kind=AgentYieldKind.PROGRESS,
+                payload=Progress(f"signal:{signal.kind.value}"),
+            )
+        yield AgentYield(kind=AgentYieldKind.TOKEN, payload=Token("lo"))
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(output="done", metadata={}),
+        )
+
+    events = [item async for item in execute()]
+
+    assert [event.kind for event in events] == [
+        AgentYieldKind.TOKEN,
+        AgentYieldKind.PROGRESS,
+        AgentYieldKind.TOKEN,
+        AgentYieldKind.FINAL,
+    ]
+    assert queue.consumed_ids == ["signal-1"]
+
+
+def test_consume_pending_agent_signals_expect_rejects_invalid_poll_arguments() -> None:
+    """poll argument 오류가 custom error로 드러난다."""
+    queue = InboundSignalQueue()
+
+    with pytest.raises(AgentDefinitionError):
+        consume_pending_agent_signals(queue, " ")
+    with pytest.raises(AgentDefinitionError):
+        consume_pending_agent_signals(queue, "run-1", max_signals=0)


### PR DESCRIPTION
## Summary
- Add non-blocking `consume_pending_agent_signals()` with explicit `AgentSignalPollPoint` poll vocabulary.
- Preserve repository append/queue ordering by consuming only the eligible pending prefix.
- Cover inbound adapter append during a running stream without blocking model token flow.
- Document the public helper in `core/spakky-agent/README.md`.

## Validation
- `uv run ruff format .`
- `uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- layer import grep for `spakky-agent`
- `uv run ruff check .`
- `uv run pyrefly check src tests`
- `uv run pytest`
- `uv run python scripts/run_coverage.py --package spakky-agent`
- `uv run mkdocs build --strict`

Closes #229