### PR TITLE
feat(agent): enforce durable persistence contribution (#223)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -29,6 +29,8 @@ Core package는 `spakky` core에만 의존합니다. vLLM, SQLAlchemy, FastAPI, 
 
 Production persistence fallback도 제공하지 않습니다. State, signal, evidence repository 구현은 SQLAlchemy 등 provider plugin의 feature contribution으로 등록되어야 하며, 누락 시 bootstrap 단계에서 custom error로 실패해야 합니다.
 
+Durable 실행 경로는 `AgentExecutionSpec.recovery == RecoveryStrategy.ACTION_BOUNDARY` 또는 `accepted_signals` 선언에서 파생됩니다. 이 경우 bootstrap은 `IAgentStateRepository`, `IAgentSignalRepository`, `IAgentEvidenceRepository`가 모두 등록되어 있는지 검증하고, 누락 시 필요한 repository type과 설치해야 할 `spakky-sqlalchemy[agent]` / `spakky.contributions.spakky.agent` provider contribution을 error message에 포함합니다. 운영용 in-memory repository fallback은 없습니다.
+
 `AgentEvidenceRepository`의 agent-facing interface는 append/read 계열만 노출합니다. Redaction, correction, context digest 갱신은 기존 evidence를 수정하지 않고 새 evidence를 append하는 방식으로 표현합니다.
 
 ## 사용 예시

--- a/core/spakky-agent/src/spakky/agent/execution.py
+++ b/core/spakky-agent/src/spakky/agent/execution.py
@@ -108,6 +108,25 @@ class Agent(Pod):
         """Re-run definition validation during application bootstrap."""
         self._validate_execute_contract(self._ensure_agent_class(self.target))
 
+    def required_persistence_repository_types(self) -> tuple[type[object], ...]:
+        """Return repository ports required by this Agent's durable path."""
+        from spakky.agent.interfaces.repository import (
+            IAgentEvidenceRepository,
+            IAgentSignalRepository,
+            IAgentStateRepository,
+        )
+
+        if (
+            self.spec.recovery is RecoveryStrategy.ACTION_BOUNDARY
+            or len(self.spec.accepted_signals) > 0
+        ):
+            return (
+                IAgentStateRepository,
+                IAgentSignalRepository,
+                IAgentEvidenceRepository,
+            )
+        return ()
+
     def _ensure_agent_class(self, obj: PodType) -> type[object]:
         if not isinstance(obj, type):
             raise AgentDefinitionError("@Agent can only annotate classes")

--- a/core/spakky-agent/src/spakky/agent/post_processor.py
+++ b/core/spakky-agent/src/spakky/agent/post_processor.py
@@ -1,17 +1,34 @@
 """Bootstrap validation for Agent Pod instances."""
 
-from typing import override
+from typing import NoReturn, override
 
 from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
 from spakky.core.pod.interfaces.post_processor import IPostProcessor
 
-from spakky.agent.error import AgentBootstrapError, AgentDefinitionError
+from spakky.agent.error import (
+    AgentBootstrapError,
+    AgentDefinitionError,
+    AgentPersistenceConfigurationError,
+)
 from spakky.agent.execution import Agent
 
 
 @Pod()
-class AgentBootstrapValidationPostProcessor(IPostProcessor):
+class AgentBootstrapValidationPostProcessor(IPostProcessor, IContainerAware):
     """Validate Agent metadata during application bootstrap."""
+
+    _container: IContainer | None
+
+    def __init__(self) -> None:
+        """Initialize without assuming application context injection happened."""
+        self._container = None
+
+    @override
+    def set_container(self, container: IContainer) -> None:
+        """Receive the active container for contribution validation."""
+        self._container = container
 
     @override
     def post_process(self, pod: object) -> object:
@@ -23,4 +40,42 @@ class AgentBootstrapValidationPostProcessor(IPostProcessor):
             agent.validate_bootstrap()
         except AgentDefinitionError as e:
             raise AgentBootstrapError("Agent bootstrap contract is invalid") from e
+        self._validate_persistence_contributions(agent)
         return pod
+
+    def _validate_persistence_contributions(self, agent: Agent) -> None:
+        required_types = agent.required_persistence_repository_types()
+        if len(required_types) == 0:
+            return
+        container = self._container
+        if container is None:
+            self._raise_missing_persistence(agent, required_types)
+        missing_types = tuple(
+            repository_type
+            for repository_type in required_types
+            if not container.contains(repository_type)
+        )
+        if len(missing_types) > 0:
+            self._raise_missing_persistence(agent, missing_types)
+
+    def _raise_missing_persistence(
+        self,
+        agent: Agent,
+        missing_types: tuple[type[object], ...],
+    ) -> NoReturn:
+        agent_name = self._agent_type_name(agent)
+        repository_names = ", ".join(
+            repository_type.__name__ for repository_type in missing_types
+        )
+        raise AgentPersistenceConfigurationError(
+            "Agent persistence contribution is required for "
+            f"{agent_name}. Missing repositories: {repository_names}. "
+            "Install/activate provider contribution: spakky-sqlalchemy[agent] "
+            "via spakky.contributions.spakky.agent."
+        )
+
+    def _agent_type_name(self, agent: Agent) -> str:
+        target = agent.target
+        if isinstance(target, type):
+            return target.__name__
+        return str(target)

--- a/core/spakky-agent/tests/unit/test_public_api.py
+++ b/core/spakky-agent/tests/unit/test_public_api.py
@@ -16,9 +16,12 @@ from spakky.agent import (
     AgentEvidence,
     AgentExecutionLimits,
     AgentExecutionSpec,
+    AgentPersistenceConfigurationError,
     AgentSignal,
     AgentSignalConsumptionBatch,
+    AgentSignalKind,
     AgentState,
+    AgentStatus,
     AgentYield,
     Cancel,
     ContextDigest,
@@ -37,6 +40,7 @@ from spakky.agent import (
     ModelToolCall,
     ModelToolSpec,
     Progress,
+    RecoveryStrategy,
     StreamingOptions,
     Token,
     Tool,
@@ -50,6 +54,7 @@ from spakky.agent.main import initialize
 from spakky.agent.post_processor import AgentBootstrapValidationPostProcessor
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.annotations.pod import Pod
 
 
 def test_public_api_expect_exports_required_agent_surface() -> None:
@@ -189,3 +194,173 @@ def test_agent_bootstrap_expect_surfaces_execute_contract_as_custom_error(
 
 async def _invalid_execute(command: str) -> AsyncGenerator[str, None]:
     yield command
+
+
+def test_agent_bootstrap_expect_durable_agent_requires_persistence_contribution() -> (
+    None
+):
+    """durable 실행 경로가 repository contribution 없이 시작되지 않음을 검증한다."""
+
+    @Agent(spec=AgentExecutionSpec(recovery=RecoveryStrategy.ACTION_BOUNDARY))
+    class DurableAgentWithoutPersistence:
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=agent_api.AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    app = SpakkyApplication(ApplicationContext())
+    initialize(app)
+    app.add(DurableAgentWithoutPersistence)
+
+    with pytest.raises(AgentPersistenceConfigurationError) as exc_info:
+        app.start()
+
+    message = str(exc_info.value)
+    assert "DurableAgentWithoutPersistence" in message
+    assert "IAgentStateRepository" in message
+    assert "IAgentSignalRepository" in message
+    assert "IAgentEvidenceRepository" in message
+    assert "spakky-sqlalchemy[agent]" in message
+    assert "spakky.contributions.spakky.agent" in message
+
+
+def test_agent_bootstrap_expect_manual_processor_requires_injected_container() -> None:
+    """수동 post processor 호출도 durable fallback 없이 custom error를 낸다."""
+
+    @Agent(spec=AgentExecutionSpec(recovery=RecoveryStrategy.ACTION_BOUNDARY))
+    class DurableAgentWithoutContainer:
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=agent_api.AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    with pytest.raises(AgentPersistenceConfigurationError):
+        AgentBootstrapValidationPostProcessor().post_process(
+            DurableAgentWithoutContainer()
+        )
+
+
+def test_agent_bootstrap_expect_signal_acceptance_requires_persistence_contribution() -> (
+    None
+):
+    """signal을 받는 agent가 durable inbound queue contribution을 요구한다."""
+
+    @Agent(spec=AgentExecutionSpec(accepted_signals=(AgentSignalKind.USER_MESSAGE,)))
+    class SignaledAgentWithoutPersistence:
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=agent_api.AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    app = SpakkyApplication(ApplicationContext())
+    initialize(app)
+    app.add(SignaledAgentWithoutPersistence)
+
+    with pytest.raises(AgentPersistenceConfigurationError):
+        app.start()
+
+
+def test_agent_bootstrap_expect_durable_agent_starts_with_repository_contribution() -> (
+    None
+):
+    """필수 repository port가 등록되면 durable agent bootstrap이 통과한다."""
+
+    @Agent(spec=AgentExecutionSpec(recovery=RecoveryStrategy.ACTION_BOUNDARY))
+    class DurableAgentWithPersistence:
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=agent_api.AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    app = SpakkyApplication(ApplicationContext())
+    initialize(app)
+    app.add(FakeAgentStateRepository)
+    app.add(FakeAgentSignalRepository)
+    app.add(FakeAgentEvidenceRepository)
+    app.add(DurableAgentWithPersistence)
+
+    app.start()
+
+    app.stop()
+
+
+def test_agent_bootstrap_type_name_expect_handles_non_class_target() -> None:
+    """diagnostic helper가 비정상 target도 문자열로 표현한다."""
+
+    agent = Agent()
+    agent.target = _invalid_execute
+
+    name = AgentBootstrapValidationPostProcessor()._agent_type_name(agent)
+
+    assert name == str(_invalid_execute)
+
+
+class FakeRepositoryAccessError(Exception):
+    """Raised when a repository test double is invoked unexpectedly."""
+
+
+@Pod()
+class FakeAgentStateRepository(IAgentStateRepository):
+    """Test-only AgentState repository double."""
+
+    def get(self, state_id: str) -> AgentState:
+        raise FakeRepositoryAccessError
+
+    def get_or_none(self, state_id: str) -> AgentState | None:
+        raise FakeRepositoryAccessError
+
+    def save(self, state: AgentState) -> AgentState:
+        return state
+
+    def list_by_status(self, status: AgentStatus) -> tuple[AgentState, ...]:
+        return ()
+
+    def list_resume_candidates(self) -> tuple[AgentState, ...]:
+        return ()
+
+
+@Pod()
+class FakeAgentSignalRepository(IAgentSignalRepository):
+    """Test-only AgentSignal repository double."""
+
+    def append(self, signal: AgentSignal) -> AgentSignal:
+        return signal
+
+    def list_pending(self, state_id: str) -> tuple[AgentSignal, ...]:
+        return ()
+
+    def mark_consumed(self, signal_id: str) -> AgentSignal:
+        raise FakeRepositoryAccessError
+
+
+@Pod()
+class FakeAgentEvidenceRepository(IAgentEvidenceRepository):
+    """Test-only AgentEvidence repository double."""
+
+    def append(self, evidence: AgentEvidence) -> AgentEvidence:
+        return evidence
+
+    def get(self, evidence_id: str) -> AgentEvidence:
+        raise FakeRepositoryAccessError
+
+    def list_by_state(self, state_id: str) -> tuple[AgentEvidence, ...]:
+        return ()
+
+    def list_by_manifest_ref(self, manifest_ref: str) -> tuple[AgentEvidence, ...]:
+        return ()

--- a/plugins/spakky-sqlalchemy/README.md
+++ b/plugins/spakky-sqlalchemy/README.md
@@ -259,6 +259,14 @@ pip install "spakky-sqlalchemy[agent]"
 spakky-sqlalchemy = "spakky.plugins.sqlalchemy.contributions.agent:initialize"
 ```
 
+`spakky-agent`와 `spakky-sqlalchemy` base plugin이 함께 active이면 contribution loader가
+`AgentStateTable`, `AgentSignalTable`, `AgentEvidenceTable`과 세 repository 구현을 등록합니다.
+`AgentExecutionSpec(recovery=RecoveryStrategy.ACTION_BOUNDARY)` 또는 `accepted_signals`를
+사용하는 Agent는 bootstrap 시 `IAgentStateRepository`, `IAgentSignalRepository`,
+`IAgentEvidenceRepository`를 모두 요구하므로, 이 contribution이 누락되면 core가
+`AgentPersistenceConfigurationError`로 실패합니다. 이 패키지는 production in-memory
+fallback을 제공하지 않습니다.
+
 `spakky-agent`와 `spakky-sqlalchemy`가 모두 active이면 다음 Pod과 schema가
 등록됩니다.
 


### PR DESCRIPTION
## Summary

- Enforce durable agent persistence contribution validation at bootstrap for action-boundary recovery and accepted signal paths.
- Surface missing repository ports with actionable `AgentPersistenceConfigurationError` guidance for `spakky-sqlalchemy[agent]` / `spakky.contributions.spakky.agent`.
- Document the no production in-memory fallback contract in `spakky-agent` and SQLAlchemy agent contribution docs.

Closes #223

## Acceptance Criteria

- [x] Production `src` has no in-memory `AgentStateRepository`, `AgentSignalRepository`, or `AgentEvidenceRepository` implementation.
- [x] Test fake repositories are under `core/spakky-agent/tests` only.
- [x] Durable execution paths fail at bootstrap when persistence contribution is missing.
- [x] Missing contribution error identifies required repository types and the provider contribution to install/activate.

## Verification

- [x] `cd core/spakky-agent && uv run --project ../.. --group dev ruff format .`
- [x] `cd core/spakky-agent && uv run --project ../.. --group dev python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- [x] `cd core/spakky-agent && uv run --project ../.. --group dev ruff check .`
- [x] `cd core/spakky-agent && uv run --project ../.. --group dev pyrefly check src tests --config pyproject.toml`
- [x] `cd core/spakky-agent && uv run --project ../.. --group dev pytest` (78 passed, 100% coverage)
- [x] `uv run mkdocs build --strict`
- [x] `cd plugins/spakky-sqlalchemy && uv run pytest tests/unit/test_agent_contribution.py tests/unit/test_entry_points.py --no-cov` (7 passed)

## Acceptance Grep

- acceptance_check: missing (issue body has no literal grep/find command lines)
- `rg "InMemory.*Agent(State|Signal|Evidence)Repository|Agent(State|Signal|Evidence)Repository.*InMemory|class .*InMemory.*Repository|FakeAgent(State|Signal|Evidence)Repository" core/spakky-agent/src plugins/spakky-sqlalchemy/src core/spakky-agent/tests plugins/spakky-sqlalchemy/tests` shows only test fake repositories under `core/spakky-agent/tests`.
