### PR TITLE
docs: align auth ADR scope with milestone spec (#278)

### DIFF
--- a/docs/adr/0011-auth-contribution-routing-boundary.md
+++ b/docs/adr/0011-auth-contribution-routing-boundary.md
@@ -1,0 +1,142 @@
+# ADR-0011: Auth Contribution Routing Boundary
+
+- **상태**: Proposed
+- **날짜**: 2026-05-15
+- **대체**: 해당 없음
+- **관련**: [ADR-0010](0010-feature-contribution-policy.md), [인증/인가 마일스톤 스펙](../planning/auth-authorization-milestone-scope.md)
+
+## 맥락 (Context)
+
+인증/인가 마일스톤은 `spakky-auth` 코어 패키지와 provider plugin을 도입한다. 이 과정에서 여러 provider가 같은 capability를 제공할 수 있다. 예를 들어 policy evaluator, relation checker, snapshot signer, password verifier가 모두 `spakky.contributions.spakky.auth` contribution으로 들어올 수 있다.
+
+ADR-0010은 feature contribution loading의 일반 정책이다. 그러나 인증/인가 마일스톤의 현재 구현 범위는 generic multi-contribution routing engine을 만드는 것이 아니다. 현재 마일스톤은 auth feature 내부에서 protected metadata와 snapshot propagation config가 요구하는 capability를 검증하고, 정확히 하나의 provider가 필요한 경우 startup에서 fail fast하는 데 집중한다.
+
+따라서 본 ADR은 **미래의 generic contribution routing proposal**이다. 현재 인증/인가 구현의 SSOT (Single Source of Truth)는 이 ADR이 아니라 인증/인가 마일스톤과 자식 이슈 본문, 그리고 [인증/인가 마일스톤 스펙](../planning/auth-authorization-milestone-scope.md)이다.
+
+## 결정 동인 (Decision Drivers)
+
+- 여러 feature가 provider contribution을 요구할 때 routing 규칙이 feature마다 중복될 수 있다.
+- provider 우선순위, qualifier, binding policy, diagnostics를 feature-neutral 형태로 재사용할 여지가 있다.
+- 다만 인증/인가 마일스톤은 기존 코드와 충돌하지 않는 작은 단위로 진행되어야 한다.
+- generic routing을 선행 구현하면 `spakky-auth`의 핵심 계약, AOP enforcement, provider/boundary integration보다 큰 선행 dependency가 생긴다.
+
+## 제안 (Proposal)
+
+향후 Spakky Framework는 feature contribution을 단순 loading 단위에서 routing 가능한 provider 후보 집합으로 확장할 수 있다.
+
+제안 방향:
+
+- feature core는 capability key와 selection policy를 선언한다.
+- provider contribution은 capability set과 diagnostic metadata를 선언한다.
+- application config 또는 feature-local metadata가 capability별 provider binding을 지정할 수 있다.
+- routing 결과는 startup diagnostics에 후보, 선택 근거, 충돌 원인을 구조화해 기록한다.
+- 단수 provider가 필요한 capability에서 후보가 0개 또는 2개 이상이면 startup failure로 처리한다.
+
+이 제안은 ADR-0010의 contribution loading 이후 단계에 위치한다.
+
+```text
+spakky.plugins base loading
+  -> active feature discovery
+  -> spakky.contributions.<feature> loading
+  -> future contribution routing proposal
+  -> feature-local startup validation
+  -> ApplicationContext.start()
+```
+
+## 현재 인증/인가 마일스톤에 적용하지 않는 범위
+
+본 ADR은 현재 마일스톤에서 다음 구현을 요구하지 않는다.
+
+- generic multi-contribution routing engine
+- provider priority/routing DSL (Domain-Specific Language)
+- Redis 또는 SQLAlchemy auth persistence contribution
+- audit log platform
+- approval grant lifecycle
+- MCP (Model Context Protocol) runtime/tool authorization
+- authorized data/query filtering
+- OIDC browser login/callback/session/refresh/logout route
+- OpenFGA tuple/model admin 또는 list-resources API
+
+현재 인증/인가 구현은 `spakky-auth` feature-local validation으로 충분해야 한다. protected auth usage 또는 snapshot propagation config가 요구하는 capability마다 provider count를 검증하고, 0개 또는 2개 이상이면 structured auth startup error와 startup diagnostic detail로 실패한다. provider-specific priority/routing은 구현하지 않는다.
+
+## 현재 마일스톤의 기준
+
+현재 기준은 다음과 같다.
+
+- `spakky-auth`는 provider-neutral model, ABC port, decorator metadata, AOP enforcement, feature-local startup validation을 소유한다.
+- provider plugin은 `spakky.contributions.spakky.auth` contribution으로 capability를 제공한다.
+- protected/decorated boundary는 fail closed이고 decorator가 없는 boundary는 allow all이다.
+- task, broker, event, saga 전파는 raw bearer token이 아니라 signed `AuthContextSnapshot`을 사용한다.
+- permission, role, scope, resource, action, claim, tenant 값은 string canonical ref로 둔다.
+- public port는 ABC + `abstractmethod`를 사용하며 `Protocol`은 사용하지 않는다.
+- Phase 3.5 Loop-3에서 통과한 DAG (Directed Acyclic Graph)와 scope는 [인증/인가 마일스톤 스펙](../planning/auth-authorization-milestone-scope.md)을 따른다.
+
+## 고려한 대안 (Considered Options)
+
+### 대안 A: ADR-0011을 현재 auth 구현 SSOT로 승격
+
+장점:
+
+- provider routing의 큰 그림을 한 번에 설명할 수 있다.
+
+단점:
+
+- 현재 마일스톤 범위보다 넓은 generic routing을 구현 전제로 만들 수 있다.
+- #279 이후 티켓의 작은 DAG (Directed Acyclic Graph) 단위가 불필요하게 커진다.
+- Redis/SQLAlchemy persistence, audit, approval, MCP runtime auth, data filtering 같은 범위 밖 항목이 auth core 작업으로 오인될 수 있다.
+
+### 대안 B: ADR-0011을 만들지 않음
+
+장점:
+
+- 현재 구현 범위가 단순하게 유지된다.
+
+단점:
+
+- 향후 여러 feature가 provider routing 요구를 공유할 때 논의 출발점이 없다.
+- ADR-0010과 auth feature-local validation 사이의 미래 확장 여지를 문서화하지 못한다.
+
+### 대안 C: Future proposal로만 유지
+
+장점:
+
+- 현재 인증/인가 구현 범위와 미래 generic routing 논의를 분리한다.
+- downstream issue는 feature-local validation과 provider/boundary integration에 집중할 수 있다.
+- scope drift를 막으면서도 향후 generic routing 설계의 자리표시자를 남긴다.
+
+단점:
+
+- 향후 구현 시 별도 ADR 또는 본 ADR의 Accepted 전환 PR이 필요하다.
+
+## 결정 (Decision)
+
+대안 C를 채택한다.
+
+ADR-0011은 현재 `Proposed` 상태의 future generic contribution routing proposal로 남긴다. 현재 인증/인가 마일스톤의 구현 SSOT가 아니며, #279 이후 티켓은 본 ADR을 필수 구현 대상으로 삼지 않는다.
+
+현재 마일스톤에서 필요한 provider count 검증은 `spakky-auth` feature-local startup validation으로 구현한다. generic routing engine, provider priority, Redis/SQLAlchemy auth persistence contribution, audit, approval, MCP runtime auth, data filtering은 모두 범위 밖이다.
+
+## Consequences
+
+### 긍정적
+
+- 인증/인가 마일스톤의 현재 구현 범위가 작고 검증 가능하게 유지된다.
+- ADR-0010 contribution loading 정책과 충돌하지 않는다.
+- 향후 generic routing이 필요해질 때 논의 대상과 비대상을 분리한 출발점이 생긴다.
+
+### 부정적
+
+- provider routing을 원하는 future feature는 당장 공통 routing API를 재사용할 수 없다.
+- provider priority가 필요한 요구는 현재 마일스톤에서 의도적으로 거절되어야 한다.
+
+### 중립적
+
+- `spakky-auth`는 contribution loading 이후 자체 validation을 수행한다.
+- `spakky-policy`, `spakky-openfga`, `spakky-oidc`, `spakky-cryptography`는 provider-specific routing DSL 없이 capability를 제공한다.
+
+## 검증 기준
+
+- ADR-0011 본문은 현재 auth 구현 SSOT가 아님을 명시한다.
+- 범위 밖 항목이 Redis/SQLAlchemy auth persistence contribution, audit, approval, MCP runtime auth, data filtering을 포함한다.
+- 현재 마일스톤의 DAG (Directed Acyclic Graph)와 scope 기준은 별도 스펙 문서로 연결된다.
+- `uv run mkdocs build --strict`가 통과한다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,7 @@ Architecture Decision Record는 소프트웨어 아키텍처에 영향을 미치
 | [ADR-0008](0008-type-safety-hardening.md) | 타입 안전성 강화 — pyrefly ignore 박멸과 구조적 개선 | Accepted | 2026-04-13 |
 | [ADR-0009](0009-agentic-hexagonal-architecture.md) | Agentic Hexagonal Architecture — agent runtime 논의 보존 | Proposed | 2026-05-04 |
 | [ADR-0010](0010-feature-contribution-policy.md) | Feature Contribution Policy — core feature별 plugin contribution 로딩 정책 | Accepted | 2026-05-05 |
+| [ADR-0011](0011-auth-contribution-routing-boundary.md) | Auth Contribution Routing Boundary — 인증/인가 contribution routing 범위 경계 | Proposed | 2026-05-15 |
 
 ## 새 ADR 작성 가이드
 

--- a/docs/planning/auth-authorization-milestone-scope.md
+++ b/docs/planning/auth-authorization-milestone-scope.md
@@ -1,0 +1,161 @@
+# Authentication and Authorization Milestone Scope
+
+- **상태**: Active scope baseline
+- **작성일**: 2026-05-15
+- **대상 마일스톤**: 프레임워크 인증/인가
+- **관련 ADR**: [ADR-0011](../adr/0011-auth-contribution-routing-boundary.md)
+
+## 목적
+
+이 문서는 인증/인가 마일스톤의 downstream issue가 공유해야 하는 scope와 DAG (Directed Acyclic Graph) 기준을 고정한다. ADR-0011은 future generic contribution routing proposal이며, 현재 인증/인가 구현의 SSOT (Single Source of Truth)가 아니다.
+
+현재 구현 기준은 이 문서와 GitHub milestone issue body다. 코드 작업 티켓은 이 문서를 기준으로 scope drift를 판단하고, 각 티켓의 수용 기준을 넘는 구현을 추가하지 않는다.
+
+## 범위
+
+현재 마일스톤은 다음을 포함한다.
+
+- `core/spakky-auth` 신규 core package 등록
+- `AuthContext`, `CredentialCarrier`, `AuthContextSnapshot`, decision/error model
+- ABC + `abstractmethod` 기반 auth port와 `AuthCapability` enum
+- decorator metadata와 sync/async AOP enforcement
+- feature-local capability startup validation
+- `spakky-cryptography`, `spakky-oidc`, `spakky-policy`, `spakky-openfga` provider plugin
+- FastAPI, gRPC, Typer, task, Celery, event, RabbitMQ, Kafka, Saga boundary integration
+- `spakky-security` shim 없는 제거와 migration documentation
+
+## 범위 밖
+
+다음은 현재 인증/인가 마일스톤에서 구현하지 않는다.
+
+- generic multi-contribution routing engine
+- provider priority/routing DSL (Domain-Specific Language)
+- Redis auth persistence contribution
+- SQLAlchemy auth persistence contribution
+- audit log platform
+- approval grant lifecycle
+- MCP (Model Context Protocol) runtime/tool authorization
+- authorized data/query filtering
+- OIDC browser login/callback/session/refresh/logout route
+- OpenFGA tuple/model admin 또는 list-resources API
+- generic policy engine, policy UI/API
+
+범위 밖 항목이 downstream issue에서 발견되면 현재 PR에 섞지 않고 follow-up issue로 분리한다.
+
+## 핵심 결정
+
+- decorator가 없는 boundary는 allow all이다.
+- protected/decorated boundary는 fail closed다.
+- auth failure decision state는 `ALLOW`, `CHALLENGE`, `DENY`, `ERROR`다.
+- `AuthContext`는 `ApplicationContext` request/context scope에 저장된다.
+- inbound adapter는 기존 `clear_context` 이후 사용자 handler/task/step 호출 전에 `AuthContext`를 seed한다.
+- task, broker, event, saga 전파는 raw bearer token이 아니라 signed `AuthContextSnapshot`을 사용한다.
+- framework 고정 어휘는 typed model 또는 `Enum`으로 정의한다.
+- permission, role, scope, resource, action, claim, tenant 값은 string canonical ref로 둔다.
+- public port는 ABC + `abstractmethod`를 사용하며 `Protocol`은 사용하지 않는다.
+- auth capability provider 수가 0개 또는 2개 이상이면 feature-local startup validation에서 structured auth startup error로 실패한다.
+- provider-specific priority/routing은 구현하지 않는다.
+
+## Phase 3.5 Loop-3 결과
+
+Phase 3.5 Loop-3는 `BLOCKING=false`, `CONFIDENCE=HIGH`로 통과했다. 이 baseline은 다음을 의미한다.
+
+- DAG (Directed Acyclic Graph) 모순 0건
+- 누락 blocker 0건
+- 도달 불가능한 성공 기준 0건
+- 표면적 매핑 0건
+- scope drift 0건
+- hard block 0건
+
+Downstream issue는 아래 DAG 기준을 따른다. #278은 문서/spec 정합성 고정 작업이며, #279 이후 구현 티켓의 코드를 선행 구현하지 않는다.
+
+## DAG 기준
+
+```mermaid
+graph TD
+    A01["#278 A01: ADR and spec alignment"]
+    A02["#279 A02: spakky-auth package registration"]
+    A03["#280 A03: AuthContext and decision model"]
+    A04["#281 A04: ABC ports and AuthCapability"]
+    A05["#282 A05: decorators and AOP enforcement"]
+    A06["#283 A06: capability startup validation"]
+
+    P01["#284 P01: cryptography provider"]
+    P02["#285 P02: OIDC bearer provider"]
+    P03["#286 P03: policy evaluator provider"]
+    P04["#287 P04: OpenFGA relation provider"]
+
+    B01["#288 B01: FastAPI boundary"]
+    B02["#289 B02: gRPC boundary"]
+    B03["#290 B03: Typer boundary"]
+    B04["#291 B04: task direct execution"]
+    B05["#292 B05: Celery boundary"]
+    B06["#293 B06: event snapshot propagation"]
+    B07["#294 B07: RabbitMQ boundary"]
+    B08["#295 B08: Kafka boundary"]
+    B09["#296 B09: Saga boundary"]
+
+    R01["#297 R01: security symbol mapping"]
+    R02["#298 R02: remove spakky-security"]
+    R04["#299 R04: final docs and migration guide"]
+    R03["#300 R03: final conformance matrix"]
+
+    A01 --> A02 --> A03 --> A04 --> A05 --> A06
+    A04 --> P01
+    A04 --> P02
+    A04 --> P03
+    A04 --> P04
+    A05 --> B01
+    A06 --> B01
+    A05 --> B02
+    A06 --> B02
+    A05 --> B03
+    A06 --> B03
+    A05 --> B04
+    A06 --> B04
+    B04 --> B05
+    P01 --> B05
+    P01 --> B06
+    B06 --> B07
+    A05 --> B07
+    A06 --> B07
+    B06 --> B08
+    A05 --> B08
+    A06 --> B08
+    A05 --> B09
+    A06 --> B09
+    P01 --> B09
+    P01 --> R01
+    P02 --> R01
+    R01 --> R02
+    P01 --> R02
+    P02 --> R02
+    P03 --> R02
+    P04 --> R02
+    R02 --> R04 --> R03
+    P01 --> R03
+    P02 --> R03
+```
+
+## Downstream issue body contract
+
+The issue bodies for #279 through #300 are treated as the implementation contract for their own tickets. They must stay aligned with this baseline.
+
+- #279 starts only after #278.
+- #280 starts only after package registration in #279.
+- #281 starts only after the semantic model in #280.
+- #282 starts only after the public port/capability contract in #281.
+- #283 validates auth feature capabilities locally; it does not implement generic contribution routing.
+- Provider tickets #284 through #287 depend on the public auth contract in #281.
+- Boundary tickets #288 through #296 depend on decorator/AOP enforcement and startup validation where their issue body lists #282 and #283.
+- Removal/documentation tickets #297 through #300 run after provider and cleanup prerequisites listed in their issue bodies.
+
+If a downstream ticket appears to require Redis/SQLAlchemy auth persistence, audit, approval, MCP runtime auth, data filtering, or generic provider routing, that requirement is out of scope for the current milestone unless a later issue explicitly accepts it.
+
+## 검증
+
+This document is documentation-only. The required verification for #278 is:
+
+```bash
+uv run mkdocs build --strict
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
       - AOP 가이드: aop-guide.md
       - 이벤트 시스템: event-system.md
       - 플러그인 API: plugin-api.md
+      - 인증/인가 마일스톤 스펙: planning/auth-authorization-milestone-scope.md
   - 참조:
       - 용어 사전: glossary.md
       - 에러 계층 구조: error-hierarchy.md
@@ -173,3 +174,7 @@ nav:
       - ADR-0005 Outbox SQLAlchemy 통합: adr/0005-merge-outbox-sqlalchemy-into-sqlalchemy.md
       - ADR-0006 spakky-outbox 코어 승격: adr/0006-move-outbox-to-core.md
       - ADR-0007 spakky-saga 분산 트랜잭션 오케스트레이션: adr/0007-spakky-saga-plan.md
+      - ADR-0008 타입 안전성 강화: adr/0008-type-safety-hardening.md
+      - ADR-0009 Agentic Hexagonal Architecture: adr/0009-agentic-hexagonal-architecture.md
+      - ADR-0010 Feature Contribution Policy: adr/0010-feature-contribution-policy.md
+      - ADR-0011 Auth Contribution Routing Boundary: adr/0011-auth-contribution-routing-boundary.md


### PR DESCRIPTION
## Summary
- Add ADR-0011 as a Proposed future generic contribution routing boundary, explicitly not the current auth implementation SSOT.
- Add the authentication/authorization milestone scope and DAG baseline from Phase 3.5 Loop-3.
- Register the new ADR and milestone spec in MkDocs navigation and ADR index.

## Acceptance Criteria (자가 grep)
- [x] 이슈 본문에 실행 가능한 grep/find/rg 라인이 없음 -> acceptance_check: missing
- [x] ADR-0011은 future generic contribution routing proposal로만 남고 현재 인증/인가 구현 SSOT가 아님을 명시
- [x] Redis/SQLAlchemy auth persistence contribution, audit, approval, MCP runtime auth, data filtering 범위 밖 명시
- [x] Phase 3.5 Loop-3 DAG와 scope baseline 문서화

## Verification
- `uv run mkdocs build --strict`

Closes #278
