### PR TITLE
feat(agent): add inbound adapter stream examples (#238)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -176,6 +176,8 @@ async def run_shell(command: str) -> dict[str, str]:
 
 테스트는 scripted `IAgentModel`로 vLLM-compatible token/tool-call stream을 모사합니다. 실제 로컬 vLLM 연결은 core 예제가 아니라 `plugins/spakky-vllm`의 `VllmAgentModel`을 생성자에 주입해서 구성합니다. 운영 persistence fallback은 제공하지 않으며, durable 실행에는 SQLAlchemy contribution 같은 실제 repository provider가 필요합니다.
 
+`examples/inbound_adapter_examples.py`는 `spakky-fastapi`의 `@ApiController`/`@websocket`과 `spakky-typer`의 `@CliController`/`@command`로 `CodeAssistant.execute()` stream을 노출하는 app-level wiring을 보여줍니다. 두 adapter 모두 container에서 `CodeAssistant`를 UseCase처럼 resolve하고 `AgentYield`를 transport event로 변환하며, approval/user input은 `IAgentSignalRepository.append()`로 추가합니다. 이 예제는 기존 plugin building block 조합이며 `spakky-agent-fastapi`나 `spakky-agent-typer` 패키지를 만들지 않습니다.
+
 ## Context contract
 
 Model input context는 raw 문자열을 이어 붙인 prompt snapshot이 아니라 `ContextPack` sequence로 전달합니다. 각 pack은 source, role, freshness, relevance, token budget, sensitivity metadata를 보존하고, `ContextManifest`는 pack 구성과 origin/evidence reference를 audit 단위로 남깁니다. 압축이나 요약은 원본 evidence를 대체하지 않고 `ContextDigest` derived evidence로 표현합니다.

--- a/core/spakky-agent/examples/inbound_adapter_examples.py
+++ b/core/spakky-agent/examples/inbound_adapter_examples.py
@@ -1,0 +1,317 @@
+"""FastAPI WebSocket and Typer CLI inbound adapters for CodeAssistant.
+
+The examples live with the demo application code, not in an agent-specific
+plugin. They compose the existing FastAPI/Typer controller building blocks with
+the `@Agent` business object that is already registered in the container.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from dataclasses import fields, is_dataclass
+from enum import Enum
+import json
+from sys import stdin as process_stdin, stdout as process_stdout
+from typing import TextIO, override
+from uuid import uuid4
+
+from examples.code_assistant_demo import CodeAssistant, CodeAssistantCommand
+from fastapi import WebSocket
+from spakky.agent import (
+    IAgentSignalRepository,
+    AgentSignal,
+    AgentSignalKind,
+    AgentYield,
+    AgentYieldKind,
+    Approval,
+    ApprovalDecision,
+    JsonObject,
+    JsonValue,
+)
+from spakky.agent.error import AgentDefinitionError
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.plugins.fastapi.routes import websocket
+from spakky.plugins.fastapi.stereotypes.api_controller import ApiController
+from spakky.plugins.typer.stereotypes.cli_controller import CliController, command
+
+
+class InboundAdapterExampleError(Exception):
+    """Raised when an inbound adapter example receives malformed input."""
+
+
+class AgentJsonWebSocket(ABC):
+    """Small surface the example needs from FastAPI WebSocket."""
+
+    @abstractmethod
+    async def send_json(self, data: object) -> None: ...
+
+    @abstractmethod
+    async def receive_json(self) -> object: ...
+
+
+@ApiController("/agents")
+class CodeAssistantWebSocketController(IContainerAware):
+    """FastAPI WebSocket adapter for the CodeAssistant agent stream."""
+
+    _container: IContainer | None = None
+
+    @override
+    def set_container(self, container: IContainer) -> None:
+        self._container = container
+
+    @websocket("/code/ws")
+    async def code_assistant(self, socket: WebSocket) -> None:
+        await socket.accept()
+        command = code_assistant_command_from_json(await socket.receive_json())
+        await stream_code_assistant_to_websocket(
+            _require_container(self._container),
+            socket,
+            command,
+        )
+        await socket.close()
+
+
+@CliController("agents")
+class CodeAssistantCliController(IContainerAware):
+    """Typer CLI adapter for the CodeAssistant agent stream."""
+
+    _container: IContainer | None = None
+
+    @override
+    def set_container(self, container: IContainer) -> None:
+        self._container = container
+
+    @command("code", help="Run the CodeAssistant demo agent.")
+    async def code_assistant(
+        self,
+        state_id: str,
+        instruction: str,
+        resume: bool = False,
+        read_stdin_signal: bool = False,
+    ) -> None:
+        await stream_code_assistant_to_stdout(
+            _require_container(self._container),
+            CodeAssistantCommand(
+                state_id=state_id,
+                instruction=instruction,
+                resume=resume,
+            ),
+            stdout=process_stdout,
+            stdin=process_stdin,
+            read_stdin_signal=read_stdin_signal,
+        )
+
+
+async def stream_code_assistant_to_websocket(
+    container: IContainer,
+    socket: AgentJsonWebSocket | WebSocket,
+    command: CodeAssistantCommand,
+) -> None:
+    """Resolve CodeAssistant from the container and stream yields as JSON."""
+    agent = container.get(CodeAssistant)
+    signals = container.get(IAgentSignalRepository)
+    async for item in agent.execute(command):
+        await socket.send_json(agent_yield_to_event(item))
+        if item.kind is AgentYieldKind.APPROVAL:
+            signals.append(
+                agent_signal_from_json(
+                    command.state_id,
+                    await socket.receive_json(),
+                    approval=_approval_payload(item),
+                )
+            )
+
+
+async def stream_code_assistant_to_stdout(
+    container: IContainer,
+    command: CodeAssistantCommand,
+    *,
+    stdout: TextIO,
+    stdin: TextIO,
+    read_stdin_signal: bool = False,
+) -> None:
+    """Resolve CodeAssistant and expose its AgentYield stream on stdout."""
+    signals = container.get(IAgentSignalRepository)
+    if read_stdin_signal:
+        _append_signal_line(signals, command.state_id, stdin.readline())
+
+    agent = container.get(CodeAssistant)
+    async for item in agent.execute(command):
+        event = agent_yield_to_event(item)
+        if item.kind is AgentYieldKind.TOKEN:
+            stdout.write(_event_text(event))
+            stdout.flush()
+        else:
+            stdout.write(f"{event}\n")
+            stdout.flush()
+        if item.kind is AgentYieldKind.APPROVAL:
+            _append_signal_line(
+                signals,
+                command.state_id,
+                stdin.readline(),
+                approval=_approval_payload(item),
+            )
+
+
+def code_assistant_command_from_json(payload: object) -> CodeAssistantCommand:
+    """Build the command DTO from an inbound JSON payload."""
+    data = _mapping(payload, "CodeAssistant command")
+    state_id = _text(data, "state_id")
+    instruction = _text(data, "instruction")
+    resume = data.get("resume") is True
+    return CodeAssistantCommand(
+        state_id=state_id,
+        instruction=instruction,
+        resume=resume,
+    )
+
+
+def agent_yield_to_event(item: AgentYield[object]) -> dict[str, JsonValue]:
+    """Encode one AgentYield into a transport-neutral JSON event."""
+    return {
+        "kind": item.kind.value,
+        "payload": _json_value(item.payload),
+    }
+
+
+def agent_signal_from_json(
+    state_id: str,
+    payload: object,
+    *,
+    approval: Approval | None = None,
+) -> AgentSignal:
+    """Materialize an AgentSignal from WebSocket or stdin JSON payload."""
+    data = _mapping(payload, "Agent signal")
+    kind = _signal_kind(data)
+    signal_payload = _signal_payload(kind, data, approval)
+    return AgentSignal(
+        id=_signal_id(state_id, kind, data, approval),
+        agent_state_id=state_id,
+        kind=kind,
+        payload=signal_payload,
+    )
+
+
+def _append_signal_line(
+    signals: IAgentSignalRepository,
+    state_id: str,
+    line: str,
+    *,
+    approval: Approval | None = None,
+) -> None:
+    text = line.strip()
+    if not text:
+        return
+    signals.append(
+        agent_signal_from_json(state_id, json.loads(text), approval=approval)
+    )
+
+
+def _event_text(event: Mapping[str, JsonValue]) -> str:
+    payload = event.get("payload")
+    if not isinstance(payload, Mapping):
+        return ""
+    text = payload.get("text")
+    if isinstance(text, str):
+        return text
+    return ""
+
+
+def _signal_kind(data: Mapping[str, object]) -> AgentSignalKind:
+    kind = data.get("kind")
+    if kind == AgentSignalKind.APPROVAL_DECISION.value:
+        return AgentSignalKind.APPROVAL_DECISION
+    if kind == AgentSignalKind.CANCEL.value:
+        return AgentSignalKind.CANCEL
+    if kind in (None, AgentSignalKind.USER_MESSAGE.value):
+        return AgentSignalKind.USER_MESSAGE
+    raise InboundAdapterExampleError(f"Unsupported agent signal kind: {kind}")
+
+
+def _signal_payload(
+    kind: AgentSignalKind,
+    data: Mapping[str, object],
+    approval: Approval | None,
+) -> JsonObject:
+    if kind is AgentSignalKind.APPROVAL_DECISION:
+        decision = _approval_decision(data)
+        request_id = _optional_text(data, "request_id")
+        if request_id is None and approval is not None:
+            request_id = approval.id
+        if request_id is None:
+            raise InboundAdapterExampleError("Approval signal requires request_id")
+        return {"request_id": request_id, "decision": decision.value}
+    if kind is AgentSignalKind.CANCEL:
+        return {"requested_by": _optional_text(data, "requested_by") or "user"}
+    return {"message": _text(data, "message")}
+
+
+def _approval_decision(data: Mapping[str, object]) -> ApprovalDecision:
+    decision = _optional_text(data, "decision") or ApprovalDecision.APPROVE.value
+    for candidate in ApprovalDecision:
+        if candidate.value == decision:
+            return candidate
+    raise InboundAdapterExampleError(f"Unsupported approval decision: {decision}")
+
+
+def _signal_id(
+    state_id: str,
+    kind: AgentSignalKind,
+    data: Mapping[str, object],
+    approval: Approval | None,
+) -> str:
+    signal_id = _optional_text(data, "id")
+    if signal_id is not None:
+        return signal_id
+    if kind is AgentSignalKind.APPROVAL_DECISION and approval is not None:
+        return approval.id
+    return f"signal:{state_id}:{kind.value}:{uuid4().hex}"
+
+
+def _approval_payload(item: AgentYield[object]) -> Approval:
+    if isinstance(item.payload, Approval):
+        return item.payload
+    raise AgentDefinitionError("Approval yield must carry an Approval payload")
+
+
+def _json_value(value: object) -> JsonValue:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value):
+        return {
+            field.name: _json_value(getattr(value, field.name))
+            for field in fields(value)
+        }
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return tuple(_json_value(item) for item in value)
+    return str(value)
+
+
+def _require_container(container: IContainer | None) -> IContainer:
+    if container is None:
+        raise InboundAdapterExampleError("Container was not injected")
+    return container
+
+
+def _mapping(value: object, label: str) -> Mapping[str, object]:
+    if isinstance(value, Mapping):
+        return value
+    raise InboundAdapterExampleError(f"{label} must be a JSON object")
+
+
+def _text(data: Mapping[str, object], name: str) -> str:
+    value = data.get(name)
+    if isinstance(value, str) and value.strip():
+        return value
+    raise InboundAdapterExampleError(f"{name} must be non-empty text")
+
+
+def _optional_text(data: Mapping[str, object], name: str) -> str | None:
+    value = data.get(name)
+    if isinstance(value, str) and value.strip():
+        return value
+    return None

--- a/core/spakky-agent/tests/unit/test_inbound_adapter_examples.py
+++ b/core/spakky-agent/tests/unit/test_inbound_adapter_examples.py
@@ -1,0 +1,221 @@
+"""Tests for FastAPI/Typer inbound adapter examples."""
+
+from collections.abc import Callable, Sequence
+from io import StringIO
+from typing import TypeVar, cast, overload
+
+from examples.code_assistant_demo import CodeAssistant, CodeAssistantCommand
+from examples.inbound_adapter_examples import (
+    AgentJsonWebSocket,
+    agent_signal_from_json,
+    stream_code_assistant_to_stdout,
+    stream_code_assistant_to_websocket,
+)
+from spakky.agent import (
+    IAgentSignalRepository,
+    AgentSignalKind,
+    AgentYieldKind,
+    JsonValue,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+)
+from spakky.core.pod.annotations.pod import Pod, PodType
+from spakky.core.pod.interfaces.container import IContainer, NoSuchPodError
+from tests.unit.test_code_assistant_demo import (
+    FakeEvidenceRepository,
+    FakeGit,
+    FakeShell,
+    FakeSignalRepository,
+    FakeStateRepository,
+    FakeWorkspace,
+    RecordingModel,
+    _tool_call,
+)
+
+ObjectT = TypeVar("ObjectT", bound=object)
+
+
+async def test_fastapi_websocket_example_expect_streams_agent_yields_and_appends_approval() -> (
+    None
+):
+    """WebSocket adapter resolves @Agent and forwards token/progress/approval/final."""
+    signals = FakeSignalRepository(())
+    container = RecordingContainer(_code_assistant(signals), signals)
+    socket = RecordingWebSocket(
+        (
+            {
+                "kind": "approval_decision",
+                "decision": "approve",
+            },
+        )
+    )
+
+    await stream_code_assistant_to_websocket(
+        container,
+        socket,
+        CodeAssistantCommand(state_id="ws-run", instruction="write approved note"),
+    )
+
+    assert container.resolved_types == (CodeAssistant, IAgentSignalRepository)
+    assert _event_kinds(socket.sent) >= {
+        AgentYieldKind.APPROVAL.value,
+        AgentYieldKind.FINAL.value,
+        AgentYieldKind.PROGRESS.value,
+        AgentYieldKind.TOKEN.value,
+    }
+    assert signals.list_pending("ws-run") == ()
+
+
+async def test_typer_cli_example_expect_stdout_streaming_and_stdin_user_signal_append() -> (
+    None
+):
+    """Typer adapter streams to stdout and appends stdin user/approval signals."""
+    signals = FakeSignalRepository(())
+    container = RecordingContainer(_code_assistant(signals), signals)
+    stdout = StringIO()
+    stdin = StringIO(
+        "".join(
+            (
+                '{"kind":"user_message","message":"keep it small"}\n',
+                '{"kind":"approval_decision","decision":"approve"}\n',
+            )
+        )
+    )
+
+    await stream_code_assistant_to_stdout(
+        container,
+        CodeAssistantCommand(state_id="cli-run", instruction="write approved note"),
+        stdout=stdout,
+        stdin=stdin,
+        read_stdin_signal=True,
+    )
+
+    output = stdout.getvalue()
+    assert "thinking" in output
+    assert "'kind': 'progress'" in output
+    assert "'kind': 'approval'" in output
+    assert "'kind': 'final'" in output
+    assert container.resolved_types == (IAgentSignalRepository, CodeAssistant)
+    assert signals.list_pending("cli-run") == ()
+
+
+def test_agent_signal_from_json_expect_maps_user_message_to_appendable_signal() -> None:
+    """Inbound JSON payloads become framework AgentSignal values."""
+    signal = agent_signal_from_json(
+        "run-1",
+        {"kind": "user_message", "message": "please continue"},
+    )
+
+    assert signal.kind is AgentSignalKind.USER_MESSAGE
+    assert signal.agent_state_id == "run-1"
+    assert signal.payload == {"message": "please continue"}
+
+
+def _code_assistant(signals: IAgentSignalRepository) -> CodeAssistant:
+    return CodeAssistant(
+        RecordingModel(
+            (
+                ModelStreamEvent(
+                    kind=ModelStreamEventKind.TOKEN_DELTA,
+                    token_delta="thinking",
+                ),
+                _tool_call(
+                    "workspace.write",
+                    {"path": "notes.md", "content": "approved"},
+                    "write-1",
+                ),
+                ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+            )
+        ),
+        FakeWorkspace({}),
+        FakeShell(),
+        FakeGit(),
+        FakeStateRepository(),
+        signals,
+        FakeEvidenceRepository(),
+    )
+
+
+def _event_kinds(events: Sequence[dict[str, JsonValue]]) -> set[str]:
+    return {str(event["kind"]) for event in events}
+
+
+class RecordingWebSocket(AgentJsonWebSocket):
+    """WebSocket test double for JSON event streaming."""
+
+    def __init__(self, incoming: Sequence[object]) -> None:
+        self._incoming = tuple(incoming)
+        self._index = 0
+        self.sent: tuple[dict[str, JsonValue], ...] = ()
+
+    async def send_json(self, data: object) -> None:
+        if not isinstance(data, dict):
+            raise NoSuchPodError
+        self.sent = (*self.sent, data)
+
+    async def receive_json(self) -> object:
+        payload = self._incoming[self._index]
+        self._index += 1
+        return payload
+
+
+class RecordingContainer(IContainer):
+    """Container double that records CodeAssistant resolution."""
+
+    def __init__(
+        self,
+        agent: CodeAssistant,
+        signals: IAgentSignalRepository,
+    ) -> None:
+        self._agent = agent
+        self._signals = signals
+        self.resolved_types: tuple[type[object], ...] = ()
+
+    @property
+    def pods(self) -> dict[str, Pod]:
+        return {}
+
+    def add(self, obj: PodType) -> None:
+        return None
+
+    @overload
+    def get(self, type_: type[ObjectT]) -> ObjectT: ...
+
+    @overload
+    def get(self, type_: type[ObjectT], name: str) -> ObjectT: ...
+
+    def get(
+        self,
+        type_: type[ObjectT],
+        name: str | None = None,
+    ) -> ObjectT:
+        self.resolved_types = (*self.resolved_types, type_)
+        if type_ is CodeAssistant:
+            return cast(ObjectT, self._agent)
+        if type_ is IAgentSignalRepository:
+            return cast(ObjectT, self._signals)
+        raise NoSuchPodError
+
+    @overload
+    def get_or_none(self, type_: type[ObjectT]) -> ObjectT | None: ...
+
+    @overload
+    def get_or_none(self, type_: type[ObjectT], name: str) -> ObjectT | None: ...
+
+    def get_or_none(
+        self,
+        type_: type[ObjectT],
+        name: str | None = None,
+    ) -> ObjectT | None:
+        try:
+            if name is None:
+                return self.get(type_)
+            return self.get(type_, name)
+        except NoSuchPodError:
+            return None
+
+    def contains(self, type_: type, name: str | None = None) -> bool:
+        return type_ in (CodeAssistant, IAgentSignalRepository)
+
+    def find(self, selector: Callable[[Pod], bool]) -> set[object]:
+        return set()

--- a/docs/guides/agent-code-assistant.md
+++ b/docs/guides/agent-code-assistant.md
@@ -57,6 +57,29 @@ items = await collect_stream(
 
 반환되는 item은 `AgentYield` stream입니다. inbound adapter는 `token`, `tool`, `evidence`, `approval`, `cancel`, `final`을 transport별 이벤트로 바꾸면 됩니다. 별도 agent-specific inbound adapter package는 필요하지 않습니다.
 
+## FastAPI WebSocket / Typer adapter 예제
+
+`core/spakky-agent/examples/inbound_adapter_examples.py`는 기존 `spakky-fastapi`와 `spakky-typer` building block으로 같은 `CodeAssistant` stream을 노출합니다. 이 파일은 app-level wiring 예제이며 `spakky-agent-fastapi`나 `spakky-agent-typer` 패키지를 만들지 않습니다.
+
+FastAPI 쪽은 `@ApiController`와 `@websocket`을 사용합니다. 컨트롤러는 container-aware Pod로 등록되고, connection handler 안에서 `CodeAssistant`를 `@UseCase`처럼 container에서 resolve한 뒤 `execute()`를 순회합니다.
+
+```python
+from examples.inbound_adapter_examples import CodeAssistantWebSocketController
+
+# 앱 scan 대상 모듈에 controller를 포함합니다.
+# WebSocket path: /agents/code/ws
+```
+
+각 `AgentYield`는 `{"kind": ..., "payload": ...}` JSON event로 전송됩니다. `approval` event를 보낸 뒤 client가 `{"kind": "approval_decision", "decision": "approve"}` 같은 payload를 보내면 adapter가 `IAgentSignalRepository.append()`로 decision signal을 추가하고 generator를 계속 소비합니다.
+
+Typer 쪽은 `@CliController("agents")`와 `@command("code")`를 사용합니다. command handler 역시 container에서 `CodeAssistant`를 resolve하고 `execute()`를 호출합니다.
+
+```bash
+python main.py agents code --state-id run-1 --instruction "inspect and edit" --read-stdin-signal
+```
+
+`token` yield는 stdout에 즉시 이어 쓰고, `progress`, `approval`, `final` 같은 구조화 event는 줄 단위로 출력합니다. `--read-stdin-signal`을 켜면 첫 stdin JSON line을 user message signal로 append하고, approval 대기 시 다음 stdin JSON line을 approval decision signal로 append합니다.
+
 ## Approval과 resume
 
 읽기 도구(`workspace.read`, `workspace.search`, `git.status`, `git.diff`)는 approval 없이 진행됩니다. 쓰기 또는 side effect 도구(`workspace.write`, `shell.command`, `git.apply`)는 `plan_agent_tool_approval()` 결과에 따라 `AgentYieldKind.APPROVAL`을 먼저 내보냅니다.

--- a/docs/guides/fastapi.md
+++ b/docs/guides/fastapi.md
@@ -206,6 +206,53 @@ class ChatController:
             await socket.send_text(f"Echo: {message}")
 ```
 
+### AgentYield stream 노출
+
+`@Agent`는 inbound adapter에서 `@UseCase`처럼 container로 resolve한 뒤 `execute()`를 호출합니다. Agent 전용 FastAPI plugin package를 만들 필요는 없습니다. CodeAssistant demo의 WebSocket 예제는 `core/spakky-agent/examples/inbound_adapter_examples.py`에 있습니다.
+
+```python
+from examples.code_assistant_demo import CodeAssistant
+from examples.inbound_adapter_examples import (
+    agent_signal_from_json,
+    agent_yield_to_event,
+    code_assistant_command_from_json,
+)
+from fastapi import WebSocket
+from spakky.agent import IAgentSignalRepository
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.plugins.fastapi.routes import websocket
+from spakky.plugins.fastapi.stereotypes.api_controller import ApiController
+
+
+@ApiController("/agents")
+class AgentController(IContainerAware):
+    _container: IContainer
+
+    def set_container(self, container: IContainer) -> None:
+        self._container = container
+
+    @websocket("/code/ws")
+    async def code(self, socket: WebSocket) -> None:
+        await socket.accept()
+        command = code_assistant_command_from_json(await socket.receive_json())
+        agent = self._container.get(CodeAssistant)
+        signals = self._container.get(IAgentSignalRepository)
+
+        async for item in agent.execute(command):
+            await socket.send_json(agent_yield_to_event(item))
+            if item.kind.value == "approval":
+                signals.append(
+                    agent_signal_from_json(
+                        command.state_id,
+                        await socket.receive_json(),
+                        approval=item.payload,
+                    )
+                )
+```
+
+실제 예제는 inbound JSON을 `CodeAssistantCommand`와 `AgentSignal`로 변환합니다. 핵심은 WebSocket이 transport 변환만 담당하고, agent business workflow는 container에서 얻은 `CodeAssistant.execute()` 안에 남긴다는 점입니다.
+
 ---
 
 ## 분산 트레이싱

--- a/docs/guides/typer.md
+++ b/docs/guides/typer.md
@@ -185,3 +185,44 @@ class OrderCLI:
 ```
 
 명령 옵션 이름은 Typer의 기본 규칙을 따릅니다. 위 예시는 `python main.py orders import --path ./orders.json`처럼 호출합니다. `@command(name=None)`이면 메서드명이 Typer command 이름이 되고, 그룹 이름은 `@CliController("orders")` 또는 클래스명 kebab-case로 정해집니다.
+
+## AgentYield stream CLI
+
+`@Agent`도 CLI adapter에서는 UseCase와 같은 방식으로 다룹니다. Typer 전용 agent plugin을 만들지 않고, `@CliController` command가 container에서 agent Pod를 resolve한 뒤 `execute()`를 순회하면 됩니다. CodeAssistant demo의 CLI 예제는 `core/spakky-agent/examples/inbound_adapter_examples.py`에 있습니다.
+
+```python
+from examples.code_assistant_demo import CodeAssistant, CodeAssistantCommand
+from examples.inbound_adapter_examples import agent_signal_from_json, agent_yield_to_event
+from spakky.agent import IAgentSignalRepository
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.plugins.typer.stereotypes.cli_controller import CliController, command
+
+
+@CliController("agents")
+class AgentCLI(IContainerAware):
+    _container: IContainer
+
+    def set_container(self, container: IContainer) -> None:
+        self._container = container
+
+    @command("code")
+    async def code(self, state_id: str, instruction: str) -> None:
+        command_dto = CodeAssistantCommand(state_id=state_id, instruction=instruction)
+        agent = self._container.get(CodeAssistant)
+        signals = self._container.get(IAgentSignalRepository)
+
+        async for item in agent.execute(command_dto):
+            event = agent_yield_to_event(item)
+            print(event["payload"].get("text", ""), end="")
+            if item.kind.value == "approval":
+                signals.append(
+                    agent_signal_from_json(
+                        state_id,
+                        {"kind": "approval_decision", "decision": "approve"},
+                        approval=item.payload,
+                    )
+                )
+```
+
+실제 예제 command는 `token`을 stdout에 즉시 쓰고, 다른 `AgentYield`는 줄 단위 event로 출력합니다. `--read-stdin-signal` 옵션을 켜면 stdin JSON line을 `AgentSignalKind.USER_MESSAGE` 또는 `AgentSignalKind.APPROVAL_DECISION`으로 변환해 repository에 append합니다.


### PR DESCRIPTION
## Summary
- Add app-level FastAPI WebSocket and Typer CLI examples for streaming `CodeAssistant.execute()` `AgentYield` events.
- Resolve `CodeAssistant` from the Spakky container like a UseCase, then map token/progress/approval/final events to WebSocket JSON or CLI stdout.
- Append user/approval signals through `IAgentSignalRepository` without creating `spakky-agent-fastapi` or `spakky-agent-typer` packages.
- Document the adapter wiring in the CodeAssistant, FastAPI, Typer, and package README docs.

## Acceptance Criteria
- [x] FastAPI/WebSocket example forwards `AgentYield` token/progress/approval/final stream events.
- [x] Typer/CLI example streams stdout and appends stdin/user/approval signals.
- [x] No `spakky-agent-fastapi` or `spakky-agent-typer` package is created.
- [x] Inbound adapters resolve `@Agent CodeAssistant` from `IContainer` and call `execute()`.
- [x] Acceptance grep: missing literal grep/find/rg lines in issue body.

## Validation
- `uv run ruff format .`
- `uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- `uv run ruff check .`
- `uv run pyrefly check src examples tests`
- `uv run pytest`
- `uv run mkdocs build --strict`

Closes #238
