### PR TITLE
feat(typer): integrate auth boundary enforcement (#290)

### DIFF
--- a/core/spakky-auth/README.md
+++ b/core/spakky-auth/README.md
@@ -47,7 +47,7 @@ class DocumentController:
 
 Stacked requirement는 canonical `AuthRequirement` tuple로 aggregate되며, exact duplicate는 제거됩니다. Class-level requirement와 method-level requirement는 AND semantics로 결합됩니다. `public_access`와 protected requirement가 effective metadata에서 동시에 관찰되면 `ConflictingAuthMetadataError`가 발생합니다. OR/ANY semantics는 decorator 조합이 아니라 후속 `spakky-policy` named policy로 표현합니다.
 
-`AuthorizationAspect`와 `AsyncAuthorizationAspect`는 메서드 인자로 `AuthContext`를 요구하지 않습니다. 각 inbound adapter가 `ApplicationContext` request/context scope에 seed한 `AuthContext`를 `require_auth_context()`로 읽고, provider-neutral checker port decision이 `ALLOW`가 아니면 `AuthRequirementDeniedError`로 실패합니다.
+`AuthorizationAspect`와 `AsyncAuthorizationAspect`는 메서드 인자로 `AuthContext`를 요구하지 않습니다. 각 inbound adapter가 `ApplicationContext` request/context scope에 seed한 `AuthContext`를 `require_auth_context()`로 읽고, provider-neutral checker port decision이 `ALLOW`가 아니면 `AuthRequirementDeniedError`로 실패합니다. 이 오류는 non-ALLOW `AuthorizationDecision`을 `decision` 속성에 보존하므로 inbound adapter는 원래 reason code를 CLI/HTTP/gRPC 등 transport별 응답으로 매핑할 수 있습니다.
 
 ## Provider Contribution Contract
 

--- a/core/spakky-auth/src/spakky/auth/error.py
+++ b/core/spakky-auth/src/spakky/auth/error.py
@@ -3,7 +3,6 @@
 from abc import ABC
 
 from spakky.auth.decision import AuthorizationDecision
-
 from spakky.core.common.error import AbstractSpakkyFrameworkError
 
 

--- a/docs/guides/typer.md
+++ b/docs/guides/typer.md
@@ -186,6 +186,36 @@ class OrderCLI:
 
 명령 옵션 이름은 Typer의 기본 규칙을 따릅니다. 위 예시는 `python main.py orders import --path ./orders.json`처럼 호출합니다. `@command(name=None)`이면 메서드명이 Typer command 이름이 되고, 그룹 이름은 `@CliController("orders")` 또는 클래스명 kebab-case로 정해집니다.
 
+## Auth boundary 통합
+
+`spakky-auth`를 함께 사용하면 CLI command method에 `@protected`, `@require_scope`, `@require_role`, `@require_permission`, `@require_policy`, `@require_relation` metadata를 선언할 수 있습니다. Typer adapter는 command 실행 직전에 `--auth-token` option을 먼저 읽고, 없으면 `SPAKKY_AUTH_TOKEN` env var를 읽어 `CredentialCarrier(location=CLI_OPTION)`로 provider에 전달합니다. stdin은 auth 전달체가 아닙니다.
+
+```python
+from spakky.auth import require_scope
+from spakky.plugins.typer.stereotypes.cli_controller import CliController, command
+
+
+@CliController("documents")
+class DocumentCLI:
+    @command("read")
+    @require_scope("documents:read")
+    def read_document(self, document_id: str) -> None:
+        print(f"reading {document_id}")
+```
+
+```bash
+python main.py documents read --document-id doc-1 --auth-token "$TOKEN"
+SPAKKY_AUTH_TOKEN="$TOKEN" python main.py documents read --document-id doc-1
+```
+
+Decorator가 없는 command는 auth provider 없이도 allow all입니다. Protected command는 token, authentication provider, `AuthContext`, authorization checker 중 필요한 요소가 없거나 decision이 `ALLOW`가 아니면 fail closed 됩니다. CLI 출력은 reason code 기반이며 exit code는 다음처럼 고정됩니다.
+
+| Decision | Exit code | 예시 reason code |
+|----------|-----------|------------------|
+| `CHALLENGE` | `2` | `MISSING_CREDENTIAL`, `INVALID_CREDENTIAL` |
+| `DENY` | `3` | `INSUFFICIENT_SCOPE`, `POLICY_DENIED` |
+| `ERROR` | `1` | `VERIFICATION_PROVIDER_UNAVAILABLE` |
+
 ## AgentYield stream CLI
 
 `@Agent`도 CLI adapter에서는 UseCase와 같은 방식으로 다룹니다. Typer 전용 agent plugin을 만들지 않고, `@CliController` command가 container에서 agent Pod를 resolve한 뒤 `execute()`를 순회하면 됩니다. CodeAssistant demo의 CLI 예제는 `core/spakky-agent/examples/inbound_adapter_examples.py`에 있습니다.

--- a/plugins/spakky-typer/README.md
+++ b/plugins/spakky-typer/README.md
@@ -20,6 +20,7 @@ pip install spakky[typer]
 - **비동기 지원**: CLI command에서 async/await 전체 지원
 - **Command grouping**: command를 논리적 group으로 구성
 - **의존성 주입**: 서비스가 controller에 자동 주입
+- **Auth boundary 통합**: `--auth-token` / `SPAKKY_AUTH_TOKEN` 전달체로 `AuthContext` seed 및 protected command fail-closed 처리
 - **Rich 통합**: Typer의 rich console output 활용
 - **Actuator command**: `spakky-actuator` 로드 시 `actuator` 상태 command 등록
 
@@ -115,6 +116,40 @@ typer_app = application.container.get(Typer)
 if __name__ == "__main__":
     typer_app()
 ```
+
+### Auth boundary
+
+`spakky-auth` decorator를 CLI controller method에 선언하면 Typer adapter가 command 실행 전에 auth 전달체를 추출하고 `ApplicationContext`에 `AuthContext`를 seed합니다.
+
+전달체 우선순위는 `--auth-token` option, 그 다음 `SPAKKY_AUTH_TOKEN` env var입니다. stdin은 auth 전달체로 사용하지 않습니다.
+
+```python
+from spakky.auth import protected, require_scope
+from spakky.plugins.typer.stereotypes.cli_controller import CliController, command
+
+
+@CliController("docs")
+class DocumentCliController:
+    @command("read")
+    @require_scope("documents:read")
+    def read_document(self, document_id: str) -> None:
+        print(f"read {document_id}")
+```
+
+```bash
+python main.py docs read --document-id doc-1 --auth-token "$TOKEN"
+SPAKKY_AUTH_TOKEN="$TOKEN" python main.py docs read --document-id doc-1
+```
+
+Auth 결과는 reason code를 출력하고 Typer exit code로 매핑됩니다.
+
+| Decision | Exit code |
+|----------|-----------|
+| `CHALLENGE` | `2` |
+| `DENY` | `3` |
+| `ERROR` | `1` |
+
+Decorator가 없는 command는 provider나 token 없이 허용됩니다. Protected command는 token/provider/AuthContext/checker가 없거나 authorization decision이 `ALLOW`가 아니면 fail closed 됩니다.
 
 ### Actuator command
 

--- a/plugins/spakky-typer/pyproject.toml
+++ b/plugins/spakky-typer/pyproject.toml
@@ -6,7 +6,12 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = { text = "MIT" }
 authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
-dependencies = ["spakky>=6.5.0", "spakky-actuator>=6.5.0", "typer>=0.24.1"]
+dependencies = [
+  "spakky>=6.5.0",
+  "spakky-actuator>=6.5.0",
+  "spakky-auth>=6.5.0",
+  "typer>=0.24.1",
+]
 
 [project.entry-points."spakky.plugins"]
 spakky-typer = "spakky.plugins.typer.main:initialize"
@@ -69,3 +74,4 @@ exclude_lines = [
 [tool.uv.sources]
 spakky = { workspace = true }
 spakky-actuator = { workspace = true }
+spakky-auth = { workspace = true }

--- a/plugins/spakky-typer/src/spakky/plugins/typer/post_processor.py
+++ b/plugins/spakky-typer/src/spakky/plugins/typer/post_processor.py
@@ -5,10 +5,28 @@ decorated classes, with support for both sync and async command handlers.
 """
 
 from functools import wraps
-from inspect import getmembers, iscoroutinefunction
+from inspect import Parameter, Signature, getmembers, iscoroutinefunction, signature
 from logging import getLogger
-from typing import Any
+import os
+from typing import Any, Callable, Never, cast
 
+from spakky.auth import (
+    AuthContextNotFoundError,
+    AuthInvocation,
+    AuthRequirementDeniedError,
+    AuthRequirementProviderUnavailableError,
+    AuthVerificationProviderUnavailableError,
+    AuthenticationError,
+    AuthorizationDecision,
+    AuthorizationReasonCode,
+    AuthorizationDecisionState,
+    CredentialCarrier,
+    CredentialCarrierKind,
+    CredentialCarrierLocation,
+    IAuthenticationProvider,
+    get_effective_auth_metadata,
+    store_auth_context,
+)
 from spakky.core.pod.annotations.order import Order
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.interfaces.application_context import IApplicationContext
@@ -22,9 +40,77 @@ from typing import override
 
 from spakky.plugins.typer.stereotypes.cli_controller import CliController, TyperCommand
 from spakky.plugins.typer.utils.asyncio import run_async
-from typer import Typer
+from typer import Exit, Option, Typer, echo
+from typer.models import OptionInfo
 
 logger = getLogger(__name__)
+
+AUTH_TOKEN_OPTION_PARAMETER = "_spakky_auth_token"
+AUTH_TOKEN_ENV_VAR = "SPAKKY_AUTH_TOKEN"
+
+
+def _auth_token_parameter() -> Parameter:
+    return Parameter(
+        AUTH_TOKEN_OPTION_PARAMETER,
+        kind=Parameter.KEYWORD_ONLY,
+        default=Option(
+            None,
+            "--auth-token",
+            envvar=AUTH_TOKEN_ENV_VAR,
+            help="Authentication bearer token.",
+        ),
+        annotation=str | None,
+    )
+
+
+def _existing_auth_token_parameter(original: Signature) -> str | None:
+    for parameter in original.parameters.values():
+        if parameter.name in {AUTH_TOKEN_OPTION_PARAMETER, "auth_token"}:
+            return parameter.name
+        if (
+            isinstance(parameter.default, OptionInfo)
+            and parameter.default.param_decls is not None
+            and "--auth-token" in parameter.default.param_decls
+        ):
+            return parameter.name
+    return None
+
+
+def _with_auth_token_option(method: Callable[..., object]) -> Signature:
+    original = signature(method)
+    if _existing_auth_token_parameter(original) is not None:
+        return original
+    return original.replace(
+        parameters=tuple(original.parameters.values()) + (_auth_token_parameter(),)
+    )
+
+
+def _invocation(controller_type: type[object], method_name: str) -> AuthInvocation:
+    return AuthInvocation(
+        boundary="CLI",
+        operation=f"{controller_type.__module__}.{controller_type.__qualname__}.{method_name}",
+    )
+
+
+def _carrier(auth_token: str) -> CredentialCarrier:
+    return CredentialCarrier(
+        kind=CredentialCarrierKind.BEARER_TOKEN,
+        location=CredentialCarrierLocation.CLI_OPTION,
+        material=auth_token,
+        name="--auth-token",
+        scheme="Bearer",
+    )
+
+
+def _exit(decision: AuthorizationDecision) -> Never:
+    echo(decision.reason_code.value)
+    if decision.reason is not None:
+        echo(decision.reason)
+    if decision.state is AuthorizationDecisionState.CHALLENGE:
+        raise Exit(code=2)
+    if decision.state is AuthorizationDecisionState.DENY:
+        raise Exit(code=3)
+    raise Exit(code=1)
 
 
 @Order(0)
@@ -88,6 +174,13 @@ class TyperCLIPostProcessor(IPostProcessor, IContainerAware, IApplicationContext
         for name, method in getmembers(pod, callable):
             command: TyperCommand | None = TyperCommand.get_or_none(method)
             if command is not None:
+                auth_metadata = get_effective_auth_metadata(
+                    method,
+                    owner_type=controller.type_,
+                )
+                existing_auth_token_parameter = _existing_auth_token_parameter(
+                    signature(method)
+                )
                 # pylint: disable=line-too-long
                 logger.info(
                     f"[{type(self).__name__}] {command.name!r} -> {'async' if iscoroutinefunction(method) else ''} {method.__qualname__}"
@@ -99,11 +192,55 @@ class TyperCLIPostProcessor(IPostProcessor, IContainerAware, IApplicationContext
                     method_name: str = name,
                     controller_type: type[object] = controller.type_,
                     container: IContainer = self.__container,
+                    protected: bool = auth_metadata.protected,
+                    auth_token_parameter: str | None = existing_auth_token_parameter,
                     **kwargs: Any,
                 ) -> Any:
+                    auth_token = (
+                        kwargs.get(auth_token_parameter)
+                        if auth_token_parameter is not None
+                        else kwargs.pop(AUTH_TOKEN_OPTION_PARAMETER, None)
+                    )
+                    if auth_token is None:
+                        auth_token = os.environ.get(AUTH_TOKEN_ENV_VAR)
                     # CLI invocations often share the same interpreter session,
                     # so purge any context-scoped Pods to avoid cross-command leaks.
                     self.__application_context.clear_context()
+                    invocation = _invocation(controller_type, method_name)
+                    if isinstance(auth_token, str) and auth_token:
+                        provider = container.get_or_none(IAuthenticationProvider)
+                        if provider is None:
+                            if protected:
+                                _exit(
+                                    AuthorizationDecision.error(
+                                        AuthorizationReasonCode.VERIFICATION_PROVIDER_UNAVAILABLE
+                                    )
+                                )
+                        else:
+                            try:
+                                auth_context = provider.authenticate(
+                                    _carrier(auth_token),
+                                    invocation,
+                                )
+                            except AuthVerificationProviderUnavailableError:
+                                _exit(
+                                    AuthorizationDecision.error(
+                                        AuthorizationReasonCode.VERIFICATION_PROVIDER_UNAVAILABLE
+                                    )
+                                )
+                            except AuthenticationError:
+                                _exit(
+                                    AuthorizationDecision.challenge(
+                                        AuthorizationReasonCode.INVALID_CREDENTIAL
+                                    )
+                                )
+                            store_auth_context(self.__application_context, auth_context)
+                    elif protected:
+                        _exit(
+                            AuthorizationDecision.challenge(
+                                AuthorizationReasonCode.MISSING_CREDENTIAL
+                            )
+                        )
                     controller_instance = container.get(controller_type)
                     # 프레임워크 내부: CLI 커맨드 메서드 동적 디스패치
                     method_to_call = getattr(  # command decorator method lookup
@@ -111,7 +248,30 @@ class TyperCLIPostProcessor(IPostProcessor, IContainerAware, IApplicationContext
                     )
                     if iscoroutinefunction(method_to_call):
                         method_to_call = run_async(method_to_call)
-                    return method_to_call(*args, **kwargs)
+                    try:
+                        return method_to_call(*args, **kwargs)
+                    except AuthContextNotFoundError:
+                        _exit(
+                            AuthorizationDecision.challenge(
+                                AuthorizationReasonCode.MISSING_CREDENTIAL
+                            )
+                        )
+                    except AuthRequirementProviderUnavailableError:
+                        _exit(
+                            AuthorizationDecision.error(
+                                AuthorizationReasonCode.VERIFICATION_PROVIDER_UNAVAILABLE
+                            )
+                        )
+                    except AuthRequirementDeniedError as error:
+                        _exit(
+                            error.decision
+                            if error.decision is not None
+                            else AuthorizationDecision.deny(
+                                AuthorizationReasonCode.POLICY_DENIED
+                            )
+                        )
+
+                cast(Any, endpoint).__signature__ = _with_auth_token_option(method)
 
                 command_group.command(
                     name=command.name,

--- a/plugins/spakky-typer/tests/test_command.py
+++ b/plugins/spakky-typer/tests/test_command.py
@@ -1,6 +1,172 @@
+from inspect import signature
+from typing import Literal, override
+
 from click.testing import Result
-from typer import Typer
+from pytest import MonkeyPatch
+import spakky.auth
+from spakky.auth import (
+    AuthCapability,
+    AuthContext,
+    AuthInvocation,
+    AuthProviderContribution,
+    AuthSubject,
+    AuthorizationDecision,
+    AuthorizationReasonCode,
+    CredentialCarrier,
+    IAuthenticationProvider,
+    IScopeChecker,
+    ScopeCheckRequest,
+    AuthenticationError,
+    AuthVerificationProviderUnavailableError,
+    protected,
+    require_auth_context,
+    require_scope,
+)
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.annotations.pod import Pod
+from typer import Option, Typer
 from typer.testing import CliRunner
+
+import spakky.plugins.typer
+from spakky.plugins.typer.post_processor import _with_auth_token_option
+from spakky.plugins.typer.stereotypes.cli_controller import CliController, command
+
+
+@CliController("auth-boundary")
+class AuthBoundaryController:
+    @command("open")
+    def open_command(self) -> None:
+        print("open")
+
+    @command("context")
+    def context_command(self) -> None:
+        require_auth_context(_AUTH_APP_CONTEXT)
+        print("context")
+
+    @command("protected")
+    @protected
+    def protected_command(self) -> None:
+        auth_context = require_auth_context(_AUTH_APP_CONTEXT)
+        print(auth_context.subject.id)
+
+    @command("existing-token")
+    @protected
+    def existing_token_command(self, auth_token: str | None = None) -> None:
+        auth_context = require_auth_context(_AUTH_APP_CONTEXT)
+        print(f"{auth_context.subject.id}:{auth_token}")
+
+    @command("denied")
+    @require_scope("documents:write")
+    def denied_command(self) -> None:
+        print("denied")
+
+
+@Pod()
+class AllowingAuthenticationProvider(IAuthenticationProvider):
+    @override
+    def authenticate(
+        self,
+        credential: CredentialCarrier,
+        invocation: AuthInvocation,
+    ) -> AuthContext:
+        _AUTH_CREDENTIALS.append(credential)
+        _AUTH_INVOCATIONS.append(invocation)
+        return AuthContext(
+            subject=AuthSubject(id="cli-user"),
+            issuer="issuer:test",
+            credential_carrier=credential,
+        )
+
+
+@Pod()
+class UnavailableAuthenticationProvider(IAuthenticationProvider):
+    @override
+    def authenticate(
+        self,
+        credential: CredentialCarrier,
+        invocation: AuthInvocation,
+    ) -> AuthContext:
+        raise AuthVerificationProviderUnavailableError()
+
+
+@Pod()
+class InvalidAuthenticationProvider(IAuthenticationProvider):
+    @override
+    def authenticate(
+        self,
+        credential: CredentialCarrier,
+        invocation: AuthInvocation,
+    ) -> AuthContext:
+        raise AuthenticationError()
+
+
+@Pod()
+class DenyingScopeChecker(IScopeChecker):
+    @override
+    def check_scope(self, request: ScopeCheckRequest) -> AuthorizationDecision:
+        return AuthorizationDecision.deny(
+            AuthorizationReasonCode.INSUFFICIENT_SCOPE,
+            reason="scope denied",
+        )
+
+
+@Pod()
+def _auth_provider_contribution() -> AuthProviderContribution:
+    return AuthProviderContribution(
+        provider_id="typer-test",
+        capabilities=frozenset(
+            {
+                AuthCapability.AUTHENTICATION,
+                AuthCapability.SCOPE_CHECK,
+            }
+        ),
+    )
+
+
+@Pod(name="cli")
+def _get_auth_cli() -> Typer:
+    return Typer()
+
+
+_AUTH_CREDENTIALS: list[CredentialCarrier] = []
+_AUTH_INVOCATIONS: list[AuthInvocation] = []
+_AUTH_APP_CONTEXT = ApplicationContext()
+
+
+def _start_auth_cli(
+    *,
+    include_auth_plugin: bool,
+    provider: Literal["allow", "unavailable", "invalid"] | None,
+    include_scope_checker: bool = True,
+) -> tuple[SpakkyApplication, Typer]:
+    global _AUTH_APP_CONTEXT
+
+    _AUTH_CREDENTIALS.clear()
+    _AUTH_INVOCATIONS.clear()
+    _AUTH_APP_CONTEXT = ApplicationContext()
+    plugins = {spakky.plugins.typer.PLUGIN_NAME}
+    if include_auth_plugin:
+        plugins.add(spakky.auth.PLUGIN_NAME)
+
+    app = (
+        SpakkyApplication(_AUTH_APP_CONTEXT)
+        .load_plugins(include=plugins)
+        .add(_get_auth_cli)
+        .add(AuthBoundaryController)
+    )
+    if provider == "allow":
+        app.add(AllowingAuthenticationProvider)
+    if provider == "unavailable":
+        app.add(UnavailableAuthenticationProvider)
+    if provider == "invalid":
+        app.add(InvalidAuthenticationProvider)
+    if provider is not None:
+        app.add(_auth_provider_contribution)
+    if include_scope_checker:
+        app.add(DenyingScopeChecker)
+    app.start()
+    return app, app.container.get(type_=Typer)
 
 
 def test_sync_function(cli: Typer, runner: CliRunner) -> None:
@@ -36,3 +202,249 @@ def test_execute_dummy(cli: Typer, runner: CliRunner) -> None:
     result: Result = runner.invoke(cli, ["second", "dummy"])
     assert result.exit_code == 0
     assert result.output == "Just Use Case!\n"
+
+
+def test_protected_command_seeds_auth_context_from_option(
+    runner: CliRunner,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """--auth-token 옵션이 env var보다 우선하여 AuthContext를 seed한다."""
+    monkeypatch.setenv("SPAKKY_AUTH_TOKEN", "env-token")
+    app, auth_cli = _start_auth_cli(include_auth_plugin=True, provider="allow")
+    try:
+        result = runner.invoke(
+            auth_cli,
+            ["auth-boundary", "protected", "--auth-token", "option-token"],
+        )
+    finally:
+        app.stop()
+
+    assert result.exit_code == 0
+    assert result.output == "cli-user\n"
+    assert _AUTH_CREDENTIALS[0].material == "option-token"
+    assert _AUTH_CREDENTIALS[0].location.value == "CLI_OPTION"
+    assert _AUTH_INVOCATIONS[0].boundary == "CLI"
+
+
+def test_protected_command_uses_env_token(
+    runner: CliRunner, monkeypatch: MonkeyPatch
+) -> None:
+    """SPAKKY_AUTH_TOKEN env var를 옵션 부재 시 전달체로 사용한다."""
+    monkeypatch.setenv("SPAKKY_AUTH_TOKEN", "env-token")
+    app, auth_cli = _start_auth_cli(include_auth_plugin=True, provider="allow")
+    try:
+        result = runner.invoke(auth_cli, ["auth-boundary", "protected"])
+    finally:
+        app.stop()
+
+    assert result.exit_code == 0
+    assert result.output == "cli-user\n"
+    assert _AUTH_CREDENTIALS[0].material == "env-token"
+
+
+def test_stdin_is_not_auth_carrier(runner: CliRunner) -> None:
+    """stdin 입력은 auth 전달체로 취급하지 않는다."""
+    app, auth_cli = _start_auth_cli(include_auth_plugin=False, provider=None)
+    try:
+        result = runner.invoke(
+            auth_cli,
+            ["auth-boundary", "protected"],
+            input="stdin-token\n",
+        )
+    finally:
+        app.stop()
+
+    assert result.exit_code == 2
+    assert result.output == "MISSING_CREDENTIAL\n"
+
+
+def test_command_without_auth_decorator_is_allowed(runner: CliRunner) -> None:
+    """auth decorator가 없는 CLI command는 provider 없이 허용한다."""
+    app, auth_cli = _start_auth_cli(include_auth_plugin=False, provider=None)
+    try:
+        result = runner.invoke(auth_cli, ["auth-boundary", "open"])
+    finally:
+        app.stop()
+
+    assert result.exit_code == 0
+    assert result.output == "open\n"
+
+
+def test_command_without_auth_decorator_ignores_global_token_without_provider(
+    runner: CliRunner,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """decorator가 없는 command는 global token이 있어도 provider 없이 허용한다."""
+    monkeypatch.setenv("SPAKKY_AUTH_TOKEN", "env-token")
+    app, auth_cli = _start_auth_cli(include_auth_plugin=False, provider=None)
+    try:
+        result = runner.invoke(auth_cli, ["auth-boundary", "open"])
+    finally:
+        app.stop()
+
+    assert result.exit_code == 0
+    assert result.output == "open\n"
+
+
+def test_protected_command_fails_closed_without_token(runner: CliRunner) -> None:
+    """보호된 CLI command는 token 부재 시 CHALLENGE로 fail-closed 된다."""
+    app, auth_cli = _start_auth_cli(include_auth_plugin=False, provider=None)
+    try:
+        result = runner.invoke(auth_cli, ["auth-boundary", "protected"])
+    finally:
+        app.stop()
+
+    assert result.exit_code == 2
+    assert result.output == "MISSING_CREDENTIAL\n"
+
+
+def test_denied_command_exits_with_deny_reason_code(runner: CliRunner) -> None:
+    """authorization DENY는 exit code 3과 reason code 메시지를 출력한다."""
+    app, auth_cli = _start_auth_cli(include_auth_plugin=True, provider="allow")
+    try:
+        result = runner.invoke(
+            auth_cli,
+            ["auth-boundary", "denied", "--auth-token", "valid-token"],
+        )
+    finally:
+        app.stop()
+
+    assert result.exit_code == 3
+    assert result.output == "INSUFFICIENT_SCOPE\nscope denied\n"
+
+
+def test_provider_unavailable_exits_with_error_reason_code(runner: CliRunner) -> None:
+    """provider 부재는 exit code 1과 ERROR reason code를 출력한다."""
+    app, auth_cli = _start_auth_cli(include_auth_plugin=False, provider=None)
+    try:
+        result = runner.invoke(
+            auth_cli,
+            ["auth-boundary", "protected", "--auth-token", "token"],
+        )
+    finally:
+        app.stop()
+
+    assert result.exit_code == 1
+    assert result.output == "VERIFICATION_PROVIDER_UNAVAILABLE\n"
+
+
+def test_auth_provider_unavailable_error_maps_to_error(runner: CliRunner) -> None:
+    """provider unavailable 예외도 ERROR reason code로 매핑한다."""
+    app, auth_cli = _start_auth_cli(
+        include_auth_plugin=True,
+        provider="unavailable",
+    )
+    try:
+        result = runner.invoke(
+            auth_cli,
+            ["auth-boundary", "protected", "--auth-token", "token"],
+        )
+    finally:
+        app.stop()
+
+    assert result.exit_code == 1
+    assert result.output == "VERIFICATION_PROVIDER_UNAVAILABLE\n"
+
+
+def test_authentication_error_maps_to_challenge(runner: CliRunner) -> None:
+    """authentication failure는 CHALLENGE reason code로 매핑한다."""
+    app, auth_cli = _start_auth_cli(include_auth_plugin=True, provider="invalid")
+    try:
+        result = runner.invoke(
+            auth_cli,
+            ["auth-boundary", "protected", "--auth-token", "bad-token"],
+        )
+    finally:
+        app.stop()
+
+    assert result.exit_code == 2
+    assert result.output == "INVALID_CREDENTIAL\n"
+
+
+def test_method_auth_context_lookup_failure_maps_to_challenge(
+    runner: CliRunner,
+) -> None:
+    """method 내부 AuthContext 조회 실패도 CHALLENGE로 fail-closed 된다."""
+    app, auth_cli = _start_auth_cli(include_auth_plugin=False, provider=None)
+    try:
+        result = runner.invoke(auth_cli, ["auth-boundary", "context"])
+    finally:
+        app.stop()
+
+    assert result.exit_code == 2
+    assert result.output == "MISSING_CREDENTIAL\n"
+
+
+def test_authorization_provider_unavailable_maps_to_error(runner: CliRunner) -> None:
+    """authorization provider 부재는 ERROR reason code로 매핑한다."""
+    app, auth_cli = _start_auth_cli(
+        include_auth_plugin=True,
+        provider="allow",
+        include_scope_checker=False,
+    )
+    try:
+        result = runner.invoke(
+            auth_cli,
+            ["auth-boundary", "denied", "--auth-token", "valid-token"],
+        )
+    finally:
+        app.stop()
+
+    assert result.exit_code == 1
+    assert result.output == "VERIFICATION_PROVIDER_UNAVAILABLE\n"
+
+
+def test_existing_auth_token_signature_parameter_is_preserved() -> None:
+    """public auth_token parameter가 이미 있으면 signature를 중복 확장하지 않는다."""
+
+    def command_with_auth_token(*, auth_token: str | None = None) -> None:
+        return None
+
+    assert _with_auth_token_option(command_with_auth_token) == signature(
+        command_with_auth_token
+    )
+
+
+def test_existing_auth_token_option_decl_is_preserved() -> None:
+    """기존 --auth-token option 선언도 중복 확장하지 않는다."""
+
+    def command_with_auth_option(
+        token: str | None = Option(None, "--auth-token"),
+    ) -> None:
+        return None
+
+    assert _with_auth_token_option(command_with_auth_option) == signature(
+        command_with_auth_option
+    )
+
+
+def test_non_auth_token_option_still_gets_internal_auth_option() -> None:
+    """다른 option 선언은 내부 auth option 추가를 막지 않는다."""
+
+    def command_with_other_option(
+        token: str | None = Option(None, "--token"),
+    ) -> None:
+        return None
+
+    assert (
+        "_spakky_auth_token"
+        in _with_auth_token_option(command_with_other_option).parameters
+    )
+
+
+def test_existing_auth_token_option_is_preserved_and_used_for_seeding(
+    runner: CliRunner,
+) -> None:
+    """기존 --auth-token 옵션은 command 인자와 auth seed에 모두 보존된다."""
+    app, auth_cli = _start_auth_cli(include_auth_plugin=True, provider="allow")
+    try:
+        result = runner.invoke(
+            auth_cli,
+            ["auth-boundary", "existing-token", "--auth-token", "existing-token"],
+        )
+    finally:
+        app.stop()
+
+    assert result.exit_code == 0
+    assert result.output == "cli-user:existing-token\n"
+    assert _AUTH_CREDENTIALS[0].material == "existing-token"

--- a/uv.lock
+++ b/uv.lock
@@ -3125,6 +3125,7 @@ source = { editable = "plugins/spakky-typer" }
 dependencies = [
     { name = "spakky" },
     { name = "spakky-actuator" },
+    { name = "spakky-auth" },
     { name = "typer" },
 ]
 
@@ -3132,6 +3133,7 @@ dependencies = [
 requires-dist = [
     { name = "spakky", editable = "core/spakky" },
     { name = "spakky-actuator", editable = "core/spakky-actuator" },
+    { name = "spakky-auth", editable = "core/spakky-auth" },
     { name = "typer", specifier = ">=0.24.1" },
 ]
 


### PR DESCRIPTION
## Summary
- Add Typer CLI auth extraction for `--auth-token` and `SPAKKY_AUTH_TOKEN` with stdin explicitly ignored as a carrier.
- Seed `AuthContext` before command invocation and map CHALLENGE/DENY/ERROR decisions to exit codes 2/3/1 with reason-code output.
- Preserve non-ALLOW `AuthorizationDecision` on `AuthRequirementDeniedError` so CLI responses can report the original reason code.
- Document Typer auth boundary behavior in package and user docs.

## Acceptance Criteria (자가 grep)

- 이슈 본문 수용 기준에 grep/rg/find 명령형 acceptance line이 없어 `acceptance_check: missing`으로 기록합니다.
- 기능 수용 기준은 패키지 단위 lint/type/test/coverage 100%와 Typer auth boundary tests로 검증했습니다.

## Verification
- `plugins/spakky-typer`: `uv run --with ruff ruff format .`; harness validation; `uv run --with ruff ruff check .`; `uv run --with pyrefly --with pytest pyrefly check src tests`
- `core/spakky-auth`: `uv run --with ruff ruff format .`; harness validation; `uv run --with ruff ruff check .`; `uv run --with pyrefly --with pytest pyrefly check src tests`
- `uv run python scripts/run_coverage.py --package spakky-typer --sequential`
- `uv run python scripts/run_coverage.py --package spakky-auth --sequential`

Closes #290
