### PR TITLE
feat(vllm): constrain tool structured outputs (#227)

### DIFF
--- a/plugins/spakky-vllm/README.md
+++ b/plugins/spakky-vllm/README.md
@@ -32,17 +32,30 @@ Loading the plugin registers:
 - an explicit `IAgentModel -> VllmAgentModel` binding
 
 `VllmAgentModel.complete()` sends OpenAI-compatible chat completion requests and
-maps provider responses into `ModelResponse`. `VllmAgentModel.stream()` sends the
-same request with `stream=true`, decodes server-sent event chunks, and emits
-provider-neutral `ModelStreamEvent` values:
+maps provider responses into `ModelResponse`. Structured output requests include
+both OpenAI-compatible `response_format` and vLLM `structured_outputs.json`
+constraints, then parse and validate the returned JSON before exposing
+`ModelResponse.structured_output`.
+
+Tool calling uses the `ModelToolSpec.parameters.schema` object generated from
+`@agent_tool` descriptors as the vLLM function parameter schema. Required tool
+choice is treated as constrained decoding; `auto` plus strict tool schemas fails
+with a capability error because vLLM does not guarantee schema-constrained auto
+tool arguments. Returned tool arguments are parsed and validated against the same
+schema before a `ModelToolCall` can be emitted.
+
+`VllmAgentModel.stream()` sends the same request with `stream=true`, decodes
+server-sent event chunks, and emits provider-neutral `ModelStreamEvent` values:
 
 - token deltas become `ModelStreamEventKind.TOKEN_DELTA`
 - streamed function-call fragments become `TOOL_CALL_CANDIDATE` at the
   `tool_calls` finish boundary
+- structured JSON content becomes `STRUCTURED_OUTPUT` after terminal validation
 - usage chunks are attached to the final `DONE` event when requested by
   `StreamingOptions.include_usage`
-- timeout, transport, invalid chunk, provider error, refusal, and non-success
-  finish reasons become typed `ERROR` events followed by `DONE`
+- timeout, transport, invalid chunk, invalid structured output, provider error,
+  refusal, unsupported constrained decoding mode, and non-success finish reasons
+  become typed `ERROR` events followed by `DONE`
 
 Agent implementations can forward token events as `AgentYieldKind.TOKEN` payloads
 and close the async stream when their cancellation lifecycle asks the model call

--- a/plugins/spakky-vllm/src/spakky/plugins/vllm/error.py
+++ b/plugins/spakky-vllm/src/spakky/plugins/vllm/error.py
@@ -29,6 +29,12 @@ class VllmResponseError(AbstractVllmError):
     message = "vLLM response is invalid"
 
 
+class VllmConstrainedDecodingUnsupportedError(AbstractVllmError):
+    """Raised when requested tool constraints are not enforced by vLLM."""
+
+    message = "vLLM cannot enforce requested constrained decoding mode"
+
+
 class VllmStreamingDisabledError(AbstractVllmError):
     """Raised when streaming is disabled by plugin configuration."""
 

--- a/plugins/spakky-vllm/src/spakky/plugins/vllm/model.py
+++ b/plugins/spakky-vllm/src/spakky/plugins/vllm/model.py
@@ -8,6 +8,7 @@ from typing import override
 from spakky.agent import (
     IAgentModel,
     JsonObject,
+    JsonSchemaConstraint,
     JsonValue,
     ModelError,
     ModelMessage,
@@ -19,6 +20,8 @@ from spakky.agent import (
     ModelToolCall,
     ModelToolChoice,
     ModelUsage,
+    StructuredOutputSpec,
+    ToolCallingSpec,
 )
 from spakky.core.pod.annotations.pod import Pod
 
@@ -26,6 +29,7 @@ from spakky.plugins.vllm.client import IVllmChatClient
 from spakky.plugins.vllm.config import VllmConfig
 from spakky.plugins.vllm.error import (
     AbstractVllmError,
+    VllmConstrainedDecodingUnsupportedError,
     VllmModelRefusalError,
     VllmResponseError,
     VllmStreamingDisabledError,
@@ -48,10 +52,11 @@ class _ToolCallBuffer:
     def to_tool_call(self, adapter: "VllmAgentModel") -> ModelToolCall:
         if self.name is None:
             raise VllmResponseError
+        constraint = adapter._tool_constraint_for(self.name)
         provider_arguments = "".join(self.arguments_fragments)
         return ModelToolCall(
             name=self.name,
-            arguments=adapter._to_tool_arguments(provider_arguments),
+            arguments=adapter._to_tool_arguments(provider_arguments, constraint),
             call_id=self.call_id,
             metadata={"provider_arguments": provider_arguments},
         )
@@ -63,17 +68,22 @@ class VllmAgentModel(IAgentModel):
 
     __config: VllmConfig
     __client: IVllmChatClient
+    __tool_schema_by_name: Mapping[str, JsonSchemaConstraint] | None
 
     def __init__(self, config: VllmConfig, client: IVllmChatClient) -> None:
         self.__config = config
         self.__client = client
+        self.__tool_schema_by_name = None
 
     @override
     async def complete(self, request: ModelRequest) -> ModelResponse:
         """Return a provider-neutral model response from vLLM chat completions."""
         payload = self._to_chat_completion_payload(request, stream=False)
+        self.__tool_schema_by_name = self._tool_constraints_by_name(
+            request.tool_calling
+        )
         response = await self.__client.complete(payload, self.__config)
-        return self._to_model_response(response)
+        return self._to_model_response(response, request)
 
     @override
     def stream(self, request: ModelRequest) -> AsyncGenerator[ModelStreamEvent, None]:
@@ -89,7 +99,16 @@ class VllmAgentModel(IAgentModel):
             yield self._done_event(None, None)
             return
 
-        payload = self._to_chat_completion_payload(request, stream=True)
+        try:
+            payload = self._to_chat_completion_payload(request, stream=True)
+        except AbstractVllmError as e:
+            yield self._to_error_event(e)
+            yield self._done_event(None, None)
+            return
+        self.__tool_schema_by_name = self._tool_constraints_by_name(
+            request.tool_calling
+        )
+        structured_fragments: list[str] = []
         tool_buffers: dict[int, _ToolCallBuffer] = {}
         finish_reason: str | None = None
         usage: ModelUsage | None = None
@@ -116,6 +135,8 @@ class VllmAgentModel(IAgentModel):
                     choice = self._expect_mapping(raw_choice)
                     async for event in self._stream_choice_events(
                         choice,
+                        request.structured_output,
+                        structured_fragments,
                         tool_buffers,
                     ):
                         yield event
@@ -127,6 +148,14 @@ class VllmAgentModel(IAgentModel):
                         if finish_reason == "tool_calls":
                             for event in self._tool_call_events(tool_buffers):
                                 yield event
+                        if (
+                            finish_reason == "stop"
+                            and request.structured_output is not None
+                        ):
+                            yield self._to_structured_output_event(
+                                structured_fragments,
+                                request.structured_output,
+                            )
                         terminal_error = self._finish_reason_error(finish_reason)
         except AbstractVllmError as e:
             yield self._to_error_event(e)
@@ -163,6 +192,7 @@ class VllmAgentModel(IAgentModel):
         if request.sampling.max_tokens is not None:
             payload["max_tokens"] = request.sampling.max_tokens
         if request.structured_output is not None:
+            structured_schema = request.structured_output.constraint.schema
             payload["response_format"] = {
                 "type": "json_schema",
                 "json_schema": {
@@ -170,18 +200,21 @@ class VllmAgentModel(IAgentModel):
                         request.structured_output.output_type_name
                         or "structured_output"
                     ),
-                    "schema": dict(request.structured_output.constraint.schema),
+                    "schema": structured_schema,
                     "strict": request.structured_output.constraint.strict,
                 },
             }
+            payload["structured_outputs"] = {"json": structured_schema}
         if request.tool_calling is not None:
+            self._ensure_tool_constraints_supported(request.tool_calling)
             payload["tools"] = [
                 {
                     "type": "function",
                     "function": {
                         "name": tool.name,
                         "description": tool.description or "",
-                        "parameters": dict(tool.parameters.schema),
+                        "parameters": tool.parameters.schema,
+                        "strict": tool.parameters.strict,
                     },
                 }
                 for tool in request.tool_calling.tools
@@ -204,7 +237,11 @@ class VllmAgentModel(IAgentModel):
             ModelToolChoice.REQUIRED: "required",
         }[choice]
 
-    def _to_model_response(self, response: Mapping[str, object]) -> ModelResponse:
+    def _to_model_response(
+        self,
+        response: Mapping[str, object],
+        request: ModelRequest,
+    ) -> ModelResponse:
         choices = self._expect_sequence(response.get("choices"))
         if len(choices) == 0:
             raise VllmResponseError
@@ -217,9 +254,22 @@ class VllmAgentModel(IAgentModel):
         if finish_reason == "content_filter":
             raise VllmModelRefusalError
         tool_calls = tuple(self._to_tool_calls(message.get("tool_calls")))
+        if (
+            request.tool_calling is not None
+            and request.tool_calling.choice == ModelToolChoice.NONE
+            and len(tool_calls) > 0
+        ):
+            raise VllmResponseError
         content = self._to_message_content(message.get("content"), tool_calls)
+        structured_output = None
+        if request.structured_output is not None:
+            structured_output = self._to_structured_output(
+                content,
+                request.structured_output.constraint,
+            )
         return ModelResponse(
             content=content,
+            structured_output=structured_output,
             tool_calls=tool_calls,
             usage=self._to_usage(response.get("usage")),
             metadata={"provider": "vllm", "finish_reason": finish_reason},
@@ -228,6 +278,8 @@ class VllmAgentModel(IAgentModel):
     async def _stream_choice_events(
         self,
         choice: Mapping[str, object],
+        structured_output: StructuredOutputSpec | None,
+        structured_fragments: list[str],
         tool_buffers: dict[int, _ToolCallBuffer],
     ) -> AsyncIterator[ModelStreamEvent]:
         delta_value = choice.get("delta")
@@ -236,6 +288,8 @@ class VllmAgentModel(IAgentModel):
         delta = self._expect_mapping(delta_value)
         content = self._optional_string(delta.get("content"))
         if content is not None and content != "":
+            if structured_output is not None:
+                structured_fragments.append(content)
             yield ModelStreamEvent(
                 kind=ModelStreamEventKind.TOKEN_DELTA,
                 token_delta=content,
@@ -295,6 +349,20 @@ class VllmAgentModel(IAgentModel):
         tool_buffers.clear()
         return events
 
+    def _to_structured_output_event(
+        self,
+        structured_fragments: Sequence[str],
+        structured_output: StructuredOutputSpec,
+    ) -> ModelStreamEvent:
+        return ModelStreamEvent(
+            kind=ModelStreamEventKind.STRUCTURED_OUTPUT,
+            structured_output=self._to_structured_output(
+                "".join(structured_fragments),
+                structured_output.constraint,
+            ),
+            metadata={"provider": "vllm"},
+        )
+
     def _to_provider_error(self, value: object) -> ModelError | None:
         if value is None:
             return None
@@ -351,6 +419,13 @@ class VllmAgentModel(IAgentModel):
                 retryable=False,
                 metadata={"provider": "vllm"},
             )
+        if isinstance(error, VllmConstrainedDecodingUnsupportedError):
+            return ModelError(
+                code="vllm_constrained_decoding_unsupported",
+                message=VllmConstrainedDecodingUnsupportedError.message,
+                retryable=False,
+                metadata={"provider": "vllm"},
+            )
         return ModelError(
             code="vllm_response_error",
             message=VllmResponseError.message,
@@ -391,10 +466,14 @@ class VllmAgentModel(IAgentModel):
             name = function.get("name")
             if not isinstance(name, str):
                 raise VllmResponseError
+            constraint = self._tool_constraint_for(name)
             calls.append(
                 ModelToolCall(
                     name=name,
-                    arguments=self._to_tool_arguments(function.get("arguments")),
+                    arguments=self._to_tool_arguments(
+                        function.get("arguments"),
+                        constraint,
+                    ),
                     call_id=self._optional_string(item.get("id")),
                     metadata={
                         "provider_arguments": self._optional_string(
@@ -406,15 +485,41 @@ class VllmAgentModel(IAgentModel):
             )
         return tuple(calls)
 
-    def _to_tool_arguments(self, value: object) -> JsonObject:
+    def _to_tool_arguments(
+        self,
+        value: object,
+        constraint: JsonSchemaConstraint | None = None,
+    ) -> JsonObject:
         raw_arguments = self._optional_string(value)
         if raw_arguments is None or raw_arguments == "":
-            return {}
+            arguments: JsonObject = {}
+            if constraint is not None:
+                self._validate_json_value(arguments, constraint.schema)
+            return arguments
         try:
             decoded: object = loads(raw_arguments)
         except JSONDecodeError as e:
             raise VllmResponseError from e
-        return self._to_json_object(decoded)
+        arguments = self._to_json_object(decoded)
+        if constraint is not None:
+            self._validate_json_value(arguments, constraint.schema)
+        return arguments
+
+    def _to_structured_output(
+        self,
+        value: object,
+        constraint: JsonSchemaConstraint,
+    ) -> JsonValue:
+        raw_content = self._optional_string(value)
+        if raw_content is None or raw_content == "":
+            raise VllmResponseError
+        try:
+            decoded: object = loads(raw_content)
+        except JSONDecodeError as e:
+            raise VllmResponseError from e
+        structured_output = self._to_json_value(decoded)
+        self._validate_json_value(structured_output, constraint.schema)
+        return structured_output
 
     def _to_json_object(self, value: object) -> JsonObject:
         if not isinstance(value, Mapping):
@@ -434,6 +539,170 @@ class VllmAgentModel(IAgentModel):
         if isinstance(value, Sequence):
             return tuple(self._to_json_value(item) for item in value)
         raise VllmResponseError
+
+    def _tool_constraints_by_name(
+        self,
+        tool_calling: ToolCallingSpec | None,
+    ) -> Mapping[str, JsonSchemaConstraint] | None:
+        if tool_calling is None:
+            return None
+        constraints: dict[str, JsonSchemaConstraint] = {}
+        for tool in tool_calling.tools:
+            if tool.name in constraints:
+                raise VllmResponseError
+            constraints[tool.name] = tool.parameters
+        return constraints
+
+    def _tool_constraint_for(self, name: str) -> JsonSchemaConstraint | None:
+        if self.__tool_schema_by_name is None:
+            return None
+        constraint = self.__tool_schema_by_name.get(name)
+        if constraint is None:
+            raise VllmResponseError
+        return constraint
+
+    def _ensure_tool_constraints_supported(
+        self,
+        tool_calling: ToolCallingSpec,
+    ) -> None:
+        if tool_calling.choice != ModelToolChoice.AUTO:
+            return
+        for tool in tool_calling.tools:
+            if tool.parameters.strict:
+                raise VllmConstrainedDecodingUnsupportedError
+
+    def _validate_json_value(
+        self,
+        value: JsonValue,
+        schema: Mapping[str, JsonValue],
+    ) -> None:
+        alternatives = schema.get("anyOf")
+        if alternatives is not None:
+            self._validate_any_of(value, alternatives)
+            return
+        enum_values = schema.get("enum")
+        if enum_values is not None:
+            self._validate_enum(value, enum_values)
+        schema_type = self._optional_string(schema.get("type"))
+        if schema_type is None:
+            return
+        if schema_type == "object":
+            self._validate_object(value, schema)
+            return
+        if schema_type == "array":
+            self._validate_array(value, schema)
+            return
+        if schema_type == "string" and not isinstance(value, str):
+            raise VllmResponseError
+        if schema_type == "integer" and (
+            not isinstance(value, int) or isinstance(value, bool)
+        ):
+            raise VllmResponseError
+        if schema_type == "number" and (
+            not isinstance(value, int | float) or isinstance(value, bool)
+        ):
+            raise VllmResponseError
+        if schema_type == "boolean" and not isinstance(value, bool):
+            raise VllmResponseError
+        if schema_type == "null" and value is not None:
+            raise VllmResponseError
+
+    def _validate_any_of(self, value: JsonValue, alternatives: JsonValue) -> None:
+        if not isinstance(alternatives, Sequence) or isinstance(alternatives, str):
+            raise VllmResponseError
+        for alternative in alternatives:
+            if not isinstance(alternative, Mapping):
+                raise VllmResponseError
+            try:
+                self._validate_json_value(value, alternative)
+                return
+            except VllmResponseError:
+                continue
+        raise VllmResponseError
+
+    def _validate_enum(self, value: JsonValue, enum_values: JsonValue) -> None:
+        if not isinstance(enum_values, Sequence) or isinstance(enum_values, str):
+            raise VllmResponseError
+        if value not in enum_values:
+            raise VllmResponseError
+
+    def _validate_object(
+        self,
+        value: JsonValue,
+        schema: Mapping[str, JsonValue],
+    ) -> None:
+        if not isinstance(value, Mapping):
+            raise VllmResponseError
+        required = schema.get("required", ())
+        if not isinstance(required, Sequence) or isinstance(required, str):
+            raise VllmResponseError
+        for required_key in required:
+            if not isinstance(required_key, str) or required_key not in value:
+                raise VllmResponseError
+        properties = schema.get("properties", {})
+        if not isinstance(properties, Mapping):
+            raise VllmResponseError
+        additional_properties = schema.get("additionalProperties", True)
+        for key, item in value.items():
+            property_schema = properties.get(key)
+            if property_schema is None:
+                self._validate_additional_property(item, additional_properties)
+                continue
+            if not isinstance(property_schema, Mapping):
+                raise VllmResponseError
+            self._validate_json_value(item, property_schema)
+
+    def _validate_additional_property(
+        self,
+        value: JsonValue,
+        additional_properties: JsonValue,
+    ) -> None:
+        if additional_properties is False:
+            raise VllmResponseError
+        if additional_properties is True:
+            return
+        if not isinstance(additional_properties, Mapping):
+            raise VllmResponseError
+        self._validate_json_value(value, additional_properties)
+
+    def _validate_array(
+        self,
+        value: JsonValue,
+        schema: Mapping[str, JsonValue],
+    ) -> None:
+        if not isinstance(value, Sequence) or isinstance(value, str):
+            raise VllmResponseError
+        min_items = self._optional_int(schema.get("minItems"))
+        if min_items is not None and len(value) < min_items:
+            raise VllmResponseError
+        max_items = self._optional_int(schema.get("maxItems"))
+        if max_items is not None and len(value) > max_items:
+            raise VllmResponseError
+        prefix_items = schema.get("prefixItems")
+        if prefix_items is not None:
+            self._validate_prefix_items(value, prefix_items)
+            return
+        item_schema = schema.get("items")
+        if item_schema is None:
+            return
+        if not isinstance(item_schema, Mapping):
+            raise VllmResponseError
+        for item in value:
+            self._validate_json_value(item, item_schema)
+
+    def _validate_prefix_items(
+        self,
+        value: Sequence[JsonValue],
+        prefix_items: JsonValue,
+    ) -> None:
+        if not isinstance(prefix_items, Sequence) or isinstance(prefix_items, str):
+            raise VllmResponseError
+        if len(value) < len(prefix_items):
+            raise VllmResponseError
+        for index, item_schema in enumerate(prefix_items):
+            if not isinstance(item_schema, Mapping):
+                raise VllmResponseError
+            self._validate_json_value(value[index], item_schema)
 
     def _to_usage(self, value: object) -> ModelUsage:
         if value is None:

--- a/plugins/spakky-vllm/tests/unit/test_model.py
+++ b/plugins/spakky-vllm/tests/unit/test_model.py
@@ -7,6 +7,8 @@ import pytest
 from spakky.agent import (
     ContextPack,
     ContextPackRole,
+    JsonObject,
+    JsonValue,
     ModelMessage,
     ModelMessageRole,
     ModelRequest,
@@ -24,6 +26,7 @@ from spakky.plugins.vllm.client import IVllmChatClient
 from spakky.plugins.vllm.config import VllmConfig
 from spakky.plugins.vllm.error import (
     AbstractVllmError,
+    VllmConstrainedDecodingUnsupportedError,
     VllmModelRefusalError,
     VllmResponseError,
     VllmTimeoutError,
@@ -152,6 +155,22 @@ async def test_complete_assembles_context_pack_messages_into_payload() -> None:
 
 async def test_complete_maps_tool_calling_surface() -> None:
     """tool calling 요청은 OpenAI function tool payload로 변환된다."""
+    search_schema = {
+        "type": "object",
+        "properties": {
+            "q": {"type": "string"},
+            "limit": {"type": "integer"},
+            "exact": {"type": "boolean"},
+            "filters": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+            },
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "empty": {"anyOf": [{"type": "null"}, {"type": "string"}]},
+        },
+        "required": ["q"],
+        "additionalProperties": False,
+    }
     client = RecordingClient(
         {
             "choices": [
@@ -185,9 +204,7 @@ async def test_complete_maps_tool_calling_surface() -> None:
                 ModelToolSpec(
                     name="search",
                     description="Search workspace",
-                    parameters=JsonSchemaConstraint(
-                        schema={"type": "object", "properties": {}},
-                    ),
+                    parameters=JsonSchemaConstraint(schema=search_schema),
                 ),
             ),
             choice=ModelToolChoice.REQUIRED,
@@ -215,7 +232,8 @@ async def test_complete_maps_tool_calling_surface() -> None:
             "function": {
                 "name": "search",
                 "description": "Search workspace",
-                "parameters": {"type": "object", "properties": {}},
+                "parameters": search_schema,
+                "strict": True,
             },
         }
     ]
@@ -250,36 +268,48 @@ async def test_complete_accepts_tool_calls_without_text_content() -> None:
 
 async def test_complete_maps_structured_output_and_optional_tool_choice() -> None:
     """structured output과 optional tool choice가 OpenAI-compatible payload에 반영된다."""
-    client = RecordingClient({"choices": [{"message": {"content": "{}"}}]})
+    client = RecordingClient({"choices": [{"message": {"content": '{"answer":"ok"}'}}]})
     model = VllmAgentModel(VllmConfig(), client)
+    output_schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+        "additionalProperties": False,
+    }
+    tool_schema = {"type": "object"}
     request = ModelRequest(
         messages=(ModelMessage(ModelMessageRole.USER, "json"),),
         structured_output=StructuredOutputSpec(
-            constraint=JsonSchemaConstraint(schema={"type": "object"}, strict=False),
+            constraint=JsonSchemaConstraint(schema=output_schema, strict=False),
         ),
         tool_calling=ToolCallingSpec(
             tools=(
                 ModelToolSpec(
                     name="noop",
-                    parameters=JsonSchemaConstraint(schema={"type": "object"}),
+                    parameters=JsonSchemaConstraint(schema=tool_schema),
                 ),
             ),
             choice=ModelToolChoice.NONE,
         ),
     )
 
-    await model.complete(request)
+    response = await model.complete(request)
 
+    assert response.structured_output == {"answer": "ok"}
     assert client.payload is not None
     assert client.payload["response_format"] == {
         "type": "json_schema",
         "json_schema": {
             "name": "structured_output",
-            "schema": {"type": "object"},
+            "schema": output_schema,
             "strict": False,
         },
     }
+    assert client.payload["structured_outputs"] == {"json": output_schema}
     assert client.payload["tool_choice"] == "none"
+    tools = client.payload["tools"]
+    assert isinstance(tools, list)
+    assert tools[0]["function"]["parameters"] is tool_schema
 
 
 async def test_complete_maps_named_structured_output_and_auto_tool_choice() -> None:
@@ -296,7 +326,10 @@ async def test_complete_maps_named_structured_output_and_auto_tool_choice() -> N
             tools=(
                 ModelToolSpec(
                     name="noop",
-                    parameters=JsonSchemaConstraint(schema={"type": "object"}),
+                    parameters=JsonSchemaConstraint(
+                        schema={"type": "object"},
+                        strict=False,
+                    ),
                 ),
             ),
             choice=ModelToolChoice.AUTO,
@@ -310,6 +343,318 @@ async def test_complete_maps_named_structured_output_and_auto_tool_choice() -> N
     assert isinstance(response_format, dict)
     assert response_format["json_schema"]["name"] == "Answer"
     assert client.payload["tool_choice"] == "auto"
+
+
+async def test_complete_auto_strict_tool_choice_expect_capability_error() -> None:
+    """vLLM auto tool choice는 schema constrained decoding 보장을 조용히 가장하지 않는다."""
+    client = RecordingClient({"choices": [{"message": {"content": "{}"}}]})
+    model = VllmAgentModel(VllmConfig(), client)
+    request = ModelRequest(
+        messages=(ModelMessage(ModelMessageRole.USER, "call tool"),),
+        tool_calling=ToolCallingSpec(
+            tools=(
+                ModelToolSpec(
+                    name="search",
+                    parameters=JsonSchemaConstraint(
+                        schema={"type": "object"},
+                        strict=True,
+                    ),
+                ),
+            ),
+            choice=ModelToolChoice.AUTO,
+        ),
+    )
+
+    with pytest.raises(VllmConstrainedDecodingUnsupportedError):
+        await model.complete(request)
+
+
+async def test_complete_invalid_structured_output_expect_response_error() -> None:
+    """structured output 응답은 tool 실행 후보로 넘어가기 전에 parse/validation 된다."""
+    client = RecordingClient({"choices": [{"message": {"content": '{"count":"bad"}'}}]})
+    model = VllmAgentModel(VllmConfig(), client)
+    request = ModelRequest(
+        messages=(ModelMessage(ModelMessageRole.USER, "json"),),
+        structured_output=StructuredOutputSpec(
+            constraint=JsonSchemaConstraint(
+                schema={
+                    "type": "object",
+                    "properties": {"count": {"type": "integer"}},
+                    "required": ["count"],
+                    "additionalProperties": False,
+                },
+            ),
+        ),
+    )
+
+    with pytest.raises(VllmResponseError):
+        await model.complete(request)
+
+
+async def test_complete_invalid_tool_arguments_expect_response_error() -> None:
+    """tool arguments가 schema와 맞지 않으면 ModelToolCall 후보 생성 전에 실패한다."""
+    client = RecordingClient(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "function": {
+                                    "name": "search",
+                                    "arguments": '{"limit":"bad"}',
+                                }
+                            }
+                        ],
+                    }
+                }
+            ],
+        }
+    )
+    model = VllmAgentModel(VllmConfig(), client)
+    request = ModelRequest(
+        messages=(ModelMessage(ModelMessageRole.USER, "call tool"),),
+        tool_calling=ToolCallingSpec(
+            tools=(
+                ModelToolSpec(
+                    name="search",
+                    parameters=JsonSchemaConstraint(
+                        schema={
+                            "type": "object",
+                            "properties": {
+                                "q": {"type": "string"},
+                                "limit": {"type": "integer"},
+                            },
+                            "required": ["q"],
+                            "additionalProperties": False,
+                        },
+                    ),
+                ),
+            ),
+            choice=ModelToolChoice.REQUIRED,
+        ),
+    )
+
+    with pytest.raises(VllmResponseError):
+        await model.complete(request)
+
+
+async def test_complete_none_tool_choice_with_tool_call_expect_response_error() -> None:
+    """tool_choice none인데 provider가 tool call을 반환하면 명시적으로 실패한다."""
+    client = RecordingClient(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": "",
+                        "tool_calls": [
+                            {"function": {"name": "search", "arguments": "{}"}}
+                        ],
+                    }
+                }
+            ],
+        }
+    )
+    model = VllmAgentModel(VllmConfig(), client)
+    request = ModelRequest(
+        messages=(ModelMessage(ModelMessageRole.USER, "do not call"),),
+        tool_calling=ToolCallingSpec(
+            tools=(
+                ModelToolSpec(
+                    name="search",
+                    parameters=JsonSchemaConstraint(schema={"type": "object"}),
+                ),
+            ),
+            choice=ModelToolChoice.NONE,
+        ),
+    )
+
+    with pytest.raises(VllmResponseError):
+        await model.complete(request)
+
+
+async def test_complete_unknown_tool_call_name_expect_response_error() -> None:
+    """요청하지 않은 tool 이름은 실행 후보로 정규화하지 않는다."""
+    client = RecordingClient(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": "",
+                        "tool_calls": [
+                            {"function": {"name": "other", "arguments": "{}"}}
+                        ],
+                    }
+                }
+            ],
+        }
+    )
+    model = VllmAgentModel(VllmConfig(), client)
+    request = ModelRequest(
+        messages=(ModelMessage(ModelMessageRole.USER, "call tool"),),
+        tool_calling=ToolCallingSpec(
+            tools=(
+                ModelToolSpec(
+                    name="search",
+                    parameters=JsonSchemaConstraint(schema={"type": "object"}),
+                ),
+            ),
+            choice=ModelToolChoice.REQUIRED,
+        ),
+    )
+
+    with pytest.raises(VllmResponseError):
+        await model.complete(request)
+
+
+async def test_complete_empty_tool_arguments_are_validated() -> None:
+    """빈 tool arguments도 schema가 요구하는 필드가 있으면 실패한다."""
+    client = RecordingClient(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": "",
+                        "tool_calls": [
+                            {"function": {"name": "search", "arguments": ""}}
+                        ],
+                    }
+                }
+            ],
+        }
+    )
+    model = VllmAgentModel(VllmConfig(), client)
+    request = ModelRequest(
+        messages=(ModelMessage(ModelMessageRole.USER, "call tool"),),
+        tool_calling=ToolCallingSpec(
+            tools=(
+                ModelToolSpec(
+                    name="search",
+                    parameters=JsonSchemaConstraint(
+                        schema={
+                            "type": "object",
+                            "properties": {"q": {"type": "string"}},
+                            "required": ["q"],
+                        },
+                    ),
+                ),
+            ),
+            choice=ModelToolChoice.REQUIRED,
+        ),
+    )
+
+    with pytest.raises(VllmResponseError):
+        await model.complete(request)
+
+
+def test_duplicate_tool_schema_names_expect_response_error() -> None:
+    """중복 tool name은 provider response 검증 map을 만들 수 없다."""
+    model = VllmAgentModel(VllmConfig(), RecordingClient({"choices": []}))
+    tool_calling = ToolCallingSpec(
+        tools=(
+            ModelToolSpec(
+                name="search",
+                parameters=JsonSchemaConstraint(schema={"type": "object"}),
+            ),
+            ModelToolSpec(
+                name="search",
+                parameters=JsonSchemaConstraint(schema={"type": "object"}),
+            ),
+        ),
+    )
+
+    with pytest.raises(VllmResponseError):
+        model._tool_constraints_by_name(tool_calling)
+
+
+@pytest.mark.parametrize("content", ["", "not-json"])
+async def test_complete_malformed_structured_output_expect_response_error(
+    content: str,
+) -> None:
+    """structured output content가 비었거나 JSON이 아니면 실패한다."""
+    client = RecordingClient({"choices": [{"message": {"content": content}}]})
+    model = VllmAgentModel(VllmConfig(), client)
+    request = ModelRequest(
+        messages=(ModelMessage(ModelMessageRole.USER, "json"),),
+        structured_output=StructuredOutputSpec(
+            constraint=JsonSchemaConstraint(schema={"type": "object"}),
+        ),
+    )
+
+    with pytest.raises(VllmResponseError):
+        await model.complete(request)
+
+
+def test_schema_validator_accepts_core_generated_schema_shapes() -> None:
+    """로컬 schema validator는 core가 생성하는 JSON Schema subset을 수용한다."""
+    model = VllmAgentModel(VllmConfig(), RecordingClient({"choices": []}))
+
+    model._validate_json_value("a", {"enum": ["a"], "type": "string"})
+    model._validate_json_value("a", {"enum": ["a"]})
+    model._validate_json_value(
+        "a", {"anyOf": [{"type": "integer"}, {"type": "string"}]}
+    )
+    model._validate_json_value(
+        {"extra": "ok"},
+        {"type": "object", "additionalProperties": True},
+    )
+    model._validate_json_value(
+        {"extra": "ok"},
+        {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
+    )
+    model._validate_json_value(("a", 1), {"type": "array"})
+    model._validate_json_value(
+        ("a", 1),
+        {"type": "array", "prefixItems": [{"type": "string"}, {"type": "integer"}]},
+    )
+    model._validate_json_value(
+        ("a", "b"), {"type": "array", "items": {"type": "string"}}
+    )
+    model._validate_json_value(("a",), {"type": "array", "minItems": 1, "maxItems": 2})
+
+
+@pytest.mark.parametrize(
+    "value,schema",
+    [
+        ("a", {"enum": "bad"}),
+        ("a", {"enum": ["b"]}),
+        ("a", {"anyOf": "bad"}),
+        ("a", {"anyOf": ["bad"]}),
+        ("a", {"anyOf": [{"type": "integer"}]}),
+        (1, {"type": "object"}),
+        ({}, {"type": "object", "required": "bad"}),
+        ({}, {"type": "object", "required": [1]}),
+        ({"x": 1}, {"type": "object", "properties": "bad"}),
+        ({"x": 1}, {"type": "object", "properties": {"x": "bad"}}),
+        ({"x": 1}, {"type": "object", "additionalProperties": False}),
+        ({"x": 1}, {"type": "object", "additionalProperties": "bad"}),
+        ("a", {"type": "array"}),
+        ((), {"type": "array", "minItems": 1}),
+        (("a", "b"), {"type": "array", "maxItems": 1}),
+        (("a",), {"type": "array", "items": "bad"}),
+        ((), {"type": "array", "prefixItems": [{"type": "string"}]}),
+        (("a",), {"type": "array", "prefixItems": "bad"}),
+        (("a",), {"type": "array", "prefixItems": ["bad"]}),
+        (1, {"type": "string"}),
+        (True, {"type": "integer"}),
+        (True, {"type": "number"}),
+        ("true", {"type": "boolean"}),
+        ("null", {"type": "null"}),
+    ],
+)
+def test_schema_validator_rejects_invalid_shapes(
+    value: JsonValue,
+    schema: JsonObject,
+) -> None:
+    """schema subset 위반은 모두 provider response error로 표면화된다."""
+    model = VllmAgentModel(VllmConfig(), RecordingClient({"choices": []}))
+
+    with pytest.raises(VllmResponseError):
+        model._validate_json_value(value, schema)
 
 
 async def test_complete_invalid_response_expect_vllm_response_error() -> None:
@@ -460,6 +805,51 @@ async def test_stream_maps_token_deltas_usage_and_done_event() -> None:
     assert client.payload["stream_options"] == {"include_usage": True}
 
 
+async def test_stream_emits_structured_output_event_after_json_completion() -> None:
+    """streaming structured output은 token 이후 검증된 STRUCTURED_OUTPUT event를 낸다."""
+    client = RecordingClient(
+        {"choices": []},
+        stream_chunks=(
+            {"choices": [{"delta": {"content": '{"answer"'}}]},
+            {"choices": [{"delta": {"content": ':"ok"}'}, "finish_reason": "stop"}]},
+        ),
+    )
+    model = VllmAgentModel(VllmConfig(), client)
+    request = ModelRequest(
+        messages=(ModelMessage(ModelMessageRole.USER, "json"),),
+        structured_output=StructuredOutputSpec(
+            constraint=JsonSchemaConstraint(
+                schema={
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                    "additionalProperties": False,
+                },
+            ),
+        ),
+    )
+
+    events = [event async for event in model.stream(request)]
+
+    assert events[0].kind == ModelStreamEventKind.TOKEN_DELTA
+    assert events[1].kind == ModelStreamEventKind.TOKEN_DELTA
+    assert events[2] == ModelStreamEvent(
+        kind=ModelStreamEventKind.STRUCTURED_OUTPUT,
+        structured_output={"answer": "ok"},
+        metadata={"provider": "vllm"},
+    )
+    assert events[3].kind == ModelStreamEventKind.DONE
+    assert client.payload is not None
+    assert client.payload["structured_outputs"] == {
+        "json": {
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+            "additionalProperties": False,
+        }
+    }
+
+
 async def test_stream_maps_tool_call_chunks_after_tool_finish_reason() -> None:
     """streaming tool_call delta 조각은 완료 시점에 ModelToolCall 후보가 된다."""
     client = RecordingClient(
@@ -573,6 +963,30 @@ async def test_stream_tool_call_chunks_accept_omitted_index_and_function() -> No
     assert events[0].tool_call is not None
     assert events[0].tool_call.name == "search"
     assert events[0].tool_call.arguments == {}
+
+
+async def test_stream_auto_strict_tool_choice_emits_capability_error() -> None:
+    """stream()은 지원되지 않는 constrained decoding 조합을 ERROR event로 표면화한다."""
+    model = VllmAgentModel(VllmConfig(), RecordingClient({"choices": []}))
+    request = ModelRequest(
+        messages=(ModelMessage(ModelMessageRole.USER, "call tool"),),
+        tool_calling=ToolCallingSpec(
+            tools=(
+                ModelToolSpec(
+                    name="search",
+                    parameters=JsonSchemaConstraint(schema={"type": "object"}),
+                ),
+            ),
+            choice=ModelToolChoice.AUTO,
+        ),
+    )
+
+    events = [event async for event in model.stream(request)]
+
+    assert events[0].kind == ModelStreamEventKind.ERROR
+    assert events[0].error is not None
+    assert events[0].error.code == "vllm_constrained_decoding_unsupported"
+    assert events[1].kind == ModelStreamEventKind.DONE
 
 
 async def test_stream_tool_call_finish_without_name_expect_error_event() -> None:


### PR DESCRIPTION
## Summary
- map Spakky tool schemas into vLLM function parameter payloads without copying the schema object
- add vLLM structured output payload support plus response parsing/validation
- surface unsupported strict auto tool-choice as a capability error instead of silent fallback
- validate structured output and tool-call arguments before exposing model outputs

## Validation
- `uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- `uv run ruff check .`
- `uv run pyrefly check src tests --config pyproject.toml`
- `uv run pytest` (85 passed, 100% coverage)
- `uv run mkdocs build --strict`

Closes #227
