### PR TITLE
test(vllm): add local endpoint smoke path (#228)

### DIFF
--- a/docs/api/plugins/spakky-vllm.md
+++ b/docs/api/plugins/spakky-vllm.md
@@ -1,3 +1,54 @@
 # spakky-vllm
 
+`spakky-vllm` is the local, OpenAI-compatible `IAgentModel` implementation for
+ADR-0009 agent workflows. It is intentionally an outbound model adapter: core
+agent contracts stay in `spakky-agent`, while this plugin owns vLLM HTTP
+configuration, completion mapping, streaming events, and tool-call argument
+validation.
+
+## Local Smoke
+
+Use the package-local smoke path when you want to prove complete, stream, and
+tool schema behavior against a real local vLLM server without a paid SaaS key.
+The smoke tests are opt-in and skip by default, so CI does not fail when no local
+model is present.
+
+Minimum local target:
+
+- vLLM OpenAI-compatible chat server exposing `/v1/chat/completions`
+- streaming enabled on the server and in `SPAKKY_VLLM__STREAM_ENABLED`
+- tool calling support for `tool_choice="required"` with a configured tool-call
+  parser; vLLM documents required tool choice for `vllm>=0.8.3`
+- a chat/instruct model compatible with that parser, such as
+  `Qwen/Qwen2.5-7B-Instruct` with `--tool-call-parser hermes`
+
+```bash
+vllm serve Qwen/Qwen2.5-7B-Instruct \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --enable-auto-tool-choice \
+  --tool-call-parser hermes
+
+export SPAKKY_VLLM__ENDPOINT_URL=http://127.0.0.1:8000/v1
+export SPAKKY_VLLM__MODEL=Qwen/Qwen2.5-7B-Instruct
+export SPAKKY_VLLM_SMOKE=1
+
+cd plugins/spakky-vllm
+uv run pytest tests/smoke/test_local_vllm.py -q
+uv run python examples/local_smoke.py
+```
+
+Expected stream trace shape:
+
+```text
+COMPLETE ...
+TOKEN_DELTA ...
+DONE usage=...
+TOOL_CALL lookup_weather {'city': 'Seoul', 'unit': 'celsius'}
+```
+
+The exact token text is model-dependent. The stable contract is that stream
+chunks map to `ModelStreamEventKind.TOKEN_DELTA`, stream termination maps to
+`DONE`, and required tool calls become schema-validated `ModelToolCall` values.
+
 ::: spakky.plugins.vllm

--- a/plugins/spakky-vllm/README.md
+++ b/plugins/spakky-vllm/README.md
@@ -61,3 +61,66 @@ Agent implementations can forward token events as `AgentYieldKind.TOKEN` payload
 and close the async stream when their cancellation lifecycle asks the model call
 to stop. The HTTP stream is owned by the async generator, so `aclose()` releases
 the underlying client stream instead of leaving a background request running.
+
+## Local vLLM Smoke Path
+
+The package includes an opt-in smoke path for adopters who want to verify the
+adapter against a real local vLLM server without using a paid SaaS key. The
+default test suite skips this path unless `SPAKKY_VLLM_SMOKE=1` is set, and the
+smoke tests also skip when the local `/models` endpoint is unavailable.
+
+Minimum server capability:
+
+- OpenAI-compatible vLLM chat completions endpoint at `/v1/chat/completions`
+- streaming chat completion support
+- tool calling support for `tool_choice="required"`; vLLM documents this for
+  `vllm>=0.8.3` with a tool parser configured
+- a chat/instruct model whose template is compatible with the selected tool
+  parser; `Qwen/Qwen2.5-7B-Instruct` with the `hermes` parser is a practical
+  local smoke target
+
+Start the server in a separate shell:
+
+```bash
+vllm serve Qwen/Qwen2.5-7B-Instruct \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --enable-auto-tool-choice \
+  --tool-call-parser hermes
+```
+
+Run the package-local smoke tests from this package directory:
+
+```bash
+export SPAKKY_VLLM__ENDPOINT_URL=http://127.0.0.1:8000/v1
+export SPAKKY_VLLM__MODEL=Qwen/Qwen2.5-7B-Instruct
+export SPAKKY_VLLM_SMOKE=1
+
+uv run pytest tests/smoke/test_local_vllm.py -q
+```
+
+The smoke tests cover three paths:
+
+- `complete()` returns a non-empty response from the local endpoint
+- `stream()` yields at least one `TOKEN_DELTA` and a terminal `DONE` event
+- required tool calling emits a `lookup_weather` tool call whose arguments pass
+  the provided JSON schema
+
+For a visible command-line trace, run the example:
+
+```bash
+uv run python examples/local_smoke.py
+```
+
+Expected output shape:
+
+```text
+COMPLETE ...spakky-vllm-smoke...
+TOKEN_DELTA ...
+TOKEN_DELTA ...
+DONE usage=...
+TOOL_CALL lookup_weather {'city': 'Seoul', 'unit': 'celsius'}
+```
+
+Exact token boundaries and wording are model-dependent; the adapter-level
+contract is the event shape, terminal `DONE`, and schema-validated tool call.

--- a/plugins/spakky-vllm/examples/local_smoke.py
+++ b/plugins/spakky-vllm/examples/local_smoke.py
@@ -1,0 +1,100 @@
+"""Run a local vLLM complete/stream/tool smoke path from the command line."""
+
+from asyncio import run
+from collections.abc import AsyncIterator, Mapping
+
+from spakky.agent import (
+    JsonSchemaConstraint,
+    JsonValue,
+    ModelMessage,
+    ModelMessageRole,
+    ModelRequest,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolChoice,
+    ModelToolSpec,
+    SamplingOptions,
+    ToolCallingSpec,
+)
+
+from spakky.plugins.vllm.client import HttpxVllmChatClient
+from spakky.plugins.vllm.config import VllmConfig
+from spakky.plugins.vllm.model import VllmAgentModel
+
+
+def _text_request(prompt: str) -> ModelRequest:
+    return ModelRequest(
+        messages=(
+            ModelMessage(ModelMessageRole.SYSTEM, "Answer briefly."),
+            ModelMessage(ModelMessageRole.USER, prompt),
+        ),
+        sampling=SamplingOptions(temperature=0.0, max_tokens=48),
+    )
+
+
+def _tool_request() -> ModelRequest:
+    tool_schema: Mapping[str, JsonValue] = {
+        "type": "object",
+        "properties": {
+            "city": {"type": "string"},
+            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+        },
+        "required": ["city", "unit"],
+        "additionalProperties": False,
+    }
+    return ModelRequest(
+        messages=(
+            ModelMessage(
+                ModelMessageRole.SYSTEM,
+                "Use the provided tool instead of answering directly.",
+            ),
+            ModelMessage(
+                ModelMessageRole.USER,
+                "Call lookup_weather for Seoul using celsius.",
+            ),
+        ),
+        tool_calling=ToolCallingSpec(
+            tools=(
+                ModelToolSpec(
+                    name="lookup_weather",
+                    description="Look up a city's current weather.",
+                    parameters=JsonSchemaConstraint(schema=tool_schema),
+                ),
+            ),
+            choice=ModelToolChoice.REQUIRED,
+        ),
+        sampling=SamplingOptions(temperature=0.0, max_tokens=96),
+    )
+
+
+async def _stream_lines(
+    stream: AsyncIterator[ModelStreamEvent],
+) -> AsyncIterator[str]:
+    async for event in stream:
+        if event.kind == ModelStreamEventKind.TOKEN_DELTA:
+            yield f"TOKEN_DELTA {event.token_delta}"
+        elif event.kind == ModelStreamEventKind.TOOL_CALL_CANDIDATE:
+            yield f"TOOL_CALL {event.tool_call}"
+        elif event.kind == ModelStreamEventKind.ERROR:
+            yield f"ERROR {event.error}"
+        elif event.kind == ModelStreamEventKind.DONE:
+            yield f"DONE usage={event.usage}"
+
+
+async def main() -> None:
+    """Run the smoke path using SPAKKY_VLLM__* environment settings."""
+    model = VllmAgentModel(VllmConfig(), HttpxVllmChatClient())
+
+    complete_response = await model.complete(_text_request("Say spakky-vllm-smoke."))
+    print(f"COMPLETE {complete_response.content}")
+
+    async for line in _stream_lines(model.stream(_text_request("Say stream-ok."))):
+        print(line)
+
+    tool_response = await model.complete(_tool_request())
+    for tool_call in tool_response.tool_calls:
+        print(f"TOOL_CALL {tool_call.name} {tool_call.arguments}")
+
+
+if __name__ == "__main__":
+    run(main())

--- a/plugins/spakky-vllm/tests/smoke/test_local_vllm.py
+++ b/plugins/spakky-vllm/tests/smoke/test_local_vllm.py
@@ -1,0 +1,137 @@
+"""Opt-in smoke tests against a local vLLM OpenAI-compatible endpoint."""
+
+from collections.abc import Mapping
+from os import environ
+
+import httpx
+import pytest
+from spakky.agent import (
+    JsonSchemaConstraint,
+    JsonValue,
+    ModelMessage,
+    ModelMessageRole,
+    ModelRequest,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolChoice,
+    ModelToolSpec,
+    SamplingOptions,
+    ToolCallingSpec,
+)
+
+from spakky.plugins.vllm.client import HttpxVllmChatClient
+from spakky.plugins.vllm.config import VllmConfig
+from spakky.plugins.vllm.model import VllmAgentModel
+
+SMOKE_ENV = "SPAKKY_VLLM_SMOKE"
+SMOKE_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _smoke_enabled() -> bool:
+    return environ.get(SMOKE_ENV, "").casefold() in SMOKE_TRUE_VALUES
+
+
+async def _local_smoke_model() -> VllmAgentModel:
+    if not _smoke_enabled():
+        pytest.skip(f"set {SMOKE_ENV}=1 to run local vLLM smoke tests")
+
+    config = VllmConfig()
+    models_url = f"{config.endpoint_url.rstrip('/')}/models"
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as client:
+            response = await client.get(models_url)
+            response.raise_for_status()
+    except httpx.HTTPError as e:
+        pytest.skip(f"local vLLM endpoint unavailable at {models_url}: {e!s}")
+
+    return VllmAgentModel(config, HttpxVllmChatClient())
+
+
+def _text_request(prompt: str) -> ModelRequest:
+    return ModelRequest(
+        messages=(
+            ModelMessage(
+                ModelMessageRole.SYSTEM,
+                "Return a concise plain text answer for a smoke test.",
+            ),
+            ModelMessage(ModelMessageRole.USER, prompt),
+        ),
+        sampling=SamplingOptions(temperature=0.0, max_tokens=32),
+    )
+
+
+def _tool_request() -> ModelRequest:
+    tool_schema: Mapping[str, JsonValue] = {
+        "type": "object",
+        "properties": {
+            "city": {"type": "string"},
+            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+        },
+        "required": ["city", "unit"],
+        "additionalProperties": False,
+    }
+    return ModelRequest(
+        messages=(
+            ModelMessage(
+                ModelMessageRole.SYSTEM,
+                "Use the provided tool instead of answering directly.",
+            ),
+            ModelMessage(
+                ModelMessageRole.USER,
+                "Call lookup_weather for Seoul using celsius.",
+            ),
+        ),
+        tool_calling=ToolCallingSpec(
+            tools=(
+                ModelToolSpec(
+                    name="lookup_weather",
+                    description="Look up a city's current weather.",
+                    parameters=JsonSchemaConstraint(schema=tool_schema),
+                ),
+            ),
+            choice=ModelToolChoice.REQUIRED,
+        ),
+        sampling=SamplingOptions(temperature=0.0, max_tokens=96),
+    )
+
+
+async def test_local_vllm_complete_smoke_expect_text_response() -> None:
+    """local vLLM complete() returns a non-empty model response when opted in."""
+    model = await _local_smoke_model()
+
+    response = await model.complete(_text_request("Say spakky-vllm-smoke."))
+
+    assert response.content.strip() != ""
+
+
+async def test_local_vllm_stream_smoke_expect_token_delta_and_done() -> None:
+    """local vLLM stream() yields token deltas and a terminal DONE event."""
+    model = await _local_smoke_model()
+    events: list[ModelStreamEvent] = []
+
+    async for event in model.stream(_text_request("Say stream-ok.")):
+        events.append(event)
+
+    errors = tuple(event.error for event in events if event.error is not None)
+    token_text = "".join(
+        event.token_delta or ""
+        for event in events
+        if event.kind == ModelStreamEventKind.TOKEN_DELTA
+    )
+    assert errors == ()
+    assert token_text.strip() != ""
+    assert events[-1].kind == ModelStreamEventKind.DONE
+
+
+async def test_local_vllm_tool_schema_smoke_expect_tool_call() -> None:
+    """local vLLM required tool choice returns schema-validated tool arguments."""
+    model = await _local_smoke_model()
+
+    response = await model.complete(_tool_request())
+
+    matching_calls = tuple(
+        call for call in response.tool_calls if call.name == "lookup_weather"
+    )
+    assert len(matching_calls) == 1
+    assert matching_calls[0].arguments["city"] != ""
+    assert matching_calls[0].arguments["unit"] in ("celsius", "fahrenheit")


### PR DESCRIPTION
## 설명

- `plugins/spakky-vllm`에 opt-in local vLLM smoke tests를 추가했습니다.
- `examples/local_smoke.py`로 complete/stream/tool-call trace를 직접 확인할 수 있게 했습니다.
- README와 API docs에 최소 local target, `vllm serve` command, `SPAKKY_VLLM__*`/`SPAKKY_VLLM_SMOKE` env, expected stream output shape를 문서화했습니다.

## 관련 이슈

Closes #228

## 변경 유형

- [ ] 🐛 버그 수정(기존 동작을 깨지 않고 issue 수정)
- [x] ✨ 새 기능(기존 동작을 깨지 않고 기능 추가)
- [ ] 💥 호환성 파괴 변경(기존 기능이 예상대로 동작하지 않을 수 있는 수정/기능)
- [x] 📚 문서 업데이트
- [ ] 🔧 리팩터링(기능 변경 없음)
- [x] 🧪 테스트 업데이트
- [ ] 🏗️ 빌드/CI 업데이트

## 체크리스트

- [x] [기여 가이드](CONTRIBUTING.md)를 읽었습니다.
- [x] 코드가 프로젝트 coding style을 따릅니다.
- [x] 수정/기능이 동작함을 증명하는 test를 추가했습니다.
- [x] 새 test와 기존 test가 local에서 통과합니다(각 package directory에서 `uv run pytest` 실행).
- [x] linter를 실행했습니다(`uv run ruff check`).
- [x] formatter를 실행했습니다(`uv run ruff format`).
- [x] type checker를 실행했습니다(`uv run pyrefly check`).
- [x] 필요한 경우 문서를 업데이트했습니다.
- [x] commit이 [Conventional Commits](https://www.conventionalcommits.org/) format을 따릅니다.

## 스크린샷 / 예시

```bash
export SPAKKY_VLLM__ENDPOINT_URL=http://127.0.0.1:8000/v1
export SPAKKY_VLLM__MODEL=Qwen/Qwen2.5-7B-Instruct
export SPAKKY_VLLM_SMOKE=1
uv run pytest tests/smoke/test_local_vllm.py -q
uv run python examples/local_smoke.py
```

Expected stream trace shape:

```text
COMPLETE ...
TOKEN_DELTA ...
DONE usage=...
TOOL_CALL lookup_weather {'city': 'Seoul', 'unit': 'celsius'}
```

## 추가 메모

검증:

- `uv run --with ruff ruff format .`
- `uv run --with ruff ruff check .`
- `uv run --with pyrefly --with pytest pyrefly check src tests examples`
- `uv run --with pytest --with pytest-asyncio --with pytest-cov --with pytest-spec --with pytest-xdist pytest` (`85 passed, 3 skipped`, coverage 100%)
- `uv run mkdocs build --strict`
