### PR TITLE
feat(agent): add CodeAssistant building-block demo (#237)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -168,6 +168,14 @@ async def run_shell(command: str) -> dict[str, str]:
 
 `IAgentModel.stream()`은 model adapter가 token delta, tool-call candidate, structured output, error, done을 `ModelStreamEventKind`로 구분해 내보내는 계약입니다. 실제 vLLM/OpenAI-compatible HTTP 연결은 `plugins/spakky-vllm` 같은 outbound adapter가 담당하며, core package에는 production model implementation을 넣지 않습니다.
 
+## CodeAssistant demo
+
+`examples/code_assistant_demo.py`는 ADR-0009의 Claude Code-like 흐름을 프레임워크 building block 조합으로 보여주는 예제입니다. 완제품 coding app이 아니라 `@Agent CodeAssistant`가 constructor DI로 `IAgentModel`, workspace/shell/git ports, `IAgentStateRepository`, `IAgentSignalRepository`, `IAgentEvidenceRepository`를 받고, 외부 동작을 `@agent_tool`로 노출하는 방식을 검증합니다.
+
+노출되는 tool schema는 `workspace.read`, `workspace.search`, `workspace.write`, `shell.command`, `git.status`, `git.diff`, `git.apply`입니다. 읽기 도구는 approval 없이 진행하고, workspace write/shell/git apply처럼 side effect가 있는 도구는 `plan_agent_tool_approval()`로 `AgentYieldKind.APPROVAL`을 먼저 내보냅니다. 실행 중 user message, approval decision, cancel signal은 repository에서 non-blocking으로 소비되며, action-boundary checkpoint evidence는 restart/resume 판단에 사용됩니다.
+
+테스트는 scripted `IAgentModel`로 vLLM-compatible token/tool-call stream을 모사합니다. 실제 로컬 vLLM 연결은 core 예제가 아니라 `plugins/spakky-vllm`의 `VllmAgentModel`을 생성자에 주입해서 구성합니다. 운영 persistence fallback은 제공하지 않으며, durable 실행에는 SQLAlchemy contribution 같은 실제 repository provider가 필요합니다.
+
 ## Context contract
 
 Model input context는 raw 문자열을 이어 붙인 prompt snapshot이 아니라 `ContextPack` sequence로 전달합니다. 각 pack은 source, role, freshness, relevance, token budget, sensitivity metadata를 보존하고, `ContextManifest`는 pack 구성과 origin/evidence reference를 audit 단위로 남깁니다. 압축이나 요약은 원본 evidence를 대체하지 않고 `ContextDigest` derived evidence로 표현합니다.

--- a/core/spakky-agent/examples/__init__.py
+++ b/core/spakky-agent/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable examples for spakky-agent."""

--- a/core/spakky-agent/examples/code_assistant_demo.py
+++ b/core/spakky-agent/examples/code_assistant_demo.py
@@ -1,0 +1,875 @@
+"""Claude Code-like CodeAssistant demo built from spakky-agent contracts."""
+
+from collections.abc import AsyncGenerator, AsyncIterator, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from subprocess import PIPE, run
+from typing import override
+
+from spakky.agent import (
+    IAgentEvidenceRepository,
+    IAgentModel,
+    IAgentSignalRepository,
+    IAgentStateRepository,
+    Agent,
+    AgentActionBoundaryCheckpoint,
+    AgentEvidence,
+    AgentEvidenceCandidate,
+    AgentEvidenceKind,
+    AgentExecutionLimits,
+    AgentExecutionSpec,
+    AgentApprovalRequest,
+    AgentSignal,
+    AgentSignalKind,
+    AgentState,
+    AgentStateTransition,
+    AgentStatus,
+    AgentYield,
+    AgentYieldKind,
+    ApprovalDecision,
+    Cancel,
+    Evidence,
+    EvidenceCapture,
+    Final,
+    Idempotency,
+    JsonSchemaConstraint,
+    JsonValue,
+    ModelMessage,
+    ModelMessageRole,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    ModelToolChoice,
+    ModelToolSpec,
+    Progress,
+    RecoveryStrategy,
+    SamplingOptions,
+    Tool,
+    ToolApprovalRequirement,
+    ToolCallingSpec,
+    ToolEffects,
+    Token,
+    agent_tool,
+    begin_agent_cancellation,
+    complete_agent_cancellation,
+    materialize_agent_approval_decision_state,
+    parse_agent_approval_decision_signal,
+    plan_agent_resume,
+    plan_agent_tool_approval,
+    run_agent_cancellation_cleanup,
+)
+from spakky.agent.error import AgentDefinitionError
+from spakky.agent.tooling import AgentToolDescriptor
+
+
+@dataclass(frozen=True, slots=True)
+class CodeAssistantCommand:
+    """Command DTO consumed by the CodeAssistant demo agent."""
+
+    state_id: str
+    instruction: str
+    resume: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class CodeAssistantResult:
+    """Final summary returned by the demo scenario."""
+
+    state_id: str
+    status: str
+    tool_calls: tuple[str, ...]
+    evidence_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceSearchHit:
+    """One workspace search hit."""
+
+    path: str
+    line_number: int
+    line: str
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceReadResult:
+    """Result of reading a workspace file."""
+
+    path: str
+    content: str
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceSearchResult:
+    """Result of searching workspace text."""
+
+    query: str
+    hits: tuple[WorkspaceSearchHit, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceWriteResult:
+    """Result of writing a workspace file."""
+
+    path: str
+    bytes_written: int
+
+
+@dataclass(frozen=True, slots=True)
+class ShellCommandResult:
+    """Captured shell command result."""
+
+    command: str
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+@dataclass(frozen=True, slots=True)
+class GitCommandResult:
+    """Captured git command result."""
+
+    operation: str
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class CodeAssistantDemoError(Exception):
+    """Demo configuration or model-routing failure."""
+
+
+class IWorkspacePort:
+    """Workspace file-system capability injected into CodeAssistant."""
+
+    def read_text(self, path: str) -> WorkspaceReadResult:
+        """Read one text file from the workspace."""
+        raise NotImplementedError
+
+    def search_text(self, query: str, pattern: str = "*") -> WorkspaceSearchResult:
+        """Search workspace text files."""
+        raise NotImplementedError
+
+    def write_text(self, path: str, content: str) -> WorkspaceWriteResult:
+        """Write one text file in the workspace."""
+        raise NotImplementedError
+
+
+class IShellPort:
+    """Local shell command capability injected into CodeAssistant."""
+
+    def run(self, command: str) -> ShellCommandResult:
+        """Run one shell command and capture output."""
+        raise NotImplementedError
+
+
+class IGitPort:
+    """Git capability injected into CodeAssistant."""
+
+    def status(self) -> GitCommandResult:
+        """Return git status."""
+        raise NotImplementedError
+
+    def diff(self, path: str | None = None) -> GitCommandResult:
+        """Return git diff."""
+        raise NotImplementedError
+
+    def apply_patch(self, patch: str) -> GitCommandResult:
+        """Apply a git patch."""
+        raise NotImplementedError
+
+
+class LocalWorkspaceAdapter(IWorkspacePort):
+    """Path-bounded workspace adapter for the demo."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root.resolve()
+
+    @override
+    def read_text(self, path: str) -> WorkspaceReadResult:
+        target = self._resolve(path)
+        return WorkspaceReadResult(path=path, content=target.read_text())
+
+    @override
+    def search_text(self, query: str, pattern: str = "*") -> WorkspaceSearchResult:
+        hits: list[WorkspaceSearchHit] = []
+        for target in sorted(self._root.rglob(pattern)):
+            if not target.is_file():
+                continue
+            relative = target.relative_to(self._root).as_posix()
+            for index, line in enumerate(target.read_text().splitlines(), start=1):
+                if query in line:
+                    hits.append(
+                        WorkspaceSearchHit(
+                            path=relative,
+                            line_number=index,
+                            line=line,
+                        )
+                    )
+        return WorkspaceSearchResult(query=query, hits=tuple(hits))
+
+    @override
+    def write_text(self, path: str, content: str) -> WorkspaceWriteResult:
+        target = self._resolve(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+        return WorkspaceWriteResult(path=path, bytes_written=len(content.encode()))
+
+    def _resolve(self, path: str) -> Path:
+        target = (self._root / path).resolve()
+        if not target.is_relative_to(self._root):
+            raise CodeAssistantDemoError("Workspace path escapes the configured root")
+        return target
+
+
+class SubprocessShellAdapter(IShellPort):
+    """Subprocess-backed shell adapter for the demo."""
+
+    def __init__(self, cwd: Path) -> None:
+        self._cwd = cwd
+
+    @override
+    def run(self, command: str) -> ShellCommandResult:
+        completed = run(
+            command,
+            cwd=self._cwd,
+            shell=True,
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+            check=False,
+        )
+        return ShellCommandResult(
+            command=command,
+            exit_code=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+
+
+class GitCliAdapter(IGitPort):
+    """Git CLI adapter composed from the shell port."""
+
+    def __init__(self, shell: IShellPort) -> None:
+        self._shell = shell
+
+    @override
+    def status(self) -> GitCommandResult:
+        return _git_result("status", self._shell.run("git status --short"))
+
+    @override
+    def diff(self, path: str | None = None) -> GitCommandResult:
+        command = "git diff" if path is None else f"git diff -- {path}"
+        return _git_result("diff", self._shell.run(command))
+
+    @override
+    def apply_patch(self, patch: str) -> GitCommandResult:
+        quoted_patch = patch.replace("'", "'\"'\"'")
+        return _git_result(
+            "apply", self._shell.run(f"printf '%s' '{quoted_patch}' | git apply")
+        )
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="code_assistant",
+        objective="demonstrate a Claude Code-like coding agent from framework parts",
+        accepted_signals=(
+            AgentSignalKind.USER_MESSAGE,
+            AgentSignalKind.APPROVAL_DECISION,
+            AgentSignalKind.CANCEL,
+            AgentSignalKind.RESUME,
+        ),
+        recovery=RecoveryStrategy.ACTION_BOUNDARY,
+        limits=AgentExecutionLimits(timeout_seconds=600),
+        delegation_allowed=True,
+        metadata={"demo": "framework-building-block"},
+    )
+)
+class CodeAssistant:
+    """Framework building-block demo, not a packaged coding product."""
+
+    def __init__(
+        self,
+        model: IAgentModel,
+        workspace: IWorkspacePort,
+        shell: IShellPort,
+        git: IGitPort,
+        states: IAgentStateRepository,
+        signals: IAgentSignalRepository,
+        evidence: IAgentEvidenceRepository,
+    ) -> None:
+        self._model = model
+        self._workspace = workspace
+        self._shell = shell
+        self._git = git
+        self._states = states
+        self._signals = signals
+        self._evidence = evidence
+
+    async def execute(
+        self,
+        command: CodeAssistantCommand,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        """Run one model-mediated coding-assistant scenario."""
+        state = self._ensure_active_state(command)
+        if command.resume:
+            async for item in self._emit_resume_plan(state):
+                yield item
+            state = self._states.get(command.state_id)
+
+        cancel = await self._consume_cancel(state)
+        if cancel is not None:
+            yield cancel
+            return
+
+        tool_calls: list[str] = []
+        yield AgentYield(
+            kind=AgentYieldKind.PROGRESS,
+            payload=Progress("preparing model request", current_step="model"),
+        )
+        self._append_boundary(
+            state.id,
+            AgentActionBoundaryCheckpoint.before_model_call(
+                "model:code_assistant_decision",
+                idempotency=Idempotency.IDEMPOTENT,
+            ),
+        )
+        request = self._model_request(command)
+        async for event in self._model.stream(request):
+            cancel = await self._consume_cancel(state)
+            if cancel is not None:
+                yield cancel
+                return
+
+            async for signal_item in self._consume_user_messages(state):
+                yield signal_item
+
+            if event.kind is ModelStreamEventKind.TOKEN_DELTA:
+                yield AgentYield(
+                    kind=AgentYieldKind.TOKEN,
+                    payload=Token(event.token_delta or ""),
+                )
+            elif (
+                event.kind is ModelStreamEventKind.TOOL_CALL_CANDIDATE
+                and event.tool_call is not None
+            ):
+                async for tool_item in self._execute_tool_call(state, event.tool_call):
+                    yield tool_item
+                if self._states.get(state.id).status is not AgentStatus.ACTIVE:
+                    return
+                tool_calls.append(event.tool_call.name)
+            elif event.kind is ModelStreamEventKind.DONE:
+                self._append_boundary(
+                    state.id,
+                    AgentActionBoundaryCheckpoint.after_model_call(
+                        "model:code_assistant_decision",
+                        idempotency=Idempotency.IDEMPOTENT,
+                    ),
+                )
+
+        final_state = self._states.save(
+            replace(
+                self._states.get(state.id),
+                status=AgentStatus.COMPLETED,
+                transition=AgentStateTransition.COMPLETED,
+                current_activity="demo completed",
+            )
+        )
+        result = CodeAssistantResult(
+            state_id=final_state.id,
+            status=final_state.status.value,
+            tool_calls=tuple(tool_calls),
+            evidence_count=len(self._evidence.list_by_state(final_state.id)),
+        )
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(output=result, metadata={"demo": "code_assistant"}),
+        )
+
+    @agent_tool(
+        schema_name="workspace.read",
+        description="Read a text file from the bounded workspace.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def workspace_read(self, path: str) -> WorkspaceReadResult:
+        """Read a workspace file."""
+        return self._workspace.read_text(path)
+
+    @agent_tool(
+        schema_name="workspace.search",
+        description="Search text files in the bounded workspace.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def workspace_search(
+        self,
+        query: str,
+        pattern: str = "*",
+    ) -> WorkspaceSearchResult:
+        """Search the workspace."""
+        return self._workspace.search_text(query, pattern)
+
+    @agent_tool(
+        schema_name="workspace.write",
+        description="Write a text file in the bounded workspace.",
+        effects=ToolEffects.write_state(),
+        idempotency=Idempotency.CONDITIONALLY_IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+    )
+    def workspace_write(self, path: str, content: str) -> WorkspaceWriteResult:
+        """Write a workspace file after approval."""
+        return self._workspace.write_text(path, content)
+
+    @agent_tool(
+        schema_name="shell.command",
+        description="Run a local shell command.",
+        effects=ToolEffects.external_side_effect(),
+        idempotency=Idempotency.NON_IDEMPOTENT,
+        evidence=EvidenceCapture.SUMMARY,
+    )
+    def shell_command(self, command: str) -> ShellCommandResult:
+        """Run an approved shell command."""
+        return self._shell.run(command)
+
+    @agent_tool(
+        schema_name="git.status",
+        description="Read git status.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def git_status(self) -> GitCommandResult:
+        """Read git status."""
+        return self._git.status()
+
+    @agent_tool(
+        schema_name="git.diff",
+        description="Read git diff.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def git_diff(self, path: str | None = None) -> GitCommandResult:
+        """Read git diff."""
+        return self._git.diff(path)
+
+    @agent_tool(
+        schema_name="git.apply",
+        description="Apply a patch to the worktree.",
+        effects=ToolEffects.destructive_action(),
+        idempotency=Idempotency.CONDITIONALLY_IDEMPOTENT,
+        evidence=EvidenceCapture.SUMMARY,
+    )
+    def git_apply(self, patch: str) -> GitCommandResult:
+        """Apply a patch after approval."""
+        return self._git.apply_patch(patch)
+
+    def _ensure_active_state(self, command: CodeAssistantCommand) -> AgentState:
+        existing = self._states.get_or_none(command.state_id)
+        if existing is not None:
+            return self._states.save(
+                replace(
+                    existing,
+                    status=AgentStatus.ACTIVE,
+                    transition=AgentStateTransition.RUNNING,
+                    current_activity=command.instruction,
+                )
+            )
+        return self._states.save(
+            AgentState(
+                id=command.state_id,
+                agent_type="CodeAssistant",
+                status=AgentStatus.ACTIVE,
+                transition=AgentStateTransition.RUNNING,
+                current_activity=command.instruction,
+                input_ref=command.instruction,
+            )
+        )
+
+    async def _emit_resume_plan(
+        self,
+        state: AgentState,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        plan = plan_agent_resume(
+            state,
+            self._evidence.list_by_state(state.id),
+            self._signals.list_pending(state.id),
+        )
+        self._states.save(plan.state)
+        yield AgentYield(
+            kind=AgentYieldKind.PROGRESS,
+            payload=Progress(
+                f"resume action: {plan.action.value}",
+                current_step="resume",
+                metadata={
+                    "requires_human_input": plan.requires_human_input,
+                    "can_resume_automatically": plan.can_resume_automatically,
+                },
+            ),
+        )
+
+    def _model_request(self, command: CodeAssistantCommand) -> ModelRequest:
+        tools = tuple(
+            ModelToolSpec(
+                name=descriptor.schema.name,
+                description=descriptor.description,
+                parameters=JsonSchemaConstraint(schema=descriptor.schema.input_schema),
+                metadata={"tool_identity": descriptor.identity.key},
+            )
+            for descriptor in Agent.get(CodeAssistant).tool_catalog.descriptors
+        )
+        return ModelRequest(
+            messages=(
+                ModelMessage(
+                    ModelMessageRole.SYSTEM,
+                    "Use CodeAssistant tools for workspace, shell, and git actions.",
+                ),
+                ModelMessage(ModelMessageRole.USER, command.instruction),
+            ),
+            tool_calling=ToolCallingSpec(tools=tools, choice=ModelToolChoice.AUTO),
+            sampling=SamplingOptions(temperature=0.0, max_tokens=512),
+            metadata={"state_id": command.state_id, "demo": "code_assistant"},
+        )
+
+    async def _execute_tool_call(
+        self,
+        state: AgentState,
+        call: ModelToolCall,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        descriptor = Agent.get(CodeAssistant).tool_catalog.by_schema_name(call.name)
+        approval = plan_agent_tool_approval(
+            descriptor=descriptor,
+            approval_id=f"approval:{state.id}:{call.name}",
+            agent_state_id=state.id,
+            agent_type="CodeAssistant",
+            call_id=call.call_id,
+        )
+        if approval.requires_approval and approval.yield_item is not None:
+            self._append_boundary(
+                state.id,
+                AgentActionBoundaryCheckpoint.before_approval_wait(
+                    f"approval:{call.name}",
+                    metadata={"call_id": call.call_id or ""},
+                ),
+            )
+            if approval.state is not None:
+                self._states.save(approval.state)
+            yield AgentYield[object](
+                kind=approval.yield_item.kind,
+                payload=approval.yield_item.payload,
+            )
+            if not self._consume_approval(state.id, approval.request):
+                return
+            self._append_boundary(
+                state.id,
+                AgentActionBoundaryCheckpoint.after_approval_wait(
+                    f"approval:{call.name}",
+                    metadata={"call_id": call.call_id or ""},
+                ),
+            )
+
+        self._append_boundary(
+            state.id,
+            AgentActionBoundaryCheckpoint.before_tool_call(
+                f"tool:{call.name}",
+                idempotency=descriptor.metadata.idempotency,
+                metadata={"call_id": call.call_id or ""},
+            ),
+        )
+        result = self._invoke_tool(call)
+        self._append_boundary(
+            state.id,
+            AgentActionBoundaryCheckpoint.after_tool_call(
+                f"tool:{call.name}",
+                idempotency=descriptor.metadata.idempotency,
+                metadata={"call_id": call.call_id or ""},
+            ),
+        )
+        evidence = self._append_tool_evidence(state.id, descriptor, result)
+        yield AgentYield(
+            kind=AgentYieldKind.TOOL,
+            payload=Tool(
+                name=call.name,
+                call_id=call.call_id,
+                arguments=call.arguments,
+                result=result,
+                metadata={"tool_identity": descriptor.identity.key},
+            ),
+        )
+        yield AgentYield(
+            kind=AgentYieldKind.EVIDENCE,
+            payload=Evidence(evidence=evidence),
+        )
+
+    def _invoke_tool(self, call: ModelToolCall) -> JsonValue:
+        if call.name == "workspace.read":
+            return _workspace_read_result(
+                self.workspace_read(_text_arg(call, "path")),
+            )
+        if call.name == "workspace.search":
+            return _workspace_search_result(
+                self.workspace_search(
+                    _text_arg(call, "query"),
+                    _optional_text_arg(call, "pattern") or "*",
+                ),
+            )
+        if call.name == "workspace.write":
+            return _workspace_write_result(
+                self.workspace_write(
+                    _text_arg(call, "path"),
+                    _text_arg(call, "content"),
+                ),
+            )
+        if call.name == "shell.command":
+            return _shell_result(self.shell_command(_text_arg(call, "command")))
+        if call.name == "git.status":
+            return _git_json_result(self.git_status())
+        if call.name == "git.diff":
+            return _git_json_result(self.git_diff(_optional_text_arg(call, "path")))
+        if call.name == "git.apply":
+            return _git_json_result(self.git_apply(_text_arg(call, "patch")))
+        raise CodeAssistantDemoError(f"Unknown CodeAssistant tool: {call.name}")
+
+    def _append_tool_evidence(
+        self,
+        state_id: str,
+        descriptor: AgentToolDescriptor,
+        result: JsonValue,
+    ) -> AgentEvidence:
+        payload = result if isinstance(result, dict) else {"result": result}
+        candidate = AgentEvidenceCandidate.tool_result(
+            tool_identity=descriptor.identity.key,
+            tool_schema_name=descriptor.schema.name,
+            result=payload,
+            capture=descriptor.metadata.evidence,
+            summary=f"{descriptor.schema.name} completed",
+        )
+        return self._append_candidate(state_id, candidate)
+
+    def _append_boundary(
+        self,
+        state_id: str,
+        checkpoint: AgentActionBoundaryCheckpoint,
+    ) -> AgentEvidence:
+        return self._append_candidate(
+            state_id,
+            checkpoint.to_evidence_candidate(summary=checkpoint.action_id),
+        )
+
+    def _append_candidate(
+        self,
+        state_id: str,
+        candidate: AgentEvidenceCandidate,
+    ) -> AgentEvidence:
+        index = len(self._evidence.list_by_state(state_id)) + 1
+        return self._evidence.append(
+            candidate.to_evidence(
+                evidence_id=f"{state_id}:evidence:{index}",
+                agent_state_id=state_id,
+            )
+        )
+
+    async def _consume_user_messages(
+        self,
+        state: AgentState,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        for signal in self._signals.list_pending(state.id):
+            if signal.kind is not AgentSignalKind.USER_MESSAGE:
+                continue
+            self._signals.mark_consumed(signal.id)
+            self._append_candidate(
+                state.id,
+                AgentEvidenceCandidate(
+                    kind=AgentEvidenceKind.EVALUATION,
+                    payload={"signal_id": signal.id, "payload": signal.payload},
+                    summary="user signal consumed",
+                ),
+            )
+            yield AgentYield[object](
+                kind=AgentYieldKind.PROGRESS,
+                payload=Progress(
+                    "user message consumed",
+                    current_step="signal",
+                    metadata={"signal_id": signal.id},
+                ),
+            )
+
+    async def _consume_cancel(
+        self,
+        state: AgentState,
+    ) -> AgentYield[object] | None:
+        for signal in self._signals.list_pending(state.id):
+            if signal.kind is not AgentSignalKind.CANCEL:
+                continue
+            self._signals.mark_consumed(signal.id)
+            cancelling = self._states.save(begin_agent_cancellation(state, signal))
+            report = await run_agent_cancellation_cleanup(
+                state=cancelling,
+                signal=signal,
+                tasks=(),
+            )
+            self._append_candidate(
+                state.id,
+                report.to_evidence_candidate(summary="cancel cleanup completed"),
+            )
+            completed = self._states.save(
+                complete_agent_cancellation(cancelling, report)
+            )
+            return AgentYield[object](
+                kind=AgentYieldKind.CANCEL,
+                payload=Cancel(
+                    reason=completed.reason.value if completed.reason else None,
+                    requested_by=_optional_signal_text(signal, "requested_by"),
+                    metadata={"state": completed.status.value},
+                ),
+            )
+        return None
+
+    def _consume_approval(
+        self,
+        state_id: str,
+        request: AgentApprovalRequest | None,
+    ) -> bool:
+        for signal in self._signals.list_pending(state_id):
+            if signal.kind is not AgentSignalKind.APPROVAL_DECISION:
+                continue
+            if (
+                request is not None
+                and _optional_signal_text(
+                    signal,
+                    "request_id",
+                )
+                != request.id
+            ):
+                continue
+            outcome = parse_agent_approval_decision_signal(signal, request=request)
+            self._signals.mark_consumed(signal.id)
+            current = self._states.get(state_id)
+            next_state = materialize_agent_approval_decision_state(current, outcome)
+            self._states.save(next_state)
+            self._append_candidate(
+                state_id,
+                AgentEvidenceCandidate(
+                    kind=AgentEvidenceKind.APPROVAL,
+                    payload={
+                        "signal_id": signal.id,
+                        "request_id": outcome.request_id,
+                        "decision": outcome.decision.value,
+                    },
+                    summary="approval decision consumed",
+                ),
+            )
+            return outcome.decision in (
+                ApprovalDecision.APPROVE,
+                ApprovalDecision.MODIFY,
+            )
+        return False
+
+
+def _git_result(operation: str, result: ShellCommandResult) -> GitCommandResult:
+    return GitCommandResult(
+        operation=operation,
+        exit_code=result.exit_code,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+def _workspace_read_result(result: WorkspaceReadResult) -> dict[str, JsonValue]:
+    return {"path": result.path, "content": result.content}
+
+
+def _workspace_search_result(result: WorkspaceSearchResult) -> dict[str, JsonValue]:
+    return {
+        "query": result.query,
+        "hits": tuple(
+            {"path": hit.path, "line_number": hit.line_number, "line": hit.line}
+            for hit in result.hits
+        ),
+    }
+
+
+def _workspace_write_result(result: WorkspaceWriteResult) -> dict[str, JsonValue]:
+    return {"path": result.path, "bytes_written": result.bytes_written}
+
+
+def _shell_result(result: ShellCommandResult) -> dict[str, JsonValue]:
+    return {
+        "command": result.command,
+        "exit_code": result.exit_code,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def _git_json_result(result: GitCommandResult) -> dict[str, JsonValue]:
+    return {
+        "operation": result.operation,
+        "exit_code": result.exit_code,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def _text_arg(call: ModelToolCall, name: str) -> str:
+    value = call.arguments.get(name)
+    if not isinstance(value, str) or not value.strip():
+        raise AgentDefinitionError(f"Model tool argument '{name}' must be text")
+    return value
+
+
+def _optional_text_arg(call: ModelToolCall, name: str) -> str | None:
+    value = call.arguments.get(name)
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _optional_signal_text(signal: AgentSignal, name: str) -> str | None:
+    value = signal.payload.get(name)
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+async def collect_stream(
+    model: IAgentModel,
+    workspace: IWorkspacePort,
+    shell: IShellPort,
+    git: IGitPort,
+    states: IAgentStateRepository,
+    signals: IAgentSignalRepository,
+    evidence: IAgentEvidenceRepository,
+    command: CodeAssistantCommand,
+) -> tuple[AgentYield[object], ...]:
+    """Small inbound-adapter-shaped collector for docs and tests."""
+    agent = CodeAssistant(model, workspace, shell, git, states, signals, evidence)
+    items: list[AgentYield[object]] = []
+    async for item in agent.execute(command):
+        items.append(item)
+    return tuple(items)
+
+
+class StaticModel(IAgentModel):
+    """Tiny scripted model useful for the example module's smoke wiring."""
+
+    def __init__(self, events: Sequence[ModelStreamEvent]) -> None:
+        self._events = tuple(events)
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        return ModelResponse(content="static-demo")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        for event in self._events:
+            yield event

--- a/core/spakky-agent/tests/unit/test_code_assistant_demo.py
+++ b/core/spakky-agent/tests/unit/test_code_assistant_demo.py
@@ -1,0 +1,502 @@
+"""Tests for the CodeAssistant building-block demo."""
+
+from collections.abc import AsyncIterator, Sequence
+from typing import override
+
+from examples.code_assistant_demo import (
+    IGitPort,
+    IShellPort,
+    IWorkspacePort,
+    CodeAssistant,
+    CodeAssistantCommand,
+    CodeAssistantResult,
+    GitCommandResult,
+    ShellCommandResult,
+    StaticModel,
+    WorkspaceReadResult,
+    WorkspaceSearchHit,
+    WorkspaceSearchResult,
+    WorkspaceWriteResult,
+    collect_stream,
+)
+from spakky.agent import (
+    IAgentEvidenceRepository,
+    IAgentSignalRepository,
+    IAgentStateRepository,
+    Agent,
+    AgentEvidence,
+    AgentEvidenceKind,
+    AgentSignal,
+    AgentSignalKind,
+    AgentState,
+    AgentStatus,
+    AgentYield,
+    AgentYieldKind,
+    Approval,
+    ApprovalDecision,
+    Cancel,
+    Evidence,
+    Final,
+    IAgentModel,
+    JsonValue,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    Progress,
+    Token,
+    Tool,
+)
+from spakky.agent.error import AgentDefinitionError
+
+
+def test_code_assistant_demo_expect_constructor_di_agent_and_expected_tools() -> None:
+    """CodeAssistant demo가 @Agent와 @agent_tool catalog로 구성된다."""
+    agent = Agent.get(CodeAssistant)
+
+    assert agent.spec.name == "code_assistant"
+    assert agent.required_persistence_repository_types() == (
+        IAgentStateRepository,
+        IAgentSignalRepository,
+        IAgentEvidenceRepository,
+    )
+    assert set(agent.dependencies) >= {
+        "model",
+        "workspace",
+        "shell",
+        "git",
+        "states",
+        "signals",
+        "evidence",
+    }
+    assert [
+        descriptor.schema.name for descriptor in agent.tool_catalog.descriptors
+    ] == [
+        "git.apply",
+        "git.diff",
+        "git.status",
+        "shell.command",
+        "workspace.read",
+        "workspace.search",
+        "workspace.write",
+    ]
+
+
+async def test_code_assistant_demo_expect_runs_end_to_end_building_block_scenario() -> (
+    None
+):
+    """vLLM-shaped stream, tools, approval, signal, evidence를 한 scenario로 검증한다."""
+    model = RecordingModel(
+        (
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.TOKEN_DELTA,
+                token_delta="planning",
+            ),
+            _tool_call("workspace.read", {"path": "README.md"}, "read-1"),
+            _tool_call(
+                "workspace.search",
+                {"query": "agent", "pattern": "*.md"},
+                "search-1",
+            ),
+            _tool_call(
+                "workspace.write",
+                {"path": "notes.md", "content": "approved write"},
+                "write-1",
+            ),
+            _tool_call("shell.command", {"command": "printf ok"}, "shell-1"),
+            _tool_call("git.status", {}, "status-1"),
+            _tool_call("git.diff", {"path": "notes.md"}, "diff-1"),
+            _tool_call("git.apply", {"patch": "diff --git a/x b/x"}, "apply-1"),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    workspace = FakeWorkspace({"README.md": "hello agent"})
+    shell = FakeShell()
+    git = FakeGit()
+    states = FakeStateRepository()
+    signals = FakeSignalRepository(
+        (
+            _user_signal("run-1", "please keep the diff small"),
+            _approval_signal("run-1", "approval:run-1:workspace.write"),
+            _approval_signal("run-1", "approval:run-1:shell.command"),
+            _approval_signal("run-1", "approval:run-1:git.apply"),
+        )
+    )
+    evidence = FakeEvidenceRepository()
+
+    items = await collect_stream(
+        model,
+        workspace,
+        shell,
+        git,
+        states,
+        signals,
+        evidence,
+        CodeAssistantCommand(state_id="run-1", instruction="make a small edit"),
+    )
+
+    assert _kinds(items) == {
+        AgentYieldKind.APPROVAL,
+        AgentYieldKind.EVIDENCE,
+        AgentYieldKind.FINAL,
+        AgentYieldKind.PROGRESS,
+        AgentYieldKind.TOKEN,
+        AgentYieldKind.TOOL,
+    }
+    assert sum(1 for item in items if isinstance(item.payload, Approval)) == 3
+    assert sum(1 for item in items if isinstance(item.payload, Tool)) == 7
+    assert any(isinstance(item.payload, Token) for item in items)
+    assert any(isinstance(item.payload, Evidence) for item in items)
+    assert workspace.files["notes.md"] == "approved write"
+    assert shell.commands == ("printf ok",)
+    assert git.operations == ("status", "diff:notes.md", "apply")
+    assert states.get("run-1").status is AgentStatus.COMPLETED
+    assert {artifact.kind for artifact in evidence.list_by_state("run-1")} >= {
+        AgentEvidenceKind.ACTION_BOUNDARY,
+        AgentEvidenceKind.APPROVAL,
+        AgentEvidenceKind.EVALUATION,
+        AgentEvidenceKind.TOOL,
+    }
+    assert model.requests
+    assert model.requests[0].tool_calling is not None
+    assert [tool.name for tool in model.requests[0].tool_calling.tools] == [
+        "git.apply",
+        "git.diff",
+        "git.status",
+        "shell.command",
+        "workspace.read",
+        "workspace.search",
+        "workspace.write",
+    ]
+    final_payload = _final_payload(items)
+
+    assert final_payload.output == CodeAssistantResult(
+        state_id="run-1",
+        status="completed",
+        tool_calls=(
+            "workspace.read",
+            "workspace.search",
+            "workspace.write",
+            "shell.command",
+            "git.status",
+            "git.diff",
+            "git.apply",
+        ),
+        evidence_count=len(evidence.list_by_state("run-1")),
+    )
+
+
+async def test_code_assistant_demo_expect_cancellation_reaches_terminal_state() -> None:
+    """cancel signal은 CANCELLING을 거쳐 CANCELLED와 evidence로 남는다."""
+    states = FakeStateRepository()
+    evidence = FakeEvidenceRepository()
+
+    items = await collect_stream(
+        StaticModel(
+            (
+                ModelStreamEvent(
+                    kind=ModelStreamEventKind.TOKEN_DELTA,
+                    token_delta="unused",
+                ),
+            )
+        ),
+        FakeWorkspace({}),
+        FakeShell(),
+        FakeGit(),
+        states,
+        FakeSignalRepository((_cancel_signal("cancel-run"),)),
+        evidence,
+        CodeAssistantCommand(state_id="cancel-run", instruction="stop now"),
+    )
+
+    assert len(items) == 1
+    assert isinstance(items[0].payload, Cancel)
+    assert states.get("cancel-run").status is AgentStatus.CANCELLED
+    assert AgentEvidenceKind.CANCELLATION in {
+        artifact.kind for artifact in evidence.list_by_state("cancel-run")
+    }
+
+
+async def test_code_assistant_demo_expect_restart_resume_uses_persisted_boundaries() -> (
+    None
+):
+    """restart 후 persisted state/evidence만으로 resume 계획을 stream에 노출한다."""
+    states = FakeStateRepository()
+    signals = FakeSignalRepository(())
+    evidence = FakeEvidenceRepository()
+    workspace = FakeWorkspace({})
+    shell = FakeShell()
+    git = FakeGit()
+
+    await collect_stream(
+        StaticModel(
+            (
+                _tool_call("git.status", {}, "status-1"),
+                ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+            )
+        ),
+        workspace,
+        shell,
+        git,
+        states,
+        signals,
+        evidence,
+        CodeAssistantCommand(state_id="resume-run", instruction="status"),
+    )
+    items = await collect_stream(
+        StaticModel((ModelStreamEvent(kind=ModelStreamEventKind.DONE),)),
+        workspace,
+        shell,
+        git,
+        states,
+        signals,
+        evidence,
+        CodeAssistantCommand(
+            state_id="resume-run",
+            instruction="resume",
+            resume=True,
+        ),
+    )
+
+    assert any(
+        item.kind is AgentYieldKind.PROGRESS
+        and isinstance(item.payload, Progress)
+        and "skip_completed" in item.payload.message
+        for item in items
+    )
+
+
+class RecordingModel(IAgentModel):
+    """Scripted model that records the provider-neutral request."""
+
+    def __init__(self, events: Sequence[ModelStreamEvent]) -> None:
+        self._events = tuple(events)
+        self.requests: list[ModelRequest] = []
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        self.requests.append(request)
+        return ModelResponse(content="recorded")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        self.requests.append(request)
+        for event in self._events:
+            yield event
+
+
+class FakeWorkspace(IWorkspacePort):
+    """Workspace test double."""
+
+    def __init__(self, files: dict[str, str]) -> None:
+        self.files = dict(files)
+
+    @override
+    def read_text(self, path: str) -> WorkspaceReadResult:
+        return WorkspaceReadResult(path=path, content=self.files[path])
+
+    @override
+    def search_text(self, query: str, pattern: str = "*") -> WorkspaceSearchResult:
+        hits = tuple(
+            WorkspaceSearchHit(path=path, line_number=1, line=content)
+            for path, content in sorted(self.files.items())
+            if query in content and (pattern == "*" or path.endswith(pattern[1:]))
+        )
+        return WorkspaceSearchResult(query=query, hits=hits)
+
+    @override
+    def write_text(self, path: str, content: str) -> WorkspaceWriteResult:
+        self.files[path] = content
+        return WorkspaceWriteResult(path=path, bytes_written=len(content.encode()))
+
+
+class FakeShell(IShellPort):
+    """Shell test double."""
+
+    def __init__(self) -> None:
+        self.commands: tuple[str, ...] = ()
+
+    @override
+    def run(self, command: str) -> ShellCommandResult:
+        self.commands = (*self.commands, command)
+        return ShellCommandResult(
+            command=command,
+            exit_code=0,
+            stdout="ok",
+            stderr="",
+        )
+
+
+class FakeGit(IGitPort):
+    """Git test double."""
+
+    def __init__(self) -> None:
+        self.operations: tuple[str, ...] = ()
+
+    @override
+    def status(self) -> GitCommandResult:
+        self.operations = (*self.operations, "status")
+        return GitCommandResult("status", 0, " M notes.md", "")
+
+    @override
+    def diff(self, path: str | None = None) -> GitCommandResult:
+        operation = "diff" if path is None else f"diff:{path}"
+        self.operations = (*self.operations, operation)
+        return GitCommandResult("diff", 0, "diff --git a/notes.md b/notes.md", "")
+
+    @override
+    def apply_patch(self, patch: str) -> GitCommandResult:
+        self.operations = (*self.operations, "apply")
+        return GitCommandResult("apply", 0, patch, "")
+
+
+class FakeStateRepository(IAgentStateRepository):
+    """State repository test double."""
+
+    def __init__(self) -> None:
+        self._states: dict[str, AgentState] = {}
+
+    @override
+    def get(self, state_id: str) -> AgentState:
+        state = self.get_or_none(state_id)
+        if state is None:
+            raise AgentDefinitionError("Missing test state")
+        return state
+
+    @override
+    def get_or_none(self, state_id: str) -> AgentState | None:
+        return self._states.get(state_id)
+
+    @override
+    def save(self, state: AgentState) -> AgentState:
+        self._states[state.id] = state
+        return state
+
+    @override
+    def list_by_status(self, status: AgentStatus) -> Sequence[AgentState]:
+        return tuple(state for state in self._states.values() if state.status is status)
+
+    @override
+    def list_resume_candidates(self) -> Sequence[AgentState]:
+        return tuple(
+            state
+            for state in self._states.values()
+            if state.status in (AgentStatus.ACTIVE, AgentStatus.INTERRUPTED)
+        )
+
+
+class FakeSignalRepository(IAgentSignalRepository):
+    """Signal repository test double."""
+
+    def __init__(self, signals: Sequence[AgentSignal]) -> None:
+        self._signals = tuple(signals)
+        self._consumed: set[str] = set()
+
+    @override
+    def append(self, signal: AgentSignal) -> AgentSignal:
+        self._signals = (*self._signals, signal)
+        return signal
+
+    @override
+    def list_pending(self, state_id: str) -> Sequence[AgentSignal]:
+        return tuple(
+            signal
+            for signal in self._signals
+            if signal.agent_state_id == state_id and signal.id not in self._consumed
+        )
+
+    @override
+    def mark_consumed(self, signal_id: str) -> AgentSignal:
+        for signal in self._signals:
+            if signal.id == signal_id:
+                self._consumed.add(signal_id)
+                return signal
+        raise AgentDefinitionError("Missing test signal")
+
+
+class FakeEvidenceRepository(IAgentEvidenceRepository):
+    """Evidence repository test double."""
+
+    def __init__(self) -> None:
+        self._evidence: dict[str, AgentEvidence] = {}
+
+    @override
+    def append(self, evidence: AgentEvidence) -> AgentEvidence:
+        self._evidence[evidence.id] = evidence
+        return evidence
+
+    @override
+    def get(self, evidence_id: str) -> AgentEvidence:
+        evidence = self._evidence.get(evidence_id)
+        if evidence is None:
+            raise AgentDefinitionError("Missing test evidence")
+        return evidence
+
+    @override
+    def list_by_state(self, state_id: str) -> Sequence[AgentEvidence]:
+        return tuple(
+            artifact
+            for artifact in self._evidence.values()
+            if artifact.agent_state_id == state_id
+        )
+
+    @override
+    def list_by_manifest_ref(self, manifest_ref: str) -> Sequence[AgentEvidence]:
+        return tuple(
+            artifact
+            for artifact in self._evidence.values()
+            if artifact.manifest_ref == manifest_ref
+        )
+
+
+def _tool_call(
+    name: str,
+    arguments: dict[str, JsonValue],
+    call_id: str,
+) -> ModelStreamEvent:
+    return ModelStreamEvent(
+        kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+        tool_call=ModelToolCall(name=name, arguments=arguments, call_id=call_id),
+    )
+
+
+def _user_signal(state_id: str, message: str) -> AgentSignal:
+    return AgentSignal(
+        id=f"user:{state_id}",
+        agent_state_id=state_id,
+        kind=AgentSignalKind.USER_MESSAGE,
+        payload={"message": message},
+    )
+
+
+def _approval_signal(state_id: str, request_id: str) -> AgentSignal:
+    return AgentSignal(
+        id=request_id,
+        agent_state_id=state_id,
+        kind=AgentSignalKind.APPROVAL_DECISION,
+        payload={
+            "request_id": request_id,
+            "decision": ApprovalDecision.APPROVE.value,
+        },
+    )
+
+
+def _cancel_signal(state_id: str) -> AgentSignal:
+    return AgentSignal(
+        id=f"cancel:{state_id}",
+        agent_state_id=state_id,
+        kind=AgentSignalKind.CANCEL,
+        payload={"reason": "user requested", "requested_by": "tester"},
+    )
+
+
+def _kinds(items: Sequence[AgentYield[object]]) -> set[AgentYieldKind]:
+    return {item.kind for item in items}
+
+
+def _final_payload(items: Sequence[AgentYield[object]]) -> Final[CodeAssistantResult]:
+    for item in reversed(items):
+        if isinstance(item.payload, Final):
+            return item.payload
+    raise AgentDefinitionError("Missing final payload")

--- a/docs/guides/agent-code-assistant.md
+++ b/docs/guides/agent-code-assistant.md
@@ -1,0 +1,96 @@
+# CodeAssistant building-block demo
+
+`core/spakky-agent/examples/code_assistant_demo.py`는 ADR-0009의 Claude Code-like 흐름을 제품 앱이 아니라 프레임워크 조합 예제로 보여줍니다. 핵심은 `@Agent` business component가 constructor DI로 model, workspace, shell, git, state/signal/evidence repository를 받고, 외부 세계 동작은 `@agent_tool` method로 노출한다는 점입니다.
+
+## 무엇을 검증하나
+
+이 demo는 다음 building block이 한 execution 안에서 연결되는지 보여줍니다.
+
+- `@Agent CodeAssistant`와 constructor DI
+- `workspace.read`, `workspace.search`, `workspace.write`
+- `shell.command`
+- `git.status`, `git.diff`, `git.apply`
+- `IAgentModel.stream()` 기반 vLLM-compatible token/tool-call stream
+- risk-boundary approval wait와 `AgentSignalKind.APPROVAL_DECISION`
+- 실행 중 `AgentSignalKind.USER_MESSAGE` 소비
+- append-only `AgentEvidence`
+- `AgentSignalKind.CANCEL`을 통한 cancellation lifecycle
+- action-boundary evidence 기반 restart/resume 계획
+
+운영용 persistence나 production in-memory fallback은 포함하지 않습니다. 실제 운영에서는 `IAgentStateRepository`, `IAgentSignalRepository`, `IAgentEvidenceRepository`를 SQLAlchemy contribution 같은 provider plugin으로 주입해야 합니다.
+
+## 구조
+
+```python
+from examples.code_assistant_demo import CodeAssistant
+from spakky.agent import Agent
+
+agent = Agent.get(CodeAssistant)
+
+print(agent.spec.name)
+print([descriptor.schema.name for descriptor in agent.tool_catalog.descriptors])
+```
+
+`CodeAssistant`는 model backend를 직접 고르지 않습니다. 생성자에 `IAgentModel`을 받으므로 테스트에서는 scripted model을, 로컬 smoke에서는 `plugins/spakky-vllm`의 `VllmAgentModel`을 주입할 수 있습니다. 이 의존 방향 덕분에 `spakky-agent` core는 vLLM이나 SQLAlchemy를 import하지 않습니다.
+
+## 실행 collector
+
+예제 파일의 `collect_stream()`은 FastAPI, WebSocket, Typer 같은 inbound adapter가 할 일을 작은 함수로 축약한 것입니다.
+
+```python
+from examples.code_assistant_demo import CodeAssistantCommand, collect_stream
+
+items = await collect_stream(
+    model,
+    workspace,
+    shell,
+    git,
+    states,
+    signals,
+    evidence,
+    CodeAssistantCommand(
+        state_id="run-1",
+        instruction="inspect the workspace and make a small approved edit",
+    ),
+)
+```
+
+반환되는 item은 `AgentYield` stream입니다. inbound adapter는 `token`, `tool`, `evidence`, `approval`, `cancel`, `final`을 transport별 이벤트로 바꾸면 됩니다. 별도 agent-specific inbound adapter package는 필요하지 않습니다.
+
+## Approval과 resume
+
+읽기 도구(`workspace.read`, `workspace.search`, `git.status`, `git.diff`)는 approval 없이 진행됩니다. 쓰기 또는 side effect 도구(`workspace.write`, `shell.command`, `git.apply`)는 `plan_agent_tool_approval()` 결과에 따라 `AgentYieldKind.APPROVAL`을 먼저 내보냅니다.
+
+approval decision은 durable signal queue에 append되어야 합니다.
+
+```python
+from spakky.agent import AgentSignal, AgentSignalKind, ApprovalDecision
+
+signals.append(
+    AgentSignal(
+        id="approval:run-1:workspace.write",
+        agent_state_id="run-1",
+        kind=AgentSignalKind.APPROVAL_DECISION,
+        payload={
+            "request_id": "approval:run-1:workspace.write",
+            "decision": ApprovalDecision.APPROVE.value,
+        },
+    )
+)
+```
+
+restart 후에는 저장된 `AgentState`, pending `AgentSignal`, append-only `AgentEvidence`를 사용해 `plan_agent_resume()`이 다음 action을 결정합니다. 완료된 boundary는 `skip_completed`, incomplete idempotent boundary는 `retry`, 불확실하거나 approval wait 중인 boundary는 `require_hitl`로 materialize됩니다.
+
+## 실제 vLLM 연결
+
+로컬 vLLM 서버 연결은 core demo가 아니라 `spakky-vllm` plugin이 담당합니다.
+
+```python
+from spakky.plugins.vllm.client import HttpxVllmChatClient
+from spakky.plugins.vllm.config import VllmConfig
+from spakky.plugins.vllm.model import VllmAgentModel
+
+model = VllmAgentModel(VllmConfig(), HttpxVllmChatClient())
+```
+
+이 model을 `CodeAssistant` 생성자에 주입하면 `IAgentModel.stream()`에서 vLLM OpenAI-compatible SSE가 provider-neutral `ModelStreamEvent`로 변환되어 demo agent에 들어옵니다.

--- a/docs/index.md
+++ b/docs/index.md
@@ -214,6 +214,7 @@ app = (
 | [사가 오케스트레이션](guides/saga.md) | SagaFlow, SagaStep, 보상 기반 롤백, ErrorStrategy |
 | [애플리케이션 데이터 캐시](guides/cache.md) | `CacheHit`, `CacheMiss`, `@cacheable`, Redis 백엔드 |
 | [gRPC 통합](guides/grpc.md) | `@GrpcController`, `@rpc`, code-first 프로토콜 생성 |
+| [CodeAssistant 에이전트 예제](guides/agent-code-assistant.md) | `@Agent`, `@agent_tool`, vLLM stream, approval, evidence, cancel/resume |
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - 사가 오케스트레이션: guides/saga.md
       - 애플리케이션 데이터 캐시: guides/cache.md
       - gRPC 통합: guides/grpc.md
+      - CodeAssistant 에이전트 예제: guides/agent-code-assistant.md
   - 심화 가이드:
       - DI/IoC 컨테이너: di-container.md
       - AOP 가이드: aop-guide.md


### PR DESCRIPTION
## Summary

- Add a `spakky-agent` CodeAssistant building-block demo using `@Agent`, constructor DI, and `@agent_tool` workspace/shell/git capabilities.
- Cover vLLM-shaped streaming, approval decision signals, user signals, append-only evidence, cancellation, and restart/resume with package-local tests.
- Document the demo as a framework composition example, not a full coding product or production in-memory persistence fallback.

## Acceptance Criteria

- [x] `@Agent CodeAssistant` with constructor DI: covered by `test_code_assistant_demo_expect_constructor_di_agent_and_expected_tools`.
- [x] Workspace read/search/write, shell command, git status/diff/apply exposed as `@agent_tool`: covered by tool catalog assertions.
- [x] vLLM streaming, approval wait, user signal, evidence append, cancellation, restart/resume: covered by `test_code_assistant_demo_expect_runs_end_to_end_building_block_scenario`, cancellation, and resume tests.
- [x] Building-block documentation: added `docs/guides/agent-code-assistant.md` and README/index/nav updates.

## Acceptance Criteria (자가 grep)

- [x] Issue body has no executable grep/find/rg acceptance lines → `acceptance_check: missing`.

## Validation

- `uv run --project ../.. ruff check examples/code_assistant_demo.py tests/unit/test_code_assistant_demo.py`
- `uv run --project ../.. pyrefly check src tests examples`
- `uv run --project ../.. pytest` (172 passed, coverage 100%)
- `uv run --project . mkdocs build --strict`

Closes #237
