### PR TITLE
test(agent): add ADR-0009 acceptance conformance suite (#240)

### DIFF
--- a/core/spakky-agent/pyproject.toml
+++ b/core/spakky-agent/pyproject.toml
@@ -8,6 +8,12 @@ license = { text = "MIT" }
 authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
 dependencies = ["spakky>=6.5.0"]
 
+[dependency-groups]
+dev = [
+    "spakky-fastapi>=6.5.0",
+    "spakky-typer>=6.5.0",
+]
+
 [project.entry-points."spakky.plugins"]
 spakky-agent = "spakky.agent.main:initialize"
 
@@ -68,3 +74,5 @@ exclude_lines = [
 
 [tool.uv.sources]
 spakky = { workspace = true }
+spakky-fastapi = { workspace = true }
+spakky-typer = { workspace = true }

--- a/core/spakky-agent/tests/acceptance/conftest.py
+++ b/core/spakky-agent/tests/acceptance/conftest.py
@@ -1,0 +1,6 @@
+"""Acceptance test import path setup for example modules."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parents[2]))

--- a/core/spakky-agent/tests/acceptance/test_adr0009_contract_conformance.py
+++ b/core/spakky-agent/tests/acceptance/test_adr0009_contract_conformance.py
@@ -1,0 +1,374 @@
+"""Acceptance tests for ADR-0009 core agent contracts."""
+
+from collections.abc import AsyncGenerator, AsyncIterator, Sequence
+from dataclasses import dataclass
+from typing import override
+
+from spakky.agent import (
+    IAgentEvidenceRepository,
+    IAgentModel,
+    IAgentSignalRepository,
+    IAgentStateRepository,
+    Agent,
+    AgentEvidence,
+    AgentEvidenceCandidate,
+    AgentEvidenceKind,
+    AgentExecutionSpec,
+    AgentSignal,
+    AgentSignalKind,
+    AgentState,
+    AgentStateTransition,
+    AgentStatus,
+    AgentYield,
+    AgentYieldKind,
+    Evidence,
+    EvidenceCapture,
+    Final,
+    Idempotency,
+    JsonSchemaConstraint,
+    ModelMessage,
+    ModelMessageRole,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    ModelToolChoice,
+    ModelToolSpec,
+    Progress,
+    RecoveryStrategy,
+    Token,
+    Tool,
+    ToolApprovalRequirement,
+    ToolCallingSpec,
+    ToolEffects,
+    agent_tool,
+)
+from spakky.agent.error import AgentDefinitionError
+
+
+@dataclass(frozen=True, slots=True)
+class _AgentCommand:
+    state_id: str
+    instruction: str
+
+
+@dataclass(frozen=True, slots=True)
+class _AgentResult:
+    answer: str
+
+
+@dataclass(frozen=True, slots=True)
+class _WorkspaceReadResult:
+    path: str
+    include_metadata: bool
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="adr0009_acceptance_agent",
+        accepted_signals=(AgentSignalKind.USER_MESSAGE,),
+        recovery=RecoveryStrategy.ACTION_BOUNDARY,
+    )
+)
+class _AcceptanceAgent:
+    def __init__(
+        self,
+        model: IAgentModel,
+        states: IAgentStateRepository,
+        signals: IAgentSignalRepository,
+        evidence: IAgentEvidenceRepository,
+    ) -> None:
+        self._model = model
+        self._states = states
+        self._signals = signals
+        self._evidence = evidence
+
+    @agent_tool(
+        schema_name="workspace.read",
+        description="Read a workspace path.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def read_workspace(
+        self,
+        path: str,
+        include_metadata: bool = False,
+    ) -> _WorkspaceReadResult:
+        return _WorkspaceReadResult(path=path, include_metadata=include_metadata)
+
+    async def execute(
+        self,
+        command: _AgentCommand,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        self._states.save(
+            AgentState(
+                id=command.state_id,
+                agent_type="AcceptanceAgent",
+                status=AgentStatus.ACTIVE,
+                transition=AgentStateTransition.RUNNING,
+                current_activity=command.instruction,
+                pending_signal_count=len(self._signals.list_pending(command.state_id)),
+            )
+        )
+        yield AgentYield(
+            kind=AgentYieldKind.PROGRESS,
+            payload=Progress("model request prepared", current_step="model"),
+        )
+        request = self._request(command)
+        async for event in self._model.stream(request):
+            if event.kind is ModelStreamEventKind.TOKEN_DELTA:
+                yield AgentYield(
+                    kind=AgentYieldKind.TOKEN,
+                    payload=Token(event.token_delta or ""),
+                )
+            if (
+                event.kind is ModelStreamEventKind.TOOL_CALL_CANDIDATE
+                and event.tool_call is not None
+            ):
+                descriptor = Agent.get(_AcceptanceAgent).tool_catalog.by_schema_name(
+                    event.tool_call.name
+                )
+                evidence = AgentEvidenceCandidate.tool_result(
+                    tool_identity=descriptor.identity.key,
+                    tool_schema_name=descriptor.schema.name,
+                    result=event.tool_call.arguments,
+                    capture=descriptor.metadata.evidence,
+                    summary="tool candidate accepted",
+                ).to_evidence(
+                    evidence_id=f"{command.state_id}:evidence:1",
+                    agent_state_id=command.state_id,
+                )
+                self._evidence.append(evidence)
+                yield AgentYield(
+                    kind=AgentYieldKind.TOOL,
+                    payload=Tool(
+                        name=event.tool_call.name,
+                        call_id=event.tool_call.call_id,
+                        arguments=event.tool_call.arguments,
+                    ),
+                )
+                yield AgentYield(
+                    kind=AgentYieldKind.EVIDENCE,
+                    payload=Evidence(evidence=evidence),
+                )
+        self._states.save(
+            AgentState(
+                id=command.state_id,
+                agent_type="AcceptanceAgent",
+                status=AgentStatus.COMPLETED,
+                transition=AgentStateTransition.COMPLETED,
+            )
+        )
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(output=_AgentResult("done"), metadata={}),
+        )
+
+    def _request(self, command: _AgentCommand) -> ModelRequest:
+        descriptor = Agent.get(_AcceptanceAgent).tool_catalog.by_schema_name(
+            "workspace.read"
+        )
+        return ModelRequest(
+            messages=(
+                ModelMessage(ModelMessageRole.SYSTEM, "Use typed tools."),
+                ModelMessage(ModelMessageRole.USER, command.instruction),
+            ),
+            tool_calling=ToolCallingSpec(
+                tools=(
+                    ModelToolSpec(
+                        name=descriptor.schema.name,
+                        description=descriptor.description,
+                        parameters=JsonSchemaConstraint(
+                            schema=descriptor.schema.input_schema
+                        ),
+                        metadata={"tool_identity": descriptor.identity.key},
+                    ),
+                ),
+                choice=ModelToolChoice.REQUIRED,
+            ),
+        )
+
+
+async def test_adr0009_core_contract_acceptance_expect_agent_stream_model_tool_and_state() -> (
+    None
+):
+    """ADR-0009 core contract가 @Agent부터 state/evidence stream까지 조립된다."""
+    model = _ScriptedModel(
+        (
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.TOKEN_DELTA,
+                token_delta="reading",
+            ),
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+                tool_call=ModelToolCall(
+                    name="workspace.read",
+                    arguments={"path": "README.md", "include_metadata": True},
+                    call_id="call-1",
+                ),
+            ),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    states = _StateRepository()
+    signals = _SignalRepository(
+        (
+            AgentSignal(
+                id="signal-1",
+                agent_state_id="run-1",
+                kind=AgentSignalKind.USER_MESSAGE,
+                payload={"message": "continue"},
+            ),
+        )
+    )
+    evidence = _EvidenceRepository()
+    agent = _AcceptanceAgent(model, states, signals, evidence)
+
+    items = [item async for item in agent.execute(_AgentCommand("run-1", "inspect"))]
+
+    assert Agent.get(_AcceptanceAgent).spec.name == "adr0009_acceptance_agent"
+    assert Agent.get(_AcceptanceAgent).required_persistence_repository_types() == (
+        IAgentStateRepository,
+        IAgentSignalRepository,
+        IAgentEvidenceRepository,
+    )
+    descriptor = Agent.get(_AcceptanceAgent).tool_catalog.by_schema_name(
+        "workspace.read"
+    )
+    assert descriptor.schema.input_schema == {
+        "type": "object",
+        "title": "workspace.read.input",
+        "properties": {
+            "path": {"type": "string"},
+            "include_metadata": {"type": "boolean"},
+        },
+        "additionalProperties": False,
+        "required": ["path"],
+    }
+    assert model.requests[0].tool_calling is not None
+    assert model.requests[0].tool_calling.tools[0].parameters.schema is (
+        descriptor.schema.input_schema
+    )
+    assert [item.kind for item in items] == [
+        AgentYieldKind.PROGRESS,
+        AgentYieldKind.TOKEN,
+        AgentYieldKind.TOOL,
+        AgentYieldKind.EVIDENCE,
+        AgentYieldKind.FINAL,
+    ]
+    assert states.get("run-1").status is AgentStatus.COMPLETED
+    assert signals.list_pending("run-1")[0].kind is AgentSignalKind.USER_MESSAGE
+    assert evidence.list_by_state("run-1")[0].kind is AgentEvidenceKind.TOOL
+
+
+class _ScriptedModel(IAgentModel):
+    def __init__(self, events: Sequence[ModelStreamEvent]) -> None:
+        self._events = tuple(events)
+        self.requests: list[ModelRequest] = []
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        self.requests.append(request)
+        return ModelResponse(content="complete")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        self.requests.append(request)
+        for event in self._events:
+            yield event
+
+
+class _StateRepository(IAgentStateRepository):
+    def __init__(self) -> None:
+        self._states: dict[str, AgentState] = {}
+
+    @override
+    def get(self, state_id: str) -> AgentState:
+        state = self.get_or_none(state_id)
+        if state is None:
+            raise AgentDefinitionError("Missing acceptance state")
+        return state
+
+    @override
+    def get_or_none(self, state_id: str) -> AgentState | None:
+        return self._states.get(state_id)
+
+    @override
+    def save(self, state: AgentState) -> AgentState:
+        self._states[state.id] = state
+        return state
+
+    @override
+    def list_by_status(self, status: AgentStatus) -> Sequence[AgentState]:
+        return tuple(state for state in self._states.values() if state.status is status)
+
+    @override
+    def list_resume_candidates(self) -> Sequence[AgentState]:
+        return tuple(
+            state
+            for state in self._states.values()
+            if state.status in (AgentStatus.ACTIVE, AgentStatus.INTERRUPTED)
+        )
+
+
+class _SignalRepository(IAgentSignalRepository):
+    def __init__(self, signals: Sequence[AgentSignal]) -> None:
+        self._signals = tuple(signals)
+        self._consumed: set[str] = set()
+
+    @override
+    def append(self, signal: AgentSignal) -> AgentSignal:
+        self._signals = (*self._signals, signal)
+        return signal
+
+    @override
+    def list_pending(self, state_id: str) -> Sequence[AgentSignal]:
+        return tuple(
+            signal
+            for signal in self._signals
+            if signal.agent_state_id == state_id and signal.id not in self._consumed
+        )
+
+    @override
+    def mark_consumed(self, signal_id: str) -> AgentSignal:
+        for signal in self._signals:
+            if signal.id == signal_id:
+                self._consumed.add(signal_id)
+                return signal
+        raise AgentDefinitionError("Missing acceptance signal")
+
+
+class _EvidenceRepository(IAgentEvidenceRepository):
+    def __init__(self) -> None:
+        self._evidence: dict[str, AgentEvidence] = {}
+
+    @override
+    def append(self, evidence: AgentEvidence) -> AgentEvidence:
+        self._evidence[evidence.id] = evidence
+        return evidence
+
+    @override
+    def get(self, evidence_id: str) -> AgentEvidence:
+        evidence = self._evidence.get(evidence_id)
+        if evidence is None:
+            raise AgentDefinitionError("Missing acceptance evidence")
+        return evidence
+
+    @override
+    def list_by_state(self, state_id: str) -> Sequence[AgentEvidence]:
+        return tuple(
+            artifact
+            for artifact in self._evidence.values()
+            if artifact.agent_state_id == state_id
+        )
+
+    @override
+    def list_by_manifest_ref(self, manifest_ref: str) -> Sequence[AgentEvidence]:
+        return tuple(
+            artifact
+            for artifact in self._evidence.values()
+            if artifact.manifest_ref == manifest_ref
+        )

--- a/core/spakky-agent/tests/acceptance/test_code_assistant_demo_acceptance.py
+++ b/core/spakky-agent/tests/acceptance/test_code_assistant_demo_acceptance.py
@@ -1,0 +1,166 @@
+"""Acceptance tests for the ADR-0009 CodeAssistant demo."""
+
+from examples.code_assistant_demo import (
+    CodeAssistantCommand,
+    CodeAssistantResult,
+    StaticModel,
+    collect_stream,
+)
+from spakky.agent import (
+    AgentEvidenceKind,
+    AgentStatus,
+    AgentYield,
+    AgentYieldKind,
+    Approval,
+    Cancel,
+    Evidence,
+    Final,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    Progress,
+    Token,
+    Tool,
+)
+from spakky.agent.error import AgentDefinitionError
+from tests.unit.test_code_assistant_demo import (
+    FakeEvidenceRepository,
+    FakeGit,
+    FakeShell,
+    FakeSignalRepository,
+    FakeStateRepository,
+    FakeWorkspace,
+    RecordingModel,
+    _approval_signal,
+    _cancel_signal,
+    _tool_call,
+    _user_signal,
+)
+
+
+async def test_code_assistant_acceptance_expect_streaming_approval_signal_evidence_and_resume() -> (
+    None
+):
+    """CodeAssistant demo가 stream/approval/signal/evidence/restart-resume을 end-to-end로 보인다."""
+    states = FakeStateRepository()
+    signals = FakeSignalRepository(
+        (
+            _user_signal("run-1", "prefer the smaller patch"),
+            _approval_signal("run-1", "approval:run-1:workspace.write"),
+            _approval_signal("run-1", "approval:run-1:shell.command"),
+        )
+    )
+    evidence = FakeEvidenceRepository()
+    workspace = FakeWorkspace({"README.md": "hello agent"})
+    shell = FakeShell()
+    git = FakeGit()
+    model = RecordingModel(
+        (
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.TOKEN_DELTA,
+                token_delta="planning",
+            ),
+            _tool_call("workspace.read", {"path": "README.md"}, "read-1"),
+            _tool_call(
+                "workspace.write",
+                {"path": "notes.md", "content": "approved"},
+                "write-1",
+            ),
+            _tool_call("shell.command", {"command": "printf ok"}, "shell-1"),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+
+    items = await collect_stream(
+        model,
+        workspace,
+        shell,
+        git,
+        states,
+        signals,
+        evidence,
+        CodeAssistantCommand(state_id="run-1", instruction="make a safe edit"),
+    )
+
+    assert _payload_count(items, Token) == 1
+    assert _payload_count(items, Approval) == 2
+    assert _payload_count(items, Tool) == 3
+    assert _payload_count(items, Evidence) == 3
+    assert workspace.files["notes.md"] == "approved"
+    assert shell.commands == ("printf ok",)
+    assert states.get("run-1").status is AgentStatus.COMPLETED
+    assert {artifact.kind for artifact in evidence.list_by_state("run-1")} >= {
+        AgentEvidenceKind.ACTION_BOUNDARY,
+        AgentEvidenceKind.APPROVAL,
+        AgentEvidenceKind.EVALUATION,
+        AgentEvidenceKind.TOOL,
+    }
+    assert _final_payload(items).output == CodeAssistantResult(
+        state_id="run-1",
+        status="completed",
+        tool_calls=("workspace.read", "workspace.write", "shell.command"),
+        evidence_count=len(evidence.list_by_state("run-1")),
+    )
+
+    restarted_items = await collect_stream(
+        StaticModel((ModelStreamEvent(kind=ModelStreamEventKind.DONE),)),
+        workspace,
+        shell,
+        git,
+        states,
+        signals,
+        evidence,
+        CodeAssistantCommand(
+            state_id="run-1",
+            instruction="resume",
+            resume=True,
+        ),
+    )
+
+    assert restarted_items[0].kind is AgentYieldKind.PROGRESS
+    assert isinstance(restarted_items[0].payload, Progress)
+    assert "skip_completed" in restarted_items[0].payload.message
+
+
+async def test_code_assistant_acceptance_expect_cancellation_terminal_state() -> None:
+    """CodeAssistant demo cancel signal은 terminal state와 cancellation evidence를 남긴다."""
+    states = FakeStateRepository()
+    evidence = FakeEvidenceRepository()
+
+    items = await collect_stream(
+        StaticModel(
+            (
+                ModelStreamEvent(
+                    kind=ModelStreamEventKind.TOKEN_DELTA,
+                    token_delta="unused",
+                ),
+            )
+        ),
+        FakeWorkspace({}),
+        FakeShell(),
+        FakeGit(),
+        states,
+        FakeSignalRepository((_cancel_signal("cancel-run"),)),
+        evidence,
+        CodeAssistantCommand(state_id="cancel-run", instruction="stop"),
+    )
+
+    assert len(items) == 1
+    assert isinstance(items[0].payload, Cancel)
+    assert states.get("cancel-run").status is AgentStatus.CANCELLED
+    assert AgentEvidenceKind.CANCELLATION in {
+        artifact.kind for artifact in evidence.list_by_state("cancel-run")
+    }
+
+
+def _payload_count(
+    items: tuple[AgentYield[object], ...],
+    payload_type: type[object],
+) -> int:
+    return sum(1 for item in items if isinstance(item.payload, payload_type))
+
+
+def _final_payload(items: tuple[AgentYield[object], ...]) -> Final[CodeAssistantResult]:
+    for item in reversed(items):
+        if isinstance(item.payload, Final):
+            return item.payload
+    raise AgentDefinitionError("Missing final payload")

--- a/plugins/spakky-sqlalchemy/tests/acceptance/test_agent_persistence_acceptance.py
+++ b/plugins/spakky-sqlalchemy/tests/acceptance/test_agent_persistence_acceptance.py
@@ -1,0 +1,161 @@
+"""Acceptance tests for SQLAlchemy agent persistence contribution."""
+
+from collections.abc import Generator
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import cast
+
+import pytest
+from spakky.agent import (
+    AgentEvidence,
+    AgentEvidenceKind,
+    AgentSignal,
+    AgentSignalKind,
+    AgentState,
+    AgentStateReason,
+    AgentStateTransition,
+    AgentStatus,
+)
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from spakky.plugins.sqlalchemy.agent.repository import (
+    SqlAlchemyAgentEvidenceRepository,
+    SqlAlchemyAgentSignalRepository,
+    SqlAlchemyAgentStateRepository,
+)
+from spakky.plugins.sqlalchemy.agent.table import (
+    AgentEvidenceTable,
+    AgentSignalTable,
+    AgentStateTable,
+)
+from spakky.plugins.sqlalchemy.persistency.session_manager import SessionManager
+
+
+@dataclass(slots=True)
+class _SessionManagerStub:
+    session: Session
+
+
+@pytest.fixture(name="engine")
+def engine_fixture(tmp_path: Path) -> Generator[Engine, None, None]:
+    """Create a file-backed SQLite database to model process restart."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'agent-acceptance.db'}")
+    AgentStateTable.metadata.create_all(engine)
+    AgentSignalTable.metadata.create_all(engine)
+    AgentEvidenceTable.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+def test_sqlalchemy_agent_contribution_acceptance_expect_restart_resume_state_signal_evidence(
+    engine: Engine,
+) -> None:
+    """SQLAlchemy contribution이 restart 후 state/signal/evidence resume을 보존한다."""
+    session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+    with session_factory() as first_session:
+        states, signals, evidence = _repositories(first_session)
+        state = AgentState(
+            id="run-1",
+            agent_type="CodeAssistant",
+            status=AgentStatus.INTERRUPTED,
+            transition=AgentStateTransition.WAITING_APPROVAL,
+            reason=AgentStateReason.APPROVAL_REQUIRED,
+            recovery_marker="boundary:workspace.write",
+            metadata={"resume": "action_boundary"},
+            created_at=datetime(2026, 5, 6, 1),
+            updated_at=datetime(2026, 5, 6, 2),
+        )
+        signal = AgentSignal(
+            id="signal-1",
+            agent_state_id=state.id,
+            kind=AgentSignalKind.APPROVAL_DECISION,
+            payload={"decision": "approve", "request_id": "approval-1"},
+            created_at=datetime(2026, 5, 6, 3),
+        )
+        boundary = AgentEvidence(
+            id="evidence-1",
+            agent_state_id=state.id,
+            kind=AgentEvidenceKind.ACTION_BOUNDARY,
+            payload={"action_id": "tool:workspace.write", "stage": "before"},
+            summary="before workspace write",
+            manifest_ref="manifest-1",
+            created_at=datetime(2026, 5, 6, 4),
+        )
+        tool = AgentEvidence(
+            id="evidence-2",
+            agent_state_id=state.id,
+            kind=AgentEvidenceKind.TOOL,
+            payload={"tool": "workspace.write"},
+            summary="workspace write completed",
+            manifest_ref="manifest-1",
+            created_at=datetime(2026, 5, 6, 5),
+        )
+
+        states.save(state)
+        signals.append(signal)
+        evidence.append(boundary)
+        evidence.append(tool)
+        first_session.commit()
+
+    with session_factory() as restarted_session:
+        states, signals, evidence = _repositories(restarted_session)
+
+        assert states.get("run-1").recovery_marker == "boundary:workspace.write"
+        assert states.list_resume_candidates() == [states.get("run-1")]
+        assert signals.list_pending("run-1") == [
+            AgentSignal(
+                id="signal-1",
+                agent_state_id="run-1",
+                kind=AgentSignalKind.APPROVAL_DECISION,
+                payload={"decision": "approve", "request_id": "approval-1"},
+                created_at=datetime(2026, 5, 6, 3),
+            )
+        ]
+        assert [artifact.id for artifact in evidence.list_by_state("run-1")] == [
+            "evidence-1",
+            "evidence-2",
+        ]
+        assert [
+            artifact.id for artifact in evidence.list_by_manifest_ref("manifest-1")
+        ] == [
+            "evidence-1",
+            "evidence-2",
+        ]
+        signals.mark_consumed("signal-1")
+        restarted_session.commit()
+
+    with session_factory() as resumed_session:
+        states, signals, _ = _repositories(resumed_session)
+        resumed = states.save(
+            AgentState(
+                id="run-1",
+                agent_type="CodeAssistant",
+                status=AgentStatus.ACTIVE,
+                transition=AgentStateTransition.RUNNING,
+                recovery_marker="boundary:workspace.write",
+            )
+        )
+        resumed_session.commit()
+
+        assert resumed.status is AgentStatus.ACTIVE
+        assert signals.list_pending("run-1") == []
+        assert states.list_resume_candidates() == [resumed]
+
+
+def _repositories(
+    session: Session,
+) -> tuple[
+    SqlAlchemyAgentStateRepository,
+    SqlAlchemyAgentSignalRepository,
+    SqlAlchemyAgentEvidenceRepository,
+]:
+    session_manager = cast(SessionManager, _SessionManagerStub(session=session))
+    return (
+        SqlAlchemyAgentStateRepository(session_manager),
+        SqlAlchemyAgentSignalRepository(session_manager),
+        SqlAlchemyAgentEvidenceRepository(session_manager),
+    )

--- a/plugins/spakky-vllm/tests/acceptance/test_vllm_acceptance.py
+++ b/plugins/spakky-vllm/tests/acceptance/test_vllm_acceptance.py
@@ -1,0 +1,182 @@
+"""Acceptance tests for the vLLM agent model adapter."""
+
+from collections.abc import AsyncGenerator, Mapping
+from importlib import import_module
+from typing import override
+
+from spakky.agent import (
+    JsonObject,
+    JsonSchemaConstraint,
+    ModelMessage,
+    ModelMessageRole,
+    ModelRequest,
+    ModelStreamEventKind,
+    ModelToolChoice,
+    ModelToolSpec,
+    SamplingOptions,
+    StructuredOutputSpec,
+    ToolCallingSpec,
+)
+
+from spakky.plugins.vllm.client import IVllmChatClient
+from spakky.plugins.vllm.config import VllmConfig
+from spakky.plugins.vllm.model import VllmAgentModel
+
+
+async def test_vllm_acceptance_fake_expect_streaming_tokens_structured_output_and_tool_call() -> (
+    None
+):
+    """CI-safe fake stream이 token, structured output, tool call을 core event로 매핑한다."""
+    client = _FakeVllmClient(
+        stream_chunks=(
+            {
+                "choices": [
+                    {
+                        "delta": {"content": '{"answer":"ok"}'},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 4,
+                    "completion_tokens": 3,
+                    "total_tokens": 7,
+                },
+            },
+        ),
+    )
+    model = VllmAgentModel(VllmConfig(), client)
+
+    events = [event async for event in model.stream(_structured_request())]
+
+    assert [event.kind for event in events] == [
+        ModelStreamEventKind.TOKEN_DELTA,
+        ModelStreamEventKind.STRUCTURED_OUTPUT,
+        ModelStreamEventKind.DONE,
+    ]
+    assert events[0].token_delta == '{"answer":"ok"}'
+    assert events[1].structured_output == {"answer": "ok"}
+    assert events[-1].usage is not None
+    assert events[-1].usage.total_tokens == 7
+    assert client.payload is not None
+    assert client.payload["stream"] is True
+    assert client.payload["stream_options"] == {"include_usage": True}
+    assert client.payload["structured_outputs"] == {
+        "json": _structured_schema(),
+    }
+
+    tool_client = _FakeVllmClient(
+        response={
+            "choices": [
+                {
+                    "message": {
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "function": {
+                                    "name": "lookup_weather",
+                                    "arguments": '{"city":"Seoul","unit":"celsius"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        },
+    )
+    response = await VllmAgentModel(VllmConfig(), tool_client).complete(_tool_request())
+
+    assert response.tool_calls[0].name == "lookup_weather"
+    assert response.tool_calls[0].arguments == {
+        "city": "Seoul",
+        "unit": "celsius",
+    }
+    assert tool_client.payload is not None
+    assert tool_client.payload["tool_choice"] == "required"
+
+
+def test_vllm_acceptance_expect_local_smoke_remains_opt_in() -> None:
+    """local vLLM smoke는 CI fake acceptance와 별도 opt-in env gate를 유지한다."""
+    smoke = import_module("tests.smoke.test_local_vllm")
+
+    assert smoke.SMOKE_ENV == "SPAKKY_VLLM_SMOKE"
+    assert smoke._smoke_enabled() is False
+
+
+class _FakeVllmClient(IVllmChatClient):
+    def __init__(
+        self,
+        response: Mapping[str, object] | None = None,
+        stream_chunks: tuple[Mapping[str, object], ...] = (),
+    ) -> None:
+        self.payload: Mapping[str, object] | None = None
+        self.response = response or {"choices": [{"message": {"content": "ok"}}]}
+        self.stream_chunks = stream_chunks
+
+    @override
+    async def complete(
+        self,
+        payload: Mapping[str, object],
+        config: VllmConfig,
+    ) -> Mapping[str, object]:
+        self.payload = payload
+        return self.response
+
+    @override
+    def stream(
+        self,
+        payload: Mapping[str, object],
+        config: VllmConfig,
+    ) -> AsyncGenerator[Mapping[str, object], None]:
+        self.payload = payload
+        return self._stream()
+
+    async def _stream(self) -> AsyncGenerator[Mapping[str, object], None]:
+        for chunk in self.stream_chunks:
+            yield chunk
+
+
+def _structured_request() -> ModelRequest:
+    return ModelRequest(
+        messages=(ModelMessage(ModelMessageRole.USER, "return json"),),
+        structured_output=StructuredOutputSpec(
+            constraint=JsonSchemaConstraint(schema=_structured_schema())
+        ),
+        sampling=SamplingOptions(temperature=0.0, max_tokens=32),
+    )
+
+
+def _structured_schema() -> JsonObject:
+    schema: JsonObject = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+        "additionalProperties": False,
+    }
+    return schema
+
+
+def _tool_request() -> ModelRequest:
+    return ModelRequest(
+        messages=(ModelMessage(ModelMessageRole.USER, "weather in Seoul"),),
+        tool_calling=ToolCallingSpec(
+            tools=(
+                ModelToolSpec(
+                    name="lookup_weather",
+                    description="Look up weather.",
+                    parameters=JsonSchemaConstraint(
+                        schema={
+                            "type": "object",
+                            "properties": {
+                                "city": {"type": "string"},
+                                "unit": {"type": "string"},
+                            },
+                            "required": ["city", "unit"],
+                            "additionalProperties": False,
+                        }
+                    ),
+                ),
+            ),
+            choice=ModelToolChoice.REQUIRED,
+        ),
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2590,8 +2590,20 @@ dependencies = [
     { name = "spakky" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "spakky-fastapi" },
+    { name = "spakky-typer" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "spakky", editable = "core/spakky" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "spakky-fastapi", editable = "plugins/spakky-fastapi" },
+    { name = "spakky-typer", editable = "plugins/spakky-typer" },
+]
 
 [[package]]
 name = "spakky-cache"


### PR DESCRIPTION
## Summary
- Add ADR-0009 core contract acceptance covering `@Agent`, `AgentYield`, `IAgentModel`, tool schema, and state/signal/evidence assembly.
- Add SQLAlchemy agent persistence acceptance for state/signal/evidence durability across restart/resume.
- Add vLLM acceptance split between CI-safe fake model mapping and opt-in local smoke gate.
- Add CodeAssistant demo acceptance for streaming, approval, signal/evidence, cancellation, and restart/resume.
- Add package-local dev wiring so `spakky-agent` example tests can resolve FastAPI/Typer plugin building blocks without adding production core dependencies.

## Validation
- `uv run --with ruff ruff check .` in `core/spakky-agent`, `plugins/spakky-sqlalchemy`, `plugins/spakky-vllm`
- `uv run --with pyrefly pyrefly check src tests/acceptance` in `core/spakky-agent`, `plugins/spakky-sqlalchemy`, `plugins/spakky-vllm`
- `uv run --with pytest-cov --with pytest-xdist --with pytest-spec pytest` in `core/spakky-agent` → 178 passed, coverage 100%
- `uv run --with pytest-cov --with pytest-xdist --with pytest-spec --with pytest-integration-mark pytest` in `plugins/spakky-sqlalchemy` → 117 passed, 152 skipped, coverage 100%
- `uv run --with pytest-cov --with pytest-xdist --with pytest-spec pytest` in `plugins/spakky-vllm` → 87 passed, 3 skipped, coverage 100%

Closes #240
