### PR TITLE
feat(agent): add action boundary resume contracts (#224)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -18,6 +18,7 @@
 - `AgentSignalPollPoint`, `consume_pending_agent_signals`: safe boundary나 configured poll point에서 durable signal queue를 대기 없이 소비하는 helper
 - `AgentEvidence`: tool/model/context 판단 근거를 위한 append-only artifact
 - `AgentEvidenceCandidate`: tool result와 model/tool decision을 append-only evidence 후보로 변환하는 contract
+- `AgentActionBoundaryCheckpoint`, `plan_agent_resume`: model call, tool call, approval wait 전후 checkpoint evidence와 restart/resume 결정 helper
 - `DelegationPacket`, `DelegationResult`, `IAgentDelegate`: 다른 `@Agent` component로 작업을 위임하고 parent evidence/stream에 결과를 연결하는 계약
 - `ContextPack`, `ContextManifest`, `ContextDigest`: model input context와 audit/digest evidence를 위한 typed contract
 - `IAgentStateRepository`, `IAgentSignalRepository`, `IAgentEvidenceRepository`: persistence provider가 구현하는 core port
@@ -99,6 +100,8 @@ class CodeAssistant:
 `AgentYieldKind`의 public status vocabulary는 `token`, `progress`, `tool`, `evidence`, `approval`, `final`, `error`, `cancel`입니다. 각 item의 payload는 `Token`, `Progress`, `Tool`, `Evidence`, `Approval`, `Final[T]`, `Error`, `Cancel` value object로 구분되므로 inbound adapter는 별도 stream projector 없이 generator를 직접 순회해 transport별 이벤트로 바꿀 수 있습니다.
 
 실행 중 inbound adapter가 user message, approval decision, cancel, resume signal을 append하면 orchestration은 safe boundary, action boundary, model stream tick 같은 poll point에서 `consume_pending_agent_signals()`를 호출합니다. 이 helper는 sleep/poll loop 없이 현재 pending queue만 읽고 append order의 eligible prefix를 consumed 처리하므로 token streaming을 불필요하게 block하지 않습니다. Repository 구현은 `list_pending()` 결과를 append/queue order로 반환해야 하며, helper는 earlier unaccepted signal을 건너뛰어 later signal을 먼저 소비하지 않습니다.
+
+Action-boundary recovery는 model call, tool call, approval wait 전후에 `AgentActionBoundaryCheckpoint`를 append-only `AgentEvidenceKind.ACTION_BOUNDARY` evidence로 저장하는 방식으로 표현합니다. Restart 후 scheduler나 application orchestration은 `IAgentStateRepository`가 반환한 state, `IAgentSignalRepository`의 pending signal, `IAgentEvidenceRepository`의 state evidence만으로 `plan_agent_resume()`을 호출해 다음 동작을 복원합니다. 마지막 boundary가 completed이면 `SKIP_COMPLETED`로 중복 실행을 피하고, incomplete idempotent action이면 `RETRY`를 반환합니다. Incomplete non-idempotent/unknown action 또는 unresolved approval wait는 state를 `INTERRUPTED` / `RECOVERY_REQUIRES_HITL`로 materialize해 자동 재실행하지 않습니다.
 
 `@agent_tool` descriptor는 Python 함수 signature와 type hint를 정본으로 삼아 `AgentToolSchemaHandle.input_schema` / `output_schema`에 model-facing JSON schema를 보존합니다. 입력 schema는 `self`/`cls`를 제외한 실제 호출 parameter를 object schema로 표현하며, required 여부는 Python default 유무를 따릅니다. 지원 타입은 primitive, enum, dataclass, `list[T]`, `tuple[...]`, `Mapping[str, T]`, `T | None`, `Union[...]`, `Annotated[T, ...]`입니다. `Any`, untyped parameter/return, untyped mapping, non-string mapping key, positional-only parameter, `*args`, `**kwargs`, JSON schema로 표현할 수 없는 임의 object는 definition/bootstrap 단계에서 `AgentDefinitionError`로 실패합니다.
 

--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -25,6 +25,15 @@ from spakky.agent.evidence import (
     AgentEvidenceCandidate,
     AgentEvidenceKind,
 )
+from spakky.agent.recovery import (
+    AgentActionBoundaryCheckpoint,
+    AgentActionBoundaryStage,
+    AgentActionKind,
+    AgentResumeAction,
+    AgentResumeBoundary,
+    AgentResumePlan,
+    plan_agent_resume,
+)
 from spakky.agent.delegation import (
     AgentDelegateTarget,
     DelegationBudget,
@@ -131,6 +140,9 @@ __all__ = [
     "IAgentStateRepository",
     "AbstractSpakkyAgentError",
     "Agent",
+    "AgentActionBoundaryCheckpoint",
+    "AgentActionBoundaryStage",
+    "AgentActionKind",
     "AgentBootstrapError",
     "AgentDelegateTarget",
     "AgentDefinitionError",
@@ -142,6 +154,9 @@ __all__ = [
     "AgentExecutionSpec",
     "AgentModelConfigurationError",
     "AgentPersistenceConfigurationError",
+    "AgentResumeAction",
+    "AgentResumeBoundary",
+    "AgentResumePlan",
     "AgentSignal",
     "AgentSignalConsumptionBatch",
     "AgentSignalKind",
@@ -225,4 +240,5 @@ __all__ = [
     "consume_pending_agent_signals",
     "agent_tool",
     "discover_agent_tools",
+    "plan_agent_resume",
 ]

--- a/core/spakky-agent/src/spakky/agent/evidence.py
+++ b/core/spakky-agent/src/spakky/agent/evidence.py
@@ -12,6 +12,7 @@ from spakky.agent.types import JsonObject
 class AgentEvidenceKind(StrEnum):
     """Kinds of append-only evidence captured by agent execution."""
 
+    ACTION_BOUNDARY = "action_boundary"
     MODEL = "model"
     TOOL = "tool"
     CONTEXT = "context"

--- a/core/spakky-agent/src/spakky/agent/recovery.py
+++ b/core/spakky-agent/src/spakky/agent/recovery.py
@@ -1,0 +1,357 @@
+"""Action-boundary recovery contracts for durable agent execution."""
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from enum import StrEnum
+
+from spakky.agent.error import AgentDefinitionError
+from spakky.agent.evidence import (
+    AgentEvidence,
+    AgentEvidenceCandidate,
+    AgentEvidenceKind,
+)
+from spakky.agent.state import (
+    AgentState,
+    AgentStateReason,
+    AgentStateTransition,
+    AgentStatus,
+)
+from spakky.agent.signal import AgentSignal
+from spakky.agent.tooling import Idempotency, ToolResumeAction, ToolResumeMetadata
+from spakky.agent.types import JsonObject, JsonValue
+
+
+class AgentActionKind(StrEnum):
+    """Recoverable external action classes in an agent execution."""
+
+    MODEL_CALL = "model_call"
+    TOOL_CALL = "tool_call"
+    APPROVAL_WAIT = "approval_wait"
+
+
+class AgentActionBoundaryStage(StrEnum):
+    """Checkpoint side recorded around an action boundary."""
+
+    BEFORE = "before"
+    AFTER = "after"
+
+
+class AgentResumeAction(StrEnum):
+    """Orchestration action selected from persisted checkpoint evidence."""
+
+    START = "start"
+    SKIP_COMPLETED = "skip_completed"
+    RETRY = "retry"
+    REQUIRE_HITL = "require_hitl"
+    NOT_RESUMABLE = "not_resumable"
+
+
+@dataclass(frozen=True, slots=True)
+class AgentActionBoundaryCheckpoint:
+    """Serializable checkpoint recorded before or after one external action."""
+
+    action_id: str
+    action_kind: AgentActionKind
+    stage: AgentActionBoundaryStage
+    idempotency: Idempotency = Idempotency.UNKNOWN
+    metadata: JsonObject = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Reject checkpoints that cannot be correlated after restart."""
+        if not self.action_id.strip():
+            raise AgentDefinitionError("Agent action boundary id cannot be blank")
+
+    @classmethod
+    def before_model_call(
+        cls,
+        action_id: str,
+        *,
+        idempotency: Idempotency = Idempotency.UNKNOWN,
+        metadata: JsonObject | None = None,
+    ) -> "AgentActionBoundaryCheckpoint":
+        """Create the checkpoint recorded before a model call is attempted."""
+        return cls._for_action(
+            action_id,
+            AgentActionKind.MODEL_CALL,
+            AgentActionBoundaryStage.BEFORE,
+            idempotency=idempotency,
+            metadata=metadata,
+        )
+
+    @classmethod
+    def after_model_call(
+        cls,
+        action_id: str,
+        *,
+        idempotency: Idempotency = Idempotency.UNKNOWN,
+        metadata: JsonObject | None = None,
+    ) -> "AgentActionBoundaryCheckpoint":
+        """Create the checkpoint recorded after a model call completes."""
+        return cls._for_action(
+            action_id,
+            AgentActionKind.MODEL_CALL,
+            AgentActionBoundaryStage.AFTER,
+            idempotency=idempotency,
+            metadata=metadata,
+        )
+
+    @classmethod
+    def before_tool_call(
+        cls,
+        action_id: str,
+        *,
+        idempotency: Idempotency,
+        metadata: JsonObject | None = None,
+    ) -> "AgentActionBoundaryCheckpoint":
+        """Create the checkpoint recorded before a tool call is attempted."""
+        return cls._for_action(
+            action_id,
+            AgentActionKind.TOOL_CALL,
+            AgentActionBoundaryStage.BEFORE,
+            idempotency=idempotency,
+            metadata=metadata,
+        )
+
+    @classmethod
+    def after_tool_call(
+        cls,
+        action_id: str,
+        *,
+        idempotency: Idempotency,
+        metadata: JsonObject | None = None,
+    ) -> "AgentActionBoundaryCheckpoint":
+        """Create the checkpoint recorded after a tool call completes."""
+        return cls._for_action(
+            action_id,
+            AgentActionKind.TOOL_CALL,
+            AgentActionBoundaryStage.AFTER,
+            idempotency=idempotency,
+            metadata=metadata,
+        )
+
+    @classmethod
+    def before_approval_wait(
+        cls,
+        action_id: str,
+        *,
+        metadata: JsonObject | None = None,
+    ) -> "AgentActionBoundaryCheckpoint":
+        """Create the checkpoint recorded before waiting for approval."""
+        return cls._for_action(
+            action_id,
+            AgentActionKind.APPROVAL_WAIT,
+            AgentActionBoundaryStage.BEFORE,
+            idempotency=Idempotency.NON_IDEMPOTENT,
+            metadata=metadata,
+        )
+
+    @classmethod
+    def after_approval_wait(
+        cls,
+        action_id: str,
+        *,
+        metadata: JsonObject | None = None,
+    ) -> "AgentActionBoundaryCheckpoint":
+        """Create the checkpoint recorded after an approval wait resolves."""
+        return cls._for_action(
+            action_id,
+            AgentActionKind.APPROVAL_WAIT,
+            AgentActionBoundaryStage.AFTER,
+            idempotency=Idempotency.NON_IDEMPOTENT,
+            metadata=metadata,
+        )
+
+    @classmethod
+    def _for_action(
+        cls,
+        action_id: str,
+        action_kind: AgentActionKind,
+        stage: AgentActionBoundaryStage,
+        *,
+        idempotency: Idempotency,
+        metadata: JsonObject | None,
+    ) -> "AgentActionBoundaryCheckpoint":
+        return cls(
+            action_id=action_id,
+            action_kind=action_kind,
+            stage=stage,
+            idempotency=idempotency,
+            metadata={} if metadata is None else metadata,
+        )
+
+    def to_evidence_candidate(
+        self,
+        *,
+        summary: str | None = None,
+    ) -> AgentEvidenceCandidate:
+        """Represent this checkpoint as append-only evidence."""
+        return AgentEvidenceCandidate(
+            kind=AgentEvidenceKind.ACTION_BOUNDARY,
+            payload={
+                "action_id": self.action_id,
+                "action_kind": self.action_kind.value,
+                "stage": self.stage.value,
+                "idempotency": self.idempotency.value,
+                "metadata": self.metadata,
+            },
+            summary=summary,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AgentResumeBoundary:
+    """Last action boundary reconstructed from append-only evidence."""
+
+    action_id: str
+    action_kind: AgentActionKind
+    stage: AgentActionBoundaryStage
+    idempotency: Idempotency
+    evidence_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class AgentResumePlan:
+    """Resume decision derived from persisted state and checkpoint evidence."""
+
+    state: AgentState
+    action: AgentResumeAction
+    boundary: AgentResumeBoundary | None = None
+    signals: tuple[AgentSignal, ...] = ()
+
+    @property
+    def requires_human_input(self) -> bool:
+        """Return whether automatic replay must stop at HITL recovery."""
+        return self.action is AgentResumeAction.REQUIRE_HITL
+
+    @property
+    def can_resume_automatically(self) -> bool:
+        """Return whether orchestration may continue without approval."""
+        return self.action in (
+            AgentResumeAction.START,
+            AgentResumeAction.SKIP_COMPLETED,
+            AgentResumeAction.RETRY,
+        )
+
+
+def plan_agent_resume(
+    state: AgentState,
+    evidence: Sequence[AgentEvidence],
+    signals: Sequence[AgentSignal] = (),
+) -> AgentResumePlan:
+    """Restore the next resume action using only persisted state and evidence."""
+    persisted_signals = tuple(signals)
+    if state.status in (
+        AgentStatus.COMPLETED,
+        AgentStatus.FAILED,
+        AgentStatus.CANCELLED,
+    ):
+        return AgentResumePlan(
+            state=state,
+            action=AgentResumeAction.NOT_RESUMABLE,
+            signals=persisted_signals,
+        )
+
+    boundary = _last_action_boundary(evidence)
+    if boundary is None:
+        return AgentResumePlan(
+            state=state,
+            action=AgentResumeAction.START,
+            signals=persisted_signals,
+        )
+
+    if boundary.stage is AgentActionBoundaryStage.AFTER:
+        return AgentResumePlan(
+            state=replace(state, recovery_marker=boundary.action_id),
+            action=AgentResumeAction.SKIP_COMPLETED,
+            boundary=boundary,
+            signals=persisted_signals,
+        )
+
+    if boundary.action_kind is AgentActionKind.APPROVAL_WAIT:
+        return AgentResumePlan(
+            state=_interrupt_for_human_recovery(state, boundary),
+            action=AgentResumeAction.REQUIRE_HITL,
+            boundary=boundary,
+            signals=persisted_signals,
+        )
+
+    resume_action = ToolResumeMetadata(
+        idempotency=boundary.idempotency,
+    ).action_for_incomplete_boundary()
+    if resume_action is ToolResumeAction.RETRY:
+        return AgentResumePlan(
+            state=replace(state, recovery_marker=boundary.action_id),
+            action=AgentResumeAction.RETRY,
+            boundary=boundary,
+            signals=persisted_signals,
+        )
+    return AgentResumePlan(
+        state=_interrupt_for_human_recovery(state, boundary),
+        action=AgentResumeAction.REQUIRE_HITL,
+        boundary=boundary,
+        signals=persisted_signals,
+    )
+
+
+def _last_action_boundary(
+    evidence: Sequence[AgentEvidence],
+) -> AgentResumeBoundary | None:
+    for artifact in reversed(evidence):
+        if artifact.kind is not AgentEvidenceKind.ACTION_BOUNDARY:
+            continue
+        return _boundary_from_evidence(artifact)
+    return None
+
+
+def _boundary_from_evidence(evidence: AgentEvidence) -> AgentResumeBoundary:
+    payload = evidence.payload
+    return AgentResumeBoundary(
+        action_id=_string_payload(payload, "action_id"),
+        action_kind=_action_kind_payload(payload),
+        stage=_boundary_stage_payload(payload),
+        idempotency=_idempotency_payload(payload),
+        evidence_id=evidence.id,
+    )
+
+
+def _string_payload(payload: Mapping[str, JsonValue], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise AgentDefinitionError("Agent action boundary evidence is invalid")
+    return value
+
+
+def _action_kind_payload(payload: Mapping[str, JsonValue]) -> AgentActionKind:
+    try:
+        return AgentActionKind(_string_payload(payload, "action_kind"))
+    except ValueError as e:
+        raise AgentDefinitionError("Agent action boundary evidence is invalid") from e
+
+
+def _boundary_stage_payload(
+    payload: Mapping[str, JsonValue],
+) -> AgentActionBoundaryStage:
+    try:
+        return AgentActionBoundaryStage(_string_payload(payload, "stage"))
+    except ValueError as e:
+        raise AgentDefinitionError("Agent action boundary evidence is invalid") from e
+
+
+def _idempotency_payload(payload: Mapping[str, JsonValue]) -> Idempotency:
+    try:
+        return Idempotency(_string_payload(payload, "idempotency"))
+    except ValueError as e:
+        raise AgentDefinitionError("Agent action boundary evidence is invalid") from e
+
+
+def _interrupt_for_human_recovery(
+    state: AgentState,
+    boundary: AgentResumeBoundary,
+) -> AgentState:
+    return replace(
+        state,
+        status=AgentStatus.INTERRUPTED,
+        transition=AgentStateTransition.INTERRUPTED,
+        reason=AgentStateReason.RECOVERY_REQUIRES_HITL,
+        recovery_marker=boundary.action_id,
+    )

--- a/core/spakky-agent/tests/unit/test_public_api.py
+++ b/core/spakky-agent/tests/unit/test_public_api.py
@@ -7,6 +7,9 @@ import spakky.agent as agent_api
 import tests.fixtures.agent_app as agent_app
 from spakky.agent import (
     IAgentModel,
+    AgentActionBoundaryCheckpoint,
+    AgentActionBoundaryStage,
+    AgentActionKind,
     AgentToolCatalog,
     AgentToolBindingError,
     AgentToolBoundInvocation,
@@ -21,6 +24,9 @@ from spakky.agent import (
     AgentExecutionSpec,
     AgentDelegateTarget,
     AgentPersistenceConfigurationError,
+    AgentResumeAction,
+    AgentResumeBoundary,
+    AgentResumePlan,
     AgentSignal,
     AgentSignalConsumptionBatch,
     AgentSignalKind,
@@ -58,6 +64,7 @@ from spakky.agent import (
     ToolCallingSpec,
     agent_tool,
     consume_pending_agent_signals,
+    plan_agent_resume,
 )
 from spakky.agent.main import initialize
 from spakky.agent.post_processor import AgentBootstrapValidationPostProcessor
@@ -70,6 +77,9 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
     """이슈 #213이 요구한 public import surface를 노출하는지 검증한다."""
     required_exports = {
         "Agent",
+        "AgentActionBoundaryCheckpoint",
+        "AgentActionBoundaryStage",
+        "AgentActionKind",
         "AgentDelegateTarget",
         "AgentExecutionLimits",
         "AgentExecutionSpec",
@@ -82,6 +92,9 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
         "AgentSignalPollPoint",
         "AgentEvidence",
         "AgentEvidenceCandidate",
+        "AgentResumeAction",
+        "AgentResumeBoundary",
+        "AgentResumePlan",
         "ContextPack",
         "ContextManifest",
         "ContextDigest",
@@ -100,12 +113,16 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
         "AgentToolDescriptor",
         "AgentToolIdentity",
         "consume_pending_agent_signals",
+        "plan_agent_resume",
     }
 
     exported = set(agent_api.__all__)
 
     assert required_exports <= exported
     assert Agent is agent_api.Agent
+    assert AgentActionBoundaryCheckpoint is agent_api.AgentActionBoundaryCheckpoint
+    assert AgentActionBoundaryStage is agent_api.AgentActionBoundaryStage
+    assert AgentActionKind is agent_api.AgentActionKind
     assert AgentDelegateTarget is agent_api.AgentDelegateTarget
     assert AgentExecutionLimits is agent_api.AgentExecutionLimits
     assert AgentExecutionSpec is agent_api.AgentExecutionSpec
@@ -118,6 +135,9 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
     assert AgentSignalPollPoint is agent_api.AgentSignalPollPoint
     assert AgentEvidence is agent_api.AgentEvidence
     assert AgentEvidenceCandidate is agent_api.AgentEvidenceCandidate
+    assert AgentResumeAction is agent_api.AgentResumeAction
+    assert AgentResumeBoundary is agent_api.AgentResumeBoundary
+    assert AgentResumePlan is agent_api.AgentResumePlan
     assert ContextPack is agent_api.ContextPack
     assert ContextManifest is agent_api.ContextManifest
     assert ContextDigest is agent_api.ContextDigest
@@ -136,6 +156,7 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
     assert AgentToolDescriptor is agent_api.AgentToolDescriptor
     assert AgentToolIdentity is agent_api.AgentToolIdentity
     assert consume_pending_agent_signals is agent_api.consume_pending_agent_signals
+    assert plan_agent_resume is agent_api.plan_agent_resume
 
 
 def test_public_api_expect_exports_model_contract_types() -> None:

--- a/core/spakky-agent/tests/unit/test_recovery.py
+++ b/core/spakky-agent/tests/unit/test_recovery.py
@@ -1,0 +1,311 @@
+"""Tests for action-boundary checkpoint and resume contracts."""
+
+import pytest
+
+from spakky.agent import (
+    AgentActionBoundaryCheckpoint,
+    AgentActionBoundaryStage,
+    AgentActionKind,
+    AgentDefinitionError,
+    AgentEvidence,
+    AgentEvidenceKind,
+    AgentResumeAction,
+    AgentSignal,
+    AgentSignalKind,
+    AgentState,
+    AgentStateReason,
+    AgentStateTransition,
+    AgentStatus,
+    Idempotency,
+    plan_agent_resume,
+)
+
+
+def test_action_boundary_checkpoint_expect_records_model_tool_approval_edges() -> None:
+    """model/tool/approval action 전후 checkpoint가 evidence로 직렬화된다."""
+    checkpoints = (
+        AgentActionBoundaryCheckpoint.before_model_call("model-1"),
+        AgentActionBoundaryCheckpoint.after_model_call("model-1"),
+        AgentActionBoundaryCheckpoint.before_tool_call(
+            "tool-1",
+            idempotency=Idempotency.IDEMPOTENT,
+        ),
+        AgentActionBoundaryCheckpoint.after_tool_call(
+            "tool-1",
+            idempotency=Idempotency.IDEMPOTENT,
+        ),
+        AgentActionBoundaryCheckpoint.before_approval_wait("approval-1"),
+        AgentActionBoundaryCheckpoint.after_approval_wait("approval-1"),
+    )
+
+    evidence = tuple(
+        checkpoint.to_evidence_candidate().to_evidence(
+            evidence_id=f"evidence-{index}",
+            agent_state_id="run-1",
+        )
+        for index, checkpoint in enumerate(checkpoints, start=1)
+    )
+
+    assert {item.kind for item in evidence} == {AgentEvidenceKind.ACTION_BOUNDARY}
+    assert [item.payload["action_kind"] for item in evidence] == [
+        AgentActionKind.MODEL_CALL.value,
+        AgentActionKind.MODEL_CALL.value,
+        AgentActionKind.TOOL_CALL.value,
+        AgentActionKind.TOOL_CALL.value,
+        AgentActionKind.APPROVAL_WAIT.value,
+        AgentActionKind.APPROVAL_WAIT.value,
+    ]
+    assert [item.payload["stage"] for item in evidence] == [
+        AgentActionBoundaryStage.BEFORE.value,
+        AgentActionBoundaryStage.AFTER.value,
+        AgentActionBoundaryStage.BEFORE.value,
+        AgentActionBoundaryStage.AFTER.value,
+        AgentActionBoundaryStage.BEFORE.value,
+        AgentActionBoundaryStage.AFTER.value,
+    ]
+
+
+def test_resume_plan_expect_skips_completed_action_boundary() -> None:
+    """completed action은 idempotency와 무관하게 중복 실행하지 않는다."""
+    state = AgentState(
+        id="run-1",
+        agent_type="CodeAssistant",
+        status=AgentStatus.ACTIVE,
+    )
+    evidence = (
+        _checkpoint_evidence(
+            AgentActionBoundaryCheckpoint.before_tool_call(
+                "tool-1",
+                idempotency=Idempotency.IDEMPOTENT,
+            ),
+            evidence_id="boundary-1",
+        ),
+        _checkpoint_evidence(
+            AgentActionBoundaryCheckpoint.after_tool_call(
+                "tool-1",
+                idempotency=Idempotency.IDEMPOTENT,
+            ),
+            evidence_id="boundary-2",
+        ),
+    )
+
+    plan = plan_agent_resume(state, evidence)
+
+    assert plan.action == AgentResumeAction.SKIP_COMPLETED
+    assert plan.boundary is not None
+    assert plan.boundary.action_id == "tool-1"
+    assert plan.state.recovery_marker == "tool-1"
+    assert plan.can_resume_automatically is True
+
+
+def test_resume_plan_expect_retries_incomplete_idempotent_action() -> None:
+    """idempotent incomplete action은 restart 후 자동 retry 대상으로 복원된다."""
+    state = AgentState(
+        id="run-1",
+        agent_type="CodeAssistant",
+        status=AgentStatus.INTERRUPTED,
+    )
+    evidence = (
+        _checkpoint_evidence(
+            AgentActionBoundaryCheckpoint.before_model_call(
+                "model-1",
+                idempotency=Idempotency.IDEMPOTENT,
+            ),
+            evidence_id="boundary-1",
+        ),
+    )
+
+    plan = plan_agent_resume(state, evidence)
+
+    assert plan.action == AgentResumeAction.RETRY
+    assert plan.boundary is not None
+    assert plan.boundary.action_id == "model-1"
+    assert plan.state.recovery_marker == "model-1"
+    assert plan.requires_human_input is False
+
+
+def test_resume_plan_expect_interrupts_uncertain_non_idempotent_action() -> None:
+    """non-idempotent incomplete action은 state/evidence로 HITL 필요성을 드러낸다."""
+    state = AgentState(
+        id="run-1",
+        agent_type="CodeAssistant",
+        status=AgentStatus.ACTIVE,
+    )
+    evidence = (
+        _checkpoint_evidence(
+            AgentActionBoundaryCheckpoint.before_tool_call(
+                "shell-1",
+                idempotency=Idempotency.NON_IDEMPOTENT,
+            ),
+            evidence_id="boundary-1",
+        ),
+    )
+
+    plan = plan_agent_resume(state, evidence)
+
+    assert plan.action == AgentResumeAction.REQUIRE_HITL
+    assert plan.state.status == AgentStatus.INTERRUPTED
+    assert plan.state.transition == AgentStateTransition.INTERRUPTED
+    assert plan.state.reason == AgentStateReason.RECOVERY_REQUIRES_HITL
+    assert plan.state.recovery_marker == "shell-1"
+    assert plan.requires_human_input is True
+
+
+def test_resume_plan_expect_restores_point_from_persisted_state_signal_evidence() -> (
+    None
+):
+    """restart 시 persisted state/signal/evidence만으로 approval boundary를 복원한다."""
+    state = AgentState(
+        id="run-1",
+        agent_type="CodeAssistant",
+        status=AgentStatus.ACTIVE,
+        pending_signal_count=1,
+    )
+    signal = AgentSignal(
+        id="signal-1",
+        agent_state_id="run-1",
+        kind=AgentSignalKind.APPROVAL_DECISION,
+        payload={"decision": "approve"},
+    )
+    evidence = (
+        _checkpoint_evidence(
+            AgentActionBoundaryCheckpoint.before_approval_wait("approval-1"),
+            evidence_id="boundary-1",
+        ),
+    )
+
+    plan = plan_agent_resume(state, evidence, signals=(signal,))
+
+    assert plan.action == AgentResumeAction.REQUIRE_HITL
+    assert plan.boundary is not None
+    assert plan.boundary.action_kind == AgentActionKind.APPROVAL_WAIT
+    assert plan.signals == (signal,)
+    assert plan.state.recovery_marker == "approval-1"
+
+
+def test_resume_plan_expect_terminal_state_is_not_resumable() -> None:
+    """terminal state는 action boundary evidence가 있어도 resume 후보가 아니다."""
+    state = AgentState(
+        id="run-1",
+        agent_type="CodeAssistant",
+        status=AgentStatus.COMPLETED,
+    )
+    evidence = (
+        _checkpoint_evidence(
+            AgentActionBoundaryCheckpoint.before_tool_call(
+                "tool-1",
+                idempotency=Idempotency.IDEMPOTENT,
+            ),
+            evidence_id="boundary-1",
+        ),
+    )
+
+    plan = plan_agent_resume(state, evidence)
+
+    assert plan.action == AgentResumeAction.NOT_RESUMABLE
+    assert plan.boundary is None
+
+
+def test_resume_plan_expect_starts_when_no_action_boundary_exists() -> None:
+    """action boundary evidence가 아직 없으면 처음 safe point부터 시작한다."""
+    state = AgentState(
+        id="run-1",
+        agent_type="CodeAssistant",
+        status=AgentStatus.ACTIVE,
+    )
+    evidence = (
+        AgentEvidence(
+            id="model-1",
+            agent_state_id="run-1",
+            kind=AgentEvidenceKind.MODEL,
+            payload={"decision": "inspect"},
+        ),
+    )
+
+    plan = plan_agent_resume(state, evidence)
+
+    assert plan.action == AgentResumeAction.START
+    assert plan.boundary is None
+    assert plan.can_resume_automatically is True
+
+
+def test_action_boundary_checkpoint_expect_rejects_blank_action_id() -> None:
+    """action id가 blank면 restart 후 correlation할 수 없어 거부한다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentActionBoundaryCheckpoint.before_model_call(" ")
+
+
+def test_resume_plan_expect_rejects_corrupt_boundary_evidence() -> None:
+    """boundary evidence가 action id를 잃으면 custom error로 실패한다."""
+    state = AgentState(
+        id="run-1",
+        agent_type="CodeAssistant",
+        status=AgentStatus.ACTIVE,
+    )
+    evidence = (
+        AgentEvidence(
+            id="boundary-1",
+            agent_state_id="run-1",
+            kind=AgentEvidenceKind.ACTION_BOUNDARY,
+            payload={"action_id": " "},
+        ),
+    )
+
+    with pytest.raises(AgentDefinitionError):
+        plan_agent_resume(state, evidence)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "action_id": "action-1",
+            "action_kind": "missing_kind",
+            "stage": AgentActionBoundaryStage.BEFORE.value,
+            "idempotency": Idempotency.IDEMPOTENT.value,
+        },
+        {
+            "action_id": "action-1",
+            "action_kind": AgentActionKind.TOOL_CALL.value,
+            "stage": "missing_stage",
+            "idempotency": Idempotency.IDEMPOTENT.value,
+        },
+        {
+            "action_id": "action-1",
+            "action_kind": AgentActionKind.TOOL_CALL.value,
+            "stage": AgentActionBoundaryStage.BEFORE.value,
+            "idempotency": "missing_idempotency",
+        },
+    ],
+)
+def test_resume_plan_expect_rejects_corrupt_boundary_enum_values(
+    payload: dict[str, str],
+) -> None:
+    """boundary enum payload가 손상되면 ValueError 대신 custom error를 낸다."""
+    state = AgentState(
+        id="run-1",
+        agent_type="CodeAssistant",
+        status=AgentStatus.ACTIVE,
+    )
+    evidence = (
+        AgentEvidence(
+            id="boundary-1",
+            agent_state_id="run-1",
+            kind=AgentEvidenceKind.ACTION_BOUNDARY,
+            payload=payload,
+        ),
+    )
+
+    with pytest.raises(AgentDefinitionError):
+        plan_agent_resume(state, evidence)
+
+
+def _checkpoint_evidence(
+    checkpoint: AgentActionBoundaryCheckpoint,
+    *,
+    evidence_id: str,
+) -> AgentEvidence:
+    return checkpoint.to_evidence_candidate().to_evidence(
+        evidence_id=evidence_id,
+        agent_state_id="run-1",
+    )

--- a/docs/api/core/spakky-agent.md
+++ b/docs/api/core/spakky-agent.md
@@ -32,6 +32,12 @@ Agentic Hexagonal Architecture core contracts입니다.
     options:
       show_root_heading: false
 
+## Recovery
+
+::: spakky.agent.recovery
+    options:
+      show_root_heading: false
+
 ## Yield
 
 ::: spakky.agent.yield_


### PR DESCRIPTION
## Summary
- Add action-boundary checkpoint evidence contracts for model calls, tool calls, and approval waits.
- Add `plan_agent_resume()` to derive skip/retry/HITL resume decisions from persisted state/signal/evidence.
- Document the recovery surface in the package README and API docs.

## Validation
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pyrefly check src tests --use-ignore-files=false`
- `uv run pytest`
- `uv run mkdocs build --strict`

Closes #224