### PR TITLE
feat(task): add auth-aware direct task execution (#291)

### DIFF
--- a/core/spakky-task/README.md
+++ b/core/spakky-task/README.md
@@ -15,6 +15,7 @@ pip install spakky-task
 - **`@schedule` decorator**: 메서드를 주기 실행 대상(interval, daily, crontab)으로 표시합니다.
 - **`Crontab` value object**: `Weekday`/`Month` enum을 사용하는 Python-native cron 명세
 - **Post-processor**: `@TaskHandler` pod에서 task route를 자동 스캔하고 등록합니다.
+- **직접 실행**: 같은 프로세스에서 task를 실행할 때 기존 request-scope context를 유지합니다.
 - **구현체 중립**: 플러그인을 통해 Celery 등 임의의 태스크 큐 백엔드와 동작
 
 ## 사용법
@@ -103,6 +104,38 @@ routes = post_processor.get_task_routes()
 # {<bound method send_email>: TaskRoute(), ...}
 ```
 
+### 인증 metadata와 직접 실행
+
+`@task`는 `spakky-auth`의 보호 decorator와 함께 사용할 수 있습니다. Task route는 보호 요구사항 metadata를 보존하며, 직접 실행은 현재 `ApplicationContext`의 request-scope 값을 그대로 사용합니다. 같은 프로세스에서 실행되는 task는 `AuthContextSnapshot`이 필요하지 않고, 보호된 task도 `AuthContext`를 메서드 인자로 받을 필요가 없습니다.
+
+```python
+from spakky.auth import protected, require_auth_context
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.task import DirectTaskExecutor, DirectTaskInvocation, TaskHandler, task
+
+
+@TaskHandler()
+class ReportTaskHandler:
+    def __init__(self, application_context: IApplicationContext) -> None:
+        self._application_context = application_context
+
+    @task
+    @protected
+    def generate(self) -> str:
+        return require_auth_context(self._application_context).subject.id
+
+
+application_context: IApplicationContext = ...
+executor = DirectTaskExecutor()
+executor.set_application_context(application_context)
+result = executor.execute(
+    DirectTaskInvocation(
+        handler_type=ReportTaskHandler,
+        method_name="generate",
+    )
+)
+```
+
 ## 구성 요소
 
 | 구성 요소 | 설명 |
@@ -115,6 +148,8 @@ routes = post_processor.get_task_routes()
 | `Crontab` | cron 유사 schedule 명세용 frozen dataclass |
 | `Weekday` | 요일용 `IntEnum`(Monday=0 ... Sunday=6) |
 | `Month` | 월용 `IntEnum`(January=1 ... December=12) |
+| `DirectTaskExecutor` | request-scope context를 유지하는 같은 프로세스 task 실행기 |
+| `DirectTaskInvocation` | 직접 실행 대상 handler/method/argument metadata |
 | `TaskRegistrationPostProcessor` | `@TaskHandler` pod를 스캔하고 `@task` 메서드를 수집 |
 
 ## 에러

--- a/core/spakky-task/pyproject.toml
+++ b/core/spakky-task/pyproject.toml
@@ -8,6 +8,9 @@ license = { text = "MIT" }
 authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
 dependencies = ["spakky>=6.5.0"]
 
+[dependency-groups]
+dev = ["spakky-auth>=6.5.0"]
+
 [project.entry-points."spakky.plugins"]
 spakky-task = "spakky.task.main:initialize"
 
@@ -66,4 +69,7 @@ exclude_lines = [
     "pass",
 ]
 
+[tool.uv.sources]
+spakky = { workspace = true }
+spakky-auth = { workspace = true }
 

--- a/core/spakky-task/src/spakky/task/__init__.py
+++ b/core/spakky-task/src/spakky/task/__init__.py
@@ -2,18 +2,24 @@
 
 from spakky.core.application.plugin import Plugin
 
+from spakky.task.direct import DirectTaskExecutor, DirectTaskInvocation
 from spakky.task.error import (
     AbstractSpakkyTaskError,
     DuplicateTaskError,
     InvalidScheduleSpecificationError,
+    TaskApplicationContextNotFoundError,
+    TaskAsyncInvocationRequiredError,
     TaskNotFoundError,
 )
 from spakky.task.post_processor import TaskRegistrationPostProcessor
 from spakky.task.stereotype.crontab import Crontab, Month, Weekday
 from spakky.task.stereotype.schedule import ScheduleRoute, schedule
 from spakky.task.stereotype.task_handler import (
+    TaskAuthMetadata,
+    TaskAuthRequirementMetadata,
     TaskHandler,
     TaskRoute,
+    collect_task_auth_metadata,
     task,
 )
 
@@ -22,19 +28,27 @@ PLUGIN_NAME = Plugin(name="spakky-task")
 
 __all__ = [
     # Stereotype
+    "TaskAuthMetadata",
+    "TaskAuthRequirementMetadata",
     "TaskHandler",
     "TaskRoute",
+    "collect_task_auth_metadata",
     "task",
     "Crontab",
     "Weekday",
     "Month",
     "ScheduleRoute",
     "schedule",
+    # Direct execution
+    "DirectTaskExecutor",
+    "DirectTaskInvocation",
     # Post-Processors
     "TaskRegistrationPostProcessor",
     # Errors
     "AbstractSpakkyTaskError",
     "TaskNotFoundError",
+    "TaskApplicationContextNotFoundError",
+    "TaskAsyncInvocationRequiredError",
     "DuplicateTaskError",
     "InvalidScheduleSpecificationError",
     # Plugin

--- a/core/spakky-task/src/spakky/task/direct.py
+++ b/core/spakky-task/src/spakky/task/direct.py
@@ -1,0 +1,81 @@
+"""Direct in-process task execution support."""
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from inspect import iscoroutinefunction
+from typing import override
+
+from spakky.core.common.types import get_callable_methods
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.aware.application_context_aware import (
+    IApplicationContextAware,
+)
+from spakky.task.error import (
+    TaskApplicationContextNotFoundError,
+    TaskAsyncInvocationRequiredError,
+    TaskNotFoundError,
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class DirectTaskInvocation:
+    """A direct same-process task invocation request."""
+
+    handler_type: type[object]
+    """TaskHandler type that owns the method."""
+
+    method_name: str
+    """Task method name on the handler type."""
+
+    args: tuple[object, ...] = ()
+    """Positional arguments for the task method."""
+
+    kwargs: Mapping[str, object] = field(default_factory=dict)
+    """Keyword arguments for the task method."""
+
+
+@Pod()
+class DirectTaskExecutor(IApplicationContextAware):
+    """Execute registered tasks in the current process and context scope."""
+
+    _application_context: IApplicationContext | None
+
+    def __init__(self) -> None:
+        self._application_context = None
+
+    @override
+    def set_application_context(self, application_context: IApplicationContext) -> None:
+        """Inject the ApplicationContext used to resolve task handlers."""
+        self._application_context = application_context
+
+    def execute(self, invocation: DirectTaskInvocation) -> object:
+        """Execute a synchronous task without clearing request-scope context."""
+        method = self._resolve_method(invocation)
+        if iscoroutinefunction(method):
+            raise TaskAsyncInvocationRequiredError()
+        return method(*invocation.args, **dict(invocation.kwargs))
+
+    async def execute_async(self, invocation: DirectTaskInvocation) -> object:
+        """Execute a task in async code without clearing request-scope context."""
+        method = self._resolve_method(invocation)
+        result = method(*invocation.args, **dict(invocation.kwargs))
+        if isinstance(result, Awaitable):
+            return await result
+        return result
+
+    def _resolve_method(
+        self,
+        invocation: DirectTaskInvocation,
+    ) -> Callable[..., object]:
+        application_context = self._required_application_context()
+        handler = application_context.get(invocation.handler_type)
+        for name, method in get_callable_methods(handler):
+            if name == invocation.method_name:
+                return method
+        raise TaskNotFoundError()
+
+    def _required_application_context(self) -> IApplicationContext:
+        if self._application_context is None:
+            raise TaskApplicationContextNotFoundError()
+        return self._application_context

--- a/core/spakky-task/src/spakky/task/error.py
+++ b/core/spakky-task/src/spakky/task/error.py
@@ -17,6 +17,18 @@ class TaskNotFoundError(AbstractSpakkyTaskError):
     message = "Task not found in the registry"
 
 
+class TaskApplicationContextNotFoundError(AbstractSpakkyTaskError):
+    """Raised when direct task execution has no ApplicationContext."""
+
+    message = "ApplicationContext is required for direct task execution"
+
+
+class TaskAsyncInvocationRequiredError(AbstractSpakkyTaskError):
+    """Raised when an async task is invoked through the sync direct path."""
+
+    message = "Async task requires execute_async for direct execution"
+
+
 class DuplicateTaskError(AbstractSpakkyTaskError):
     """Raised when attempting to register a task that already exists."""
 

--- a/core/spakky-task/src/spakky/task/main.py
+++ b/core/spakky-task/src/spakky/task/main.py
@@ -2,6 +2,7 @@
 
 from spakky.core.application.application import SpakkyApplication
 
+from spakky.task.direct import DirectTaskExecutor
 from spakky.task.post_processor import TaskRegistrationPostProcessor
 
 
@@ -11,4 +12,5 @@ def initialize(app: SpakkyApplication) -> None:
     Args:
         app: The SpakkyApplication instance.
     """
+    app.add(DirectTaskExecutor)
     app.add(TaskRegistrationPostProcessor)

--- a/core/spakky-task/src/spakky/task/post_processor.py
+++ b/core/spakky-task/src/spakky/task/post_processor.py
@@ -8,7 +8,11 @@ from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.interfaces.post_processor import IPostProcessor
 from typing import override
 
-from spakky.task.stereotype.task_handler import TaskHandler, TaskRoute
+from spakky.task.stereotype.task_handler import (
+    TaskHandler,
+    TaskRoute,
+    collect_task_auth_metadata,
+)
 
 logger = getLogger(__name__)
 
@@ -46,6 +50,10 @@ class TaskRegistrationPostProcessor(IPostProcessor):
             if route is None:
                 continue
 
+            route.auth_metadata = collect_task_auth_metadata(
+                method,
+                owner_type=pod_type,
+            )
             self._task_routes[method] = route
             logger.debug(f"Registered task {pod_type.__name__}.{name}")
 

--- a/core/spakky-task/src/spakky/task/stereotype/task_handler.py
+++ b/core/spakky-task/src/spakky/task/stereotype/task_handler.py
@@ -4,11 +4,67 @@ This module provides @TaskHandler stereotype and @task decorator
 for organizing task-queue-driven architectures.
 """
 
-from dataclasses import dataclass
+from collections.abc import Iterable
+from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Callable, cast
 
+from spakky.core.common.constants import ANNOTATION_METADATA
 from spakky.core.common.annotation import FunctionAnnotation
 from spakky.core.pod.annotations.pod import Pod
+
+
+type TaskAuthRequirementRef = str
+"""Canonical auth requirement reference carried with task metadata."""
+
+type TaskAuthResourceRef = str
+"""Canonical resource reference attached to task auth metadata."""
+
+type TaskAuthActionRef = str
+"""Canonical action reference attached to task auth metadata."""
+
+type TaskAuthTenantRef = str
+"""Canonical tenant reference attached to task auth metadata."""
+
+
+_AUTH_METADATA_MODULE = "spakky.auth.metadata"
+_PROTECTED_REQUIREMENT_QUALNAME = "ProtectedRequirement"
+_PUBLIC_ACCESS_QUALNAME = "PublicAccess"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TaskAuthRequirementMetadata:
+    """Auth requirement metadata copied onto a task route."""
+
+    kind: str
+    """Provider-neutral auth requirement category."""
+
+    ref: TaskAuthRequirementRef
+    """Canonical permission, role, scope, relation, policy, or marker ref."""
+
+    resource: TaskAuthResourceRef | None = None
+    """Optional resource reference for resource-scoped checks."""
+
+    action: TaskAuthActionRef | None = None
+    """Optional action reference for policy checks."""
+
+    tenant: TaskAuthTenantRef | None = None
+    """Optional tenant reference for tenant-scoped checks."""
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TaskAuthMetadata:
+    """Auth boundary metadata associated with a task route."""
+
+    public_access: bool = False
+    """Whether the task is explicitly public."""
+
+    requirements: tuple[TaskAuthRequirementMetadata, ...] = ()
+    """Ordered, duplicate-free auth requirements inherited by the task."""
+
+    @property
+    def protected(self) -> bool:
+        """Return whether this task carries protected auth requirements."""
+        return len(self.requirements) > 0
 
 
 @dataclass
@@ -17,6 +73,9 @@ class TaskRoute(FunctionAnnotation):
 
     Associates a method as a task that can be dispatched to a task queue.
     """
+
+    auth_metadata: TaskAuthMetadata = field(default_factory=TaskAuthMetadata)
+    """Effective auth metadata for direct in-process task invocation."""
 
 
 def task[**P, T](obj: Callable[P, T]) -> Callable[P, T]:
@@ -50,3 +109,124 @@ class TaskHandler(Pod):
     """
 
     ...
+
+
+def collect_task_auth_metadata(
+    method: object,
+    *,
+    owner_type: type[object] | None = None,
+) -> TaskAuthMetadata:
+    """Collect auth decorator metadata for a task without importing spakky-auth."""
+    sources = (owner_type, method) if owner_type is not None else (method,)
+    public_access = any(
+        _has_auth_annotation(source, _PUBLIC_ACCESS_QUALNAME)
+        for source in sources
+        if source is not None
+    )
+    requirements = _dedupe_requirements(
+        requirement
+        for source in sources
+        if source is not None
+        for requirement in _auth_requirements_from_source(source)
+    )
+    return TaskAuthMetadata(public_access=public_access, requirements=requirements)
+
+
+def _has_auth_annotation(source: object, qualname: str) -> bool:
+    return any(
+        _is_auth_annotation_type(annotation_type, qualname)
+        for annotation_type, _ in _metadata_items(source)
+    )
+
+
+def _auth_requirements_from_source(
+    source: object,
+) -> tuple[TaskAuthRequirementMetadata, ...]:
+    requirements: list[TaskAuthRequirementMetadata] = []
+    for annotation_type, annotations in _metadata_items(source):
+        if not _is_auth_annotation_type(
+            annotation_type,
+            _PROTECTED_REQUIREMENT_QUALNAME,
+        ):
+            continue
+        for annotation in annotations:
+            requirement = _task_auth_requirement_from_annotation(annotation)
+            if requirement is not None:
+                requirements.append(requirement)
+    return tuple(requirements)
+
+
+def _task_auth_requirement_from_annotation(
+    annotation: object,
+) -> TaskAuthRequirementMetadata | None:
+    data = _dataclass_values(annotation)
+    requirement = data.get("requirement")
+    requirement_data = _dataclass_values(requirement)
+    if not requirement_data:
+        return None
+    kind = requirement_data.get("kind")
+    ref = requirement_data.get("ref")
+    if kind is None or not isinstance(ref, str):
+        return None
+    return TaskAuthRequirementMetadata(
+        kind=str(kind),
+        ref=ref,
+        resource=_optional_str(requirement_data.get("resource")),
+        action=_optional_str(requirement_data.get("action")),
+        tenant=_optional_str(requirement_data.get("tenant")),
+    )
+
+
+def _dataclass_values(value: object) -> dict[str, object]:
+    if isinstance(value, type) or not is_dataclass(value):
+        return {}
+    return {
+        field.name: object.__getattribute__(value, field.name)
+        for field in fields(value)
+    }
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _metadata_items(
+    source: object,
+) -> tuple[tuple[type[object], tuple[object, ...]], ...]:
+    metadata = getattr(  # framework metadata lookup mirrors Annotation internals
+        source,
+        ANNOTATION_METADATA,
+        {},
+    )
+    if not isinstance(metadata, dict):
+        return ()
+    items: list[tuple[type[object], tuple[object, ...]]] = []
+    for annotation_type, annotations in metadata.items():
+        if not isinstance(annotation_type, type) or not isinstance(annotations, list):
+            continue
+        items.append((annotation_type, tuple(annotations)))
+    return tuple(items)
+
+
+def _is_auth_annotation_type(annotation_type: type[object], qualname: str) -> bool:
+    return (
+        annotation_type.__module__ == _AUTH_METADATA_MODULE
+        and annotation_type.__qualname__ == qualname
+    )
+
+
+def _dedupe_requirements(
+    requirements: Iterable[TaskAuthRequirementMetadata],
+) -> tuple[TaskAuthRequirementMetadata, ...]:
+    ordered: list[TaskAuthRequirementMetadata] = []
+    seen: set[TaskAuthRequirementMetadata] = set()
+    for requirement in requirements:
+        if requirement in seen:
+            continue
+        seen.add(requirement)
+        ordered.append(requirement)
+    return tuple(ordered)

--- a/core/spakky-task/tests/unit/post_processor/test_task_registration.py
+++ b/core/spakky-task/tests/unit/post_processor/test_task_registration.py
@@ -1,6 +1,7 @@
 """Unit tests for TaskRegistrationPostProcessor."""
 
 from spakky.core.pod.annotations.pod import Pod
+from spakky.auth import require_scope
 
 from spakky.task.post_processor import TaskRegistrationPostProcessor
 from spakky.task.stereotype.task_handler import TaskHandler, task
@@ -107,3 +108,23 @@ def test_get_task_routes_returns_copy() -> None:
 
     assert routes1 is not routes2
     assert routes1 == routes2
+
+
+def test_post_processor_registers_task_auth_metadata() -> None:
+    """TaskRegistrationPostProcessor는 등록 route에 auth metadata를 복사한다."""
+
+    @TaskHandler()
+    class SampleTaskHandler:
+        @task
+        @require_scope("tasks:run")
+        def process(self) -> None:
+            return None
+
+    processor = TaskRegistrationPostProcessor()
+    handler = SampleTaskHandler()
+    processor.post_process(handler)
+
+    route = processor.get_task_routes()[handler.process]
+
+    assert route.auth_metadata.protected
+    assert route.auth_metadata.requirements[0].ref == "tasks:run"

--- a/core/spakky-task/tests/unit/stereotype/test_task_handler.py
+++ b/core/spakky-task/tests/unit/stereotype/test_task_handler.py
@@ -1,8 +1,17 @@
 """Unit tests for TaskHandler stereotype and @task decorator."""
 
+from dataclasses import dataclass
+
+from spakky.auth import protected, public_access, require_role, require_scope
 from spakky.core.pod.annotations.pod import Pod
 
-from spakky.task.stereotype.task_handler import TaskHandler, TaskRoute, task
+from spakky.task.stereotype.task_handler import (
+    TaskHandler,
+    TaskRoute,
+    _task_auth_requirement_from_annotation,
+    collect_task_auth_metadata,
+    task,
+)
 
 
 def test_task_handler_is_pod_subclass() -> None:
@@ -114,3 +123,129 @@ def test_task_decorator_is_simple_callable() -> None:
     handler = SimpleTaskHandler()
     route = TaskRoute.get(handler.process)
     assert isinstance(route, TaskRoute)
+
+
+def test_task_route_collects_protected_auth_metadata_without_auth_argument() -> None:
+    """@task metadata는 AuthContext method argument 없이 보호 요구사항을 보존한다."""
+
+    @require_role("role:admin", tenant="tenant:1")
+    class ProtectedTaskHandler:
+        @task
+        @require_scope("tasks:run")
+        def process(self) -> None:
+            return None
+
+    handler = ProtectedTaskHandler()
+    metadata = collect_task_auth_metadata(
+        handler.process,
+        owner_type=ProtectedTaskHandler,
+    )
+
+    assert metadata.protected
+    assert [(item.kind, item.ref, item.tenant) for item in metadata.requirements] == [
+        ("ROLE", "role:admin", "tenant:1"),
+        ("SCOPE", "tasks:run", None),
+    ]
+
+
+def test_task_route_collects_public_auth_metadata() -> None:
+    """@task metadata는 명시적 public_access marker도 보존한다."""
+
+    class PublicTaskHandler:
+        @task
+        @public_access
+        def process(self) -> None:
+            return None
+
+    handler = PublicTaskHandler()
+    metadata = collect_task_auth_metadata(handler.process)
+
+    assert metadata.public_access
+    assert not metadata.protected
+
+
+def test_task_route_auth_metadata_defaults_to_public_unprotected() -> None:
+    """auth decorator가 없는 task route는 보호 요구사항을 갖지 않는다."""
+
+    @TaskHandler()
+    class SampleTaskHandler:
+        @task
+        def process(self) -> None:
+            return None
+
+    route = TaskRoute.get(SampleTaskHandler().process)
+
+    assert not route.auth_metadata.public_access
+    assert not route.auth_metadata.protected
+
+
+def test_protected_marker_on_task_records_authenticated_requirement() -> None:
+    """@protected task는 authenticated marker requirement를 task metadata로 노출한다."""
+
+    class ProtectedTaskHandler:
+        @task
+        @protected
+        def process(self) -> None:
+            return None
+
+    handler = ProtectedTaskHandler()
+    metadata = collect_task_auth_metadata(handler.process)
+
+    assert metadata.requirements[0].kind == "AUTHENTICATED"
+
+
+def test_invalid_auth_annotation_payload_is_ignored() -> None:
+    """비정상 auth annotation payload는 task metadata requirement로 변환하지 않는다."""
+    assert _task_auth_requirement_from_annotation(object()) is None
+
+
+def test_invalid_auth_requirement_ref_is_ignored() -> None:
+    """비정상 auth requirement ref는 task metadata requirement로 변환하지 않는다."""
+
+    @dataclass
+    class BrokenRequirement:
+        kind: str | None
+        ref: object
+
+    @dataclass
+    class BrokenProtectedRequirement:
+        requirement: BrokenRequirement
+
+    annotation = BrokenProtectedRequirement(
+        requirement=BrokenRequirement(kind=None, ref=1)
+    )
+
+    assert _task_auth_requirement_from_annotation(annotation) is None
+
+
+def test_non_string_auth_requirement_fields_are_stringified() -> None:
+    """문자열이 아닌 auth metadata 필드는 task route metadata에서 문자열화된다."""
+
+    @dataclass
+    class NumericRequirement:
+        kind: str
+        ref: str
+        resource: int
+        action: int
+        tenant: int
+
+    @dataclass
+    class NumericProtectedRequirement:
+        requirement: NumericRequirement
+
+    annotation = NumericProtectedRequirement(
+        requirement=NumericRequirement(
+            kind="POLICY",
+            ref="document:1",
+            resource=1,
+            action=2,
+            tenant=3,
+        )
+    )
+
+    metadata = _task_auth_requirement_from_annotation(annotation)
+
+    assert metadata is not None
+    assert metadata.resource == "1"
+    assert metadata.action == "2"
+    assert metadata.tenant == "3"

--- a/core/spakky-task/tests/unit/test_direct.py
+++ b/core/spakky-task/tests/unit/test_direct.py
@@ -1,0 +1,168 @@
+"""Unit tests for direct in-process task execution."""
+
+import pytest
+from spakky.core.pod.annotations.pod import Pod
+
+from spakky.task.direct import DirectTaskExecutor, DirectTaskInvocation
+from spakky.task.error import (
+    TaskApplicationContextNotFoundError,
+    TaskAsyncInvocationRequiredError,
+    TaskNotFoundError,
+)
+from spakky.task.stereotype.task_handler import TaskHandler, task
+
+
+class _ApplicationContext:
+    clear_count: int
+    values: dict[str, object]
+
+    def __init__(self, handler: object) -> None:
+        self._handler = handler
+        self.clear_count = 0
+        self.values = {}
+
+    def get(self, type_: type[object]) -> object:
+        return self._handler
+
+    def clear_context(self) -> None:
+        self.clear_count += 1
+        self.values.clear()
+
+    def get_context_value(self, key: str) -> object | None:
+        return self.values.get(key)
+
+    def set_context_value(self, key: str, value: object) -> None:
+        self.values[key] = value
+
+
+def test_direct_executor_is_pod() -> None:
+    """DirectTaskExecutor는 ApplicationContext에서 등록 가능한 Pod이다."""
+    assert Pod.exists(DirectTaskExecutor)
+
+
+def test_execute_invokes_task_in_existing_context_scope() -> None:
+    """직접 실행은 기존 request-scope context를 clear하지 않고 task를 호출한다."""
+
+    @TaskHandler()
+    class SampleTaskHandler:
+        @task
+        def process(self, value: str) -> tuple[str, object | None]:
+            return value.upper(), context.get_context_value("auth")
+
+    context = _ApplicationContext(SampleTaskHandler())
+    context.set_context_value("auth", "subject-1")
+    executor = DirectTaskExecutor()
+    executor.set_application_context(context)  # type: ignore[arg-type] - focused test double
+
+    result = executor.execute(
+        DirectTaskInvocation(
+            handler_type=SampleTaskHandler,
+            method_name="process",
+            args=("ok",),
+        )
+    )
+
+    assert result == ("OK", "subject-1")
+    assert context.clear_count == 0
+
+
+async def test_execute_async_invokes_async_task_in_existing_context_scope() -> None:
+    """비동기 직접 실행도 기존 request-scope context를 유지한다."""
+
+    @TaskHandler()
+    class SampleTaskHandler:
+        @task
+        async def process(self) -> object | None:
+            return context.get_context_value("auth")
+
+    context = _ApplicationContext(SampleTaskHandler())
+    context.set_context_value("auth", "subject-async")
+    executor = DirectTaskExecutor()
+    executor.set_application_context(context)  # type: ignore[arg-type] - focused test double
+
+    result = await executor.execute_async(
+        DirectTaskInvocation(
+            handler_type=SampleTaskHandler,
+            method_name="process",
+        )
+    )
+
+    assert result == "subject-async"
+    assert context.clear_count == 0
+
+
+async def test_execute_async_accepts_sync_task() -> None:
+    """비동기 호출자는 동기 task도 같은 context에서 실행할 수 있다."""
+
+    @TaskHandler()
+    class SampleTaskHandler:
+        @task
+        def process(self) -> str:
+            return "sync"
+
+    context = _ApplicationContext(SampleTaskHandler())
+    executor = DirectTaskExecutor()
+    executor.set_application_context(context)  # type: ignore[arg-type] - focused test double
+
+    result = await executor.execute_async(
+        DirectTaskInvocation(
+            handler_type=SampleTaskHandler,
+            method_name="process",
+        )
+    )
+
+    assert result == "sync"
+
+
+def test_execute_rejects_async_task_on_sync_path() -> None:
+    """동기 직접 실행 경로는 async task를 coroutine으로 누수하지 않는다."""
+
+    @TaskHandler()
+    class SampleTaskHandler:
+        @task
+        async def process(self) -> str:
+            return "async"
+
+    context = _ApplicationContext(SampleTaskHandler())
+    executor = DirectTaskExecutor()
+    executor.set_application_context(context)  # type: ignore[arg-type] - focused test double
+
+    with pytest.raises(TaskAsyncInvocationRequiredError):
+        executor.execute(
+            DirectTaskInvocation(
+                handler_type=SampleTaskHandler,
+                method_name="process",
+            )
+        )
+
+
+def test_execute_raises_when_application_context_missing() -> None:
+    """ApplicationContext가 없으면 직접 실행을 fail-fast 한다."""
+    executor = DirectTaskExecutor()
+
+    with pytest.raises(TaskApplicationContextNotFoundError):
+        executor.execute(
+            DirectTaskInvocation(handler_type=object, method_name="missing")
+        )
+
+
+def test_execute_raises_when_task_method_missing() -> None:
+    """요청한 task method를 찾을 수 없으면 structured task error를 발생시킨다."""
+
+    @TaskHandler()
+    class SampleTaskHandler:
+        @task
+        def process(self) -> None:
+            return None
+
+    context = _ApplicationContext(SampleTaskHandler())
+    executor = DirectTaskExecutor()
+    executor.set_application_context(context)  # type: ignore[arg-type] - focused test double
+
+    with pytest.raises(TaskNotFoundError):
+        executor.execute(
+            DirectTaskInvocation(
+                handler_type=SampleTaskHandler,
+                method_name="missing",
+            )
+        )

--- a/docs/api/core/spakky-task.md
+++ b/docs/api/core/spakky-task.md
@@ -22,6 +22,12 @@ show_root_heading: false
 options:
 show_root_heading: false
 
+## 직접 실행
+
+::: spakky.task.direct
+options:
+show_root_heading: false
+
 ## 후처리기
 
 ::: spakky.task.post_processor

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -130,3 +130,33 @@ class MixedHandler:
 
 !!! tip "실제 실행은 플러그인이 담당"
 `@task`와 `@schedule`은 메타데이터만 부여합니다. 실제 실행은 `spakky-celery` 같은 플러그인이 처리합니다.
+
+---
+
+## 같은 프로세스 직접 실행과 AuthContext
+
+`DirectTaskExecutor`는 현재 `ApplicationContext`에서 task handler를 찾아 같은 프로세스 안에서 호출합니다. 이 경로는 request-scope context를 clear하지 않으므로 이미 seed된 `AuthContext`를 그대로 사용하며, `AuthContextSnapshot`을 만들거나 task method argument로 `AuthContext`를 전달하지 않습니다.
+
+```python
+from spakky.auth import protected
+from spakky.task import DirectTaskExecutor, DirectTaskInvocation, TaskHandler, task
+
+@TaskHandler()
+class ProtectedTaskHandler:
+    @task
+    @protected
+    def rebuild_index(self) -> None:
+        ...
+
+application_context = ...
+executor = DirectTaskExecutor()
+executor.set_application_context(application_context)
+executor.execute(
+    DirectTaskInvocation(
+        handler_type=ProtectedTaskHandler,
+        method_name="rebuild_index",
+    )
+)
+```
+
+보호된 task는 기존 auth AOP metadata를 route metadata로 보존합니다. 따라서 `spakky-auth` enforcement가 함께 적용된 같은 프로세스 직접 실행에서는 `ALLOW`만 사용자 task를 호출하고, `CHALLENGE`, `DENY`, `ERROR` 결정은 fail-closed로 처리됩니다.

--- a/plugins/spakky-celery/pyproject.toml
+++ b/plugins/spakky-celery/pyproject.toml
@@ -9,6 +9,7 @@ authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
 dependencies = [
     "celery>=5.6.3",
     "pydantic-settings>=2.13.1",
+    "spakky-auth>=6.5.0",
     "spakky-task>=6.5.0",
     "spakky-tracing>=6.5.0",
 ]
@@ -94,5 +95,6 @@ exclude_lines = [
 
 [tool.uv.sources]
 spakky = { workspace = true }
+spakky-auth = { workspace = true }
 spakky-task = { workspace = true }
 spakky-tracing = { workspace = true }

--- a/plugins/spakky-celery/src/spakky/plugins/celery/aspects/task_dispatch.py
+++ b/plugins/spakky-celery/src/spakky/plugins/celery/aspects/task_dispatch.py
@@ -25,7 +25,7 @@ from spakky.plugins.celery.common.task_result import CeleryTaskResult
 logger = getLogger(__name__)
 
 
-@Order(0)
+@Order(10)
 @Aspect()
 class CeleryTaskDispatchAspect(IAspect, IApplicationContextAware):
     """Intercepts synchronous @task method calls and dispatches them to Celery broker.
@@ -72,7 +72,7 @@ class CeleryTaskDispatchAspect(IAspect, IApplicationContextAware):
         return CeleryTaskResult(async_result)
 
 
-@Order(0)
+@Order(10)
 @AsyncAspect()
 class AsyncCeleryTaskDispatchAspect(IAsyncAspect, IApplicationContextAware):
     """Intercepts asynchronous @task method calls and dispatches them to Celery broker.

--- a/plugins/spakky-celery/tests/unit/test_dispatcher.py
+++ b/plugins/spakky-celery/tests/unit/test_dispatcher.py
@@ -5,9 +5,27 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from spakky.auth import (
+    AuthContext,
+    AuthRequirementDeniedError,
+    AuthSubject,
+    AuthorizationDecision,
+    AuthorizationDecisionState,
+    AuthorizationReasonCode,
+    IScopeChecker,
+    ScopeCheckRequest,
+    require_auth_context,
+    require_scope,
+    store_auth_context,
+)
+from spakky.auth.aspects.authorization import AuthorizationAspect
+from spakky.core.aop.advisor import Advisor
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.annotations.order import Order
 from spakky.task.stereotype.task_handler import TaskRoute
 from spakky.tracing.context import TraceContext
 from spakky.tracing.w3c_propagator import W3CTracePropagator
+from typing import override
 
 from spakky.plugins.celery.aspects.task_dispatch import (
     CELERY_TASK_CONTEXT_KEY,
@@ -45,6 +63,52 @@ def _create_mock_application_context(*, inside_task: bool = False) -> MagicMock:
     context = MagicMock()
     context.get_context_value.return_value = True if inside_task else None
     return context
+
+
+class ConfigurableScopeChecker(IScopeChecker):
+    decision: AuthorizationDecision
+
+    def __init__(self, decision: AuthorizationDecision) -> None:
+        self.decision = decision
+
+    @override
+    def check_scope(self, request: ScopeCheckRequest) -> AuthorizationDecision:
+        return self.decision
+
+
+def _create_direct_task_context() -> ApplicationContext:
+    context = ApplicationContext()
+    context.set_context_value(CELERY_TASK_CONTEXT_KEY, True)
+    store_auth_context(
+        context,
+        AuthContext(
+            subject=AuthSubject(id="subject-1"),
+            issuer="issuer-1",
+        ),
+    )
+    return context
+
+
+def _run_sync_task_aspect_chain(
+    application_context: ApplicationContext,
+    joinpoint: Callable[..., Any],
+    authorization_decision: AuthorizationDecision,
+) -> tuple[object, MagicMock]:
+    celery = _create_mock_celery()
+    dispatch_aspect = CeleryTaskDispatchAspect(celery)
+    dispatch_aspect.set_application_context(application_context)
+    auth_aspect = AuthorizationAspect(
+        application_context,
+        scope_checker=ConfigurableScopeChecker(authorization_decision),
+    )
+    runnable: Callable[..., Any] = joinpoint
+    for aspect in sorted(
+        (auth_aspect, dispatch_aspect),
+        key=lambda item: Order.get_or_default(item, Order()).order,
+        reverse=True,
+    ):
+        runnable = Advisor(aspect, runnable)
+    return runnable(), celery
 
 
 def _create_joinpoint(
@@ -166,6 +230,65 @@ def test_around_sends_empty_headers_when_propagator_none_expect_no_traceparent()
 
     call_kwargs = celery.send_task.call_args
     assert call_kwargs.kwargs["headers"] == {}
+
+
+def test_task_dispatch_aspect_runs_inside_authorization_aspect() -> None:
+    """Auth enforcement must wrap direct task execution before dispatch semantics."""
+    assert Order.get(AuthorizationAspect).order == 0
+    assert Order.get(CeleryTaskDispatchAspect).order == 10
+
+
+def test_protected_direct_task_uses_existing_auth_context() -> None:
+    """같은 process task 직접 실행은 snapshot 없이 기존 AuthContext를 사용한다."""
+    application_context = _create_direct_task_context()
+
+    @TaskRoute()
+    @require_scope("tasks:run")
+    def joinpoint() -> str:
+        return require_auth_context(application_context).subject.id
+
+    result, celery = _run_sync_task_aspect_chain(
+        application_context,
+        joinpoint,
+        AuthorizationDecision.allow(),
+    )
+
+    assert result == "subject-1"
+    celery.send_task.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "decision",
+    [
+        AuthorizationDecision.challenge(AuthorizationReasonCode.MISSING_CREDENTIAL),
+        AuthorizationDecision.deny(AuthorizationReasonCode.INSUFFICIENT_SCOPE),
+        AuthorizationDecision.error(AuthorizationReasonCode.INTERNAL_ERROR),
+    ],
+)
+def test_protected_direct_task_non_allow_decision_fails_closed(
+    decision: AuthorizationDecision,
+) -> None:
+    """보호된 direct task는 CHALLENGE/DENY/ERROR 결정을 fail-closed 처리한다."""
+    application_context = _create_direct_task_context()
+    called = False
+
+    @TaskRoute()
+    @require_scope("tasks:run")
+    def joinpoint() -> None:
+        nonlocal called
+        called = True
+
+    with pytest.raises(AuthRequirementDeniedError) as excinfo:
+        _run_sync_task_aspect_chain(application_context, joinpoint, decision)
+
+    assert excinfo.value.decision is decision
+    assert excinfo.value.decision is not None
+    assert excinfo.value.decision.state in {
+        AuthorizationDecisionState.CHALLENGE,
+        AuthorizationDecisionState.DENY,
+        AuthorizationDecisionState.ERROR,
+    }
+    assert not called
 
 
 # ── Async AsyncCeleryTaskDispatchAspect ──

--- a/uv.lock
+++ b/uv.lock
@@ -2717,6 +2717,7 @@ source = { editable = "plugins/spakky-celery" }
 dependencies = [
     { name = "celery" },
     { name = "pydantic-settings" },
+    { name = "spakky-auth" },
     { name = "spakky-task" },
     { name = "spakky-tracing" },
 ]
@@ -2734,6 +2735,7 @@ dev = [
 requires-dist = [
     { name = "celery", specifier = ">=5.6.3" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "spakky-auth", editable = "core/spakky-auth" },
     { name = "spakky-task", editable = "core/spakky-task" },
     { name = "spakky-tracing", editable = "core/spakky-tracing" },
 ]
@@ -3217,8 +3219,16 @@ dependencies = [
     { name = "spakky" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "spakky-auth" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "spakky", editable = "core/spakky" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "spakky-auth", editable = "core/spakky-auth" }]
 
 [[package]]
 name = "spakky-tracing"


### PR DESCRIPTION
## Summary
- Add `DirectTaskExecutor`/`DirectTaskInvocation` for same-process task calls that preserve the current request-scope context.
- Copy spakky-auth boundary metadata onto registered `TaskRoute`s without adding a runtime dependency from `spakky-task` to `spakky-auth`.
- Ensure Celery task dispatch runs inside auth enforcement for direct task execution, with CHALLENGE/DENY/ERROR fail-closed coverage.
- Update task README/API/guides for direct execution and auth metadata semantics.

## Acceptance Criteria (자가 grep)
- [x] 이슈 본문에 grep/find/rg 수용 기준 라인이 없어 `acceptance_check: missing` 으로 분류했습니다.

## Verification
- `core/spakky-task`: `uv run --with ruff ruff check .`
- `core/spakky-task`: `uv run --with pyrefly pyrefly check src tests`
- `core/spakky-task`: `uv run --with pytest-cov --with pytest-xdist --with pytest-spec pytest` (100% coverage)
- `plugins/spakky-celery`: `uv run --with ruff ruff check .`
- `plugins/spakky-celery`: `uv run --with pyrefly pyrefly check src tests`
- `plugins/spakky-celery`: `uv run --with pytest-cov --with pytest-xdist --with pytest-spec pytest` (100% coverage)
- Pre-push hooks passed for `spakky-task` and `spakky-celery`.

Closes #291
