### PR TITLE
feat(agent): add tool execution metadata contracts (#220)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -17,11 +17,13 @@
 - `AgentSignal`: 실행 중 들어오는 user message, approval, cancel 같은 inbound stimulus
 - `AgentSignalPollPoint`, `consume_pending_agent_signals`: safe boundary나 configured poll point에서 durable signal queue를 대기 없이 소비하는 helper
 - `AgentEvidence`: tool/model/context 판단 근거를 위한 append-only artifact
+- `AgentEvidenceCandidate`: tool result와 model/tool decision을 append-only evidence 후보로 변환하는 contract
 - `ContextPack`, `ContextManifest`, `ContextDigest`: model input context와 audit/digest evidence를 위한 typed contract
 - `IAgentStateRepository`, `IAgentSignalRepository`, `IAgentEvidenceRepository`: persistence provider가 구현하는 core port
 - `IAgentModel`: vLLM 등 model backend가 구현하는 outbound port
 - `ModelRequest`, `ModelResponse`, `ModelStreamEvent`: provider-neutral model 호출/응답/stream 계약
 - `ToolCallingSpec`, `ModelToolSpec`, `ModelToolCall`: model-facing tool call 요청과 후보 결과
+- `agent_tool`, `ToolEffects`, `ToolRisk`, `ToolApprovalRequirement`, `ToolResumeMetadata`, `EvidenceCapture`: tool risk, approval, idempotency, evidence capture metadata
 
 ## 의존성 경계
 
@@ -100,6 +102,32 @@ class CodeAssistant:
 `@agent_tool` descriptor는 Python 함수 signature와 type hint를 정본으로 삼아 `AgentToolSchemaHandle.input_schema` / `output_schema`에 model-facing JSON schema를 보존합니다. 입력 schema는 `self`/`cls`를 제외한 실제 호출 parameter를 object schema로 표현하며, required 여부는 Python default 유무를 따릅니다. 지원 타입은 primitive, enum, dataclass, `list[T]`, `tuple[...]`, `Mapping[str, T]`, `T | None`, `Union[...]`, `Annotated[T, ...]`입니다. `Any`, untyped parameter/return, untyped mapping, non-string mapping key, positional-only parameter, `*args`, `**kwargs`, JSON schema로 표현할 수 없는 임의 object는 definition/bootstrap 단계에서 `AgentDefinitionError`로 실패합니다.
 
 잘못된 signature나 지원하지 않는 metadata는 definition/bootstrap 단계에서 `AgentDefinitionError` 또는 `AgentBootstrapError`로 드러납니다.
+
+## Tool metadata
+
+`@agent_tool`은 method object에 descriptor metadata를 붙이고, `Agent` discovery는 owner, callable reference, schema handle, metadata를 deterministic catalog로 보존합니다. Core metadata의 정본은 permission/effects/idempotency/data access/externality/evidence capture이며, `ToolRisk`는 ADR-0009에 맞춰 이 정본 metadata에서 계산되는 derived contract입니다.
+
+```python
+from spakky.agent import (
+    EvidenceCapture,
+    Idempotency,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+
+
+@agent_tool(
+    effects=ToolEffects.external_side_effect(),
+    idempotency=Idempotency.NON_IDEMPOTENT,
+    evidence=EvidenceCapture.SUMMARY,
+    approval=ToolApprovalRequirement.DERIVED,
+)
+async def run_shell(command: str) -> dict[str, str]:
+    ...
+```
+
+`descriptor.metadata.risk`는 read/write/side-effect/destructive/network 축을 typed enum으로 노출합니다. `descriptor.metadata.requires_approval_candidate`는 HITL 후보 여부를 계산하지만, `ToolApprovalRequirement.NOT_REQUIRED`를 명시한 tool까지 approval을 강제하지 않습니다. `descriptor.metadata.resume`은 완료된 action boundary를 재실행하지 않고, incomplete idempotent action은 retry 후보로, non-idempotent/unknown action은 approval 후보로 분류합니다.
 
 `IAgentModel.stream()`은 model adapter가 token delta, tool-call candidate, structured output, error, done을 `ModelStreamEventKind`로 구분해 내보내는 계약입니다. 실제 vLLM/OpenAI-compatible HTTP 연결은 `plugins/spakky-vllm` 같은 outbound adapter가 담당하며, core package에는 production model implementation을 넣지 않습니다.
 

--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -19,7 +19,11 @@ from spakky.agent.context import (
     ContextSensitivity,
     ContextTokenBudget,
 )
-from spakky.agent.evidence import AgentEvidence, AgentEvidenceKind
+from spakky.agent.evidence import (
+    AgentEvidence,
+    AgentEvidenceCandidate,
+    AgentEvidenceKind,
+)
 from spakky.agent.execution import (
     Agent,
     AgentExecutionLimits,
@@ -80,6 +84,10 @@ from spakky.agent.tooling import (
     ToolApprovalRequirement,
     ToolEffects,
     ToolPermission,
+    ToolResumeAction,
+    ToolResumeMetadata,
+    ToolRisk,
+    ToolRiskAxis,
     agent_tool,
     discover_agent_tools,
 )
@@ -113,6 +121,7 @@ __all__ = [
     "AgentBootstrapError",
     "AgentDefinitionError",
     "AgentEvidence",
+    "AgentEvidenceCandidate",
     "AgentEvidenceKind",
     "AgentExecutionLimits",
     "AgentExecutionSpec",
@@ -185,6 +194,10 @@ __all__ = [
     "ToolCallingSpec",
     "ToolEffects",
     "ToolPermission",
+    "ToolResumeAction",
+    "ToolResumeMetadata",
+    "ToolRisk",
+    "ToolRiskAxis",
     "consume_pending_agent_signals",
     "agent_tool",
     "discover_agent_tools",

--- a/core/spakky-agent/src/spakky/agent/evidence.py
+++ b/core/spakky-agent/src/spakky/agent/evidence.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 
+from spakky.agent.error import AgentDefinitionError
+from spakky.agent.tooling import EvidenceCapture
 from spakky.agent.types import JsonObject
 
 
@@ -34,3 +36,98 @@ class AgentEvidence:
     manifest_ref: str | None = None
     reference: str | None = None
     created_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AgentEvidenceCandidate:
+    """Append-only evidence candidate before repository id assignment."""
+
+    kind: AgentEvidenceKind
+    payload: JsonObject = field(default_factory=dict)
+    summary: str | None = None
+    digest: str | None = None
+    manifest_ref: str | None = None
+    reference: str | None = None
+
+    @classmethod
+    def tool_result(
+        cls,
+        *,
+        tool_identity: str,
+        tool_schema_name: str,
+        result: JsonObject,
+        capture: EvidenceCapture,
+        summary: str | None = None,
+    ) -> "AgentEvidenceCandidate":
+        """Create evidence metadata for a captured tool result."""
+        _require_non_blank(tool_identity, "Agent tool identity")
+        _require_non_blank(tool_schema_name, "Agent tool schema name")
+        return cls(
+            kind=AgentEvidenceKind.TOOL,
+            payload={
+                "tool_identity": tool_identity,
+                "tool_schema_name": tool_schema_name,
+                "capture": capture.value,
+                "result": result,
+            },
+            summary=summary,
+        )
+
+    @classmethod
+    def model_decision(
+        cls,
+        *,
+        model: str,
+        decision: JsonObject,
+        summary: str | None = None,
+    ) -> "AgentEvidenceCandidate":
+        """Create evidence metadata for a model decision."""
+        _require_non_blank(model, "Agent model name")
+        return cls(
+            kind=AgentEvidenceKind.MODEL,
+            payload={"model": model, "decision": decision},
+            summary=summary,
+        )
+
+    @classmethod
+    def tool_decision(
+        cls,
+        *,
+        tool_identity: str,
+        decision: JsonObject,
+        summary: str | None = None,
+    ) -> "AgentEvidenceCandidate":
+        """Create evidence metadata for a tool-routing decision."""
+        _require_non_blank(tool_identity, "Agent tool identity")
+        return cls(
+            kind=AgentEvidenceKind.TOOL,
+            payload={"tool_identity": tool_identity, "decision": decision},
+            summary=summary,
+        )
+
+    def to_evidence(
+        self,
+        *,
+        evidence_id: str,
+        agent_state_id: str,
+        created_at: datetime | None = None,
+    ) -> AgentEvidence:
+        """Assign repository identity while preserving append-only contents."""
+        _require_non_blank(evidence_id, "Agent evidence id")
+        _require_non_blank(agent_state_id, "Agent state id")
+        return AgentEvidence(
+            id=evidence_id,
+            agent_state_id=agent_state_id,
+            kind=self.kind,
+            payload=self.payload,
+            summary=self.summary,
+            digest=self.digest,
+            manifest_ref=self.manifest_ref,
+            reference=self.reference,
+            created_at=created_at,
+        )
+
+
+def _require_non_blank(value: str, label: str) -> None:
+    if not value.strip():
+        raise AgentDefinitionError(f"{label} cannot be blank")

--- a/core/spakky-agent/src/spakky/agent/tooling.py
+++ b/core/spakky-agent/src/spakky/agent/tooling.py
@@ -28,8 +28,17 @@ class Idempotency(StrEnum):
     """Action idempotency declared by a tool."""
 
     IDEMPOTENT = "idempotent"
+    CONDITIONALLY_IDEMPOTENT = "conditionally_idempotent"
     NON_IDEMPOTENT = "non_idempotent"
     UNKNOWN = "unknown"
+
+
+class ToolResumeAction(StrEnum):
+    """Resume action allowed by stored tool idempotency metadata."""
+
+    RETRY = "retry"
+    REQUIRE_APPROVAL = "require_approval"
+    SKIP_COMPLETED = "skip_completed"
 
 
 class DataAccess(StrEnum):
@@ -68,6 +77,16 @@ class ToolApprovalRequirement(StrEnum):
     DERIVED = "derived"
 
 
+class ToolRiskAxis(StrEnum):
+    """Derived risk axes exposed for policy and UI decisions."""
+
+    READ = "read"
+    WRITE = "write"
+    SIDE_EFFECT = "side_effect"
+    DESTRUCTIVE = "destructive"
+    NETWORK = "network"
+
+
 @dataclass(frozen=True, slots=True)
 class ToolPermission:
     """Typed permission marker attached to a tool descriptor."""
@@ -86,6 +105,8 @@ class ToolEffects:
 
     data_access: DataAccess = DataAccess.NONE
     externality: Externality = Externality.LOCAL
+    destructive: bool = False
+    network: bool = False
 
     @classmethod
     def read_only(cls) -> "ToolEffects":
@@ -100,7 +121,20 @@ class ToolEffects:
     @classmethod
     def external_side_effect(cls) -> "ToolEffects":
         """Declare a tool that crosses an external side-effect boundary."""
-        return cls(data_access=DataAccess.READ_WRITE, externality=Externality.EXTERNAL)
+        return cls(
+            data_access=DataAccess.READ_WRITE,
+            externality=Externality.EXTERNAL,
+            network=True,
+        )
+
+    @classmethod
+    def destructive_action(cls) -> "ToolEffects":
+        """Declare a tool that may irreversibly mutate local or external state."""
+        return cls(
+            data_access=DataAccess.WRITE,
+            externality=Externality.EXTERNAL,
+            destructive=True,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -125,6 +159,31 @@ class ResultBudget:
         """Reject result budgets that cannot constrain output."""
         if self.max_bytes is not None and self.max_bytes <= 0:
             raise AgentDefinitionError("Agent tool result budget must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class ToolResumeMetadata:
+    """Stored idempotency metadata used when resuming an incomplete action."""
+
+    idempotency: Idempotency = Idempotency.UNKNOWN
+
+    @classmethod
+    def from_metadata(cls, metadata: "AgentToolMetadata") -> "ToolResumeMetadata":
+        """Build resume metadata from a tool descriptor metadata object."""
+        return cls(idempotency=metadata.idempotency)
+
+    def action_for_completed_boundary(self) -> ToolResumeAction:
+        """Return the resume action for an already completed action boundary."""
+        return ToolResumeAction.SKIP_COMPLETED
+
+    def action_for_incomplete_boundary(self) -> ToolResumeAction:
+        """Return the resume action for an incomplete action boundary."""
+        if self.idempotency in (
+            Idempotency.IDEMPOTENT,
+            Idempotency.CONDITIONALLY_IDEMPOTENT,
+        ):
+            return ToolResumeAction.RETRY
+        return ToolResumeAction.REQUIRE_APPROVAL
 
 
 @dataclass(frozen=True, slots=True)
@@ -166,7 +225,7 @@ class AgentToolIdentity:
 
 @dataclass(frozen=True, slots=True)
 class AgentToolMetadata:
-    """Typed risk, approval, and evidence metadata for a tool descriptor."""
+    """Typed approval, idempotency, and evidence metadata for a descriptor."""
 
     permissions: tuple[ToolPermission, ...] = ()
     effects: ToolEffects = field(default_factory=ToolEffects)
@@ -177,6 +236,71 @@ class AgentToolMetadata:
     result_budget: ResultBudget = field(default_factory=ResultBudget)
     evidence: EvidenceCapture = EvidenceCapture.NONE
     approval: ToolApprovalRequirement = ToolApprovalRequirement.DERIVED
+
+    @property
+    def risk(self) -> "ToolRisk":
+        """Return derived risk axes without storing risk as source metadata."""
+        return ToolRisk.from_metadata(self)
+
+    @property
+    def resume(self) -> ToolResumeMetadata:
+        """Return resume metadata derived from stored idempotency."""
+        return ToolResumeMetadata.from_metadata(self)
+
+    @property
+    def requires_approval_candidate(self) -> bool:
+        """Return whether this tool is a HITL approval candidate."""
+        if self.approval == ToolApprovalRequirement.REQUIRED:
+            return True
+        if self.approval == ToolApprovalRequirement.NOT_REQUIRED:
+            return False
+        return self.risk.requires_approval_candidate
+
+
+@dataclass(frozen=True, slots=True)
+class ToolRisk:
+    """Derived typed risk axes for policy and evidence annotations."""
+
+    axes: tuple[ToolRiskAxis, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Reject duplicate axes so risk comparisons stay deterministic."""
+        seen: set[ToolRiskAxis] = set()
+        for axis in self.axes:
+            if axis in seen:
+                raise AgentDefinitionError("Agent tool risk axes must be unique")
+            seen.add(axis)
+
+    @classmethod
+    def from_metadata(cls, metadata: AgentToolMetadata) -> "ToolRisk":
+        """Derive risk axes from source tool metadata."""
+        axes: list[ToolRiskAxis] = []
+        if metadata.data_access in (DataAccess.READ, DataAccess.READ_WRITE):
+            axes.append(ToolRiskAxis.READ)
+        if metadata.data_access in (DataAccess.WRITE, DataAccess.READ_WRITE):
+            axes.append(ToolRiskAxis.WRITE)
+        if metadata.data_access in (DataAccess.WRITE, DataAccess.READ_WRITE):
+            axes.append(ToolRiskAxis.SIDE_EFFECT)
+        if metadata.externality in (Externality.EXTERNAL, Externality.UNKNOWN):
+            axes.append(ToolRiskAxis.SIDE_EFFECT)
+        if metadata.effects.destructive:
+            axes.append(ToolRiskAxis.DESTRUCTIVE)
+        if metadata.effects.network or metadata.externality == Externality.EXTERNAL:
+            axes.append(ToolRiskAxis.NETWORK)
+        return cls(axes=_deduplicate_axes(axes))
+
+    @property
+    def requires_approval_candidate(self) -> bool:
+        """Return whether the risk is strong enough to suggest HITL approval."""
+        if self.includes(ToolRiskAxis.DESTRUCTIVE):
+            return True
+        return self.includes(ToolRiskAxis.SIDE_EFFECT) and (
+            self.includes(ToolRiskAxis.WRITE) or self.includes(ToolRiskAxis.NETWORK)
+        )
+
+    def includes(self, axis: ToolRiskAxis) -> bool:
+        """Return whether this risk contains the requested axis."""
+        return axis in self.axes
 
 
 @dataclass(frozen=True, slots=True)
@@ -577,3 +701,11 @@ def _resolve_dataclass_hints(annotation: object, label: str) -> Mapping[str, obj
         raise AgentDefinitionError(
             f"{label} dataclass annotations cannot be resolved"
         ) from e
+
+
+def _deduplicate_axes(axes: Sequence[ToolRiskAxis]) -> tuple[ToolRiskAxis, ...]:
+    ordered: list[ToolRiskAxis] = []
+    for axis in axes:
+        if axis not in ordered:
+            ordered.append(axis)
+    return tuple(ordered)

--- a/core/spakky-agent/tests/unit/test_public_api.py
+++ b/core/spakky-agent/tests/unit/test_public_api.py
@@ -10,6 +10,7 @@ from spakky.agent import (
     AgentToolCatalog,
     AgentToolDescriptor,
     AgentToolIdentity,
+    AgentEvidenceCandidate,
     Agent,
     AgentBootstrapError,
     AgentDefinitionError,
@@ -46,6 +47,10 @@ from spakky.agent import (
     Tool,
     ToolEffects,
     ToolPermission,
+    ToolResumeAction,
+    ToolResumeMetadata,
+    ToolRisk,
+    ToolRiskAxis,
     ToolCallingSpec,
     agent_tool,
     consume_pending_agent_signals,
@@ -71,6 +76,7 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
         "AgentSignalConsumptionBatch",
         "AgentSignalPollPoint",
         "AgentEvidence",
+        "AgentEvidenceCandidate",
         "ContextPack",
         "ContextManifest",
         "ContextDigest",
@@ -102,6 +108,7 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
     assert AgentSignalConsumptionBatch is agent_api.AgentSignalConsumptionBatch
     assert AgentSignalPollPoint is agent_api.AgentSignalPollPoint
     assert AgentEvidence is agent_api.AgentEvidence
+    assert AgentEvidenceCandidate is agent_api.AgentEvidenceCandidate
     assert ContextPack is agent_api.ContextPack
     assert ContextManifest is agent_api.ContextManifest
     assert ContextDigest is agent_api.ContextDigest
@@ -135,6 +142,10 @@ def test_public_api_expect_exports_tool_metadata_types() -> None:
     """@agent_tool descriptor metadata 타입을 public API로 노출한다."""
     assert ToolPermission is agent_api.ToolPermission
     assert ToolEffects is agent_api.ToolEffects
+    assert ToolRisk is agent_api.ToolRisk
+    assert ToolRiskAxis is agent_api.ToolRiskAxis
+    assert ToolResumeAction is agent_api.ToolResumeAction
+    assert ToolResumeMetadata is agent_api.ToolResumeMetadata
 
 
 def test_public_api_expect_exports_custom_error_hierarchy() -> None:

--- a/core/spakky-agent/tests/unit/test_state_signal_evidence_yield.py
+++ b/core/spakky-agent/tests/unit/test_state_signal_evidence_yield.py
@@ -7,6 +7,7 @@ import pytest
 from spakky.agent import (
     AgentDefinitionError,
     AgentEvidence,
+    AgentEvidenceCandidate,
     AgentEvidenceKind,
     AgentSignal,
     AgentSignalKind,
@@ -21,6 +22,7 @@ from spakky.agent import (
     Cancel,
     Evidence,
     Error,
+    EvidenceCapture,
     Final,
     Message,
     Progress,
@@ -154,6 +156,75 @@ def test_agent_evidence_kind_expect_covers_required_evidence_sources() -> None:
         "context_manifest",
         "evaluation",
     } <= evidence_kinds
+
+
+def test_agent_evidence_candidate_expect_converts_tool_result() -> None:
+    """tool result evidence 후보가 append-only AgentEvidence로 변환된다."""
+    candidate = AgentEvidenceCandidate.tool_result(
+        tool_identity="tests.WorkspaceTools:read_file",
+        tool_schema_name="workspace.read_file",
+        result={"content": "hello"},
+        capture=EvidenceCapture.STRUCTURED,
+        summary="read workspace file",
+    )
+
+    evidence = candidate.to_evidence(
+        evidence_id="evidence-1",
+        agent_state_id="run-1",
+    )
+
+    assert evidence.kind == AgentEvidenceKind.TOOL
+    assert evidence.agent_state_id == "run-1"
+    assert evidence.payload == {
+        "tool_identity": "tests.WorkspaceTools:read_file",
+        "tool_schema_name": "workspace.read_file",
+        "capture": "structured",
+        "result": {"content": "hello"},
+    }
+    assert evidence.summary == "read workspace file"
+
+
+def test_agent_evidence_candidate_expect_rejects_blank_identity() -> None:
+    """evidence 후보의 추적 식별자는 blank 문자열일 수 없다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentEvidenceCandidate.tool_result(
+            tool_identity=" ",
+            tool_schema_name="workspace.read_file",
+            result={},
+            capture=EvidenceCapture.STRUCTURED,
+        )
+
+
+def test_agent_evidence_candidate_expect_converts_decisions_to_evidence() -> None:
+    """model/tool decision evidence 후보가 append-only artifact shape을 가진다."""
+    model_candidate = AgentEvidenceCandidate.model_decision(
+        model="vllm/qwen",
+        decision={"next_action": "call_tool"},
+    )
+    tool_candidate = AgentEvidenceCandidate.tool_decision(
+        tool_identity="tests.ShellTools:run",
+        decision={"approved": False, "reason": "destructive"},
+    )
+
+    model_evidence = model_candidate.to_evidence(
+        evidence_id="model-evidence-1",
+        agent_state_id="run-1",
+    )
+    tool_evidence = tool_candidate.to_evidence(
+        evidence_id="tool-evidence-1",
+        agent_state_id="run-1",
+    )
+
+    assert model_evidence.kind == AgentEvidenceKind.MODEL
+    assert model_evidence.payload == {
+        "model": "vllm/qwen",
+        "decision": {"next_action": "call_tool"},
+    }
+    assert tool_evidence.kind == AgentEvidenceKind.TOOL
+    assert tool_evidence.payload == {
+        "tool_identity": "tests.ShellTools:run",
+        "decision": {"approved": False, "reason": "destructive"},
+    }
 
 
 def test_agent_yield_expect_supports_canonical_stream_vocabulary() -> None:

--- a/core/spakky-agent/tests/unit/test_tooling.py
+++ b/core/spakky-agent/tests/unit/test_tooling.py
@@ -27,6 +27,9 @@ from spakky.agent import (
     ToolApprovalRequirement,
     ToolEffects,
     ToolPermission,
+    ToolResumeAction,
+    ToolRisk,
+    ToolRiskAxis,
     agent_tool,
     discover_agent_tools,
 )
@@ -104,6 +107,8 @@ def test_agent_tool_expect_attaches_typed_descriptor_metadata_to_method() -> Non
     assert definition.metadata.idempotency == Idempotency.IDEMPOTENT
     assert definition.metadata.evidence == EvidenceCapture.STRUCTURED
     assert definition.metadata.approval == ToolApprovalRequirement.NOT_REQUIRED
+    assert definition.metadata.risk == ToolRisk(axes=(ToolRiskAxis.READ,))
+    assert definition.metadata.requires_approval_candidate is False
 
 
 def test_agent_expect_discovers_decorated_methods_as_deterministic_catalog() -> None:
@@ -678,6 +683,15 @@ def test_tool_catalog_expect_preserves_owner_callable_schema_and_metadata() -> N
     assert descriptor.metadata.effects == ToolEffects.external_side_effect()
     assert descriptor.metadata.idempotency == Idempotency.NON_IDEMPOTENT
     assert descriptor.metadata.approval == ToolApprovalRequirement.REQUIRED
+    assert descriptor.metadata.risk == ToolRisk(
+        axes=(
+            ToolRiskAxis.READ,
+            ToolRiskAxis.WRITE,
+            ToolRiskAxis.SIDE_EFFECT,
+            ToolRiskAxis.NETWORK,
+        )
+    )
+    assert descriptor.metadata.requires_approval_candidate is True
 
 
 def test_tool_catalog_expect_lookup_by_identity_and_schema_name() -> None:
@@ -864,6 +878,96 @@ def test_agent_tool_expect_derives_effect_defaults_and_overrides() -> None:
     assert definition.metadata.effects == ToolEffects.write_state()
     assert definition.metadata.data_access == DataAccess.READ_WRITE
     assert definition.metadata.externality == Externality.EXTERNAL
+    assert definition.metadata.risk == ToolRisk(
+        axes=(
+            ToolRiskAxis.READ,
+            ToolRiskAxis.WRITE,
+            ToolRiskAxis.SIDE_EFFECT,
+            ToolRiskAxis.NETWORK,
+        )
+    )
+
+
+def test_agent_tool_expect_represents_destructive_network_risk_axes() -> None:
+    """ToolRisk가 read/write/side-effect/destructive/network 축을 표현한다."""
+
+    @agent_tool(
+        effects=ToolEffects.destructive_action(),
+        data_access=DataAccess.READ_WRITE,
+    )
+    def delete_workspace(value: str) -> str:
+        return value
+
+    definition = get_agent_tool_definition(delete_workspace)
+
+    assert definition is not None
+    assert definition.metadata.risk == ToolRisk(
+        axes=(
+            ToolRiskAxis.READ,
+            ToolRiskAxis.WRITE,
+            ToolRiskAxis.SIDE_EFFECT,
+            ToolRiskAxis.DESTRUCTIVE,
+            ToolRiskAxis.NETWORK,
+        )
+    )
+    assert definition.metadata.requires_approval_candidate is True
+
+
+def test_agent_tool_expect_rejects_duplicate_risk_axes() -> None:
+    """ToolRisk 직접 생성 시 중복 축은 정의 오류로 거부한다."""
+    with pytest.raises(AgentDefinitionError):
+        ToolRisk(axes=(ToolRiskAxis.READ, ToolRiskAxis.READ))
+
+
+def test_agent_tool_expect_approval_is_candidate_not_global_requirement() -> None:
+    """approval metadata는 위험 후보를 표현하지만 모든 tool에 강제되지 않는다."""
+
+    @agent_tool(effects=ToolEffects.read_only())
+    def read_workspace(value: str) -> str:
+        return value
+
+    @agent_tool(
+        effects=ToolEffects.write_state(),
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def trusted_write(value: str) -> str:
+        return value
+
+    read_definition = get_agent_tool_definition(read_workspace)
+    write_definition = get_agent_tool_definition(trusted_write)
+
+    assert read_definition is not None
+    assert write_definition is not None
+    assert read_definition.metadata.requires_approval_candidate is False
+    assert write_definition.metadata.risk.includes(ToolRiskAxis.SIDE_EFFECT) is True
+    assert write_definition.metadata.requires_approval_candidate is False
+
+
+def test_agent_tool_expect_idempotency_drives_resume_decision() -> None:
+    """idempotency metadata가 resume 중복 실행 판단에 쓰이는 형태로 저장된다."""
+
+    @agent_tool(idempotency=Idempotency.IDEMPOTENT)
+    def read_file(value: str) -> str:
+        return value
+
+    @agent_tool(idempotency=Idempotency.NON_IDEMPOTENT)
+    def write_file(value: str) -> str:
+        return value
+
+    read_definition = get_agent_tool_definition(read_file)
+    write_definition = get_agent_tool_definition(write_file)
+
+    assert read_definition is not None
+    assert write_definition is not None
+    assert read_definition.metadata.resume.action_for_completed_boundary() == (
+        ToolResumeAction.SKIP_COMPLETED
+    )
+    assert read_definition.metadata.resume.action_for_incomplete_boundary() == (
+        ToolResumeAction.RETRY
+    )
+    assert write_definition.metadata.resume.action_for_incomplete_boundary() == (
+        ToolResumeAction.REQUIRE_APPROVAL
+    )
 
 
 def test_agent_tool_expect_rejects_corrupt_attached_metadata() -> None:


### PR DESCRIPTION
## Summary
- Add derived ToolRisk axes and resume metadata on agent tool descriptors
- Keep approval as a candidate/override contract instead of forcing HITL globally
- Add AgentEvidenceCandidate helpers for tool result and model/tool decision evidence
- Document the new spakky-agent tool metadata surface

## Acceptance Criteria
- ToolRisk covers read/write/side-effect/destructive/network axes as a derived typed contract
- Approval metadata supports REQUIRED/NOT_REQUIRED/DERIVED without making every tool require HITL
- Idempotency metadata exposes resume decisions for completed and incomplete action boundaries
- Tool result and model/tool decisions can be converted into append-only evidence candidates

## Acceptance Criteria (self grep)
- No explicit grep lines in issue body; acceptance_check: missing

## Verification
- `uv run --with ruff ruff format .`
- `uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- `uv run --with ruff ruff check .`
- `uv run --with pyrefly --with pytest pyrefly check src tests`
- `uv run python scripts/run_coverage.py --package spakky-agent`
