### PR TITLE
feat(event): propagate signed auth snapshots (#293)

### DIFF
--- a/.agents/rules/monorepo.md
+++ b/.agents/rules/monorepo.md
@@ -26,7 +26,7 @@ cd core/spakky && uv run pytest
 | `spakky` | 없음 (`optional-dependencies`는 설치 편의만 허용) | core 확장/플러그인 source import |
 | `spakky-domain`, `spakky-tracing`, `spakky-task`, `spakky-auth`, `spakky-actuator`, `spakky-cache`, `spakky-agent` | `spakky` | 다른 core 확장 역방향 의존, plugin 의존 |
 | `spakky-data` | `spakky-domain` | infra/plugin 의존 |
-| `spakky-event` | `spakky-domain`, `spakky-data`, `spakky-tracing` | outbox/saga/plugin 의존 |
+| `spakky-event` | `spakky-domain`, `spakky-data`, `spakky-auth`, `spakky-tracing` | outbox/saga/plugin 의존 |
 | `spakky-outbox` | `spakky-event`, `spakky-tracing` | saga/plugin 의존 |
 | `spakky-saga` | `spakky`, `spakky-domain` | event/outbox/plugin 의존 |
 | `plugins/*` | 필요한 core 패키지 + 외부 SDK | 다른 plugin의 `src/` 직접 import, core로의 역방향 import |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -161,7 +161,7 @@ graph TD
 - **Actuator 코어** (spakky-actuator) → `spakky` 코어에만 의존
 - **캐시 코어** (spakky-cache) → `spakky` 코어에만 의존
 - **트레이싱 코어** (spakky-tracing) → `spakky` 코어에만 의존
-- **이벤트 코어** (spakky-event) → `spakky-domain` + `spakky-data` + `spakky-tracing`에 의존
+- **이벤트 코어** (spakky-event) → `spakky-domain` + `spakky-data` + `spakky-auth` + `spakky-tracing`에 의존
 - **태스크 플러그인** (spakky-celery) → `spakky-task` + `spakky-tracing`에 의존 (컨텍스트 전파)
 - **로깅 플러그인** (spakky-logging) → `spakky` 코어에만 의존
 - **OTel 플러그인** (spakky-opentelemetry) → `spakky` + `spakky-tracing`에 의존, `spakky-logging` optional
@@ -745,7 +745,7 @@ flowchart TD
 - **Publisher** (`IEventPublisher`): `publish(event: AbstractEvent)` — 타입 기반 라우팅
   - `AbstractDomainEvent` → `EventMediator` (인프로세스 dispatch)
   - `AbstractIntegrationEvent` → `IEventBus` (외부 전송)
-- **EventBus** (`IEventBus`): `send(event: AbstractIntegrationEvent)` — Integration Event 발행 진입점, Outbox seam 역할
+- **EventBus** (`IEventBus`): `send(event: AbstractIntegrationEvent)` — Integration Event 발행 진입점, Outbox seam 역할. `DirectEventBus` / `AsyncDirectEventBus`는 기존 tracing header를 보존하고, `AuthSnapshotPropagationConfig(enabled=True)`와 request-scope `AuthContext`가 있으면 raw bearer token 대신 signed `AuthContextSnapshot` envelope를 `spakky.auth.context_snapshot` metadata로 주입합니다.
 - **EventTransport** (`IEventTransport`): `send(event: AbstractIntegrationEvent)` — 실제 메시지 브로커 전송 (Kafka/RabbitMQ 구현)
 - **Dispatcher**: `dispatch(event)` — 등록된 핸들러에 인프로세스 전달
 - **Consumer**: `register(event_type, handler)` — 이벤트 타입과 콜백 연결
@@ -1064,7 +1064,7 @@ flowchart TD
 | 컴포넌트 | 설명 |
 |---------|------|
 | `IOutboxStorage` / `IAsyncOutboxStorage` | 아웃박스 메시지 저장소 포트 |
-| `OutboxEventBus` / `AsyncOutboxEventBus` | `@Primary`로 `DirectEventBus`를 교체하는 EventBus seam |
+| `OutboxEventBus` / `AsyncOutboxEventBus` | `@Primary`로 `DirectEventBus`를 교체하는 EventBus seam. 저장되는 Outbox headers에는 tracing metadata와 signed `AuthContextSnapshot` metadata가 함께 보존되며 raw bearer token은 저장하지 않음 |
 | `OutboxRelayBackgroundService` / `AsyncOutboxRelayBackgroundService` | 백그라운드 릴레이 (polling → `IEventTransport.send()`) |
 | `OutboxConfig` | 환경변수 기반 설정 (polling interval, batch size, retry 등) |
 | `OutboxMessage` | 아웃박스 메시지 모델 |

--- a/core/spakky-event/README.md
+++ b/core/spakky-event/README.md
@@ -130,7 +130,19 @@ app = (
 | `EventMediator` / `AsyncEventMediator` | Consumer와 Dispatcher를 결합한 in-process 구현체 |
 | `EventPublisher` / `AsyncEventPublisher` | Type-based router(DomainEvent→Mediator, IntegrationEvent→EventBus) |
 | `DirectEventBus` / `AsyncDirectEventBus` | 기본 EventBus → EventTransport 위임 구현 |
+| `AuthContextSnapshotHeaderInjector` | Event/Outbox outbound header에 signed `AuthContextSnapshot` metadata를 주입하는 helper |
 | `EventHandlerRegistrationPostProcessor` | `@EventHandler` 메서드를 자동 등록 |
+
+### 전파 metadata
+
+`DirectEventBus`와 `AsyncDirectEventBus`는 `IEventTransport.send(event_name, payload, headers)` public signature를 유지하면서 outbound header를 구성합니다.
+
+| metadata | 조건 | 설명 |
+|----------|------|------|
+| `traceparent` | `spakky-tracing` propagator 활성 | 기존 W3C tracing header를 보존합니다. |
+| `spakky.auth.context_snapshot` | `AuthSnapshotPropagationConfig(enabled=True)` + request-scope `AuthContext` + snapshot signer provider | raw bearer token 대신 signed `AuthContextSnapshot` envelope를 전파합니다. |
+
+`Authorization: Bearer ...` 같은 raw bearer credential은 event header로 전파하지 않습니다.
 
 ### 타입
 
@@ -146,6 +158,8 @@ app = (
 | 클래스 | 설명 |
 |-------|-------------|
 | `AbstractSpakkyEventError` | event operation 기반 error |
+| `AuthSnapshotPropagationContextUnavailableError` | snapshot 전파가 활성화되었지만 `ApplicationContext`를 읽을 수 없을 때 발생 |
+| `AuthSnapshotPropagationSignerUnavailableError` | snapshot 전파가 활성화되었지만 signer provider가 없을 때 발생 |
 | `InvalidMessageError` | message가 malformed일 때 발생 |
 
 ## 관련 패키지

--- a/core/spakky-event/pyproject.toml
+++ b/core/spakky-event/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     "spakky-domain>=6.5.0",
     "spakky-data>=6.5.0",
+    "spakky-auth>=6.5.0",
     "spakky-tracing>=6.5.0",
     "pydantic>=2.12.5",
 ]
@@ -73,4 +74,5 @@ exclude_lines = [
 [tool.uv.sources]
 spakky-domain = { workspace = true }
 spakky-data = { workspace = true }
+spakky-auth = { workspace = true }
 spakky-tracing = { workspace = true }

--- a/core/spakky-event/src/spakky/event/__init__.py
+++ b/core/spakky-event/src/spakky/event/__init__.py
@@ -8,8 +8,11 @@ from spakky.event.bus import (
     AsyncDirectEventBus,
     DirectEventBus,
 )
+from spakky.event.auth_propagation import AuthContextSnapshotHeaderInjector
 from spakky.event.error import (
     AbstractSpakkyEventError,
+    AuthSnapshotPropagationContextUnavailableError,
+    AuthSnapshotPropagationSignerUnavailableError,
     InvalidMessageError,
 )
 from spakky.event.event_consumer import (
@@ -61,6 +64,7 @@ __all__ = [
     "AsyncEventPublisher",
     "EventPublisher",
     # Bus Implementations
+    "AuthContextSnapshotHeaderInjector",
     "AsyncDirectEventBus",
     "DirectEventBus",
     # Post-Processors
@@ -70,6 +74,8 @@ __all__ = [
     "TransactionalEventPublishingAspect",
     # Errors
     "AbstractSpakkyEventError",
+    "AuthSnapshotPropagationContextUnavailableError",
+    "AuthSnapshotPropagationSignerUnavailableError",
     "InvalidMessageError",
 ]
 

--- a/core/spakky-event/src/spakky/event/auth_propagation.py
+++ b/core/spakky-event/src/spakky/event/auth_propagation.py
@@ -1,0 +1,89 @@
+"""Auth snapshot metadata propagation for outbound integration events."""
+
+from typing import override
+
+from spakky.auth import (
+    AUTH_CONTEXT_CONTEXT_KEY,
+    AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
+    AuthContext,
+    AuthSnapshotPropagationConfig,
+    IAuthContextSnapshotSigner,
+    InvalidAuthContextValueError,
+    SnapshotSignRequest,
+)
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.aware.application_context_aware import (
+    IApplicationContextAware,
+)
+
+from spakky.event.error import (
+    AuthSnapshotPropagationContextUnavailableError,
+    AuthSnapshotPropagationSignerUnavailableError,
+)
+
+AUTHORIZATION_HEADER = "authorization"
+BEARER_AUTHORIZATION_PREFIX = "bearer "
+
+
+@Pod()
+class AuthContextSnapshotHeaderInjector(IApplicationContextAware):
+    """Inject signed AuthContextSnapshot metadata into outbound event headers."""
+
+    _auth_snapshot_signer: IAuthContextSnapshotSigner | None
+    _auth_snapshot_propagation_config: AuthSnapshotPropagationConfig
+    _application_context: IApplicationContext | None
+
+    def __init__(
+        self,
+        auth_snapshot_signer: IAuthContextSnapshotSigner | None = None,
+        auth_snapshot_propagation_config: AuthSnapshotPropagationConfig | None = None,
+    ) -> None:
+        self._auth_snapshot_signer = auth_snapshot_signer
+        self._auth_snapshot_propagation_config = (
+            auth_snapshot_propagation_config or AuthSnapshotPropagationConfig()
+        )
+        self._application_context = None
+
+    @override
+    def set_application_context(self, application_context: IApplicationContext) -> None:
+        """Inject the application context used to read request-scoped auth state."""
+        self._application_context = application_context
+
+    def inject(self, headers: dict[str, str]) -> None:
+        """Add signed snapshot metadata when outbound propagation is enabled."""
+        self._remove_raw_bearer_headers(headers)
+        if not self._auth_snapshot_propagation_config.enabled:
+            return
+        auth_context = self._current_auth_context()
+        if auth_context is None:
+            return
+        snapshot = self._required_signer().sign_snapshot(
+            SnapshotSignRequest(auth_context=auth_context)
+        )
+        headers[AUTH_CONTEXT_SNAPSHOT_METADATA_KEY] = (
+            snapshot.base64url_canonical_json()
+        )
+
+    def _current_auth_context(self) -> AuthContext | None:
+        application_context = self._application_context
+        if application_context is None:
+            raise AuthSnapshotPropagationContextUnavailableError()
+        value = application_context.get_context_value(AUTH_CONTEXT_CONTEXT_KEY)
+        if value is None:
+            return None
+        if isinstance(value, AuthContext):
+            return value
+        raise InvalidAuthContextValueError()
+
+    def _required_signer(self) -> IAuthContextSnapshotSigner:
+        if self._auth_snapshot_signer is None:
+            raise AuthSnapshotPropagationSignerUnavailableError()
+        return self._auth_snapshot_signer
+
+    def _remove_raw_bearer_headers(self, headers: dict[str, str]) -> None:
+        for key in tuple(headers.keys()):
+            if key.lower() == AUTHORIZATION_HEADER and headers[key].lower().startswith(
+                BEARER_AUTHORIZATION_PREFIX
+            ):
+                del headers[key]

--- a/core/spakky-event/src/spakky/event/bus/transport_event_bus.py
+++ b/core/spakky-event/src/spakky/event/bus/transport_event_bus.py
@@ -7,6 +7,7 @@ from spakky.core.pod.annotations.pod import Pod
 from spakky.domain.models.event import AbstractIntegrationEvent
 from spakky.tracing.propagator import ITracePropagator
 
+from spakky.event.auth_propagation import AuthContextSnapshotHeaderInjector
 from spakky.event.event_publisher import (
     IAsyncEventBus,
     IAsyncEventTransport,
@@ -21,16 +22,21 @@ class DirectEventBus(IEventBus):
 
     _transport: IEventTransport
     _propagator: ITracePropagator
+    _auth_snapshot_headers: AuthContextSnapshotHeaderInjector
     _adapters: dict[type, TypeAdapter[AbstractIntegrationEvent]]
 
     def __init__(
         self,
         transport: IEventTransport,
         propagator: ITracePropagator,
+        auth_snapshot_headers: AuthContextSnapshotHeaderInjector | None = None,
     ) -> None:
         """Initialize with the given transport and trace propagator."""
         self._transport = transport
         self._propagator = propagator
+        self._auth_snapshot_headers = (
+            auth_snapshot_headers or AuthContextSnapshotHeaderInjector()
+        )
         self._adapters = {}
 
     @override
@@ -42,6 +48,7 @@ class DirectEventBus(IEventBus):
         adapter = self._adapters[event_type]
         headers: dict[str, str] = {}
         self._propagator.inject(headers)
+        self._auth_snapshot_headers.inject(headers)
         self._transport.send(
             event.event_name,
             adapter.dump_json(event),
@@ -55,16 +62,21 @@ class AsyncDirectEventBus(IAsyncEventBus):
 
     _transport: IAsyncEventTransport
     _propagator: ITracePropagator
+    _auth_snapshot_headers: AuthContextSnapshotHeaderInjector
     _adapters: dict[type, TypeAdapter[AbstractIntegrationEvent]]
 
     def __init__(
         self,
         transport: IAsyncEventTransport,
         propagator: ITracePropagator,
+        auth_snapshot_headers: AuthContextSnapshotHeaderInjector | None = None,
     ) -> None:
         """Initialize with the given async transport and trace propagator."""
         self._transport = transport
         self._propagator = propagator
+        self._auth_snapshot_headers = (
+            auth_snapshot_headers or AuthContextSnapshotHeaderInjector()
+        )
         self._adapters = {}
 
     @override
@@ -76,6 +88,7 @@ class AsyncDirectEventBus(IAsyncEventBus):
         adapter = self._adapters[event_type]
         headers: dict[str, str] = {}
         self._propagator.inject(headers)
+        self._auth_snapshot_headers.inject(headers)
         await self._transport.send(
             event.event_name,
             adapter.dump_json(event),

--- a/core/spakky-event/src/spakky/event/error.py
+++ b/core/spakky-event/src/spakky/event/error.py
@@ -13,6 +13,18 @@ class InvalidMessageError(AbstractSpakkyEventError):
     message = "Invalid or malformed message received"
 
 
+class AuthSnapshotPropagationSignerUnavailableError(AbstractSpakkyEventError):
+    """Raised when signed snapshot propagation lacks a signer provider."""
+
+    message = "Auth snapshot propagation signer is unavailable"
+
+
+class AuthSnapshotPropagationContextUnavailableError(AbstractSpakkyEventError):
+    """Raised when signed snapshot propagation cannot read ApplicationContext."""
+
+    message = "Auth snapshot propagation context is unavailable"
+
+
 class UnknownEventTypeError(AbstractSpakkyEventError):
     """Raised when an event type is neither domain nor integration."""
 

--- a/core/spakky-event/src/spakky/event/main.py
+++ b/core/spakky-event/src/spakky/event/main.py
@@ -8,6 +8,7 @@ from spakky.event.bus.transport_event_bus import (
     AsyncDirectEventBus,
     DirectEventBus,
 )
+from spakky.event.auth_propagation import AuthContextSnapshotHeaderInjector
 from spakky.event.mediator.domain_event_mediator import (
     AsyncEventMediator,
     EventMediator,
@@ -31,6 +32,7 @@ def initialize(app: SpakkyApplication) -> None:
     app.add(AsyncEventMediator)
     app.add(EventPublisher)
     app.add(AsyncEventPublisher)
+    app.add(AuthContextSnapshotHeaderInjector)
     app.add(DirectEventBus)
     app.add(AsyncDirectEventBus)
 

--- a/core/spakky-event/tests/unit/bus/test_transport_event_bus_headers.py
+++ b/core/spakky-event/tests/unit/bus/test_transport_event_bus_headers.py
@@ -1,11 +1,30 @@
 """Unit tests for DirectEventBus/AsyncDirectEventBus trace propagation."""
 
+from datetime import UTC, datetime, timedelta
+from typing import override
+
 import pytest
+from spakky.auth import (
+    AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
+    AuthContext,
+    AuthContextSnapshot,
+    AuthContextSnapshotSignature,
+    AuthSnapshotPropagationConfig,
+    AuthSubject,
+    CredentialCarrier,
+    CredentialCarrierKind,
+    CredentialCarrierLocation,
+    IAuthContextSnapshotSigner,
+    SnapshotSignRequest,
+    store_auth_context,
+)
+from spakky.core.application.application_context import ApplicationContext
 from spakky.core.common.mutability import immutable
 from spakky.domain.models.event import AbstractIntegrationEvent
 from spakky.tracing.context import TraceContext
 from spakky.tracing.propagator import ITracePropagator
 
+from spakky.event.auth_propagation import AuthContextSnapshotHeaderInjector
 from spakky.event.bus.transport_event_bus import AsyncDirectEventBus, DirectEventBus
 from spakky.event.event_publisher import IAsyncEventTransport, IEventTransport
 
@@ -62,6 +81,71 @@ class FakePropagator(ITracePropagator):
         return ["traceparent"]
 
 
+class BearerInjectingPropagator(FakePropagator):
+    """Fake propagator that also tries to inject a raw bearer header."""
+
+    @override
+    def inject(self, carrier: dict[str, str]) -> None:
+        super().inject(carrier)
+        carrier["authorization"] = "Bearer raw-token"
+
+
+class FakeSnapshotSigner(IAuthContextSnapshotSigner):
+    """Signer that records requests and returns a deterministic snapshot."""
+
+    def __init__(self) -> None:
+        self.requests: list[SnapshotSignRequest] = []
+
+    @override
+    def sign_snapshot(self, request: SnapshotSignRequest) -> AuthContextSnapshot:
+        self.requests.append(request)
+        return AuthContextSnapshot(
+            subject=request.auth_context.subject,
+            issuer=request.auth_context.issuer,
+            issued_at=datetime(2026, 1, 1, tzinfo=UTC),
+            expires_at=datetime(2026, 1, 1, tzinfo=UTC) + timedelta(minutes=5),
+            signature=AuthContextSnapshotSignature(
+                key_id="kid-1",
+                algorithm="HS256",
+                signature="signature-1",
+            ),
+            tenant=request.auth_context.tenant,
+            roles=request.auth_context.roles,
+            scopes=request.auth_context.scopes,
+            selected_claims=request.auth_context.claims,
+        )
+
+
+def _auth_context() -> AuthContext:
+    return AuthContext(
+        subject=AuthSubject(id="subject-1", display_name="Subject One"),
+        issuer="issuer-1",
+        tenant="tenant-1",
+        roles=("role-1",),
+        scopes=("scope-1",),
+        credential_carrier=CredentialCarrier(
+            kind=CredentialCarrierKind.BEARER_TOKEN,
+            location=CredentialCarrierLocation.AUTHORIZATION_HEADER,
+            material="raw-token",
+            name="authorization",
+            scheme="Bearer",
+        ),
+    )
+
+
+def _enabled_auth_headers(
+    signer: FakeSnapshotSigner,
+) -> AuthContextSnapshotHeaderInjector:
+    application_context = ApplicationContext()
+    store_auth_context(application_context, _auth_context())
+    injector = AuthContextSnapshotHeaderInjector(
+        auth_snapshot_signer=signer,
+        auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(enabled=True),
+    )
+    injector.set_application_context(application_context)
+    return injector
+
+
 # ── Sync tests ──
 
 
@@ -82,6 +166,27 @@ def test_direct_event_bus_with_propagator_expect_headers_injected() -> None:
         headers["traceparent"]
         == "00-abcd1234abcd1234abcd1234abcd1234-1234abcd1234abcd-01"
     )
+
+
+def test_direct_event_bus_with_auth_context_expect_signed_snapshot_metadata() -> None:
+    """sync event bus가 trace header를 보존하고 signed snapshot만 전파함을 검증한다."""
+    transport = RecordingTransport()
+    signer = FakeSnapshotSigner()
+    bus = DirectEventBus(
+        transport,
+        BearerInjectingPropagator(),
+        _enabled_auth_headers(signer),
+    )
+
+    event = SampleIntegrationEvent(message="signed")
+    bus.send(event)
+
+    assert len(signer.requests) == 1
+    _, _, headers = transport.sent[0]
+    assert "traceparent" in headers
+    assert AUTH_CONTEXT_SNAPSHOT_METADATA_KEY in headers
+    assert "authorization" not in headers
+    assert all("raw-token" not in value for value in headers.values())
 
 
 # ── Async tests ──
@@ -105,3 +210,27 @@ async def test_async_direct_event_bus_with_propagator_expect_headers_injected() 
         headers["traceparent"]
         == "00-abcd1234abcd1234abcd1234abcd1234-1234abcd1234abcd-01"
     )
+
+
+@pytest.mark.asyncio
+async def test_async_direct_event_bus_with_auth_context_expect_signed_snapshot_metadata() -> (
+    None
+):
+    """async event bus가 trace header를 보존하고 signed snapshot만 전파함을 검증한다."""
+    transport = AsyncRecordingTransport()
+    signer = FakeSnapshotSigner()
+    bus = AsyncDirectEventBus(
+        transport,
+        BearerInjectingPropagator(),
+        _enabled_auth_headers(signer),
+    )
+
+    event = SampleIntegrationEvent(message="async-signed")
+    await bus.send(event)
+
+    assert len(signer.requests) == 1
+    _, _, headers = transport.sent[0]
+    assert "traceparent" in headers
+    assert AUTH_CONTEXT_SNAPSHOT_METADATA_KEY in headers
+    assert "authorization" not in headers
+    assert all("raw-token" not in value for value in headers.values())

--- a/core/spakky-event/tests/unit/test_auth_propagation.py
+++ b/core/spakky-event/tests/unit/test_auth_propagation.py
@@ -1,0 +1,153 @@
+"""Tests for outbound AuthContextSnapshot metadata propagation."""
+
+from datetime import UTC, datetime, timedelta
+from typing import override
+
+import pytest
+from spakky.auth import (
+    AUTH_CONTEXT_CONTEXT_KEY,
+    AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
+    AuthContext,
+    AuthContextSnapshot,
+    AuthContextSnapshotSignature,
+    AuthSnapshotPropagationConfig,
+    AuthSubject,
+    IAuthContextSnapshotSigner,
+    InvalidAuthContextValueError,
+    SnapshotSignRequest,
+    store_auth_context,
+)
+from spakky.core.application.application_context import ApplicationContext
+
+from spakky.event.auth_propagation import AuthContextSnapshotHeaderInjector
+from spakky.event.error import (
+    AuthSnapshotPropagationContextUnavailableError,
+    AuthSnapshotPropagationSignerUnavailableError,
+)
+
+
+class FakeSnapshotSigner(IAuthContextSnapshotSigner):
+    """Signer that records requests and returns a deterministic snapshot."""
+
+    def __init__(self) -> None:
+        self.requests: list[SnapshotSignRequest] = []
+
+    @override
+    def sign_snapshot(self, request: SnapshotSignRequest) -> AuthContextSnapshot:
+        self.requests.append(request)
+        return AuthContextSnapshot(
+            subject=request.auth_context.subject,
+            issuer=request.auth_context.issuer,
+            issued_at=datetime(2026, 1, 1, tzinfo=UTC),
+            expires_at=datetime(2026, 1, 1, tzinfo=UTC) + timedelta(minutes=5),
+            signature=AuthContextSnapshotSignature(
+                key_id="kid-1",
+                algorithm="HS256",
+                signature="signature-1",
+            ),
+            tenant=request.auth_context.tenant,
+        )
+
+
+def _auth_context() -> AuthContext:
+    return AuthContext(
+        subject=AuthSubject(id="subject-1", display_name="Subject One"),
+        issuer="issuer-1",
+        tenant="tenant-1",
+    )
+
+
+def test_disabled_propagation_removes_raw_bearer_without_context() -> None:
+    """disabled 상태에서도 raw bearer header는 제거하고 다른 header는 보존한다."""
+    headers = {
+        "Authorization": "Bearer raw-token",
+        "x-custom": "value",
+    }
+    injector = AuthContextSnapshotHeaderInjector()
+
+    injector.inject(headers)
+
+    assert "Authorization" not in headers
+    assert headers == {"x-custom": "value"}
+
+
+def test_disabled_propagation_keeps_non_bearer_authorization() -> None:
+    """raw bearer가 아닌 authorization header는 제거 대상이 아님을 검증한다."""
+    headers = {"authorization": "Basic encoded"}
+    injector = AuthContextSnapshotHeaderInjector()
+
+    injector.inject(headers)
+
+    assert headers == {"authorization": "Basic encoded"}
+
+
+def test_enabled_propagation_without_application_context_fails_loudly() -> None:
+    """enabled 상태에서 ApplicationContext가 없으면 조용히 누락하지 않는다."""
+    injector = AuthContextSnapshotHeaderInjector(
+        auth_snapshot_signer=FakeSnapshotSigner(),
+        auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(enabled=True),
+    )
+
+    with pytest.raises(AuthSnapshotPropagationContextUnavailableError):
+        injector.inject({})
+
+
+def test_enabled_propagation_without_auth_context_skips_snapshot() -> None:
+    """public flow처럼 AuthContext가 없으면 snapshot header를 만들지 않는다."""
+    signer = FakeSnapshotSigner()
+    injector = AuthContextSnapshotHeaderInjector(
+        auth_snapshot_signer=signer,
+        auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(enabled=True),
+    )
+    injector.set_application_context(ApplicationContext())
+    headers: dict[str, str] = {}
+
+    injector.inject(headers)
+
+    assert signer.requests == []
+    assert AUTH_CONTEXT_SNAPSHOT_METADATA_KEY not in headers
+
+
+def test_enabled_propagation_with_invalid_context_value_fails() -> None:
+    """ApplicationContext의 auth 값이 AuthContext가 아니면 auth 오류로 실패한다."""
+    application_context = ApplicationContext()
+    application_context.set_context_value(AUTH_CONTEXT_CONTEXT_KEY, "invalid")
+    injector = AuthContextSnapshotHeaderInjector(
+        auth_snapshot_signer=FakeSnapshotSigner(),
+        auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(enabled=True),
+    )
+    injector.set_application_context(application_context)
+
+    with pytest.raises(InvalidAuthContextValueError):
+        injector.inject({})
+
+
+def test_enabled_propagation_without_signer_fails_loudly() -> None:
+    """enabled 상태에서 signer가 없으면 snapshot 전파를 조용히 생략하지 않는다."""
+    application_context = ApplicationContext()
+    store_auth_context(application_context, _auth_context())
+    injector = AuthContextSnapshotHeaderInjector(
+        auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(enabled=True),
+    )
+    injector.set_application_context(application_context)
+
+    with pytest.raises(AuthSnapshotPropagationSignerUnavailableError):
+        injector.inject({})
+
+
+def test_enabled_propagation_injects_signed_snapshot_envelope() -> None:
+    """enabled 상태에서 AuthContext를 signed snapshot envelope로 변환한다."""
+    application_context = ApplicationContext()
+    store_auth_context(application_context, _auth_context())
+    signer = FakeSnapshotSigner()
+    injector = AuthContextSnapshotHeaderInjector(
+        auth_snapshot_signer=signer,
+        auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(enabled=True),
+    )
+    injector.set_application_context(application_context)
+    headers: dict[str, str] = {}
+
+    injector.inject(headers)
+
+    assert len(signer.requests) == 1
+    assert AUTH_CONTEXT_SNAPSHOT_METADATA_KEY in headers

--- a/core/spakky-event/tests/unit/test_event_error.py
+++ b/core/spakky-event/tests/unit/test_event_error.py
@@ -1,5 +1,7 @@
 from spakky.event.error import (
     AbstractSpakkyEventError,
+    AuthSnapshotPropagationContextUnavailableError,
+    AuthSnapshotPropagationSignerUnavailableError,
     UnknownEventTypeError,
 )
 
@@ -26,3 +28,14 @@ def test_unknown_event_type_error_stores_event_type_expect_attribute_accessible(
     assert error.event_type is SomeType
     assert error.message == "Unknown event type"
     assert isinstance(error, AbstractSpakkyEventError)
+
+
+def test_auth_snapshot_propagation_errors_are_event_errors() -> None:
+    """snapshot 전파 오류가 event error hierarchy에 속함을 검증한다."""
+    context_error = AuthSnapshotPropagationContextUnavailableError()
+    signer_error = AuthSnapshotPropagationSignerUnavailableError()
+
+    assert context_error.message == "Auth snapshot propagation context is unavailable"
+    assert signer_error.message == "Auth snapshot propagation signer is unavailable"
+    assert isinstance(context_error, AbstractSpakkyEventError)
+    assert isinstance(signer_error, AbstractSpakkyEventError)

--- a/core/spakky-outbox/README.md
+++ b/core/spakky-outbox/README.md
@@ -91,6 +91,8 @@ class CreateOrderUseCase:
 | `OutboxConfig`                                                       | 환경변수 기반 설정                                  |
 | `OutboxMessage`                                                      | Outbox message model                                                     |
 
+`OutboxEventBus`와 `AsyncOutboxEventBus`는 메시지를 저장할 때 `DirectEventBus`와 같은 outbound metadata 정책을 사용합니다. 기존 tracing header는 보존하고, auth snapshot 전파가 활성화된 request-scope에서는 `spakky.auth.context_snapshot`에 signed `AuthContextSnapshot` envelope를 저장합니다. Raw bearer token은 Outbox headers에 저장하지 않습니다.
+
 ### 커스텀 Storage 구현
 
 custom storage backend를 구현하려면 다음 interface를 구현합니다.

--- a/core/spakky-outbox/src/spakky/outbox/bus/outbox_event_bus.py
+++ b/core/spakky-outbox/src/spakky/outbox/bus/outbox_event_bus.py
@@ -7,6 +7,7 @@ from pydantic import TypeAdapter
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.annotations.primary import Primary
 from spakky.domain.models.event import AbstractIntegrationEvent
+from spakky.event.auth_propagation import AuthContextSnapshotHeaderInjector
 from spakky.event.event_publisher import IAsyncEventBus, IEventBus
 from spakky.tracing.propagator import ITracePropagator
 from typing import override
@@ -26,20 +27,26 @@ class OutboxEventBus(IEventBus):
 
     _storage: IOutboxStorage
     _propagator: ITracePropagator
+    _auth_snapshot_headers: AuthContextSnapshotHeaderInjector
 
     def __init__(
         self,
         storage: IOutboxStorage,
         propagator: ITracePropagator,
+        auth_snapshot_headers: AuthContextSnapshotHeaderInjector | None = None,
     ) -> None:
         self._storage = storage
         self._propagator = propagator
+        self._auth_snapshot_headers = (
+            auth_snapshot_headers or AuthContextSnapshotHeaderInjector()
+        )
 
     @override
     def send(self, event: AbstractIntegrationEvent) -> None:
         adapter: TypeAdapter[AbstractIntegrationEvent] = TypeAdapter(type(event))
         headers: dict[str, str] = {}
         self._propagator.inject(headers)
+        self._auth_snapshot_headers.inject(headers)
         message = OutboxMessage(
             id=uuid4(),
             event_name=event.event_name,
@@ -61,20 +68,26 @@ class AsyncOutboxEventBus(IAsyncEventBus):
 
     _storage: IAsyncOutboxStorage
     _propagator: ITracePropagator
+    _auth_snapshot_headers: AuthContextSnapshotHeaderInjector
 
     def __init__(
         self,
         storage: IAsyncOutboxStorage,
         propagator: ITracePropagator,
+        auth_snapshot_headers: AuthContextSnapshotHeaderInjector | None = None,
     ) -> None:
         self._storage = storage
         self._propagator = propagator
+        self._auth_snapshot_headers = (
+            auth_snapshot_headers or AuthContextSnapshotHeaderInjector()
+        )
 
     @override
     async def send(self, event: AbstractIntegrationEvent) -> None:
         adapter: TypeAdapter[AbstractIntegrationEvent] = TypeAdapter(type(event))
         headers: dict[str, str] = {}
         self._propagator.inject(headers)
+        self._auth_snapshot_headers.inject(headers)
         message = OutboxMessage(
             id=uuid4(),
             event_name=event.event_name,

--- a/core/spakky-outbox/tests/unit/test_outbox_event_bus.py
+++ b/core/spakky-outbox/tests/unit/test_outbox_event_bus.py
@@ -1,10 +1,31 @@
 """Tests for OutboxEventBus and AsyncOutboxEventBus."""
 
+from datetime import UTC, datetime, timedelta
+from typing import override
+
 import pytest
+from spakky.auth import (
+    AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
+    AuthContext,
+    AuthContextSnapshot,
+    AuthContextSnapshotSignature,
+    AuthSnapshotPropagationConfig,
+    AuthSubject,
+    CredentialCarrier,
+    CredentialCarrierKind,
+    CredentialCarrierLocation,
+    IAuthContextSnapshotSigner,
+    SnapshotSignRequest,
+    store_auth_context,
+)
+from spakky.core.application.application_context import ApplicationContext
 from spakky.core.common.mutability import immutable
 from spakky.domain.models.event import AbstractIntegrationEvent
 from spakky.tracing import W3CTracePropagator
+from spakky.tracing.context import TraceContext
+from spakky.tracing.propagator import ITracePropagator
 
+from spakky.event.auth_propagation import AuthContextSnapshotHeaderInjector
 from spakky.outbox.bus.outbox_event_bus import (
     AsyncOutboxEventBus,
     OutboxEventBus,
@@ -53,6 +74,81 @@ class InMemoryAsyncOutboxStorage(IAsyncOutboxStorage):
         raise AssertionError("Not expected to be called")
 
 
+class BearerInjectingPropagator(ITracePropagator):
+    """Fake propagator that injects tracing and raw bearer material."""
+
+    @override
+    def inject(self, carrier: dict[str, str]) -> None:
+        carrier["traceparent"] = (
+            "00-abcd1234abcd1234abcd1234abcd1234-1234abcd1234abcd-01"
+        )
+        carrier["authorization"] = "Bearer raw-token"
+
+    @override
+    def extract(self, carrier: dict[str, str]) -> TraceContext | None:
+        return None
+
+    @override
+    def fields(self) -> list[str]:
+        return ["traceparent"]
+
+
+class FakeSnapshotSigner(IAuthContextSnapshotSigner):
+    """Signer that records requests and returns a deterministic snapshot."""
+
+    def __init__(self) -> None:
+        self.requests: list[SnapshotSignRequest] = []
+
+    @override
+    def sign_snapshot(self, request: SnapshotSignRequest) -> AuthContextSnapshot:
+        self.requests.append(request)
+        return AuthContextSnapshot(
+            subject=request.auth_context.subject,
+            issuer=request.auth_context.issuer,
+            issued_at=datetime(2026, 1, 1, tzinfo=UTC),
+            expires_at=datetime(2026, 1, 1, tzinfo=UTC) + timedelta(minutes=5),
+            signature=AuthContextSnapshotSignature(
+                key_id="kid-1",
+                algorithm="HS256",
+                signature="signature-1",
+            ),
+            tenant=request.auth_context.tenant,
+            roles=request.auth_context.roles,
+            scopes=request.auth_context.scopes,
+            selected_claims=request.auth_context.claims,
+        )
+
+
+def _auth_context() -> AuthContext:
+    return AuthContext(
+        subject=AuthSubject(id="subject-1", display_name="Subject One"),
+        issuer="issuer-1",
+        tenant="tenant-1",
+        roles=("role-1",),
+        scopes=("scope-1",),
+        credential_carrier=CredentialCarrier(
+            kind=CredentialCarrierKind.BEARER_TOKEN,
+            location=CredentialCarrierLocation.AUTHORIZATION_HEADER,
+            material="raw-token",
+            name="authorization",
+            scheme="Bearer",
+        ),
+    )
+
+
+def _enabled_auth_headers(
+    signer: FakeSnapshotSigner,
+) -> AuthContextSnapshotHeaderInjector:
+    application_context = ApplicationContext()
+    store_auth_context(application_context, _auth_context())
+    injector = AuthContextSnapshotHeaderInjector(
+        auth_snapshot_signer=signer,
+        auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(enabled=True),
+    )
+    injector.set_application_context(application_context)
+    return injector
+
+
 # ── Sync OutboxEventBus ──
 
 
@@ -98,6 +194,27 @@ def test_send_generates_unique_message_ids() -> None:
 
     assert len(storage.saved) == 2
     assert storage.saved[0].id != storage.saved[1].id
+
+
+def test_send_stores_signed_snapshot_metadata_in_headers() -> None:
+    """OutboxEventBus가 trace를 보존하고 signed snapshot만 저장함을 검증한다."""
+    storage = InMemorySyncOutboxStorage()
+    signer = FakeSnapshotSigner()
+    bus = OutboxEventBus(
+        storage,
+        BearerInjectingPropagator(),
+        _enabled_auth_headers(signer),
+    )
+
+    event = OrderConfirmedIntegrationEvent(order_id="ORD-AUTH", amount=7000)
+    bus.send(event)
+
+    assert len(signer.requests) == 1
+    headers = storage.saved[0].headers
+    assert "traceparent" in headers
+    assert AUTH_CONTEXT_SNAPSHOT_METADATA_KEY in headers
+    assert "authorization" not in headers
+    assert all("raw-token" not in value for value in headers.values())
 
 
 # ── Async AsyncOutboxEventBus ──
@@ -148,3 +265,25 @@ async def test_async_send_generates_unique_message_ids() -> None:
 
     assert len(storage.saved) == 2
     assert storage.saved[0].id != storage.saved[1].id
+
+
+@pytest.mark.asyncio
+async def test_async_send_stores_signed_snapshot_metadata_in_headers() -> None:
+    """AsyncOutboxEventBus가 trace를 보존하고 signed snapshot만 저장함을 검증한다."""
+    storage = InMemoryAsyncOutboxStorage()
+    signer = FakeSnapshotSigner()
+    bus = AsyncOutboxEventBus(
+        storage,
+        BearerInjectingPropagator(),
+        _enabled_auth_headers(signer),
+    )
+
+    event = OrderConfirmedIntegrationEvent(order_id="ORD-ASYNC-AUTH", amount=8000)
+    await bus.send(event)
+
+    assert len(signer.requests) == 1
+    headers = storage.saved[0].headers
+    assert "traceparent" in headers
+    assert AUTH_CONTEXT_SNAPSHOT_METADATA_KEY in headers
+    assert "authorization" not in headers
+    assert all("raw-token" not in value for value in headers.values())

--- a/docs/api/core/spakky-event.md
+++ b/docs/api/core/spakky-event.md
@@ -26,6 +26,12 @@ show_root_heading: false
 options:
 show_root_heading: false
 
+## Auth Propagation
+
+::: spakky.event.auth_propagation
+options:
+show_root_heading: false
+
 ## Mediator
 
 ::: spakky.event.mediator.domain_event_mediator

--- a/docs/error-hierarchy.md
+++ b/docs/error-hierarchy.md
@@ -217,14 +217,18 @@ from spakky.domain.error import (
 ```python
 from spakky.event.error import (
     AbstractSpakkyEventError,
+    AuthSnapshotPropagationContextUnavailableError,
+    AuthSnapshotPropagationSignerUnavailableError,
     InvalidMessageError,
     UnknownEventTypeError,
 )
 ```
 
-| 에러                    | 설명                                      |
-| ----------------------- | ----------------------------------------- |
-| `InvalidMessageError`   | 잘못된 메시지 형식                        |
+| 에러 | 설명 |
+| ---- | ---- |
+| `AuthSnapshotPropagationContextUnavailableError` | snapshot 전파가 활성화되었지만 `ApplicationContext`를 읽을 수 없음 |
+| `AuthSnapshotPropagationSignerUnavailableError` | snapshot 전파가 활성화되었지만 signer provider가 없음 |
+| `InvalidMessageError` | 잘못된 메시지 형식 |
 | `UnknownEventTypeError` | Domain/Integration Event가 아닌 타입 발행 |
 
 ---

--- a/docs/event-system.md
+++ b/docs/event-system.md
@@ -239,6 +239,8 @@ class UserEventHandler:
 | `IEventConsumer` / `IAsyncEventConsumer` | `register` | 핸들러 콜백 등록 (통합) |
 | `IEventDispatcher` / `IAsyncEventDispatcher` | `dispatch` | 인프로세스 핸들러 전달 (통합) |
 
+`DirectEventBus` / `AsyncDirectEventBus`는 transport public signature를 바꾸지 않고 headers에 outbound metadata를 주입합니다. `spakky-tracing`의 tracing header는 그대로 보존하며, auth snapshot 전파가 활성화된 request-scope에서는 `spakky.auth.context_snapshot`에 signed `AuthContextSnapshot` envelope를 담습니다. Raw bearer token은 event header로 전파하지 않습니다.
+
 ---
 
 ## DomainEvent vs IntegrationEvent
@@ -355,4 +357,3 @@ Publisher 코드는 브로커에 의존하지 않습니다. `IAsyncEventPublishe
 ### 재시도 전략
 
 분산 환경에서의 재시도는 메시지 브로커 수준에서 처리됩니다. RabbitMQ의 nack/requeue, Kafka의 offset 관리 등 트랜스포트 구현체가 재시도 로직을 담당합니다. 개별 핸들러에 재시도 로직을 직접 구현할 필요는 없습니다.
-

--- a/docs/guides/kafka.md
+++ b/docs/guides/kafka.md
@@ -162,7 +162,7 @@ export SPAKKY_KAFKA__SASL_PASSWORD=my-api-secret
 
 `spakky-tracing`은 `spakky-kafka`의 필수 의존성입니다. 컨테이너에 `ITracePropagator`가 등록되어 있으면 메시지 헤더를 통해 `TraceContext`가 자동 전파됩니다.
 
-- **발행 측**: `OutboxEventBus` 또는 `DirectEventBus`가 현재 `TraceContext`를 메시지 헤더에 주입
+- **발행 측**: `OutboxEventBus` 또는 `DirectEventBus`가 현재 `TraceContext`를 메시지 헤더에 주입. `AuthSnapshotPropagationConfig(enabled=True)`가 활성화되어 있으면 raw bearer token 대신 signed `AuthContextSnapshot` metadata도 함께 주입
 - **수신 측**: `KafkaEventConsumer`가 헤더에서 `TraceContext`를 추출하여 자식 span 생성
 - 헤더가 없으면 새로운 루트 트레이스를 시작
 - `ITracePropagator`가 컨테이너에 없으면 트레이싱은 비활성 상태로, 별도 에러 없이 동작합니다

--- a/docs/guides/outbox.md
+++ b/docs/guides/outbox.md
@@ -142,3 +142,7 @@ class PlaceOrderUseCase:
 ## 분산 트레이싱
 
 `spakky-tracing`이 설치되면 `OutboxEventBus`가 현재 `TraceContext`를 메시지 헤더에 자동 주입합니다. Relay가 전송할 때 해당 헤더가 그대로 브로커 메시지에 포함되므로, 수신 측에서 트레이스 컨텍스트가 복원됩니다.
+
+## 인증 컨텍스트 전파
+
+`spakky-auth`의 `AuthSnapshotPropagationConfig(enabled=True)`가 활성화되어 있고 현재 request/context scope에 `AuthContext`가 있으면 `OutboxEventBus` / `AsyncOutboxEventBus`는 Outbox message headers에 `spakky.auth.context_snapshot` metadata를 저장합니다. 이 값은 `IAuthContextSnapshotSigner`가 만든 signed `AuthContextSnapshot` envelope이며, raw bearer token은 저장하지 않습니다. 기존 `traceparent` header는 함께 보존됩니다.

--- a/docs/guides/rabbitmq.md
+++ b/docs/guides/rabbitmq.md
@@ -156,7 +156,7 @@ sequenceDiagram
 
 `spakky-tracing`은 `spakky-rabbitmq`의 필수 의존성입니다. 컨테이너에 `ITracePropagator`가 등록되어 있으면 메시지 헤더를 통해 `TraceContext`가 자동 전파됩니다.
 
-- **발행 측**: `OutboxEventBus` 또는 `DirectEventBus`가 현재 `TraceContext`를 메시지 헤더에 주입
+- **발행 측**: `OutboxEventBus` 또는 `DirectEventBus`가 현재 `TraceContext`를 메시지 헤더에 주입. `AuthSnapshotPropagationConfig(enabled=True)`가 활성화되어 있으면 raw bearer token 대신 signed `AuthContextSnapshot` metadata도 함께 주입
 - **수신 측**: `RabbitMQEventConsumer`가 헤더에서 `TraceContext`를 추출하여 자식 span 생성
 - 헤더가 없으면 새로운 루트 트레이스를 시작
 - `ITracePropagator`가 컨테이너에 없으면 트레이싱은 비활성 상태로, 별도 에러 없이 동작합니다

--- a/uv.lock
+++ b/uv.lock
@@ -2796,6 +2796,7 @@ version = "6.5.0"
 source = { editable = "core/spakky-event" }
 dependencies = [
     { name = "pydantic" },
+    { name = "spakky-auth" },
     { name = "spakky-data" },
     { name = "spakky-domain" },
     { name = "spakky-tracing" },
@@ -2804,6 +2805,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "spakky-auth", editable = "core/spakky-auth" },
     { name = "spakky-data", editable = "core/spakky-data" },
     { name = "spakky-domain", editable = "core/spakky-domain" },
     { name = "spakky-tracing", editable = "core/spakky-tracing" },


### PR DESCRIPTION
## Summary
- Add `AuthContextSnapshotHeaderInjector` for outbound event metadata propagation.
- Wire signed snapshot metadata into `DirectEventBus` / `AsyncDirectEventBus` and `OutboxEventBus` / `AsyncOutboxEventBus` without changing `IEventTransport` signatures.
- Preserve tracing headers and remove raw bearer authorization metadata from outbound event headers.
- Update dependency matrix, package docs, API docs, guides, and error hierarchy.

## Verification
- `uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .` (`core/spakky-event`, `core/spakky-outbox`)
- `uv run ruff check .` (`core/spakky-event`, `core/spakky-outbox`)
- `uv run pyrefly check src tests` (`core/spakky-event`, `core/spakky-outbox`)
- `uv run python scripts/run_coverage.py --package spakky-event`
- `uv run python scripts/run_coverage.py --package spakky-outbox`
- Pre-push affected projects: `spakky-event`, `spakky-outbox`, `spakky-rabbitmq`, `spakky-kafka`

## Acceptance Criteria (자가 grep)

- [x] Issue body contains no executable grep/rg/find acceptance lines -> acceptance_check: missing
- [x] DirectEventBus and AsyncDirectEventBus propagate signed AuthContextSnapshot metadata when enabled
- [x] OutboxEventBus and AsyncOutboxEventBus persist signed AuthContextSnapshot metadata when enabled
- [x] Existing traceparent headers are preserved
- [x] Authorization: Bearer raw token headers are removed from outbound event metadata
- [x] IEventTransport and IAsyncEventTransport signatures are unchanged
- [x] Event propagation is documented in the auth consistency docs/matrix references

Closes #293
