### PR TITLE
feat(agent): generate agent tool schemas (#218)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -95,6 +95,8 @@ class CodeAssistant:
 
 실행 중 inbound adapter가 user message, approval decision, cancel, resume signal을 append하면 orchestration은 safe boundary, action boundary, model stream tick 같은 poll point에서 `consume_pending_agent_signals()`를 호출합니다. 이 helper는 sleep/poll loop 없이 현재 pending queue만 읽고 append order의 eligible prefix를 consumed 처리하므로 token streaming을 불필요하게 block하지 않습니다. Repository 구현은 `list_pending()` 결과를 append/queue order로 반환해야 하며, helper는 earlier unaccepted signal을 건너뛰어 later signal을 먼저 소비하지 않습니다.
 
+`@agent_tool` descriptor는 Python 함수 signature와 type hint를 정본으로 삼아 `AgentToolSchemaHandle.input_schema` / `output_schema`에 model-facing JSON schema를 보존합니다. 입력 schema는 `self`/`cls`를 제외한 실제 호출 parameter를 object schema로 표현하며, required 여부는 Python default 유무를 따릅니다. 지원 타입은 primitive, enum, dataclass, `list[T]`, `tuple[...]`, `Mapping[str, T]`, `T | None`, `Union[...]`, `Annotated[T, ...]`입니다. `Any`, untyped parameter/return, untyped mapping, non-string mapping key, positional-only parameter, `*args`, `**kwargs`, JSON schema로 표현할 수 없는 임의 object는 definition/bootstrap 단계에서 `AgentDefinitionError`로 실패합니다.
+
 잘못된 signature나 지원하지 않는 metadata는 definition/bootstrap 단계에서 `AgentDefinitionError` 또는 `AgentBootstrapError`로 드러납니다.
 
 `IAgentModel.stream()`은 model adapter가 token delta, tool-call candidate, structured output, error, done을 `ModelStreamEventKind`로 구분해 내보내는 계약입니다. 실제 vLLM/OpenAI-compatible HTTP 연결은 `plugins/spakky-vllm` 같은 outbound adapter가 담당하며, core package에는 production model implementation을 넣지 않습니다.

--- a/core/spakky-agent/src/spakky/agent/tooling.py
+++ b/core/spakky-agent/src/spakky/agent/tooling.py
@@ -1,15 +1,27 @@
 """Agent tool descriptor discovery contracts."""
 
-from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
-from enum import StrEnum
-from types import FunctionType
+import typing
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import MISSING, Field, dataclass, field, is_dataclass
+from enum import Enum, StrEnum
+from inspect import Parameter, isclass, signature
+from types import FunctionType, NoneType, UnionType
+from typing import get_args, get_origin, get_type_hints
 
 from spakky.agent.error import AgentDefinitionError
+from spakky.agent.types import JsonObject, JsonValue
 
 AGENT_TOOL_DEFINITION_KEY = "__spakky_agent_tool_definition__"
 
 AgentToolCallable = Callable[..., object]
+
+_PRIMITIVE_SCHEMA_TYPES: dict[object, str] = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+    NoneType: "null",
+}
 
 
 class Idempotency(StrEnum):
@@ -117,12 +129,13 @@ class ResultBudget:
 
 @dataclass(frozen=True, slots=True)
 class AgentToolSchemaHandle:
-    """Stable schema handle owned by a descriptor before schema generation."""
+    """Stable schema names and generated JSON schemas owned by a descriptor."""
 
     name: str
-
     input_schema_name: str
     output_schema_name: str
+    input_schema: JsonObject = field(default_factory=dict)
+    output_schema: JsonObject = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Reject blank schema handles."""
@@ -337,6 +350,8 @@ def _build_descriptor(
         name=definition.schema_name,
         input_schema_name=f"{definition.schema_name}.input",
         output_schema_name=f"{definition.schema_name}.output",
+        input_schema=_build_input_schema(function, definition.schema_name),
+        output_schema=_build_output_schema(function, definition.schema_name),
     )
     return AgentToolDescriptor(
         identity=identity,
@@ -365,3 +380,200 @@ def _normalize_name(value: str | None, default: str, label: str) -> str:
 def _require_non_blank(value: str, label: str) -> None:
     if not value.strip():
         raise AgentDefinitionError(f"{label} cannot be blank")
+
+
+def _build_input_schema(function: FunctionType, schema_name: str) -> JsonObject:
+    function_signature = signature(function)
+    type_hints = _resolve_type_hints(function)
+    properties: dict[str, JsonValue] = {}
+    required: list[str] = []
+    for parameter in function_signature.parameters.values():
+        if parameter.name in ("self", "cls"):
+            continue
+        _validate_schema_parameter(parameter)
+        annotation = type_hints.get(parameter.name, parameter.annotation)
+        if annotation == Parameter.empty:
+            raise AgentDefinitionError("Agent tool parameters must be type annotated")
+        properties[parameter.name] = _schema_for_annotation(
+            annotation,
+            f"Agent tool parameter '{parameter.name}'",
+        )
+        if parameter.default == Parameter.empty:
+            required.append(parameter.name)
+    schema: dict[str, JsonValue] = {
+        "type": "object",
+        "title": f"{schema_name}.input",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _build_output_schema(function: FunctionType, schema_name: str) -> JsonObject:
+    function_signature = signature(function)
+    type_hints = _resolve_type_hints(function)
+    annotation = type_hints.get("return", function_signature.return_annotation)
+    if annotation == Parameter.empty:
+        raise AgentDefinitionError("Agent tool return type is required")
+    output_schema = _schema_for_annotation(annotation, "Agent tool return type")
+    schema: dict[str, JsonValue] = {
+        "title": f"{schema_name}.output",
+    }
+    schema.update(output_schema)
+    return schema
+
+
+def _resolve_type_hints(function: FunctionType) -> Mapping[str, object]:
+    try:
+        return get_type_hints(function, include_extras=True)
+    except (NameError, TypeError) as e:
+        raise AgentDefinitionError(
+            "Agent tool type annotations cannot be resolved"
+        ) from e
+
+
+def _validate_schema_parameter(parameter: Parameter) -> None:
+    if parameter.kind == Parameter.POSITIONAL_ONLY:
+        raise AgentDefinitionError("Agent tool parameters cannot be positional-only")
+    if parameter.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD):
+        raise AgentDefinitionError(
+            "Agent tool parameters cannot use variable arguments"
+        )
+
+
+def _schema_for_annotation(annotation: object, label: str) -> JsonObject:
+    annotation = _unwrap_annotated(annotation)
+    if annotation is typing.Any:
+        raise AgentDefinitionError(f"{label} cannot use Any")
+    primitive_schema = _primitive_schema(annotation)
+    if primitive_schema is not None:
+        return primitive_schema
+    origin = get_origin(annotation)
+    if origin in (typing.Union, UnionType):
+        return _union_schema(annotation, label)
+    if origin in (list,):
+        return _list_schema(annotation, label)
+    if origin is tuple:
+        return _tuple_schema(annotation, label)
+    if origin in (dict, Mapping):
+        return _mapping_schema(annotation, label)
+    if isclass(annotation) and issubclass(annotation, Enum):
+        return _enum_schema(annotation)
+    if isclass(annotation) and is_dataclass(annotation):
+        return _dataclass_schema(annotation, label)
+    raise AgentDefinitionError(f"{label} is not JSON-schema compatible")
+
+
+def _unwrap_annotated(annotation: object) -> object:
+    if get_origin(annotation) is typing.Annotated:
+        return get_args(annotation)[0]
+    return annotation
+
+
+def _primitive_schema(annotation: object) -> JsonObject | None:
+    schema_type = _PRIMITIVE_SCHEMA_TYPES.get(annotation)
+    if schema_type is None:
+        return None
+    return {"type": schema_type}
+
+
+def _union_schema(annotation: object, label: str) -> JsonObject:
+    args = get_args(annotation)
+    alternatives = [_schema_for_annotation(arg, label) for arg in args]
+    return {"anyOf": alternatives}
+
+
+def _list_schema(annotation: object, label: str) -> JsonObject:
+    args = get_args(annotation)
+    return {"type": "array", "items": _schema_for_annotation(args[0], label)}
+
+
+def _tuple_schema(annotation: object, label: str) -> JsonObject:
+    args = get_args(annotation)
+    if len(args) == 2 and args[1] is Ellipsis:
+        return {"type": "array", "items": _schema_for_annotation(args[0], label)}
+    prefix_items = [_schema_for_annotation(arg, label) for arg in args]
+    return {
+        "type": "array",
+        "prefixItems": prefix_items,
+        "minItems": len(prefix_items),
+        "maxItems": len(prefix_items),
+    }
+
+
+def _mapping_schema(annotation: object, label: str) -> JsonObject:
+    args = get_args(annotation)
+    key_type, value_type = args
+    if key_type is not str:
+        raise AgentDefinitionError(f"{label} mapping keys must be strings")
+    return {
+        "type": "object",
+        "additionalProperties": _schema_for_annotation(value_type, label),
+    }
+
+
+def _enum_schema(annotation: type[Enum]) -> JsonObject:
+    values: list[JsonValue] = []
+    value_types: set[str] = set()
+    for member in annotation:
+        value = member.value
+        value_type = _json_value_type(value)
+        if value_type is None:
+            raise AgentDefinitionError("Agent tool enum values must be JSON primitives")
+        values.append(value)
+        value_types.add(value_type)
+    schema: dict[str, JsonValue] = {"enum": values}
+    if len(value_types) == 1:
+        schema["type"] = next(iter(value_types))
+    return schema
+
+
+def _json_value_type(value: object) -> str | None:
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if value is None:
+        return "null"
+    return None
+
+
+def _dataclass_schema(annotation: object, label: str) -> JsonObject:
+    type_hints = _resolve_dataclass_hints(annotation, label)
+    properties: dict[str, JsonValue] = {}
+    required: list[str] = []
+    dataclass_fields = typing.cast(
+        Mapping[str, Field[object]],
+        vars(annotation)["__dataclass_fields__"],
+    )
+    for item in dataclass_fields.values():
+        field_annotation = type_hints.get(item.name, item.type)
+        properties[item.name] = _schema_for_annotation(
+            field_annotation,
+            f"{label}.{item.name}",
+        )
+        if item.default is MISSING and item.default_factory is MISSING:
+            required.append(item.name)
+    schema: dict[str, JsonValue] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _resolve_dataclass_hints(annotation: object, label: str) -> Mapping[str, object]:
+    try:
+        return get_type_hints(annotation, include_extras=True)
+    except (NameError, TypeError) as e:
+        raise AgentDefinitionError(
+            f"{label} dataclass annotations cannot be resolved"
+        ) from e

--- a/core/spakky-agent/tests/unit/test_tooling.py
+++ b/core/spakky-agent/tests/unit/test_tooling.py
@@ -1,6 +1,10 @@
 """Tests for agent tool descriptor discovery."""
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
+import typing
+from dataclasses import dataclass
+from enum import Enum, StrEnum
+from typing import Annotated
 
 import pytest
 
@@ -27,6 +31,52 @@ from spakky.agent import (
     discover_agent_tools,
 )
 from spakky.agent.tooling import AGENT_TOOL_DEFINITION_KEY, get_agent_tool_definition
+
+
+class SearchMode(StrEnum):
+    """검색 도구 입력 enum fixture."""
+
+    EXACT = "exact"
+    FUZZY = "fuzzy"
+
+
+class ExitCode(Enum):
+    """정수 enum fixture."""
+
+    OK = 0
+    FAIL = 1
+
+
+class MixedJsonEnum(Enum):
+    """Mixed JSON primitive enum fixture."""
+
+    ENABLED = True
+    SCORE = 0.5
+    EMPTY = None
+
+
+@dataclass(frozen=True, slots=True)
+class SearchFilter:
+    """Nested dataclass fixture for schema generation."""
+
+    tags: list[str]
+    limit: int = 10
+
+
+@dataclass(frozen=True, slots=True)
+class SearchResult:
+    """Dataclass output fixture for schema generation."""
+
+    title: str
+    scores: Mapping[str, float]
+    filter_: SearchFilter | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DefaultedFilter:
+    """Dataclass fixture whose fields are all optional by default."""
+
+    enabled: bool = False
 
 
 def test_agent_tool_expect_attaches_typed_descriptor_metadata_to_method() -> None:
@@ -88,6 +138,507 @@ def test_agent_expect_discovers_decorated_methods_as_deterministic_catalog() -> 
         "read_file",
         "write_file",
     ]
+
+
+def test_tool_schema_expect_generates_input_schema_from_supported_signature() -> None:
+    """primitive/enum/dataclass/collection/optional signature를 JSON schema로 만든다."""
+
+    @Agent()
+    class SearchAgent:
+        @agent_tool(schema_name="docs.search")
+        def search(
+            self,
+            query: Annotated[str, "model-visible"],
+            mode: SearchMode,
+            filters: list[SearchFilter],
+            window: tuple[int, int],
+            metadata: Mapping[str, str] | None = None,
+        ) -> SearchResult:
+            return SearchResult(
+                title=f"{mode}:{query}",
+                scores={"total": 1.0},
+                filter_=filters[0] if filters else None,
+            )
+
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    descriptor = Agent.get(SearchAgent).tool_catalog.by_schema_name("docs.search")
+
+    assert descriptor.schema.input_schema == {
+        "type": "object",
+        "title": "docs.search.input",
+        "properties": {
+            "query": {"type": "string"},
+            "mode": {"enum": ["exact", "fuzzy"], "type": "string"},
+            "filters": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                        "limit": {"type": "integer"},
+                    },
+                    "additionalProperties": False,
+                    "required": ["tags"],
+                },
+            },
+            "window": {
+                "type": "array",
+                "prefixItems": [{"type": "integer"}, {"type": "integer"}],
+                "minItems": 2,
+                "maxItems": 2,
+            },
+            "metadata": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                    {"type": "null"},
+                ],
+            },
+        },
+        "additionalProperties": False,
+        "required": ["query", "mode", "filters", "window"],
+    }
+
+
+def test_tool_schema_expect_generates_output_schema_from_return_type() -> None:
+    """tool return annotation도 model-facing JSON schema로 검증되고 보존된다."""
+
+    @Agent()
+    class SearchAgent:
+        @agent_tool(schema_name="docs.result")
+        def result(self, status: ExitCode) -> SearchResult | str:
+            if status == ExitCode.OK:
+                return SearchResult(title="ok", scores={})
+            return "failed"
+
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    descriptor = Agent.get(SearchAgent).tool_catalog.by_schema_name("docs.result")
+
+    assert descriptor.schema.input_schema["properties"] == {
+        "status": {"enum": [0, 1], "type": "integer"},
+    }
+    assert descriptor.schema.output_schema == {
+        "title": "docs.result.output",
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "scores": {
+                        "type": "object",
+                        "additionalProperties": {"type": "number"},
+                    },
+                    "filter_": {
+                        "anyOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "tags": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                    },
+                                    "limit": {"type": "integer"},
+                                },
+                                "additionalProperties": False,
+                                "required": ["tags"],
+                            },
+                            {"type": "null"},
+                        ],
+                    },
+                },
+                "additionalProperties": False,
+                "required": ["title", "scores"],
+            },
+            {"type": "string"},
+        ],
+    }
+
+
+def test_tool_schema_expect_accepts_variadic_tuple_as_array_items() -> None:
+    """tuple[T, ...]는 동일 item type의 배열 schema로 표현한다."""
+
+    @Agent()
+    class PathAgent:
+        @agent_tool(schema_name="path.parts")
+        def join(self, parts: tuple[str, ...]) -> str:
+            return "/".join(parts)
+
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    descriptor = Agent.get(PathAgent).tool_catalog.by_schema_name("path.parts")
+
+    assert descriptor.schema.input_schema["properties"] == {
+        "parts": {"type": "array", "items": {"type": "string"}},
+    }
+
+
+def test_tool_schema_expect_omits_required_for_defaulted_parameters() -> None:
+    """default가 있는 parameter는 required 목록에 넣지 않는다."""
+
+    @Agent()
+    class PingAgent:
+        @agent_tool(schema_name="agent.ping")
+        def ping(self, verbose: bool = False) -> None:
+            return None
+
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    descriptor = Agent.get(PingAgent).tool_catalog.by_schema_name("agent.ping")
+
+    assert descriptor.schema.input_schema == {
+        "type": "object",
+        "title": "agent.ping.input",
+        "properties": {"verbose": {"type": "boolean"}},
+        "additionalProperties": False,
+    }
+    assert descriptor.schema.output_schema == {
+        "title": "agent.ping.output",
+        "type": "null",
+    }
+
+
+def test_tool_schema_expect_omits_dataclass_required_when_fields_have_defaults() -> (
+    None
+):
+    """dataclass field default도 nested required 목록에서 제외한다."""
+
+    @Agent()
+    class DefaultedDataclassAgent:
+        @agent_tool(schema_name="agent.defaulted")
+        def inspect(self, filter_: DefaultedFilter) -> str:
+            return str(filter_.enabled)
+
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    descriptor = Agent.get(DefaultedDataclassAgent).tool_catalog.by_schema_name(
+        "agent.defaulted"
+    )
+
+    assert descriptor.schema.input_schema["properties"] == {
+        "filter_": {
+            "type": "object",
+            "properties": {"enabled": {"type": "boolean"}},
+            "additionalProperties": False,
+        },
+    }
+
+
+def test_tool_schema_expect_preserves_mixed_json_primitive_enum_values() -> None:
+    """mixed primitive enum은 enum 값만 보존하고 단일 type을 강제하지 않는다."""
+
+    @Agent()
+    class MixedEnumAgent:
+        @agent_tool(schema_name="agent.mixed")
+        def inspect(self, value: MixedJsonEnum) -> str:
+            return value.name
+
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    descriptor = Agent.get(MixedEnumAgent).tool_catalog.by_schema_name("agent.mixed")
+
+    assert descriptor.schema.input_schema["properties"] == {
+        "value": {"enum": [True, 0.5, None]},
+    }
+
+
+def test_tool_schema_expect_rejects_untyped_and_unsupported_signatures() -> None:
+    """Any/untyped/unsupported 타입은 Agent definition 단계에서 custom error로 실패한다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class UntypedToolAgent:
+            @agent_tool(schema_name="invalid.untyped")
+            def invalid(self, value) -> str:
+                return value
+
+            async def execute(
+                self,
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class AnyToolAgent:
+            @agent_tool(schema_name="invalid.any")
+            def invalid(self, value: typing.Any) -> str:
+                return value
+
+            async def execute(
+                self,
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class ObjectToolAgent:
+            @agent_tool(schema_name="invalid.object")
+            def invalid(self, value: object) -> object:
+                return value
+
+            async def execute(
+                self,
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+
+def test_tool_schema_expect_rejects_untyped_mapping_and_non_string_keys() -> None:
+    """mapping은 string key와 typed value를 명시해야 model schema가 안전하다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class UntypedMappingAgent:
+            @agent_tool(schema_name="invalid.dict")
+            def invalid(self, value: dict) -> str:
+                return str(value)
+
+            async def execute(
+                self,
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class NumericKeyMappingAgent:
+            @agent_tool(schema_name="invalid.keys")
+            def invalid(self, value: dict[int, str]) -> str:
+                return str(value)
+
+            async def execute(
+                self,
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+
+def test_tool_schema_expect_rejects_parameters_without_object_schema() -> None:
+    """positional-only/varargs/varkw는 object argument schema로 표현하지 않는다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class PositionalOnlyToolAgent:
+            @agent_tool(schema_name="invalid.positional")
+            def invalid(self, value: str, /) -> str:
+                return value
+
+            async def execute(
+                self,
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class VarargsToolAgent:
+            @agent_tool(schema_name="invalid.varargs")
+            def invalid(self, *values: str) -> str:
+                return ",".join(values)
+
+            async def execute(
+                self,
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class VarkwToolAgent:
+            @agent_tool(schema_name="invalid.varkw")
+            def invalid(self, **values: str) -> str:
+                return str(values)
+
+            async def execute(
+                self,
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+
+def test_tool_schema_expect_rejects_missing_return_and_bad_enum_values() -> None:
+    """return type과 enum 값도 schema-compatible 계약을 가져야 한다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class MissingReturnToolAgent:
+            @agent_tool(schema_name="invalid.return")
+            def invalid(self, value: str):
+                return value
+
+            async def execute(
+                self,
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+    class BadEnum(Enum):
+        VALUE = ("not", "json", "primitive")
+
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent()
+        class BadEnumToolAgent:
+            @agent_tool(schema_name="invalid.enum")
+            def invalid(self, value: BadEnum) -> str:
+                return value.name
+
+            async def execute(
+                self,
+                command: str,
+            ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+                yield AgentYield(
+                    kind=AgentYieldKind.FINAL,
+                    payload=Final(output=command, metadata={}),
+                )
+
+
+def test_tool_schema_expect_rejects_unresolved_annotations() -> None:
+    """forward reference를 해소할 수 없으면 bootstrap 전 custom error로 실패한다."""
+    scope = _agent_definition_exec_scope()
+    with pytest.raises(AgentDefinitionError):
+        exec(
+            """
+@Agent()
+class UnresolvedToolAgent:
+    @agent_tool(schema_name="invalid.forward")
+    def invalid(self, value: "MissingToolType") -> str:
+        return value
+
+    async def execute(
+        self,
+        command: str,
+    ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(output=command, metadata={}),
+        )
+""",
+            scope,
+            scope,
+        )
+
+
+def test_tool_schema_expect_rejects_unresolved_dataclass_fields() -> None:
+    """dataclass field annotation도 schema generation 전에 해소되어야 한다."""
+    scope = _agent_definition_exec_scope()
+    with pytest.raises(AgentDefinitionError):
+        exec(
+            """
+@dataclass(frozen=True, slots=True)
+class BrokenDataclass:
+    value: "MissingFieldType"
+
+
+@Agent()
+class BrokenDataclassToolAgent:
+    @agent_tool(schema_name="invalid.dataclass")
+    def invalid(self, value: BrokenDataclass) -> str:
+        return str(value)
+
+    async def execute(
+        self,
+        command: str,
+    ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(output=command, metadata={}),
+        )
+""",
+            scope,
+            scope,
+        )
+
+
+def _agent_definition_exec_scope() -> dict[str, object]:
+    return {
+        "Agent": Agent,
+        "agent_tool": agent_tool,
+        "dataclass": dataclass,
+        "AsyncGenerator": AsyncGenerator,
+        "AgentYield": AgentYield,
+        "AgentYieldKind": AgentYieldKind,
+        "Final": Final,
+    }
 
 
 def test_tool_catalog_expect_preserves_owner_callable_schema_and_metadata() -> None:

--- a/docs/adr/0009-agentic-hexagonal-architecture.md
+++ b/docs/adr/0009-agentic-hexagonal-architecture.md
@@ -560,12 +560,16 @@ class DocsTools:
 
 허용되는 타입은 JSON-compatible 또는 explicit string-compatible이어야 한다.
 
+첫 core 구현은 `@agent_tool` descriptor 생성 시 함수 signature와 resolved type hint만 사용해 `AgentToolSchemaHandle.input_schema` / `output_schema`를 생성한다. 입력은 `self`/`cls`를 제외한 parameter object schema로 표현하며, Python default가 없는 parameter만 required로 표시한다. 지원 타입은 primitive, enum, dataclass, `list[T]`, `tuple[...]`, `Mapping[str, T]`, optional/union, `Annotated[T, ...]`이다. Binding과 DTO wrapping은 이 단계에서 수행하지 않는다.
+
 Opt-out 타입:
 
 - `Any`
 - untyped parameter
 - untyped return
 - untyped `dict`
+- non-string mapping key
+- positional-only, `*args`, `**kwargs`
 - untyped `list`
 - raw `object`
 - callable/function parameter


### PR DESCRIPTION
## Summary
- generate model-facing input/output JSON schemas from @agent_tool function signatures
- fail early with AgentDefinitionError for unsupported parameter and return annotations
- document supported schema types and keep #229 signal consumption README context after rebase

## Validation
- cd core/spakky-agent && uv run ruff format . && uv run python ../../.agents/skills/check/scripts/validate_python_harness.py . && uv run ruff check . && uv run pyrefly check src tests
- cd core/spakky-agent && uv run pytest
- uv run python scripts/run_coverage.py --package spakky-agent
- uv run mkdocs build --strict

Closes #218