### PR TITLE
docs: sync ADR-0009 agent documentation (#239)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -27,7 +27,7 @@
 | **Plugin** | `spakky-security` | 암호화/해싱/JWT 유틸리티 |
 | **Plugin** | `spakky-rabbitmq` | RabbitMQ 이벤트 브로커 통합 |
 | **Plugin** | `spakky-kafka` | Apache Kafka 이벤트 브로커 통합 |
-| **Plugin** | `spakky-sqlalchemy` | SQLAlchemy ORM 통합 + Outbox 저장소 contribution |
+| **Plugin** | `spakky-sqlalchemy` | SQLAlchemy ORM 통합 + Outbox/Agent persistence contribution |
 | **Plugin** | `spakky-celery` | Celery 태스크 디스패치 및 스케줄 등록 |
 | **Plugin** | `spakky-logging` | 구조화 로깅, 컨텍스트 전파, @logged AOP Aspect |
 | **Plugin** | `spakky-opentelemetry` | OpenTelemetry SDK 브릿지 (TracerProvider, OTel Propagator) |
@@ -100,6 +100,7 @@ graph TD
 
     sqlalchemy --> data
     sqlalchemy -. outbox contribution .-> outbox
+    sqlalchemy -. agent persistence contribution .-> agent
     rabbitmq --> event
     rabbitmq --> tracing
     kafka --> event
@@ -146,11 +147,12 @@ graph TD
 
 - **UI 플러그인** (fastapi, typer) → `spakky` 코어에만 의존. fastapi는 `spakky-tracing`에도 의존 (트레이싱 미들웨어)
 - **유틸리티 플러그인** (security) → `spakky` 코어에만 의존
-- **인프라 플러그인** (sqlalchemy) → `spakky-data`에 의존. Base plugin은 SQLAlchemy substrate를 등록하고, Outbox 저장소는 `spakky-outbox`가 함께 설치·활성화된 경우 `spakky.contributions.spakky.outbox` contribution으로 등록
+- **인프라 플러그인** (sqlalchemy) → `spakky-data`에 의존. Base plugin은 SQLAlchemy substrate를 등록하고, Outbox 저장소는 `spakky-outbox`가 함께 설치·활성화된 경우 `spakky.contributions.spakky.outbox` contribution으로 등록하며, Agent state/signal/evidence 저장소는 `spakky-agent`가 함께 설치·활성화된 경우 `spakky.contributions.spakky.agent` contribution으로 등록
 - **트랜스포트 플러그인** (rabbitmq, kafka) → `spakky-event`까지 의존 (전체 코어 체인). `spakky-tracing`에도 의존 (컨텍스트 전파)
 - **Outbox 코어** (spakky-outbox) → `spakky-event` + `spakky-tracing`에 의존 (추상화 + 오케스트레이션)
 - **태스크 코어** (spakky-task) → `spakky` 코어에만 의존
-- **Agent 코어** (spakky-agent) → `spakky` 코어에만 의존. AgentYield, state/signal/evidence, model port, delegation 계약을 제공하며 vLLM/SQLAlchemy/FastAPI/Typer 같은 infrastructure dependency와 production in-memory persistence fallback을 포함하지 않음
+- **Agent 코어** (spakky-agent) → `spakky` 코어에만 의존. `@Agent` stereotype, AgentYield, state/signal/evidence, model port, tool binding, delegation 계약을 제공하며 vLLM/SQLAlchemy/FastAPI/Typer 같은 infrastructure dependency와 production in-memory persistence fallback을 포함하지 않음
+- **vLLM 플러그인** (spakky-vllm) → `spakky-agent`에 의존하는 outbound `IAgentModel` adapter. vLLM OpenAI-compatible HTTP/SSE mapping만 담당하고 core 또는 inbound adapter를 역참조하지 않음
 - **Actuator 코어** (spakky-actuator) → `spakky` 코어에만 의존
 - **캐시 코어** (spakky-cache) → `spakky` 코어에만 의존
 - **트레이싱 코어** (spakky-tracing) → `spakky` 코어에만 의존
@@ -455,6 +457,7 @@ spakky-data = "spakky.data.main:initialize"
 | `spakky-kafka` | `KafkaConnectionConfig`, Consumer/`KafkaEventTransport` (sync+async), `KafkaPostProcessor` |
 | `spakky-sqlalchemy` | `SQLAlchemyConnectionConfig`, `SchemaRegistry`, Session/ConnectionManager, Transaction |
 | `spakky-sqlalchemy` contribution for `spakky-outbox` | `SqlAlchemyOutboxStorage` (sync+async), `OutboxMessageTable` |
+| `spakky-sqlalchemy` contribution for `spakky-agent` | `SqlAlchemyAgentStateRepository`, `SqlAlchemyAgentSignalRepository`, `SqlAlchemyAgentEvidenceRepository`, `AgentStateTable`, `AgentSignalTable`, `AgentEvidenceTable` |
 | `spakky-outbox` | `OutboxConfig`, `OutboxEventBus` (sync+async), `OutboxRelayBackgroundService` (sync+async) |
 | `spakky-task` | `TaskRegistrationPostProcessor` |
 | `spakky-actuator` | `ActuatorConfig`, `ActuatorExtensionRegistry`, `ActuatorExtensionPostProcessor`, `ActuatorAggregationService` |
@@ -466,6 +469,16 @@ spakky-data = "spakky.data.main:initialize"
 | `spakky-grpc` | `RegisterServicesPostProcessor`, `AddInterceptorsPostProcessor`, `BindServerPostProcessor` |
 | `spakky-redis` | `RedisCacheConfig`, `RedisCache` |
 | `spakky-vllm` | `VllmConfig`, `HttpxVllmChatClient`, `VllmAgentModel` |
+
+### Agentic workflow layer
+
+`spakky-agent`는 LLM SDK wrapper가 아니라 application layer building block입니다. `@Agent`는 `@UseCase`와 동격인 `@Pod` 계열 stereotype이고, inbound adapter는 `execute()`가 내보내는 `AgentYield` stream을 HTTP/WebSocket/CLI 이벤트로 변환합니다. Agent 내부의 비결정적 orchestration은 business workflow로 남고, 외부 세계 접근은 constructor DI로 받은 outbound port와 `@agent_tool` descriptor를 통해서만 표현합니다.
+
+Core public API의 중심은 `AgentExecutionSpec`, `AgentYield`, `AgentState`, `AgentSignal`, `AgentEvidence`, `IAgentModel`, `@agent_tool`, `DelegationPacket`/`IAgentDelegate`, context/safety/recovery contract입니다. Durable 실행은 `RecoveryStrategy.ACTION_BOUNDARY` 또는 `accepted_signals` 선언에서 파생되며, bootstrap 단계에서 `IAgentStateRepository`, `IAgentSignalRepository`, `IAgentEvidenceRepository`가 모두 등록되어 있는지 검증합니다. Core는 production in-memory repository fallback을 제공하지 않습니다.
+
+`spakky-vllm`은 첫 공식 model provider plugin입니다. `VllmConfig`, `HttpxVllmChatClient`, `VllmAgentModel`을 등록하고 `IAgentModel -> VllmAgentModel` binding을 추가합니다. 이 패키지는 OpenAI-compatible vLLM `/v1/chat/completions` 요청, SSE stream, structured output, tool-call JSON validation을 provider-neutral `ModelResponse`/`ModelStreamEvent`로 변환하며, `spakky-agent` core와 inbound adapter package를 역참조하지 않습니다.
+
+`spakky-sqlalchemy`는 ADR-0010 feature contribution 정책에 따라 Agent persistence를 기여합니다. `spakky.contributions.spakky.agent` entry point는 `spakky-agent` feature와 `spakky-sqlalchemy` provider가 모두 active일 때 base plugin 이후 로드되어 `AgentStateTable`, `AgentSignalTable`, `AgentEvidenceTable`과 세 repository Pod을 등록합니다. Signal은 `consumed_at`으로 pending queue를 구분하고, Evidence repository는 append/read만 노출해 append-only contract를 유지합니다. 별도 `spakky-agent-sqlalchemy` plugin은 만들지 않습니다.
 
 ### 애플리케이션 데이터 캐시
 
@@ -1052,6 +1065,8 @@ flowchart TD
 
 `spakky-sqlalchemy`는 `spakky.contributions.spakky.outbox` entry point로 `SqlAlchemyOutboxStorage`와 `OutboxMessageTable`을 기여합니다. 이 contribution은 `spakky-outbox` feature와 `spakky-sqlalchemy` provider가 모두 active일 때 base plugin 이후 로드됩니다. 커스텀 저장소는 `IAsyncOutboxStorage`를 구현합니다.
 
+Agent persistence도 같은 contribution 모델을 사용합니다. `spakky.contributions.spakky.agent` entry point는 `SqlAlchemyAgentStateRepository`, `SqlAlchemyAgentSignalRepository`, `SqlAlchemyAgentEvidenceRepository`와 `spakky_agent_state`, `spakky_agent_signal`, `spakky_agent_evidence` table을 등록합니다. Durable `@Agent`는 이 repository port가 없으면 bootstrap에서 실패하며, 운영용 in-memory fallback은 없습니다.
+
 > **설계 배경**: [ADR-0002](docs/adr/0002-outbox-plugin-architecture.md), [ADR-0005](docs/adr/0005-merge-outbox-sqlalchemy-into-sqlalchemy.md), [ADR-0006](docs/adr/0006-move-outbox-to-core.md) 참조.
 
 ---
@@ -1199,7 +1214,7 @@ flowchart TD
 
 | 플러그인 | 등록 컴포넌트 | 외부 의존성 |
 |---------|-------------|-----------|
-| `spakky-sqlalchemy` | ConnectionConfig, SchemaRegistry, Session/ConnectionManager, Transaction; `spakky-outbox` contribution으로 `SqlAlchemyOutboxStorage` (sync+async), `OutboxMessageTable` | `sqlalchemy`; outbox contribution에는 `spakky-outbox` extra 또는 별도 설치 필요 |
+| `spakky-sqlalchemy` | ConnectionConfig, SchemaRegistry, Session/ConnectionManager, Transaction; `spakky-outbox` contribution으로 `SqlAlchemyOutboxStorage` (sync+async), `OutboxMessageTable`; `spakky-agent` contribution으로 agent state/signal/evidence repository와 table | `sqlalchemy`; outbox contribution에는 `spakky-outbox` extra, agent contribution에는 `spakky-agent` extra 또는 별도 설치 필요 |
 | `spakky-security` | (등록 없음 — 유틸리티 함수만) | `argon2-cffi`, `bcrypt`, `pycryptodome` |
 | `spakky-redis` | `RedisCacheConfig`, `RedisCache` (sync+async) | `redis`, `pydantic-settings`, `spakky-cache` |
 | `spakky-vllm` | `VllmConfig`, `HttpxVllmChatClient`, `VllmAgentModel` | `httpx`, `pydantic-settings`, `spakky-agent` |

--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@
 
 ---
 
-**Spakky**는 확장 가능하고 모듈화된 애플리케이션을 쉽게 만들 수 있도록 설계된 현대적인 Spring-inspired Python 의존성 주입 프레임워크입니다. Inversion of Control(IoC)과 Aspect-Oriented Programming(AOP)을 Python 생태계에 맞게 제공하며 **FastAPI**, **RabbitMQ**, **Typer**를 일급으로 지원합니다.
+**Spakky**는 확장 가능하고 모듈화된 애플리케이션을 쉽게 만들 수 있도록 설계된 현대적인 Spring-inspired Python 의존성 주입 프레임워크입니다. Inversion of Control(IoC)과 Aspect-Oriented Programming(AOP)을 Python 생태계에 맞게 제공하며 **FastAPI**, **RabbitMQ**, **Typer**, **Agentic workflow**를 일급으로 지원합니다.
 
 ## ✨ 주요 기능
 
 - **의존성 주입(DI)**: `@Pod` 데코레이터를 사용하는 강력한 IoC 컨테이너이며 Singleton, Prototype, Context 스코프를 지원합니다.
 - **관점 지향 프로그래밍(AOP)**: `@Aspect`, `@Before`, `@After`, `@Around`를 기본 제공하여 로깅과 트랜잭션 같은 횡단 관심사를 처리합니다.
 - **모듈형 플러그인 시스템**: 주요 라이브러리를 플러그인으로 쉽게 확장할 수 있는 아키텍처.
+- **Agentic workflow**: `@Agent`, `AgentYield`, `IAgentModel`, `@agent_tool`로 Claude Code-like workflow를 UseCase처럼 구성합니다.
 - **타입 안전성**: 현대적인 Python 타입 힌트를 기준으로 설계되었습니다.
 - **비동기 우선**: `asyncio`와 비동기 의존성 주입을 네이티브로 지원합니다.
 
@@ -107,6 +108,12 @@ pip install spakky
 
 ```bash
 pip install "spakky[fastapi,kafka]"
+```
+
+Agentic workflow를 구성할 때는 core contract, model adapter, durable persistence provider를 명시적으로 설치합니다. 운영용 in-memory persistence fallback은 제공하지 않습니다.
+
+```bash
+pip install spakky-agent spakky-vllm "spakky-sqlalchemy[agent]"
 ```
 
 ### 기본 사용법

--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -9,6 +9,22 @@
 - model adapter를 `IAgentModel` outbound port로 구현하려는 경우
 - long-running execution의 state, signal, evidence 계약을 plugin contribution으로 구현하려는 경우
 
+## 설치
+
+Core contract만 사용할 때는 `spakky-agent`를 설치합니다.
+
+```bash
+pip install spakky-agent
+```
+
+로컬 vLLM model adapter와 SQLAlchemy durable repository를 함께 쓰는 일반적인 ADR-0009 조합은 다음처럼 설치합니다.
+
+```bash
+pip install spakky-agent spakky-vllm "spakky-sqlalchemy[agent]"
+```
+
+`spakky-agent`는 public API와 bootstrap validation만 제공합니다. Production state/signal/evidence repository는 `spakky.contributions.spakky.agent` provider contribution으로 들어와야 하며, 운영용 in-memory persistence fallback은 없습니다.
+
 ## 제공하는 public surface
 
 - `Agent`, `AgentExecutionSpec`, `AgentExecutionLimits`: `@UseCase`와 동격인 Pod stereotype과 보조 실행 의미

--- a/docs/api/core/spakky-agent.md
+++ b/docs/api/core/spakky-agent.md
@@ -2,6 +2,19 @@
 
 Agentic Hexagonal Architecture core contracts입니다.
 
+## Install
+
+```bash
+pip install spakky-agent
+```
+
+`spakky-agent` owns the public contracts: `@Agent`, `AgentExecutionSpec`,
+`AgentYield`, `AgentState`, `AgentSignal`, `AgentEvidence`, `IAgentModel`,
+`@agent_tool`, context/safety/recovery, and delegation types. It intentionally
+does not import vLLM, SQLAlchemy, FastAPI, or Typer. Durable production execution
+requires repository implementations from a provider contribution such as
+`spakky-sqlalchemy[agent]`; there is no production in-memory fallback.
+
 ## Public API
 
 ::: spakky.agent

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,6 +11,7 @@
 - [spakky-data](core/spakky-data.md) — Repository, Transaction 추상화
 - [spakky-event](core/spakky-event.md) — 인프로세스 이벤트
 - [spakky-task](core/spakky-task.md) — 태스크 추상화
+- [spakky-agent](core/spakky-agent.md) — Agentic workflow core 계약
 - [spakky-tracing](core/spakky-tracing.md) — 분산 트레이싱 추상화
 - [spakky-outbox](core/spakky-outbox.md) — Outbox 패턴
 - [spakky-saga](core/spakky-saga.md) — 사가 오케스트레이션

--- a/docs/api/plugins/spakky-sqlalchemy.md
+++ b/docs/api/plugins/spakky-sqlalchemy.md
@@ -13,6 +13,14 @@ Outbox storage/table은 base plugin 본체가 아니라
 contribution이 로드됩니다. 설치 시에는 `spakky-outbox`를 별도로 추가하거나
 `spakky-sqlalchemy[outbox]` extra를 사용하세요.
 
+Agent state/signal/evidence persistence도 base plugin 본체가 아니라
+`spakky.contributions.spakky.agent` contribution으로 등록됩니다. Durable `@Agent`
+execution을 운영에서 사용하려면 `spakky-agent`와 `spakky-sqlalchemy[agent]`를
+함께 설치하고 두 plugin을 모두 active 상태로 로드해야 합니다. 이 contribution은
+`SqlAlchemyAgentStateRepository`, `SqlAlchemyAgentSignalRepository`,
+`SqlAlchemyAgentEvidenceRepository`와 `AgentStateTable`, `AgentSignalTable`,
+`AgentEvidenceTable`을 등록합니다. 운영용 in-memory fallback은 제공하지 않습니다.
+
 ## 메인
 
 ::: spakky.plugins.sqlalchemy.main
@@ -72,6 +80,20 @@ options:
 show_root_heading: false
 
 ::: spakky.plugins.sqlalchemy.outbox.table
+options:
+show_root_heading: false
+
+## Agent Persistence
+
+::: spakky.plugins.sqlalchemy.contributions.agent
+options:
+show_root_heading: false
+
+::: spakky.plugins.sqlalchemy.agent.repository
+options:
+show_root_heading: false
+
+::: spakky.plugins.sqlalchemy.agent.table
 options:
 show_root_heading: false
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -160,6 +160,29 @@ class CreateUserUseCase:
         ...
 ```
 
+### @Agent
+
+LLM 기반 orchestration을 수행하는 application workflow component입니다. `@UseCase`와
+동격인 `@Pod` 계열 stereotype이며, inbound adapter에서 호출되고 constructor DI로
+model/workspace/shell/git/repository 같은 outbound port를 주입받습니다.
+
+`@Agent`의 `execute()`는 `AgentYield` stream을 반환할 수 있습니다. `token`,
+`progress`, `tool`, `evidence`, `approval`, `final`, `error`, `cancel` event는
+FastAPI WebSocket, CLI, SSE 같은 inbound adapter가 transport별 payload로 변환합니다.
+
+### IAgentModel
+
+`spakky-agent`가 소유하는 model outbound port입니다. `spakky-vllm`은 이 port의 첫
+공식 provider plugin으로, OpenAI-compatible vLLM HTTP/SSE 응답을 provider-neutral
+`ModelResponse`와 `ModelStreamEvent`로 변환합니다.
+
+### Agent Persistence Contribution
+
+Durable Agent 실행에 필요한 `IAgentStateRepository`, `IAgentSignalRepository`,
+`IAgentEvidenceRepository` 구현을 provider plugin이 기여하는 방식입니다.
+SQLAlchemy 구현은 `spakky.contributions.spakky.agent` entry point로 제공되며,
+운영용 in-memory fallback은 없습니다.
+
 ### @Repository
 
 데이터 접근 계층. 영속성 저장소와의 상호작용을 추상화합니다.

--- a/docs/guides/agent-code-assistant.md
+++ b/docs/guides/agent-code-assistant.md
@@ -19,6 +19,56 @@
 
 운영용 persistence나 production in-memory fallback은 포함하지 않습니다. 실제 운영에서는 `IAgentStateRepository`, `IAgentSignalRepository`, `IAgentEvidenceRepository`를 SQLAlchemy contribution 같은 provider plugin으로 주입해야 합니다.
 
+## 실행 가능한 빠른 검증
+
+이 guide의 예제는 `core/spakky-agent` 패키지에 실제 코드와 테스트로 들어 있습니다.
+문서 흐름이 코드와 맞는지 확인하려면 package directory에서 acceptance test를 실행합니다.
+
+```bash
+cd core/spakky-agent
+uv run pytest tests/acceptance/test_code_assistant_demo_acceptance.py -q --no-cov
+```
+
+이 테스트는 scripted `IAgentModel` stream을 사용하므로 로컬 vLLM 서버가 없어도 실행됩니다.
+테스트 double repository는 예제/테스트용일 뿐이며, 운영 durable 실행에는
+`spakky-sqlalchemy[agent]`가 제공하는 `spakky.contributions.spakky.agent`
+contribution을 사용해야 합니다.
+
+가장 작은 runnable `@Agent` shape는 다음 fixture와 같습니다. 파일로 저장해
+애플리케이션 scan 대상에 포함하면 `CodeAssistant`는 일반 UseCase처럼 container에서
+resolve됩니다.
+
+```python
+from collections.abc import AsyncGenerator
+
+from spakky.agent import Agent, AgentExecutionSpec, AgentYield, AgentYieldKind, Final
+from spakky.core.pod.annotations.pod import Pod
+
+
+@Pod()
+class AnswerTools:
+    def answer(self, command: str) -> str:
+        return f"handled:{command}"
+
+
+@Agent(spec=AgentExecutionSpec(name="code_assistant", objective="handle commands"))
+class CodeAssistant:
+    def __init__(self, tools: AnswerTools) -> None:
+        self._tools = tools
+
+    async def execute(
+        self,
+        command: str,
+    ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(output=self._tools.answer(command), metadata={}),
+        )
+```
+
+Claude Code-like demo는 이 최소 shape에 model stream, workspace/shell/git ports,
+approval signal, evidence repository, action-boundary resume를 더한 것입니다.
+
 ## 구조
 
 ```python

--- a/plugins/spakky-sqlalchemy/README.md
+++ b/plugins/spakky-sqlalchemy/README.md
@@ -305,6 +305,9 @@ fallback을 제공하지 않습니다.
 | `ConnectionManager` | 동기 SQLAlchemy engine lifecycle |
 | `AsyncConnectionManager` | 비동기 SQLAlchemy engine lifecycle |
 | `SQLAlchemyConnectionConfig` | 환경변수 기반 설정 |
+| `SqlAlchemyAgentStateRepository` | `IAgentStateRepository`의 SQLAlchemy 구현 |
+| `SqlAlchemyAgentSignalRepository` | `IAgentSignalRepository`의 SQLAlchemy 구현. `consumed_at`으로 pending signal queue를 구분 |
+| `SqlAlchemyAgentEvidenceRepository` | `IAgentEvidenceRepository`의 SQLAlchemy 구현. append/read만 노출 |
 
 ## Repository 메서드
 

--- a/plugins/spakky-vllm/README.md
+++ b/plugins/spakky-vllm/README.md
@@ -9,6 +9,17 @@ without adding model SDK dependencies to core.
 Use this package when an application wants to run `@Agent` workflows against a
 local vLLM server and inject the model through the core `IAgentModel` port.
 
+## Install
+
+```bash
+pip install spakky-vllm
+```
+
+Durable Agent execution also needs `spakky-agent` and a persistence provider such
+as `spakky-sqlalchemy[agent]`. `spakky-vllm` supplies the model adapter only; it
+does not provide state, signal, evidence repositories, inbound HTTP/CLI adapters,
+or a production in-memory persistence fallback.
+
 ## Configuration
 
 Settings are loaded through `VllmConfig` with the `SPAKKY_VLLM__` environment


### PR DESCRIPTION
## Summary

- Sync ADR-0009 architecture docs with `spakky-agent`, `spakky-vllm`, and SQLAlchemy agent persistence contribution boundaries.
- Add install/public API/contribution/no-production-in-memory-fallback guidance across root and package README/API surfaces.
- Expand the CodeAssistant guide with a runnable `@Agent` quick check and concrete Claude Code-like workflow wiring notes.

## Acceptance Criteria

- [x] `ARCHITECTURE.md` explains `spakky-agent`, `spakky-vllm`, SQLAlchemy agent persistence contribution location, and dependency direction.
- [x] Core/plugin READMEs explain public API, install path, contribution behavior, and no production in-memory fallback.
- [x] User guide explains a Claude Code-like `@Agent` workflow with runnable examples.
- [x] Docs terminology matches ADR-0009/public API terms.
- [x] Acceptance grep: missing explicit grep lines in issue body; verified criteria via targeted `rg` across changed docs.

## Verification

- `uv run mkdocs build --strict`
- `cd core/spakky-agent && uv run pytest tests/acceptance/test_code_assistant_demo_acceptance.py -q --no-cov`
- `git diff --check`
