### PR TITLE
feat(agent): bind structured tool invocation payloads (#219)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -24,7 +24,7 @@
 - `IAgentModel`: vLLM 등 model backend가 구현하는 outbound port
 - `ModelRequest`, `ModelResponse`, `ModelStreamEvent`: provider-neutral model 호출/응답/stream 계약
 - `ToolCallingSpec`, `ModelToolSpec`, `ModelToolCall`: model-facing tool call 요청과 후보 결과
-- `agent_tool`, `ToolEffects`, `ToolRisk`, `ToolApprovalRequirement`, `ToolResumeMetadata`, `EvidenceCapture`: tool risk, approval, idempotency, evidence capture metadata
+- `agent_tool`, `AgentToolBoundInvocation`, `AgentToolBindingError`, `ToolEffects`, `ToolRisk`, `ToolApprovalRequirement`, `ToolResumeMetadata`, `EvidenceCapture`: tool binding, risk, approval, idempotency, evidence capture metadata
 
 ## 의존성 경계
 
@@ -101,6 +101,8 @@ class CodeAssistant:
 실행 중 inbound adapter가 user message, approval decision, cancel, resume signal을 append하면 orchestration은 safe boundary, action boundary, model stream tick 같은 poll point에서 `consume_pending_agent_signals()`를 호출합니다. 이 helper는 sleep/poll loop 없이 현재 pending queue만 읽고 append order의 eligible prefix를 consumed 처리하므로 token streaming을 불필요하게 block하지 않습니다. Repository 구현은 `list_pending()` 결과를 append/queue order로 반환해야 하며, helper는 earlier unaccepted signal을 건너뛰어 later signal을 먼저 소비하지 않습니다.
 
 `@agent_tool` descriptor는 Python 함수 signature와 type hint를 정본으로 삼아 `AgentToolSchemaHandle.input_schema` / `output_schema`에 model-facing JSON schema를 보존합니다. 입력 schema는 `self`/`cls`를 제외한 실제 호출 parameter를 object schema로 표현하며, required 여부는 Python default 유무를 따릅니다. 지원 타입은 primitive, enum, dataclass, `list[T]`, `tuple[...]`, `Mapping[str, T]`, `T | None`, `Union[...]`, `Annotated[T, ...]`입니다. `Any`, untyped parameter/return, untyped mapping, non-string mapping key, positional-only parameter, `*args`, `**kwargs`, JSON schema로 표현할 수 없는 임의 object는 definition/bootstrap 단계에서 `AgentDefinitionError`로 실패합니다.
+
+Model adapter가 decoded tool-call JSON을 받으면 tool 실행 전에 `descriptor.bind_invocation(payload)`로 Python signature binding을 수행합니다. Payload는 flat keyword object(`{"query": "agent", "limit": 5}`) 또는 structured object(`{"args": ["agent"], "kwargs": {"limit": 5}}`)를 사용할 수 있습니다. Binding은 `inspect.Signature`의 required/default/duplicate/unknown argument semantics를 따르며, 실패 시 tool callable을 실행하지 않고 `AgentToolBindingError`를 발생시킵니다.
 
 ## Delegation contract
 

--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -8,6 +8,7 @@ from spakky.agent.error import (
     AgentDefinitionError,
     AgentModelConfigurationError,
     AgentPersistenceConfigurationError,
+    AgentToolBindingError,
 )
 from spakky.agent.context import (
     ContextDigest,
@@ -80,6 +81,7 @@ from spakky.agent.state import (
 )
 from spakky.agent.tooling import (
     AgentToolCatalog,
+    AgentToolBoundInvocation,
     AgentToolDefinition,
     AgentToolDescriptor,
     AgentToolIdentity,
@@ -99,6 +101,7 @@ from spakky.agent.tooling import (
     ToolRisk,
     ToolRiskAxis,
     agent_tool,
+    bind_agent_tool_invocation,
     discover_agent_tools,
 )
 from spakky.agent.types import JsonObject, JsonPrimitive, JsonValue
@@ -143,6 +146,8 @@ __all__ = [
     "AgentSignalConsumptionBatch",
     "AgentSignalKind",
     "AgentSignalPollPoint",
+    "AgentToolBindingError",
+    "AgentToolBoundInvocation",
     "AgentToolCatalog",
     "AgentToolDefinition",
     "AgentToolDescriptor",
@@ -216,6 +221,7 @@ __all__ = [
     "ToolResumeMetadata",
     "ToolRisk",
     "ToolRiskAxis",
+    "bind_agent_tool_invocation",
     "consume_pending_agent_signals",
     "agent_tool",
     "discover_agent_tools",

--- a/core/spakky-agent/src/spakky/agent/error.py
+++ b/core/spakky-agent/src/spakky/agent/error.py
@@ -17,6 +17,12 @@ class AgentDefinitionError(AbstractSpakkyAgentError):
     message = "Agent definition is invalid"
 
 
+class AgentToolBindingError(AbstractSpakkyAgentError):
+    """Raised when a model tool-call payload cannot be bound safely."""
+
+    message = "Agent tool invocation payload is invalid"
+
+
 class AgentBootstrapError(AbstractSpakkyAgentError):
     """Raised when agent bootstrap validation fails."""
 

--- a/core/spakky-agent/src/spakky/agent/tooling.py
+++ b/core/spakky-agent/src/spakky/agent/tooling.py
@@ -4,11 +4,11 @@ import typing
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import MISSING, Field, dataclass, field, is_dataclass
 from enum import Enum, StrEnum
-from inspect import Parameter, isclass, signature
+from inspect import Parameter, Signature, isclass, signature
 from types import FunctionType, NoneType, UnionType
 from typing import get_args, get_origin, get_type_hints
 
-from spakky.agent.error import AgentDefinitionError
+from spakky.agent.error import AgentDefinitionError, AgentToolBindingError
 from spakky.agent.types import JsonObject, JsonValue
 
 AGENT_TOOL_DEFINITION_KEY = "__spakky_agent_tool_definition__"
@@ -336,6 +336,18 @@ class AgentToolDescriptor:
         """Return the descriptor-local tool name."""
         return self.identity.name
 
+    def bind_invocation(self, payload: JsonObject) -> "AgentToolBoundInvocation":
+        """Bind a decoded model payload before the tool callable is invoked."""
+        return bind_agent_tool_invocation(self.callable, payload)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentToolBoundInvocation:
+    """Python-call-ready tool invocation arguments."""
+
+    args: tuple[object, ...] = ()
+    kwargs: Mapping[str, object] = field(default_factory=dict)
+
 
 @dataclass(frozen=True, slots=True)
 class AgentToolCatalog:
@@ -460,6 +472,32 @@ def get_agent_tool_definition(
     return candidate
 
 
+def bind_agent_tool_invocation(
+    function: AgentToolCallable,
+    payload: JsonObject,
+) -> AgentToolBoundInvocation:
+    """Bind a structured model payload to a tool function signature."""
+    invocation = _parse_invocation_payload(payload)
+    try:
+        function_signature = signature(function)
+    except (TypeError, ValueError) as e:
+        raise AgentToolBindingError(
+            "Agent tool callable signature cannot be inspected"
+        ) from e
+    call_signature = _drop_owner_parameter(function_signature)
+    try:
+        bound = call_signature.bind(*invocation.args, **invocation.kwargs)
+    except TypeError as e:
+        raise AgentToolBindingError(
+            "Agent tool invocation payload cannot be bound"
+        ) from e
+    bound.apply_defaults()
+    return AgentToolBoundInvocation(
+        args=tuple(bound.args),
+        kwargs=dict(bound.kwargs),
+    )
+
+
 def _build_descriptor(
     owner: type[object],
     function: FunctionType,
@@ -493,6 +531,63 @@ def _unwrap_function(member: object) -> FunctionType | None:
     if isinstance(member, FunctionType):
         return member
     return None
+
+
+@dataclass(frozen=True, slots=True)
+class _StructuredInvocationPayload:
+    args: tuple[object, ...]
+    kwargs: Mapping[str, object]
+
+
+def _parse_invocation_payload(payload: JsonObject) -> _StructuredInvocationPayload:
+    payload_dict = _copy_string_key_mapping(
+        payload,
+        "Agent tool invocation payload",
+    )
+    if "args" in payload_dict or "kwargs" in payload_dict:
+        return _parse_args_kwargs_payload(payload_dict)
+    return _StructuredInvocationPayload(args=(), kwargs=payload_dict)
+
+
+def _parse_args_kwargs_payload(
+    payload: Mapping[str, object],
+) -> _StructuredInvocationPayload:
+    extra_keys = set(payload) - {"args", "kwargs"}
+    if extra_keys:
+        raise AgentToolBindingError(
+            "Agent tool structured invocation payload cannot mix direct arguments"
+        )
+    args = _payload_args(payload.get("args", ()))
+    kwargs = _payload_kwargs(payload.get("kwargs", {}))
+    return _StructuredInvocationPayload(args=args, kwargs=kwargs)
+
+
+def _payload_args(value: object) -> tuple[object, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        raise AgentToolBindingError("Agent tool invocation args must be an array")
+    return tuple(value)
+
+
+def _payload_kwargs(value: object) -> Mapping[str, object]:
+    return _copy_string_key_mapping(value, "Agent tool invocation kwargs")
+
+
+def _copy_string_key_mapping(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        raise AgentToolBindingError(f"{label} must be an object")
+    result: dict[str, object] = {}
+    for key in value:
+        if not isinstance(key, str):
+            raise AgentToolBindingError(f"{label} keys must be strings")
+        result[key] = value[key]
+    return result
+
+
+def _drop_owner_parameter(function_signature: Signature) -> Signature:
+    parameters = tuple(function_signature.parameters.values())
+    if parameters and parameters[0].name in ("self", "cls"):
+        parameters = parameters[1:]
+    return function_signature.replace(parameters=parameters)
 
 
 def _normalize_name(value: str | None, default: str, label: str) -> str:

--- a/core/spakky-agent/tests/unit/test_public_api.py
+++ b/core/spakky-agent/tests/unit/test_public_api.py
@@ -8,6 +8,8 @@ import tests.fixtures.agent_app as agent_app
 from spakky.agent import (
     IAgentModel,
     AgentToolCatalog,
+    AgentToolBindingError,
+    AgentToolBoundInvocation,
     AgentToolDescriptor,
     AgentToolIdentity,
     AgentEvidenceCandidate,
@@ -92,6 +94,8 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
         "Token",
         "Tool",
         "agent_tool",
+        "AgentToolBindingError",
+        "AgentToolBoundInvocation",
         "AgentToolCatalog",
         "AgentToolDescriptor",
         "AgentToolIdentity",
@@ -126,6 +130,8 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
     assert Token is agent_api.Token
     assert Tool is agent_api.Tool
     assert agent_tool is agent_api.agent_tool
+    assert AgentToolBindingError is agent_api.AgentToolBindingError
+    assert AgentToolBoundInvocation is agent_api.AgentToolBoundInvocation
     assert AgentToolCatalog is agent_api.AgentToolCatalog
     assert AgentToolDescriptor is agent_api.AgentToolDescriptor
     assert AgentToolIdentity is agent_api.AgentToolIdentity

--- a/core/spakky-agent/tests/unit/test_tooling.py
+++ b/core/spakky-agent/tests/unit/test_tooling.py
@@ -12,6 +12,8 @@ from spakky.agent import (
     Agent,
     AgentDefinitionError,
     AgentToolCatalog,
+    AgentToolBindingError,
+    AgentToolBoundInvocation,
     AgentToolDescriptor,
     AgentToolIdentity,
     AgentToolSchemaHandle,
@@ -32,8 +34,14 @@ from spakky.agent import (
     ToolRiskAxis,
     agent_tool,
     discover_agent_tools,
+    JsonObject,
 )
-from spakky.agent.tooling import AGENT_TOOL_DEFINITION_KEY, get_agent_tool_definition
+from spakky.agent.tooling import (
+    AGENT_TOOL_DEFINITION_KEY,
+    AgentToolCallable,
+    bind_agent_tool_invocation,
+    get_agent_tool_definition,
+)
 
 
 class SearchMode(StrEnum):
@@ -718,6 +726,191 @@ def test_tool_catalog_expect_lookup_by_identity_and_schema_name() -> None:
     assert catalog.by_identity(descriptor.identity) is descriptor
     with pytest.raises(AgentDefinitionError):
         catalog.by_schema_name("lookup.answer: please ignore identity")
+
+
+def test_tool_binding_expect_binds_flat_keyword_payload() -> None:
+    """flat object payload는 keyword invocation으로 signature에 bind된다."""
+
+    @Agent()
+    class SearchAgent:
+        @agent_tool(schema_name="docs.search")
+        def search(self, query: str, limit: int = 5) -> str:
+            return f"{query}:{limit}"
+
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    descriptor = Agent.get(SearchAgent).tool_catalog.by_schema_name("docs.search")
+    invocation = descriptor.bind_invocation({"query": "agent"})
+
+    assert invocation == AgentToolBoundInvocation(args=("agent", 5), kwargs={})
+    assert descriptor.callable(
+        SearchAgent(), *invocation.args, **invocation.kwargs
+    ) == ("agent:5")
+
+
+def test_tool_binding_expect_binds_structured_args_and_kwargs_payload() -> None:
+    """structured payload는 positional args와 keyword args를 함께 bind한다."""
+
+    @Agent()
+    class ReplaceAgent:
+        @agent_tool(schema_name="text.replace")
+        def replace(self, text: str, old: str, new: str = "") -> str:
+            return text.replace(old, new)
+
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    descriptor = Agent.get(ReplaceAgent).tool_catalog.by_schema_name("text.replace")
+    invocation = descriptor.bind_invocation(
+        {"args": ["a-b-c", "-"], "kwargs": {"new": ":"}}
+    )
+
+    assert invocation == AgentToolBoundInvocation(args=("a-b-c", "-", ":"), kwargs={})
+    assert descriptor.callable(
+        ReplaceAgent(), *invocation.args, **invocation.kwargs
+    ) == ("a:b:c")
+
+
+def test_tool_binding_expect_preserves_vararg_signature_semantics() -> None:
+    """manual descriptor binding은 Python vararg binding 결과와 같은 호출형을 만든다."""
+
+    def collect(prefix: str, *values: str, suffix: str = "!") -> str:
+        return f"{prefix}:{','.join(values)}{suffix}"
+
+    descriptor = AgentToolDescriptor(
+        identity=AgentToolIdentity(
+            owner_module=__name__,
+            owner_qualname="ManualTools",
+            name="collect",
+        ),
+        owner=object,
+        callable=collect,
+        schema=AgentToolSchemaHandle(
+            name="manual.collect",
+            input_schema_name="manual.collect.input",
+            output_schema_name="manual.collect.output",
+        ),
+    )
+
+    invocation = descriptor.bind_invocation(
+        {"args": ["items", "a", "b"], "kwargs": {"suffix": "."}}
+    )
+
+    assert invocation == AgentToolBoundInvocation(
+        args=("items", "a", "b"),
+        kwargs={"suffix": "."},
+    )
+    assert descriptor.callable(*invocation.args, **invocation.kwargs) == "items:a,b."
+
+
+def test_tool_binding_expect_rejects_unknown_missing_and_duplicate_arguments() -> None:
+    """unknown/missing/duplicate argument는 tool 실행 전 custom error가 된다."""
+    side_effects: list[str] = []
+
+    @Agent()
+    class WriteAgent:
+        @agent_tool(schema_name="workspace.write")
+        def write(self, path: str, content: str) -> str:
+            side_effects.append(path)
+            return content
+
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    descriptor = Agent.get(WriteAgent).tool_catalog.by_schema_name("workspace.write")
+
+    with pytest.raises(AgentToolBindingError):
+        descriptor.bind_invocation({"path": "README.md", "content": "x", "mode": "w"})
+    with pytest.raises(AgentToolBindingError):
+        descriptor.bind_invocation({"path": "README.md"})
+    with pytest.raises(AgentToolBindingError):
+        descriptor.bind_invocation(
+            {"args": ["README.md"], "kwargs": {"path": "other.md", "content": "x"}}
+        )
+
+    assert side_effects == []
+
+
+def test_tool_binding_expect_rejects_malformed_structured_payload() -> None:
+    """args/kwargs envelope 자체가 JSON 호출형이 아니면 custom error로 실패한다."""
+
+    def echo(value: str) -> str:
+        return value
+
+    descriptor = AgentToolDescriptor(
+        identity=AgentToolIdentity(
+            owner_module=__name__,
+            owner_qualname="ManualTools",
+            name="echo",
+        ),
+        owner=object,
+        callable=echo,
+        schema=AgentToolSchemaHandle(
+            name="manual.echo",
+            input_schema_name="manual.echo.input",
+            output_schema_name="manual.echo.output",
+        ),
+    )
+
+    with pytest.raises(AgentToolBindingError):
+        descriptor.bind_invocation({"args": "not-array"})
+    with pytest.raises(AgentToolBindingError):
+        descriptor.bind_invocation({"args": ["x"], "unexpected": True})
+    with pytest.raises(AgentToolBindingError):
+        descriptor.bind_invocation({"kwargs": ["not-object"]})
+
+
+def test_tool_binding_expect_rejects_non_string_payload_keys() -> None:
+    """model payload object key는 문자열이어야 한다."""
+
+    def echo(value: str) -> str:
+        return value
+
+    descriptor = AgentToolDescriptor(
+        identity=AgentToolIdentity(
+            owner_module=__name__,
+            owner_qualname="ManualTools",
+            name="echo",
+        ),
+        owner=object,
+        callable=echo,
+        schema=AgentToolSchemaHandle(
+            name="manual.echo",
+            input_schema_name="manual.echo.input",
+            output_schema_name="manual.echo.output",
+        ),
+    )
+
+    with pytest.raises(AgentToolBindingError):
+        descriptor.bind_invocation(typing.cast(JsonObject, {1: "x"}))
+    with pytest.raises(AgentToolBindingError):
+        descriptor.bind_invocation(typing.cast(JsonObject, {"kwargs": {1: "x"}}))
+
+
+def test_tool_binding_expect_rejects_uninspectable_callable() -> None:
+    """callable signature를 확인할 수 없으면 custom binding error로 실패한다."""
+
+    with pytest.raises(AgentToolBindingError):
+        bind_agent_tool_invocation(typing.cast(AgentToolCallable, 42), {})
 
 
 def test_tool_catalog_expect_lookup_skips_non_matching_identity() -> None:

--- a/docs/error-hierarchy.md
+++ b/docs/error-hierarchy.md
@@ -25,6 +25,7 @@ flowchart TD
   AbstractSpakkyFrameworkError --> AbstractSpakkyTracingError
   AbstractSpakkyFrameworkError --> AbstractSpakkyOutboxError
   AbstractSpakkyFrameworkError --> AbstractSpakkySagaError
+  AbstractSpakkyFrameworkError --> AbstractSpakkyAgentError
   AbstractSpakkyFrameworkError --> AbstractSpakkyFastAPIError
   AbstractSpakkyFrameworkError --> AbstractSpakkySqlAlchemyError
   AbstractSpakkyFrameworkError --> AbstractSpakkyCeleryError
@@ -45,6 +46,12 @@ flowchart TD
   AbstractSpakkySagaError --> SagaStepTimeoutError
   AbstractSpakkySagaError --> SagaParallelMergeConflictError
   AbstractSpakkySagaError --> SagaEngineNotConnectedError
+
+  AbstractSpakkyAgentError --> AgentDefinitionError
+  AbstractSpakkyAgentError --> AgentToolBindingError
+  AbstractSpakkyAgentError --> AgentBootstrapError
+  AgentBootstrapError --> AgentPersistenceConfigurationError
+  AgentBootstrapError --> AgentModelConfigurationError
 
   AbstractSpakkyCacheError --> InvalidCacheTTLError
   AbstractSpakkyCacheError --> CacheKeyGenerationError
@@ -295,6 +302,34 @@ from spakky.tracing.error import (
 | 에러                      | 설명                               |
 | ------------------------- | ---------------------------------- |
 | `InvalidTraceparentError` | `traceparent` 헤더 형식이 유효하지 않음 |
+
+---
+
+### spakky-agent
+
+Agentic workflow contract 관련 에러입니다.
+
+```python
+from spakky.agent.error import (
+    AbstractSpakkyAgentError,
+    AgentDefinitionError,
+    AgentToolBindingError,
+    AgentBootstrapError,
+    AgentPersistenceConfigurationError,
+    AgentModelConfigurationError,
+)
+```
+
+| 에러                                    | 설명                                      | 상속                       |
+| --------------------------------------- | ----------------------------------------- | -------------------------- |
+| `AbstractSpakkyAgentError`              | agent 에러 기반 클래스                    | `AbstractSpakkyFrameworkError` |
+| `AgentDefinitionError`                  | `@Agent`/`@agent_tool` 정의 계약 오류     | `AbstractSpakkyAgentError` |
+| `AgentToolBindingError`                 | model tool-call payload를 Python signature에 bind할 수 없음 | `AbstractSpakkyAgentError` |
+| `AgentBootstrapError`                   | agent bootstrap 검증 실패                 | `AbstractSpakkyAgentError` |
+| `AgentPersistenceConfigurationError`     | durable agent persistence contribution 누락 | `AgentBootstrapError`      |
+| `AgentModelConfigurationError`          | 필요한 model adapter 등록 누락            | `AgentBootstrapError`      |
+
+`AgentToolBindingError`는 tool callable 실행 전에 발생하므로, schema에 없는 인자·필수 인자 누락·positional/keyword 중복 같은 잘못된 model payload가 side effect를 만들기 전에 차단됩니다.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `AgentToolDescriptor.bind_invocation()` and `bind_agent_tool_invocation()` for decoded model tool-call payloads
- support flat keyword payloads plus structured `{args, kwargs}` payloads with Python `inspect.Signature` binding semantics
- add `AgentToolBindingError`, public exports, package/error docs, and side-effect-prevention tests

## Acceptance Criteria
- [x] structured args payload binds to positional invocation and keyword invocation
- [x] unknown, missing required, and duplicate arguments fail with a custom binding error
- [x] binding follows Python signature default and vararg semantics
- [x] invalid model payload is rejected before the tool callable executes

## Validation
- [x] `uv run ruff format . && uv run ruff check .` in `core/spakky-agent`
- [x] `uv run pyrefly check src tests` in `core/spakky-agent` (explicit paths because worktree is under ignored `.claude/worktrees`)
- [x] `uv run pytest` in `core/spakky-agent` (109 passed, 100% coverage)
- [x] `uv run mkdocs build --strict`

Closes #219
