### PR TITLE
feat(vllm): implement streaming model calls (#226)

### DIFF
--- a/plugins/spakky-vllm/CHANGELOG.md
+++ b/plugins/spakky-vllm/CHANGELOG.md
@@ -1,3 +1,10 @@
 # Changelog
 
 All notable changes to spakky-vllm are documented in this file.
+
+## Unreleased
+
+- Implemented vLLM OpenAI-compatible streaming over chat completions SSE chunks.
+- Added typed streaming error events for timeout, transport, invalid chunk,
+  provider error, refusal, and non-success finish reasons.
+- Added token delta, tool-call candidate, usage, and cancellation-close coverage.

--- a/plugins/spakky-vllm/README.md
+++ b/plugins/spakky-vllm/README.md
@@ -31,6 +31,20 @@ Loading the plugin registers:
 - `VllmAgentModel`
 - an explicit `IAgentModel -> VllmAgentModel` binding
 
-Streaming chunk mapping is intentionally reserved for the follow-up vLLM streaming
-ticket. Until then, `stream()` exposes the contract and fails clearly instead of
-silently falling back to fake streaming.
+`VllmAgentModel.complete()` sends OpenAI-compatible chat completion requests and
+maps provider responses into `ModelResponse`. `VllmAgentModel.stream()` sends the
+same request with `stream=true`, decodes server-sent event chunks, and emits
+provider-neutral `ModelStreamEvent` values:
+
+- token deltas become `ModelStreamEventKind.TOKEN_DELTA`
+- streamed function-call fragments become `TOOL_CALL_CANDIDATE` at the
+  `tool_calls` finish boundary
+- usage chunks are attached to the final `DONE` event when requested by
+  `StreamingOptions.include_usage`
+- timeout, transport, invalid chunk, provider error, refusal, and non-success
+  finish reasons become typed `ERROR` events followed by `DONE`
+
+Agent implementations can forward token events as `AgentYieldKind.TOKEN` payloads
+and close the async stream when their cancellation lifecycle asks the model call
+to stop. The HTTP stream is owned by the async generator, so `aclose()` releases
+the underlying client stream instead of leaving a background request running.

--- a/plugins/spakky-vllm/src/spakky/plugins/vllm/__init__.py
+++ b/plugins/spakky-vllm/src/spakky/plugins/vllm/__init__.py
@@ -6,8 +6,11 @@ from spakky.plugins.vllm.client import HttpxVllmChatClient, IVllmChatClient
 from spakky.plugins.vllm.config import VllmConfig
 from spakky.plugins.vllm.error import (
     AbstractVllmError,
+    VllmModelRefusalError,
     VllmResponseError,
+    VllmStreamingDisabledError,
     VllmStreamingNotImplementedError,
+    VllmTimeoutError,
     VllmTransportError,
 )
 from spakky.plugins.vllm.model import VllmAgentModel
@@ -22,7 +25,10 @@ __all__ = [
     "PLUGIN_NAME",
     "VllmAgentModel",
     "VllmConfig",
+    "VllmModelRefusalError",
     "VllmResponseError",
+    "VllmStreamingDisabledError",
     "VllmStreamingNotImplementedError",
+    "VllmTimeoutError",
     "VllmTransportError",
 ]

--- a/plugins/spakky-vllm/src/spakky/plugins/vllm/client.py
+++ b/plugins/spakky-vllm/src/spakky/plugins/vllm/client.py
@@ -1,15 +1,19 @@
 """HTTP client boundary for the vLLM OpenAI-compatible endpoint."""
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
-from json import JSONDecodeError
+from collections.abc import AsyncGenerator, Mapping
+from json import JSONDecodeError, loads
 from typing import override
 
 import httpx
 from spakky.core.pod.annotations.pod import Pod
 
 from spakky.plugins.vllm.config import VllmConfig
-from spakky.plugins.vllm.error import VllmResponseError, VllmTransportError
+from spakky.plugins.vllm.error import (
+    VllmResponseError,
+    VllmTimeoutError,
+    VllmTransportError,
+)
 
 type JsonResponseObject = Mapping[str, object]
 
@@ -24,6 +28,15 @@ class IVllmChatClient(ABC):
         config: VllmConfig,
     ) -> JsonResponseObject:
         """Send a non-streaming chat completion request."""
+        ...
+
+    @abstractmethod
+    def stream(
+        self,
+        payload: Mapping[str, object],
+        config: VllmConfig,
+    ) -> AsyncGenerator[JsonResponseObject, None]:
+        """Stream OpenAI-compatible chat completion chunks."""
         ...
 
 
@@ -48,11 +61,54 @@ class HttpxVllmChatClient(IVllmChatClient):
                 )
             response.raise_for_status()
             decoded: object = response.json()
+        except httpx.TimeoutException as e:
+            raise VllmTimeoutError from e
         except httpx.HTTPError as e:
             raise VllmTransportError from e
         except JSONDecodeError as e:
             raise VllmResponseError from e
 
+        if not isinstance(decoded, Mapping):
+            raise VllmResponseError
+        return decoded
+
+    @override
+    async def stream(
+        self,
+        payload: Mapping[str, object],
+        config: VllmConfig,
+    ) -> AsyncGenerator[JsonResponseObject, None]:
+        """Stream server-sent event chunks from chat completions."""
+        try:
+            async with httpx.AsyncClient(
+                timeout=config.stream_timeout_seconds,
+            ) as client:
+                async with client.stream(
+                    "POST",
+                    config.chat_completions_url,
+                    json=dict(payload),
+                ) as response:
+                    response.raise_for_status()
+                    async for line in response.aiter_lines():
+                        chunk = self._decode_sse_line(line)
+                        if chunk is not None:
+                            yield chunk
+        except httpx.TimeoutException as e:
+            raise VllmTimeoutError from e
+        except httpx.HTTPError as e:
+            raise VllmTransportError from e
+        except JSONDecodeError as e:
+            raise VllmResponseError from e
+
+    def _decode_sse_line(self, line: str) -> JsonResponseObject | None:
+        if line == "" or line.startswith(":"):
+            return None
+        if not line.startswith("data:"):
+            raise VllmResponseError
+        data = line.removeprefix("data:").strip()
+        if data == "[DONE]":
+            return None
+        decoded: object = loads(data)
         if not isinstance(decoded, Mapping):
             raise VllmResponseError
         return decoded

--- a/plugins/spakky-vllm/src/spakky/plugins/vllm/error.py
+++ b/plugins/spakky-vllm/src/spakky/plugins/vllm/error.py
@@ -17,13 +17,31 @@ class VllmTransportError(AbstractVllmError):
     message = "vLLM transport request failed"
 
 
+class VllmTimeoutError(AbstractVllmError):
+    """Raised when the OpenAI-compatible vLLM endpoint times out."""
+
+    message = "vLLM request timed out"
+
+
 class VllmResponseError(AbstractVllmError):
     """Raised when a vLLM response cannot be mapped to Spakky model contracts."""
 
     message = "vLLM response is invalid"
 
 
+class VllmStreamingDisabledError(AbstractVllmError):
+    """Raised when streaming is disabled by plugin configuration."""
+
+    message = "vLLM streaming is disabled"
+
+
+class VllmModelRefusalError(AbstractVllmError):
+    """Raised when the model refuses to produce a normal completion."""
+
+    message = "vLLM model refused the request"
+
+
 class VllmStreamingNotImplementedError(AbstractVllmError):
-    """Raised until the streaming mapper lands in the dedicated follow-up."""
+    """Backward-compatible alias for pre-streaming adapter failures."""
 
     message = "vLLM streaming mapper is not implemented yet"

--- a/plugins/spakky-vllm/src/spakky/plugins/vllm/model.py
+++ b/plugins/spakky-vllm/src/spakky/plugins/vllm/model.py
@@ -1,6 +1,7 @@
 """IAgentModel implementation backed by vLLM."""
 
-from collections.abc import AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Mapping, Sequence
+from dataclasses import dataclass, field
 from json import JSONDecodeError, loads
 from typing import override
 
@@ -23,7 +24,37 @@ from spakky.core.pod.annotations.pod import Pod
 
 from spakky.plugins.vllm.client import IVllmChatClient
 from spakky.plugins.vllm.config import VllmConfig
-from spakky.plugins.vllm.error import VllmResponseError
+from spakky.plugins.vllm.error import (
+    AbstractVllmError,
+    VllmModelRefusalError,
+    VllmResponseError,
+    VllmStreamingDisabledError,
+    VllmTimeoutError,
+    VllmTransportError,
+)
+
+
+@dataclass(slots=True)
+class _ToolCallBuffer:
+    index: int
+    call_id: str | None = None
+    name: str | None = None
+    arguments_fragments: list[str] = field(default_factory=list)
+
+    def extend_arguments(self, fragment: str | None) -> None:
+        if fragment is not None:
+            self.arguments_fragments.append(fragment)
+
+    def to_tool_call(self, adapter: "VllmAgentModel") -> ModelToolCall:
+        if self.name is None:
+            raise VllmResponseError
+        provider_arguments = "".join(self.arguments_fragments)
+        return ModelToolCall(
+            name=self.name,
+            arguments=adapter._to_tool_arguments(provider_arguments),
+            call_id=self.call_id,
+            metadata={"provider_arguments": provider_arguments},
+        )
 
 
 @Pod()
@@ -45,25 +76,71 @@ class VllmAgentModel(IAgentModel):
         return self._to_model_response(response)
 
     @override
-    def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
-        """Return the streaming surface reserved for the follow-up mapper."""
-        return self._stream_not_implemented(request)
+    def stream(self, request: ModelRequest) -> AsyncGenerator[ModelStreamEvent, None]:
+        """Return provider-neutral stream events from vLLM chat completions."""
+        return self._stream(request)
 
-    async def _stream_not_implemented(
+    async def _stream(
         self,
         request: ModelRequest,
-    ) -> AsyncIterator[ModelStreamEvent]:
-        self._to_chat_completion_payload(request, stream=True)
-        yield ModelStreamEvent(
-            kind=ModelStreamEventKind.ERROR,
-            error=ModelError(
-                code="vllm_streaming_not_implemented",
-                message="vLLM streaming mapper is not implemented yet",
-                retryable=False,
-                metadata={"provider": "vllm"},
-            ),
-        )
-        yield ModelStreamEvent(kind=ModelStreamEventKind.DONE)
+    ) -> AsyncGenerator[ModelStreamEvent, None]:
+        if not self.__config.stream_enabled:
+            yield self._to_error_event(VllmStreamingDisabledError())
+            yield self._done_event(None, None)
+            return
+
+        payload = self._to_chat_completion_payload(request, stream=True)
+        tool_buffers: dict[int, _ToolCallBuffer] = {}
+        finish_reason: str | None = None
+        usage: ModelUsage | None = None
+        terminal_error: ModelError | None = None
+        try:
+            stream = self.__client.stream(payload, self.__config)
+        except AbstractVllmError as e:
+            yield self._to_error_event(e)
+            yield self._done_event(None, None)
+            return
+        try:
+            async for chunk in stream:
+                provider_error = self._to_provider_error(chunk.get("error"))
+                if provider_error is not None:
+                    terminal_error = provider_error
+                    break
+                usage_value = chunk.get("usage")
+                if usage_value is not None:
+                    usage = self._to_usage(usage_value)
+                choices = self._expect_sequence(chunk.get("choices"))
+                if len(choices) == 0:
+                    continue
+                for raw_choice in choices:
+                    choice = self._expect_mapping(raw_choice)
+                    async for event in self._stream_choice_events(
+                        choice,
+                        tool_buffers,
+                    ):
+                        yield event
+                    choice_finish_reason = self._optional_string(
+                        choice.get("finish_reason")
+                    )
+                    if choice_finish_reason is not None:
+                        finish_reason = choice_finish_reason
+                        if finish_reason == "tool_calls":
+                            for event in self._tool_call_events(tool_buffers):
+                                yield event
+                        terminal_error = self._finish_reason_error(finish_reason)
+        except AbstractVllmError as e:
+            yield self._to_error_event(e)
+            yield self._done_event(None, None)
+            return
+        finally:
+            await stream.aclose()
+
+        if terminal_error is not None:
+            yield ModelStreamEvent(
+                kind=ModelStreamEventKind.ERROR,
+                error=terminal_error,
+            )
+        yield self._done_event(finish_reason, usage)
 
     def _to_chat_completion_payload(
         self,
@@ -110,6 +187,8 @@ class VllmAgentModel(IAgentModel):
                 for tool in request.tool_calling.tools
             ]
             payload["tool_choice"] = self._to_tool_choice(request.tool_calling.choice)
+        if stream and request.streaming.include_usage:
+            payload["stream_options"] = {"include_usage": True}
         return payload
 
     def _to_openai_message(self, message: ModelMessage) -> dict[str, object]:
@@ -130,14 +209,164 @@ class VllmAgentModel(IAgentModel):
         if len(choices) == 0:
             raise VllmResponseError
         first_choice = self._expect_mapping(choices[0])
+        finish_reason = self._optional_string(first_choice.get("finish_reason"))
         message = self._expect_mapping(first_choice.get("message"))
+        refusal = self._optional_string(message.get("refusal"))
+        if refusal is not None and refusal != "":
+            raise VllmModelRefusalError
+        if finish_reason == "content_filter":
+            raise VllmModelRefusalError
         tool_calls = tuple(self._to_tool_calls(message.get("tool_calls")))
         content = self._to_message_content(message.get("content"), tool_calls)
         return ModelResponse(
             content=content,
             tool_calls=tool_calls,
             usage=self._to_usage(response.get("usage")),
+            metadata={"provider": "vllm", "finish_reason": finish_reason},
+        )
+
+    async def _stream_choice_events(
+        self,
+        choice: Mapping[str, object],
+        tool_buffers: dict[int, _ToolCallBuffer],
+    ) -> AsyncIterator[ModelStreamEvent]:
+        delta_value = choice.get("delta")
+        if delta_value is None:
+            return
+        delta = self._expect_mapping(delta_value)
+        content = self._optional_string(delta.get("content"))
+        if content is not None and content != "":
+            yield ModelStreamEvent(
+                kind=ModelStreamEventKind.TOKEN_DELTA,
+                token_delta=content,
+                metadata={"provider": "vllm"},
+            )
+        refusal = self._optional_string(delta.get("refusal"))
+        if refusal is not None and refusal != "":
+            yield ModelStreamEvent(
+                kind=ModelStreamEventKind.ERROR,
+                error=ModelError(
+                    code="model_refusal",
+                    message=refusal,
+                    retryable=False,
+                    metadata={"provider": "vllm"},
+                ),
+            )
+        tool_call_chunks = delta.get("tool_calls")
+        if tool_call_chunks is not None:
+            self._accumulate_tool_call_chunks(tool_call_chunks, tool_buffers)
+
+    def _accumulate_tool_call_chunks(
+        self,
+        value: object,
+        tool_buffers: dict[int, _ToolCallBuffer],
+    ) -> None:
+        raw_calls = self._expect_sequence(value)
+        for position, raw_call in enumerate(raw_calls):
+            item = self._expect_mapping(raw_call)
+            index = self._optional_int(item.get("index"))
+            if index is None:
+                index = position
+            buffer = tool_buffers.setdefault(index, _ToolCallBuffer(index=index))
+            call_id = self._optional_string(item.get("id"))
+            if call_id is not None:
+                buffer.call_id = call_id
+            function_value = item.get("function")
+            if function_value is None:
+                continue
+            function = self._expect_mapping(function_value)
+            name = self._optional_string(function.get("name"))
+            if name is not None:
+                buffer.name = name
+            buffer.extend_arguments(self._optional_string(function.get("arguments")))
+
+    def _tool_call_events(
+        self,
+        tool_buffers: dict[int, _ToolCallBuffer],
+    ) -> tuple[ModelStreamEvent, ...]:
+        events = tuple(
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+                tool_call=tool_buffers[index].to_tool_call(self),
+                metadata={"provider": "vllm"},
+            )
+            for index in sorted(tool_buffers)
+        )
+        tool_buffers.clear()
+        return events
+
+    def _to_provider_error(self, value: object) -> ModelError | None:
+        if value is None:
+            return None
+        error = self._expect_mapping(value)
+        code = self._optional_string(error.get("code")) or "provider_error"
+        message = self._optional_string(error.get("message")) or "vLLM stream error"
+        return ModelError(
+            code=code,
+            message=message,
+            retryable=False,
             metadata={"provider": "vllm"},
+        )
+
+    def _finish_reason_error(self, finish_reason: str) -> ModelError | None:
+        if finish_reason in ("stop", "tool_calls"):
+            return None
+        code = (
+            "model_refusal"
+            if finish_reason == "content_filter"
+            else "model_finish_reason"
+        )
+        return ModelError(
+            code=code,
+            message=f"vLLM stream finished with reason: {finish_reason}",
+            retryable=False,
+            metadata={"provider": "vllm", "finish_reason": finish_reason},
+        )
+
+    def _to_error_event(self, error: AbstractVllmError) -> ModelStreamEvent:
+        return ModelStreamEvent(
+            kind=ModelStreamEventKind.ERROR,
+            error=self._to_model_error(error),
+        )
+
+    def _to_model_error(self, error: AbstractVllmError) -> ModelError:
+        if isinstance(error, VllmTimeoutError):
+            return ModelError(
+                code="vllm_timeout",
+                message=VllmTimeoutError.message,
+                retryable=True,
+                metadata={"provider": "vllm"},
+            )
+        if isinstance(error, VllmTransportError):
+            return ModelError(
+                code="vllm_transport_error",
+                message=VllmTransportError.message,
+                retryable=True,
+                metadata={"provider": "vllm"},
+            )
+        if isinstance(error, VllmStreamingDisabledError):
+            return ModelError(
+                code="vllm_streaming_disabled",
+                message=VllmStreamingDisabledError.message,
+                retryable=False,
+                metadata={"provider": "vllm"},
+            )
+        return ModelError(
+            code="vllm_response_error",
+            message=VllmResponseError.message,
+            retryable=False,
+            metadata={"provider": "vllm"},
+        )
+
+    def _done_event(
+        self,
+        finish_reason: str | None,
+        usage: ModelUsage | None,
+    ) -> ModelStreamEvent:
+        return ModelStreamEvent(
+            kind=ModelStreamEventKind.DONE,
+            usage=usage,
+            metadata={"provider": "vllm", "finish_reason": finish_reason},
         )
 
     def _to_message_content(

--- a/plugins/spakky-vllm/tests/unit/test_client.py
+++ b/plugins/spakky-vllm/tests/unit/test_client.py
@@ -1,6 +1,6 @@
 """Tests for the vLLM HTTP client boundary."""
 
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
 from json import JSONDecodeError
 from typing import Self
 
@@ -9,7 +9,11 @@ import pytest
 
 from spakky.plugins.vllm.client import HttpxVllmChatClient
 from spakky.plugins.vllm.config import VllmConfig
-from spakky.plugins.vllm.error import VllmResponseError, VllmTransportError
+from spakky.plugins.vllm.error import (
+    VllmResponseError,
+    VllmTimeoutError,
+    VllmTransportError,
+)
 
 
 class FakeResponse:
@@ -44,11 +48,19 @@ class FailingStatusResponse(FakeResponse):
         )
 
 
+class TimeoutResponse(FakeResponse):
+    def raise_for_status(self) -> None:
+        """Raise an httpx timeout for timeout mapping."""
+        raise httpx.TimeoutException("request timed out")
+
+
 class FakeAsyncClient:
     response: FakeResponse
+    stream_response: "FakeStreamResponse"
     observed_timeout: float | None = None
     observed_url: str | None = None
     observed_json: Mapping[str, object] | None = None
+    observed_method: str | None = None
 
     def __init__(self, *, timeout: float) -> None:
         type(self).observed_timeout = timeout
@@ -74,6 +86,64 @@ class FakeAsyncClient:
         type(self).observed_json = json
         return type(self).response
 
+    def stream(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: Mapping[str, object],
+    ) -> "FakeStreamContext":
+        type(self).observed_method = method
+        type(self).observed_url = url
+        type(self).observed_json = json
+        return FakeStreamContext(type(self).stream_response)
+
+
+class FakeStreamResponse:
+    lines: tuple[str, ...]
+    status_error: httpx.HTTPStatusError | None
+    stream_error: httpx.TimeoutException | None
+
+    def __init__(
+        self,
+        lines: tuple[str, ...],
+        status_error: httpx.HTTPStatusError | None = None,
+        stream_error: httpx.TimeoutException | None = None,
+    ) -> None:
+        self.lines = lines
+        self.status_error = status_error
+        self.stream_error = stream_error
+
+    def raise_for_status(self) -> None:
+        """Raise the configured streaming status error when present."""
+        if self.status_error is not None:
+            raise self.status_error
+
+    async def aiter_lines(self) -> AsyncIterator[str]:
+        """Yield fake server-sent event lines."""
+        if self.stream_error is not None:
+            raise self.stream_error
+        for line in self.lines:
+            yield line
+
+
+class FakeStreamContext:
+    response: FakeStreamResponse
+
+    def __init__(self, response: FakeStreamResponse) -> None:
+        self.response = response
+
+    async def __aenter__(self) -> FakeStreamResponse:
+        return self.response
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc_value: object,
+        traceback: object,
+    ) -> None:
+        return None
+
 
 async def test_httpx_client_posts_chat_completion_payload(monkeypatch) -> None:
     """HTTP client가 configured endpoint로 payload를 POST하고 JSON object를 반환한다."""
@@ -97,6 +167,15 @@ async def test_httpx_client_status_error_expect_transport_error(monkeypatch) -> 
         await HttpxVllmChatClient().complete({}, VllmConfig())
 
 
+async def test_httpx_client_timeout_expect_timeout_error(monkeypatch) -> None:
+    """httpx timeout 실패는 plugin timeout error로 변환된다."""
+    FakeAsyncClient.response = TimeoutResponse({})
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    with pytest.raises(VllmTimeoutError):
+        await HttpxVllmChatClient().complete({}, VllmConfig())
+
+
 async def test_httpx_client_decode_error_expect_response_error(monkeypatch) -> None:
     """JSON decode 실패는 response shape error로 변환된다."""
     FakeAsyncClient.response = FakeResponse(
@@ -116,3 +195,76 @@ async def test_httpx_client_non_object_json_expect_response_error(monkeypatch) -
 
     with pytest.raises(VllmResponseError):
         await HttpxVllmChatClient().complete({}, VllmConfig())
+
+
+async def test_httpx_client_stream_decodes_openai_sse_chunks(monkeypatch) -> None:
+    """stream()은 OpenAI-compatible SSE data line을 JSON object chunk로 디코딩한다."""
+    FakeAsyncClient.stream_response = FakeStreamResponse(
+        (
+            ": keep-alive",
+            "",
+            'data: {"choices":[{"delta":{"content":"hi"}}]}',
+            "data: [DONE]",
+        )
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    chunks = [
+        chunk
+        async for chunk in HttpxVllmChatClient().stream({"stream": True}, VllmConfig())
+    ]
+
+    assert chunks == [{"choices": [{"delta": {"content": "hi"}}]}]
+    assert FakeAsyncClient.observed_timeout == 300.0
+    assert FakeAsyncClient.observed_method == "POST"
+    assert FakeAsyncClient.observed_url == "http://127.0.0.1:8000/v1/chat/completions"
+    assert FakeAsyncClient.observed_json == {"stream": True}
+
+
+@pytest.mark.parametrize(
+    "line",
+    ["event: nope", "data: []", "data: not-json"],
+)
+async def test_httpx_client_stream_invalid_chunk_expect_response_error(
+    monkeypatch,
+    line: str,
+) -> None:
+    """잘못된 SSE line은 invalid provider stream chunk로 실패한다."""
+    FakeAsyncClient.stream_response = FakeStreamResponse((line,))
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    with pytest.raises(VllmResponseError):
+        async for _chunk in HttpxVllmChatClient().stream({}, VllmConfig()):
+            continue
+
+
+async def test_httpx_client_stream_status_error_expect_transport_error(
+    monkeypatch,
+) -> None:
+    """streaming HTTP status 실패는 plugin transport error로 변환된다."""
+    FakeAsyncClient.stream_response = FakeStreamResponse(
+        (),
+        httpx.HTTPStatusError(
+            "bad status",
+            request=httpx.Request("POST", "http://vllm/v1/chat/completions"),
+            response=httpx.Response(500),
+        ),
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    with pytest.raises(VllmTransportError):
+        async for _chunk in HttpxVllmChatClient().stream({}, VllmConfig()):
+            continue
+
+
+async def test_httpx_client_stream_timeout_expect_timeout_error(monkeypatch) -> None:
+    """streaming timeout은 plugin timeout error로 변환된다."""
+    FakeAsyncClient.stream_response = FakeStreamResponse(
+        (),
+        stream_error=httpx.TimeoutException("stream timed out"),
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    with pytest.raises(VllmTimeoutError):
+        async for _chunk in HttpxVllmChatClient().stream({}, VllmConfig()):
+            continue

--- a/plugins/spakky-vllm/tests/unit/test_model.py
+++ b/plugins/spakky-vllm/tests/unit/test_model.py
@@ -1,6 +1,6 @@
 """Tests for vLLM model adapter mapping."""
 
-from collections.abc import Mapping
+from collections.abc import AsyncGenerator, Mapping
 from typing import override
 
 import pytest
@@ -11,6 +11,7 @@ from spakky.agent import (
     ModelMessageRole,
     ModelRequest,
     ModelStreamEvent,
+    ModelStreamEventKind,
     JsonSchemaConstraint,
     ModelToolChoice,
     ModelToolSpec,
@@ -21,17 +22,37 @@ from spakky.agent import (
 
 from spakky.plugins.vllm.client import IVllmChatClient
 from spakky.plugins.vllm.config import VllmConfig
-from spakky.plugins.vllm.error import VllmResponseError
+from spakky.plugins.vllm.error import (
+    AbstractVllmError,
+    VllmModelRefusalError,
+    VllmResponseError,
+    VllmTimeoutError,
+    VllmTransportError,
+)
 from spakky.plugins.vllm.model import VllmAgentModel
 
 
 class RecordingClient(IVllmChatClient):
     payload: Mapping[str, object] | None
     response: Mapping[str, object]
+    stream_chunks: tuple[Mapping[str, object], ...]
+    stream_error: AbstractVllmError | None
+    stream_call_error: AbstractVllmError | None
+    stream_closed: bool
 
-    def __init__(self, response: Mapping[str, object]) -> None:
+    def __init__(
+        self,
+        response: Mapping[str, object],
+        stream_chunks: tuple[Mapping[str, object], ...] = (),
+        stream_error: AbstractVllmError | None = None,
+        stream_call_error: AbstractVllmError | None = None,
+    ) -> None:
         self.payload = None
         self.response = response
+        self.stream_chunks = stream_chunks
+        self.stream_error = stream_error
+        self.stream_call_error = stream_call_error
+        self.stream_closed = False
 
     @override
     async def complete(
@@ -41,6 +62,26 @@ class RecordingClient(IVllmChatClient):
     ) -> Mapping[str, object]:
         self.payload = payload
         return self.response
+
+    @override
+    def stream(
+        self,
+        payload: Mapping[str, object],
+        config: VllmConfig,
+    ) -> AsyncGenerator[Mapping[str, object], None]:
+        self.payload = payload
+        if self.stream_call_error is not None:
+            raise self.stream_call_error
+        return self._stream()
+
+    async def _stream(self) -> AsyncGenerator[Mapping[str, object], None]:
+        try:
+            if self.stream_error is not None:
+                raise self.stream_error
+            for chunk in self.stream_chunks:
+                yield chunk
+        finally:
+            self.stream_closed = True
 
 
 async def test_complete_maps_request_to_openai_payload_and_response() -> None:
@@ -70,6 +111,7 @@ async def test_complete_maps_request_to_openai_payload_and_response() -> None:
     assert response.usage.input_tokens == 3
     assert response.usage.output_tokens == 2
     assert response.usage.total_tokens == 5
+    assert response.metadata == {"provider": "vllm", "finish_reason": None}
     assert client.payload == {
         "model": "default",
         "messages": [
@@ -279,6 +321,38 @@ async def test_complete_invalid_response_expect_vllm_response_error() -> None:
         await model.complete(request)
 
 
+async def test_complete_refusal_response_expect_model_refusal_error() -> None:
+    """non-streaming model refusal은 plugin typed error로 표현된다."""
+    model = VllmAgentModel(
+        VllmConfig(),
+        RecordingClient(
+            {"choices": [{"message": {"content": "", "refusal": "blocked"}}]}
+        ),
+    )
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+
+    with pytest.raises(VllmModelRefusalError):
+        await model.complete(request)
+
+
+async def test_complete_content_filter_finish_expect_model_refusal_error() -> None:
+    """content_filter finish reason은 non-streaming refusal error로 표현된다."""
+    model = VllmAgentModel(
+        VllmConfig(),
+        RecordingClient(
+            {
+                "choices": [
+                    {"finish_reason": "content_filter", "message": {"content": ""}}
+                ]
+            }
+        ),
+    )
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+
+    with pytest.raises(VllmModelRefusalError):
+        await model.complete(request)
+
+
 @pytest.mark.parametrize(
     "response",
     [
@@ -346,17 +420,329 @@ def test_json_argument_validation_rejects_non_json_object_shapes() -> None:
         model._to_json_value(object())
 
 
-async def test_stream_surface_emits_explicit_error_until_streaming_mapper_lands() -> (
-    None
-):
-    """stream()은 후속 mapper 구현 전까지 명시적 ERROR event를 낸다."""
-    model = VllmAgentModel(VllmConfig(), RecordingClient({"choices": []}))
+async def test_stream_maps_token_deltas_usage_and_done_event() -> None:
+    """stream()은 vLLM token delta와 usage를 provider-neutral event로 변환한다."""
+    client = RecordingClient(
+        {"choices": []},
+        stream_chunks=(
+            {"choices": [{"delta": {"content": "Hel"}, "finish_reason": None}]},
+            {
+                "choices": [{"delta": {"content": "lo"}, "finish_reason": "stop"}],
+                "usage": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 2,
+                    "total_tokens": 5,
+                },
+            },
+        ),
+    )
+    model = VllmAgentModel(VllmConfig(), client)
     request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
 
     events = [event async for event in model.stream(request)]
 
-    assert events[0].kind.value == "error"
+    assert events[0] == ModelStreamEvent(
+        kind=ModelStreamEventKind.TOKEN_DELTA,
+        token_delta="Hel",
+        metadata={"provider": "vllm"},
+    )
+    assert events[1] == ModelStreamEvent(
+        kind=ModelStreamEventKind.TOKEN_DELTA,
+        token_delta="lo",
+        metadata={"provider": "vllm"},
+    )
+    assert events[2].kind == ModelStreamEventKind.DONE
+    assert events[2].usage is not None
+    assert events[2].usage.total_tokens == 5
+    assert events[2].metadata == {"provider": "vllm", "finish_reason": "stop"}
+    assert client.payload is not None
+    assert client.payload["stream"] is True
+    assert client.payload["stream_options"] == {"include_usage": True}
+
+
+async def test_stream_maps_tool_call_chunks_after_tool_finish_reason() -> None:
+    """streaming tool_call delta 조각은 완료 시점에 ModelToolCall 후보가 된다."""
+    client = RecordingClient(
+        {"choices": []},
+        stream_chunks=(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call-1",
+                                    "function": {
+                                        "name": "search",
+                                        "arguments": '{"q":"spa',
+                                    },
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "function": {"arguments": 'kky","limit":2}'},
+                                }
+                            ]
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            },
+        ),
+    )
+    model = VllmAgentModel(VllmConfig(), client)
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+
+    events = [event async for event in model.stream(request)]
+
+    assert events[0].kind == ModelStreamEventKind.TOOL_CALL_CANDIDATE
+    assert events[0].tool_call is not None
+    assert events[0].tool_call.name == "search"
+    assert events[0].tool_call.call_id == "call-1"
+    assert events[0].tool_call.arguments == {"q": "spakky", "limit": 2}
+    assert events[1].kind == ModelStreamEventKind.DONE
+    assert events[1].metadata == {"provider": "vllm", "finish_reason": "tool_calls"}
+
+
+async def test_stream_maps_usage_only_chunk_to_done_usage() -> None:
+    """usage-only final chunk는 DONE event usage로 보존된다."""
+    model = VllmAgentModel(
+        VllmConfig(),
+        RecordingClient(
+            {"choices": []},
+            stream_chunks=(
+                {
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 4,
+                        "completion_tokens": 1,
+                        "total_tokens": 5,
+                    },
+                },
+            ),
+        ),
+    )
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+
+    events = [event async for event in model.stream(request)]
+
+    assert events[0].kind == ModelStreamEventKind.DONE
+    assert events[0].usage is not None
+    assert events[0].usage.total_tokens == 5
+    assert events[0].metadata == {"provider": "vllm", "finish_reason": None}
+
+
+async def test_stream_tool_call_chunks_accept_omitted_index_and_function() -> None:
+    """tool_call delta가 index/function 조각을 생략해도 후속 조각으로 완성된다."""
+    model = VllmAgentModel(
+        VllmConfig(),
+        RecordingClient(
+            {"choices": []},
+            stream_chunks=(
+                {"choices": [{"delta": {"tool_calls": [{"id": "call-1"}]}}]},
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {"function": {"name": "search", "arguments": None}}
+                                ]
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ]
+                },
+            ),
+        ),
+    )
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+
+    events = [event async for event in model.stream(request)]
+
+    assert events[0].tool_call is not None
+    assert events[0].tool_call.name == "search"
+    assert events[0].tool_call.arguments == {}
+
+
+async def test_stream_tool_call_finish_without_name_expect_error_event() -> None:
+    """tool_call finish 시 name이 없으면 invalid stream chunk error가 된다."""
+    model = VllmAgentModel(
+        VllmConfig(),
+        RecordingClient(
+            {"choices": []},
+            stream_chunks=(
+                {
+                    "choices": [
+                        {
+                            "delta": {"tool_calls": [{"function": {}}]},
+                            "finish_reason": "tool_calls",
+                        }
+                    ]
+                },
+            ),
+        ),
+    )
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+
+    events = [event async for event in model.stream(request)]
+
+    assert events[0].kind == ModelStreamEventKind.ERROR
     assert events[0].error is not None
-    assert events[0].error.code == "vllm_streaming_not_implemented"
-    observed: ModelStreamEvent = events[1]
-    assert observed.kind.value == "done"
+    assert events[0].error.code == "vllm_response_error"
+
+
+async def test_stream_choice_without_delta_expect_done_only() -> None:
+    """delta 없는 terminal choice는 token 없이 DONE만 만든다."""
+    model = VllmAgentModel(
+        VllmConfig(),
+        RecordingClient(
+            {"choices": []},
+            stream_chunks=({"choices": [{"finish_reason": "stop"}]},),
+        ),
+    )
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+
+    events = [event async for event in model.stream(request)]
+
+    assert events == [
+        ModelStreamEvent(
+            kind=ModelStreamEventKind.DONE,
+            metadata={"provider": "vllm", "finish_reason": "stop"},
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "chunk,code",
+    [
+        ({"choices": "bad"}, "vllm_response_error"),
+        (
+            {"choices": [{"delta": {"refusal": "cannot comply"}}]},
+            "model_refusal",
+        ),
+        (
+            {"choices": [{"delta": {}, "finish_reason": "content_filter"}]},
+            "model_refusal",
+        ),
+        (
+            {"error": {"code": "provider_down", "message": "try later"}},
+            "provider_down",
+        ),
+    ],
+)
+async def test_stream_errors_are_typed_model_error_events(
+    chunk: Mapping[str, object],
+    code: str,
+) -> None:
+    """invalid chunk, refusal, provider error는 stream ERROR event로 표현된다."""
+    model = VllmAgentModel(
+        VllmConfig(),
+        RecordingClient({"choices": []}, stream_chunks=(chunk,)),
+    )
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+
+    events = [event async for event in model.stream(request)]
+
+    assert events[0].kind == ModelStreamEventKind.ERROR
+    assert events[0].error is not None
+    assert events[0].error.code == code
+    assert events[-1].kind == ModelStreamEventKind.DONE
+
+
+async def test_stream_timeout_is_retryable_model_error_event() -> None:
+    """streaming timeout은 retryable ModelError event로 변환된다."""
+    model = VllmAgentModel(
+        VllmConfig(),
+        RecordingClient({"choices": []}, stream_error=VllmTimeoutError()),
+    )
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+
+    events = [event async for event in model.stream(request)]
+
+    assert events[0].kind == ModelStreamEventKind.ERROR
+    assert events[0].error is not None
+    assert events[0].error.code == "vllm_timeout"
+    assert events[0].error.retryable is True
+    assert events[1].kind == ModelStreamEventKind.DONE
+
+
+async def test_stream_transport_error_is_retryable_model_error_event() -> None:
+    """streaming transport failure는 retryable ModelError event로 변환된다."""
+    model = VllmAgentModel(
+        VllmConfig(),
+        RecordingClient({"choices": []}, stream_error=VllmTransportError()),
+    )
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+
+    events = [event async for event in model.stream(request)]
+
+    assert events[0].kind == ModelStreamEventKind.ERROR
+    assert events[0].error is not None
+    assert events[0].error.code == "vllm_transport_error"
+    assert events[0].error.retryable is True
+    assert events[1].kind == ModelStreamEventKind.DONE
+
+
+async def test_stream_call_error_is_model_error_event() -> None:
+    """client stream 생성 시점의 typed error도 ModelError event로 변환된다."""
+    model = VllmAgentModel(
+        VllmConfig(),
+        RecordingClient({"choices": []}, stream_call_error=VllmTransportError()),
+    )
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+
+    events = [event async for event in model.stream(request)]
+
+    assert events[0].kind == ModelStreamEventKind.ERROR
+    assert events[0].error is not None
+    assert events[0].error.code == "vllm_transport_error"
+    assert events[1].kind == ModelStreamEventKind.DONE
+
+
+async def test_stream_disabled_emits_typed_error_without_client_call(
+    monkeypatch,
+) -> None:
+    """stream_enabled=false이면 HTTP 호출 없이 명시적 stream disabled event를 낸다."""
+    monkeypatch.setenv("SPAKKY_VLLM__STREAM_ENABLED", "false")
+    client = RecordingClient({"choices": []})
+    model = VllmAgentModel(VllmConfig(), client)
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+
+    events = [event async for event in model.stream(request)]
+
+    assert events[0].kind == ModelStreamEventKind.ERROR
+    assert events[0].error is not None
+    assert events[0].error.code == "vllm_streaming_disabled"
+    assert events[1].kind == ModelStreamEventKind.DONE
+    assert client.payload is None
+
+
+async def test_stream_cancellation_closes_underlying_stream() -> None:
+    """agent cancellation lifecycle은 async generator close로 HTTP stream cleanup에 연결된다."""
+    client = RecordingClient(
+        {"choices": []},
+        stream_chunks=(
+            {"choices": [{"delta": {"content": "hi"}, "finish_reason": None}]},
+            {"choices": [{"delta": {"content": "bye"}, "finish_reason": "stop"}]},
+        ),
+    )
+    model = VllmAgentModel(VllmConfig(), client)
+    request = ModelRequest(messages=(ModelMessage(ModelMessageRole.USER, "hello"),))
+    stream = model.stream(request)
+
+    first = await stream.__anext__()
+    await stream.aclose()
+
+    assert first.token_delta == "hi"
+    assert client.stream_closed is True

--- a/plugins/spakky-vllm/tests/unit/test_public_api.py
+++ b/plugins/spakky-vllm/tests/unit/test_public_api.py
@@ -7,8 +7,11 @@ from spakky.plugins.vllm import (
     PLUGIN_NAME,
     VllmAgentModel,
     VllmConfig,
+    VllmModelRefusalError,
     VllmResponseError,
+    VllmStreamingDisabledError,
     VllmStreamingNotImplementedError,
+    VllmTimeoutError,
     VllmTransportError,
 )
 
@@ -20,6 +23,9 @@ def test_public_api_exports_vllm_surface() -> None:
     assert IVllmChatClient is vllm_api.IVllmChatClient
     assert HttpxVllmChatClient is vllm_api.HttpxVllmChatClient
     assert VllmAgentModel is vllm_api.VllmAgentModel
+    assert VllmModelRefusalError is vllm_api.VllmModelRefusalError
     assert VllmResponseError is vllm_api.VllmResponseError
+    assert VllmStreamingDisabledError is vllm_api.VllmStreamingDisabledError
     assert VllmStreamingNotImplementedError is vllm_api.VllmStreamingNotImplementedError
+    assert VllmTimeoutError is vllm_api.VllmTimeoutError
     assert VllmTransportError is vllm_api.VllmTransportError


### PR DESCRIPTION
## Summary
- implement OpenAI-compatible vLLM SSE streaming for `IAgentModel.stream()`
- map token deltas, streamed tool-call fragments, usage, refusal, finish reasons, timeout, transport, provider, and invalid chunk failures into typed model events/errors
- document the streaming behavior and add unit coverage for cancellation-close and error paths

## Validation
- `uv run --project ../.. --group dev ruff format . && uv run --project ../.. --group dev ruff check .` (in `plugins/spakky-vllm`)
- `uv run --project ../.. --group dev pyrefly check .` (in `plugins/spakky-vllm`)
- `uv run --project ../.. --group dev pytest .` (in `plugins/spakky-vllm`, 49 passed, 100% coverage)
- `uv run --project . --group dev mkdocs build --strict`

Closes #226
