### PR TITLE
feat(kafka): add auth snapshot consumer boundary (#295)

### DIFF
--- a/docs/api/plugins/spakky-kafka.md
+++ b/docs/api/plugins/spakky-kafka.md
@@ -20,6 +20,12 @@ show_root_heading: false
 options:
 show_root_heading: false
 
+## Auth Boundary
+
+::: spakky.plugins.kafka.auth
+options:
+show_root_heading: false
+
 ## 설정
 
 ::: spakky.plugins.kafka.common.config

--- a/plugins/spakky-kafka/README.md
+++ b/plugins/spakky-kafka/README.md
@@ -108,6 +108,24 @@ class AsyncUserService:
 - **소비 측**: 수신 메시지에서 `TraceContext`를 추출하여 자식 스팬을 생성합니다
 - 헤더가 없으면 새로운 루트 트레이스를 시작합니다
 
+## AuthContext 스냅샷 소비
+
+`spakky-auth` 보호 decorator가 붙은 Kafka event handler는 raw bearer token을
+받지 않습니다. Consumer는 사용자 handler 호출 직전에
+`x-spakky-auth-context-snapshot` 또는 `spakky.auth.context_snapshot` Kafka header의
+signed `AuthContextSnapshot`을 `IAuthContextSnapshotVerifier`로 검증하고,
+`ApplicationContext`에 `AuthContext`를 seed합니다.
+
+- snapshot 검증은 `KafkaPostProcessor`가 message별 `clear_context()`를 수행한 뒤,
+  사용자 handler를 호출하기 전에 실행됩니다.
+- missing, invalid, expired snapshot은 보호된 handler를 호출하지 않는 CHALLENGE
+  fail-closed로 처리하며 Kafka consumer loop는 메시지를 처리 완료로 둡니다.
+- 보호 요구사항 DENY도 handler 호출을 완료 처리하여 offset poison loop를 만들지
+  않습니다.
+- verifier provider unavailable은 ERROR로 전파되어 consumer route에서 삼키지 않고
+  broker/runtime retry 정책에 맡깁니다.
+- 기존 `traceparent` header와 event payload 역직렬화 의미는 그대로 유지됩니다.
+
 ## 주요 기능
 
 - **자동 topic 생성**: 이벤트 타입 이름을 기준으로 topic 생성
@@ -126,6 +144,7 @@ class AsyncUserService:
 | `KafkaEventConsumer` | 동기 event consumer(background service) |
 | `AsyncKafkaEventConsumer` | 비동기 event consumer(background service) |
 | `KafkaConnectionConfig` | 환경변수 기반 설정 |
+| `KafkaAuthBoundary` | signed `AuthContextSnapshot` 검증 및 `AuthContext` seeding |
 
 ## 라이선스
 

--- a/plugins/spakky-kafka/pyproject.toml
+++ b/plugins/spakky-kafka/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "confluent-kafka>=2.14.0",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.13.1",
+    "spakky-auth>=6.5.0",
     "spakky-event>=6.5.0",
     "spakky-tracing>=6.5.0",
 ]
@@ -84,5 +85,6 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
+spakky-auth = { workspace = true }
 spakky-event = { workspace = true }
 spakky-tracing = { workspace = true }

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/auth.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/auth.py
@@ -1,0 +1,112 @@
+"""Authentication helpers for Kafka consumer boundaries."""
+
+from dataclasses import dataclass
+
+from spakky.auth import (
+    AUTH_CONTEXT_SNAPSHOT_HEADER_KEY,
+    AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
+    EXPIRED_SNAPSHOT_DECISION,
+    INVALID_SNAPSHOT_DECISION,
+    MISSING_SNAPSHOT_DECISION,
+    AuthInvocation,
+    AuthInvocationAttribute,
+    AuthVerificationProviderUnavailableError,
+    AuthorizationDecision,
+    ExpiredAuthContextSnapshotError,
+    IAuthContextSnapshotVerifier,
+    InvalidAuthContextSnapshotError,
+    MissingAuthContextSnapshotError,
+    store_auth_context,
+)
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.core.pod.interfaces.container import IContainer
+
+KAFKA_AUTH_BOUNDARY = "kafka"
+"""Provider-neutral boundary name used for Kafka AuthInvocation values."""
+
+KAFKA_AUTH_HEADERS_PARAMETER = "_spakky_kafka_headers"
+"""Internal endpoint keyword used to pass Kafka message headers."""
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class KafkaHandlerAuthBinding:
+    """Auth metadata captured for one registered Kafka event handler."""
+
+    operation: str
+    """Canonical handler operation reference."""
+    protected: bool
+    """Whether the handler has effective protected auth metadata."""
+
+
+class KafkaAuthBoundary:
+    """Verify propagated snapshots and seed AuthContext for Kafka handlers."""
+
+    _container: IContainer
+    _application_context: IApplicationContext
+
+    def __init__(
+        self,
+        container: IContainer,
+        application_context: IApplicationContext,
+    ) -> None:
+        self._container = container
+        self._application_context = application_context
+
+    def seed_auth_context(
+        self,
+        headers: dict[str, str],
+        binding: KafkaHandlerAuthBinding,
+    ) -> AuthorizationDecision:
+        """Verify a Kafka snapshot header and store AuthContext before user code."""
+        snapshot = self._snapshot_header(headers)
+        if snapshot is None:
+            if binding.protected:
+                return MISSING_SNAPSHOT_DECISION
+            return AuthorizationDecision.allow()
+        verifier = self._container.get_or_none(IAuthContextSnapshotVerifier)
+        if verifier is None:
+            raise AuthVerificationProviderUnavailableError()
+        try:
+            auth_context = verifier.verify_snapshot(
+                snapshot,
+                self._invocation(binding),
+            )
+        except MissingAuthContextSnapshotError:
+            return MISSING_SNAPSHOT_DECISION
+        except InvalidAuthContextSnapshotError:
+            return INVALID_SNAPSHOT_DECISION
+        except ExpiredAuthContextSnapshotError:
+            return EXPIRED_SNAPSHOT_DECISION
+        except AuthVerificationProviderUnavailableError:
+            raise
+        store_auth_context(self._application_context, auth_context)
+        return AuthorizationDecision.allow()
+
+    def _snapshot_header(self, headers: dict[str, str]) -> str | None:
+        for name in (
+            AUTH_CONTEXT_SNAPSHOT_HEADER_KEY,
+            AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
+        ):
+            value = self._header_value(headers, name)
+            if value is not None and value != "":
+                return value
+        return None
+
+    def _header_value(self, headers: dict[str, str], name: str) -> str | None:
+        value = headers.get(name)
+        if value is not None:
+            return value
+        lower_name = name.lower()
+        for key, candidate in headers.items():
+            if key.lower() == lower_name:
+                return candidate
+        return None
+
+    def _invocation(self, binding: KafkaHandlerAuthBinding) -> AuthInvocation:
+        return AuthInvocation(
+            boundary=KAFKA_AUTH_BOUNDARY,
+            operation=binding.operation,
+            attributes=(
+                AuthInvocationAttribute(name="handler", value=binding.operation),
+            ),
+        )

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/event/consumer.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/event/consumer.py
@@ -1,6 +1,12 @@
 from logging import getLogger
 from typing import Any
 
+from spakky.auth import (
+    AuthContextNotFoundError,
+    AuthRequirementDeniedError,
+    AuthRequirementProviderUnavailableError,
+    AuthVerificationProviderUnavailableError,
+)
 from confluent_kafka import Consumer, Message
 from confluent_kafka.admin import AdminClient, NewTopic
 from confluent_kafka.aio import AIOConsumer
@@ -22,6 +28,7 @@ from spakky.tracing.context import TraceContext
 from spakky.tracing.propagator import ITracePropagator
 from typing import override
 
+from spakky.plugins.kafka.auth import KAFKA_AUTH_HEADERS_PARAMETER
 from spakky.plugins.kafka.common.config import KafkaConnectionConfig
 
 logger = getLogger(__name__)
@@ -38,6 +45,7 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
     admin: AdminClient
     consumer: Consumer
     _propagator: ITracePropagator | None
+    _auth_boundary_handlers: set[EventHandlerCallback[Any]]
 
     def __init__(self, config: KafkaConnectionConfig) -> None:
         """Initialize the Kafka consumer with connection config."""
@@ -47,6 +55,7 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
         self.type_adapters = {}
         self.handlers = {}
         self._propagator = None
+        self._auth_boundary_handlers = set()
         self.admin = AdminClient(self.config.configuration_dict)
         self.consumer = Consumer(
             self.config.configuration_dict,
@@ -60,6 +69,10 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
             propagator: An ITracePropagator instance.
         """
         self._propagator = propagator
+
+    def register_auth_boundary(self, handler: EventHandlerCallback[Any]) -> None:
+        """Mark a registered post-processor endpoint as Kafka auth-aware."""
+        self._auth_boundary_handlers.add(handler)
 
     @staticmethod
     def _to_string_headers(
@@ -120,8 +133,9 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
         if event_type is None:  # pragma: no cover - 미등록 이벤트 타입 수신 방어
             logger.warning(f"Received message for unknown event type: {topic}")
             return
+        headers = self._to_string_headers(message.headers())
         if self._propagator is not None:
-            carrier = self._to_string_headers(message.headers())
+            carrier = headers
             parent = self._propagator.extract(carrier)
             ctx = parent.child() if parent is not None else TraceContext.new_root()
             TraceContext.set(ctx)
@@ -133,7 +147,17 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
             event_data = self.type_adapters[event_type].validate_json(event_message)
             handlers = self.handlers[event_type]
             for handler in handlers:
+                if handler in self._auth_boundary_handlers:
+                    handler(event_data, **{KAFKA_AUTH_HEADERS_PARAMETER: headers})
+                    continue
                 handler(event_data)
+        except (
+            AuthVerificationProviderUnavailableError,
+            AuthRequirementProviderUnavailableError,
+        ):
+            raise
+        except (AuthContextNotFoundError, AuthRequirementDeniedError):
+            return
         except Exception as e:  # pragma: no cover - 핸들러 예외 방어
             logger.error(f"Error processing message for event type {topic}: {e}")
         finally:
@@ -188,6 +212,7 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
     admin: AdminClient
     consumer: AIOConsumer
     _propagator: ITracePropagator | None
+    _auth_boundary_handlers: set[AsyncEventHandlerCallback[Any]]
 
     def __init__(self, config: KafkaConnectionConfig) -> None:
         """Initialize the async Kafka consumer with connection config."""
@@ -197,6 +222,7 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
         self.type_adapters = {}
         self.handlers = {}
         self._propagator = None
+        self._auth_boundary_handlers = set()
         self.admin = AdminClient(self.config.configuration_dict)
 
     def set_propagator(self, propagator: ITracePropagator) -> None:
@@ -206,6 +232,10 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
             propagator: An ITracePropagator instance.
         """
         self._propagator = propagator
+
+    def register_auth_boundary(self, handler: AsyncEventHandlerCallback[Any]) -> None:
+        """Mark a registered post-processor endpoint as Kafka auth-aware."""
+        self._auth_boundary_handlers.add(handler)
 
     @staticmethod
     def _to_string_headers(
@@ -268,8 +298,9 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
         if event_type is None:  # pragma: no cover - 미등록 이벤트 타입 수신 방어
             logger.warning(f"Received message for unknown event type: {topic}")
             return
+        headers = self._to_string_headers(message.headers())
         if self._propagator is not None:
-            carrier = self._to_string_headers(message.headers())
+            carrier = headers
             parent = self._propagator.extract(carrier)
             ctx = parent.child() if parent is not None else TraceContext.new_root()
             TraceContext.set(ctx)
@@ -281,7 +312,20 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
             event_data = self.type_adapters[event_type].validate_json(event_message)
             handlers = self.handlers[event_type]
             for handler in handlers:
+                if handler in self._auth_boundary_handlers:
+                    await handler(
+                        event_data,
+                        **{KAFKA_AUTH_HEADERS_PARAMETER: headers},
+                    )
+                    continue
                 await handler(event_data)
+        except (
+            AuthVerificationProviderUnavailableError,
+            AuthRequirementProviderUnavailableError,
+        ):
+            raise
+        except (AuthContextNotFoundError, AuthRequirementDeniedError):
+            return
         except Exception as e:  # pragma: no cover - 핸들러 예외 방어
             logger.error(f"Error processing message for event type {topic}: {e}")
         finally:

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/post_processor.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/post_processor.py
@@ -3,6 +3,7 @@ from inspect import getmembers, iscoroutinefunction, ismethod
 from logging import getLogger
 from typing import Any
 
+from spakky.auth import AuthorizationDecisionState, get_effective_auth_metadata
 from spakky.core.pod.annotations.order import Order
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.interfaces.application_context import IApplicationContext
@@ -20,6 +21,11 @@ from spakky.event.event_consumer import (
 from spakky.event.stereotype.event_handler import EventHandler, EventRoute
 from spakky.tracing.propagator import ITracePropagator
 from typing import override
+
+from spakky.plugins.kafka.auth import (
+    KafkaAuthBoundary,
+    KafkaHandlerAuthBinding,
+)
 
 logger = getLogger(__name__)
 
@@ -74,6 +80,7 @@ class KafkaPostProcessor(IPostProcessor, IContainerAware, IApplicationContextAwa
         handler: EventHandler = EventHandler.get(pod)
         consumer = self.__container.get(IEventConsumer)
         async_consumer = self.__container.get(IAsyncEventConsumer)
+        auth_boundary = KafkaAuthBoundary(self.__container, self.__application_context)
         propagator = self.__application_context.get_or_none(ITracePropagator)
         if propagator is not None:
             if hasattr(  # optional tracing bridge injection
@@ -97,20 +104,37 @@ class KafkaPostProcessor(IPostProcessor, IContainerAware, IApplicationContextAwa
             logger.info(
                 f"[{type(self).__name__}] {route.event_type.__name__} -> {method.__qualname__}"
             )
+            auth_metadata = get_effective_auth_metadata(
+                method,
+                owner_type=handler.type_,
+            )
+            auth_binding = KafkaHandlerAuthBinding(
+                operation=f"{handler.type_.__module__}.{handler.type_.__qualname__}.{name}",
+                protected=auth_metadata.protected,
+            )
 
             if iscoroutinefunction(method):
 
                 @wraps(method)
                 async def async_endpoint(
                     *args: Any,
+                    _spakky_kafka_headers: dict[str, str] | None = None,
                     method_name: str = name,
                     controller_type: type[object] = handler.type_,
                     context: IContainer = self.__container,
+                    boundary: KafkaAuthBoundary = auth_boundary,
+                    binding: KafkaHandlerAuthBinding = auth_binding,
                     **kwargs: Any,
                 ) -> Any:
                     # Each message is handled in isolation, so clear the
                     # application context to avoid reusing dependency state.
                     self.__application_context.clear_context()
+                    decision = boundary.seed_auth_context(
+                        _spakky_kafka_headers or {},
+                        binding,
+                    )
+                    if decision.state is not AuthorizationDecisionState.ALLOW:
+                        return None
                     controller_instance = context.get(controller_type)
                     method_to_call = getattr(  # event handler method lookup
                         controller_instance, method_name
@@ -118,19 +142,33 @@ class KafkaPostProcessor(IPostProcessor, IContainerAware, IApplicationContextAwa
                     return await method_to_call(*args, **kwargs)
 
                 async_consumer.register(route.event_type, async_endpoint)
+                if hasattr(  # optional auth-aware Kafka consumer bridge
+                    async_consumer,
+                    "register_auth_boundary",
+                ):
+                    async_consumer.register_auth_boundary(async_endpoint)
                 continue
 
             @wraps(method)
             def endpoint(
                 *args: Any,
+                _spakky_kafka_headers: dict[str, str] | None = None,
                 method_name: str = name,
                 controller_type: type[object] = handler.type_,
                 context: IContainer = self.__container,
+                boundary: KafkaAuthBoundary = auth_boundary,
+                binding: KafkaHandlerAuthBinding = auth_binding,
                 **kwargs: Any,
             ) -> Any:
                 # Synchronous consumers share threads, so drop any lingering
                 # scoped data before invoking the handler.
                 self.__application_context.clear_context()
+                decision = boundary.seed_auth_context(
+                    _spakky_kafka_headers or {},
+                    binding,
+                )
+                if decision.state is not AuthorizationDecisionState.ALLOW:
+                    return None
                 controller_instance = context.get(controller_type)
                 method_to_call = getattr(  # async event handler method lookup
                     controller_instance, method_name
@@ -138,4 +176,9 @@ class KafkaPostProcessor(IPostProcessor, IContainerAware, IApplicationContextAwa
                 return method_to_call(*args, **kwargs)
 
             consumer.register(route.event_type, endpoint)
+            if hasattr(  # optional auth-aware Kafka consumer bridge
+                consumer,
+                "register_auth_boundary",
+            ):
+                consumer.register_auth_boundary(endpoint)
         return pod

--- a/plugins/spakky-kafka/tests/unit/test_auth.py
+++ b/plugins/spakky-kafka/tests/unit/test_auth.py
@@ -1,0 +1,171 @@
+"""Unit tests for Kafka AuthContext snapshot boundary helpers."""
+
+from typing import override
+from unittest.mock import Mock
+
+import pytest
+from spakky.auth import (
+    AUTH_CONTEXT_SNAPSHOT_HEADER_KEY,
+    AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
+    AuthContext,
+    AuthInvocation,
+    AuthSubject,
+    AuthVerificationProviderUnavailableError,
+    AuthorizationDecisionState,
+    ExpiredAuthContextSnapshotError,
+    IAuthContextSnapshotVerifier,
+    InvalidAuthContextSnapshotError,
+    MissingAuthContextSnapshotError,
+    require_auth_context,
+)
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.interfaces.container import IContainer
+
+from spakky.plugins.kafka.auth import (
+    KAFKA_AUTH_BOUNDARY,
+    KafkaAuthBoundary,
+    KafkaHandlerAuthBinding,
+)
+
+
+class RecordingSnapshotVerifier(IAuthContextSnapshotVerifier):
+    """Snapshot verifier fake recording its input and raising configured errors."""
+
+    snapshot: str | None
+    invocation: AuthInvocation | None
+    error: Exception | None
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self.snapshot = None
+        self.invocation = None
+        self.error = error
+
+    @override
+    def verify_snapshot(
+        self,
+        snapshot_envelope: str,
+        invocation: AuthInvocation,
+    ) -> AuthContext:
+        self.snapshot = snapshot_envelope
+        self.invocation = invocation
+        if self.error is not None:
+            raise self.error
+        return AuthContext(
+            subject=AuthSubject(id="user:kafka"),
+            issuer="test-verifier",
+        )
+
+
+def _container(verifier: IAuthContextSnapshotVerifier | None) -> IContainer:
+    container = Mock(spec=IContainer)
+    container.get_or_none.side_effect = lambda type_: (
+        verifier if type_ is IAuthContextSnapshotVerifier else None
+    )
+    return container
+
+
+def _binding(protected: bool = True) -> KafkaHandlerAuthBinding:
+    return KafkaHandlerAuthBinding(
+        operation="tests.handlers.SampleHandler.handle",
+        protected=protected,
+    )
+
+
+def test_seed_auth_context_with_snapshot_header_expect_context_stored() -> None:
+    """x-spakky-auth-context-snapshot header is verified and seeded."""
+    application_context = ApplicationContext()
+    verifier = RecordingSnapshotVerifier()
+    boundary = KafkaAuthBoundary(_container(verifier), application_context)
+
+    decision = boundary.seed_auth_context(
+        {AUTH_CONTEXT_SNAPSHOT_HEADER_KEY: "snapshot-envelope"},
+        _binding(),
+    )
+
+    assert decision.state is AuthorizationDecisionState.ALLOW
+    assert verifier.snapshot == "snapshot-envelope"
+    assert verifier.invocation is not None
+    assert verifier.invocation.boundary == KAFKA_AUTH_BOUNDARY
+    assert verifier.invocation.operation == "tests.handlers.SampleHandler.handle"
+    assert require_auth_context(application_context).subject.id == "user:kafka"
+
+
+def test_seed_auth_context_reads_metadata_header_fallback() -> None:
+    """Outbound event metadata key is accepted as a Kafka snapshot header."""
+    verifier = RecordingSnapshotVerifier()
+    boundary = KafkaAuthBoundary(_container(verifier), ApplicationContext())
+
+    decision = boundary.seed_auth_context(
+        {AUTH_CONTEXT_SNAPSHOT_METADATA_KEY.upper(): "metadata-envelope"},
+        _binding(),
+    )
+
+    assert decision.state is AuthorizationDecisionState.ALLOW
+    assert verifier.snapshot == "metadata-envelope"
+
+
+def test_protected_handler_missing_snapshot_challenges() -> None:
+    """Protected handlers fail closed when no snapshot is present."""
+    boundary = KafkaAuthBoundary(_container(None), ApplicationContext())
+
+    decision = boundary.seed_auth_context({}, _binding())
+
+    assert decision.state is AuthorizationDecisionState.CHALLENGE
+
+
+def test_public_handler_missing_snapshot_allows_without_provider() -> None:
+    """Public Kafka handlers preserve existing no-auth message behavior."""
+    boundary = KafkaAuthBoundary(_container(None), ApplicationContext())
+
+    decision = boundary.seed_auth_context({}, _binding(protected=False))
+
+    assert decision.state is AuthorizationDecisionState.ALLOW
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_state"),
+    [
+        (MissingAuthContextSnapshotError(), AuthorizationDecisionState.CHALLENGE),
+        (InvalidAuthContextSnapshotError(), AuthorizationDecisionState.CHALLENGE),
+        (ExpiredAuthContextSnapshotError(), AuthorizationDecisionState.CHALLENGE),
+    ],
+)
+def test_snapshot_verification_challenge_fail_closed(
+    error: Exception,
+    expected_state: AuthorizationDecisionState,
+) -> None:
+    """Missing, invalid, and expired envelopes map to CHALLENGE."""
+    verifier = RecordingSnapshotVerifier(error=error)
+    boundary = KafkaAuthBoundary(_container(verifier), ApplicationContext())
+
+    decision = boundary.seed_auth_context(
+        {AUTH_CONTEXT_SNAPSHOT_HEADER_KEY: "snapshot-envelope"},
+        _binding(),
+    )
+
+    assert decision.state is expected_state
+
+
+def test_snapshot_provider_unavailable_is_retryable_error() -> None:
+    """Verifier provider unavailability is propagated instead of swallowed."""
+    verifier = RecordingSnapshotVerifier(
+        error=AuthVerificationProviderUnavailableError()
+    )
+    boundary = KafkaAuthBoundary(_container(verifier), ApplicationContext())
+
+    with pytest.raises(AuthVerificationProviderUnavailableError):
+        boundary.seed_auth_context(
+            {AUTH_CONTEXT_SNAPSHOT_HEADER_KEY: "snapshot-envelope"},
+            _binding(),
+        )
+
+
+def test_missing_snapshot_provider_is_retryable_error() -> None:
+    """Snapshot-bearing messages require a verifier provider."""
+    boundary = KafkaAuthBoundary(_container(None), ApplicationContext())
+
+    with pytest.raises(AuthVerificationProviderUnavailableError):
+        boundary.seed_auth_context(
+            {AUTH_CONTEXT_SNAPSHOT_HEADER_KEY: "snapshot-envelope"},
+            _binding(),
+        )

--- a/plugins/spakky-kafka/tests/unit/test_consumer.py
+++ b/plugins/spakky-kafka/tests/unit/test_consumer.py
@@ -9,6 +9,11 @@ from typing import Any, Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from spakky.auth import (
+    AUTH_CONTEXT_SNAPSHOT_HEADER_KEY,
+    AuthRequirementDeniedError,
+    AuthVerificationProviderUnavailableError,
+)
 from spakky.core.common.mutability import immutable
 from spakky.domain.models.event import AbstractIntegrationEvent
 from spakky.tracing.context import TraceContext
@@ -210,6 +215,94 @@ def test_sync_consumer_route_multiple_handlers_expect_all_called(
 
 @patch("spakky.plugins.kafka.event.consumer.Consumer")
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_auth_boundary_handler_receives_headers(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """Auth-aware post-processor endpoints receive Kafka headers from consumer."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config)
+    captured_headers: list[dict[str, str] | None] = []
+
+    def handler(
+        event: SampleEvent,
+        _spakky_kafka_headers: dict[str, str] | None = None,
+    ) -> None:
+        del event
+        captured_headers.append(_spakky_kafka_headers)
+
+    consumer.register(SampleEvent, handler)
+    consumer.register_auth_boundary(handler)
+
+    mock_message = MagicMock()
+    mock_message.error.return_value = None
+    mock_message.topic.return_value = "SampleEvent"
+    mock_message.value.return_value = b'{"data": "hello"}'
+    mock_message.headers.return_value = [
+        (AUTH_CONTEXT_SNAPSHOT_HEADER_KEY, b"snapshot-envelope"),
+    ]
+
+    consumer._route_event_handler(mock_message)
+
+    assert captured_headers == [{AUTH_CONTEXT_SNAPSHOT_HEADER_KEY: "snapshot-envelope"}]
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_auth_deny_is_handled_without_retry(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """DENY-style auth failures do not escape the route handler."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config)
+
+    def handler(event: SampleEvent) -> None:
+        del event
+        raise AuthRequirementDeniedError()
+
+    consumer.register(SampleEvent, handler)
+
+    mock_message = MagicMock()
+    mock_message.error.return_value = None
+    mock_message.topic.return_value = "SampleEvent"
+    mock_message.value.return_value = b'{"data": "hello"}'
+    mock_message.headers.return_value = []
+
+    consumer._route_event_handler(mock_message)
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_provider_unavailable_is_retryable(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """Provider unavailable ERROR propagates instead of being logged and advanced."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config)
+
+    def handler(event: SampleEvent) -> None:
+        del event
+        raise AuthVerificationProviderUnavailableError()
+
+    consumer.register(SampleEvent, handler)
+
+    mock_message = MagicMock()
+    mock_message.error.return_value = None
+    mock_message.topic.return_value = "SampleEvent"
+    mock_message.value.return_value = b'{"data": "hello"}'
+    mock_message.headers.return_value = []
+
+    with pytest.raises(AuthVerificationProviderUnavailableError):
+        consumer._route_event_handler(mock_message)
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
 def test_sync_consumer_run_expect_poll_and_route(
     mock_admin_cls: MagicMock,
     mock_consumer_cls: MagicMock,
@@ -313,6 +406,22 @@ def test_async_consumer_register_multiple_handlers_expect_all_stored(
     consumer.register(SampleEvent, handler2)
 
     assert len(consumer.handlers[SampleEvent]) == 2
+
+
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_async_consumer_register_auth_boundary_expect_handler_marked(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """Async consumer records auth-aware endpoints for header delivery."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    handler = AsyncMock()
+
+    consumer.register(SampleEvent, handler)
+    consumer.register_auth_boundary(handler)
+
+    assert handler in consumer._auth_boundary_handlers
 
 
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")

--- a/plugins/spakky-kafka/tests/unit/test_post_processor.py
+++ b/plugins/spakky-kafka/tests/unit/test_post_processor.py
@@ -6,6 +6,18 @@ and correctly ignores DomainEvent handlers.
 
 from unittest.mock import Mock
 
+from typing import override
+
+from spakky.auth import (
+    AUTH_CONTEXT_SNAPSHOT_HEADER_KEY,
+    AuthContext,
+    AuthInvocation,
+    AuthSubject,
+    IAuthContextSnapshotVerifier,
+    protected,
+    require_auth_context,
+    store_auth_context,
+)
 from spakky.tracing.propagator import ITracePropagator
 
 import pytest
@@ -19,6 +31,22 @@ from spakky.event.event_consumer import (
 from spakky.event.stereotype.event_handler import EventHandler, on_event
 
 from spakky.plugins.kafka.post_processor import KafkaPostProcessor
+
+
+class RecordingSnapshotVerifier(IAuthContextSnapshotVerifier):
+    """Snapshot verifier fake for Kafka post-processor auth tests."""
+
+    @override
+    def verify_snapshot(
+        self,
+        snapshot_envelope: str,
+        invocation: AuthInvocation,
+    ) -> AuthContext:
+        del snapshot_envelope, invocation
+        return AuthContext(
+            subject=AuthSubject(id="user:kafka"),
+            issuer="test-verifier",
+        )
 
 
 @immutable
@@ -262,6 +290,154 @@ def test_kafka_post_processor_sync_endpoint_invocation_expect_handler_called() -
     assert received_event is not None
     assert received_event.message == "test"
     mock_context.clear_context.assert_called()
+
+
+def test_kafka_post_processor_seeds_auth_after_context_clear() -> None:
+    """AuthContext is seeded after clear_context and before protected handler."""
+    received_subjects: list[str] = []
+    application_context = ApplicationContext()
+    store_auth_context(
+        application_context,
+        AuthContext(subject=AuthSubject(id="stale"), issuer="stale"),
+    )
+
+    @EventHandler()
+    class ProtectedEventHandler:
+        @on_event(SampleIntegrationEvent)
+        @protected
+        def handle_integration_event(self, event: SampleIntegrationEvent) -> None:
+            del event
+            received_subjects.append(
+                require_auth_context(application_context).subject.id
+            )
+
+    mock_consumer = Mock()
+    mock_async_consumer = Mock()
+    verifier = RecordingSnapshotVerifier()
+    handler_instance = ProtectedEventHandler()
+    mock_container = Mock()
+
+    def get_mock(t: type) -> object:
+        if t == IEventConsumer:
+            return mock_consumer
+        if t == IAsyncEventConsumer:
+            return mock_async_consumer
+        if t is type(handler_instance):
+            return handler_instance
+        return None
+
+    mock_container.get.side_effect = get_mock
+    mock_container.get_or_none.side_effect = lambda t: (
+        verifier if t is IAuthContextSnapshotVerifier else None
+    )
+
+    post_processor = KafkaPostProcessor()
+    post_processor.set_container(mock_container)
+    post_processor.set_application_context(application_context)
+
+    post_processor.post_process(handler_instance)
+
+    registered_endpoint = mock_consumer.register.call_args[0][1]
+    registered_endpoint(
+        SampleIntegrationEvent(message="test"),
+        _spakky_kafka_headers={AUTH_CONTEXT_SNAPSHOT_HEADER_KEY: "snapshot"},
+    )
+
+    assert received_subjects == ["user:kafka"]
+    mock_consumer.register_auth_boundary.assert_called_once_with(registered_endpoint)
+
+
+def test_kafka_post_processor_protected_missing_snapshot_skips_handler() -> None:
+    """Protected Kafka handler is not invoked when snapshot is missing."""
+    handler_called = False
+    application_context = ApplicationContext()
+
+    @EventHandler()
+    class ProtectedEventHandler:
+        @on_event(SampleIntegrationEvent)
+        @protected
+        def handle_integration_event(self, event: SampleIntegrationEvent) -> None:
+            del event
+            nonlocal handler_called
+            handler_called = True
+
+    mock_consumer = Mock()
+    mock_async_consumer = Mock()
+    handler_instance = ProtectedEventHandler()
+    mock_container = Mock()
+    mock_container.get.side_effect = lambda t: (
+        mock_consumer
+        if t == IEventConsumer
+        else mock_async_consumer
+        if t == IAsyncEventConsumer
+        else handler_instance
+        if t is type(handler_instance)
+        else None
+    )
+    mock_container.get_or_none.return_value = None
+
+    post_processor = KafkaPostProcessor()
+    post_processor.set_container(mock_container)
+    post_processor.set_application_context(application_context)
+
+    post_processor.post_process(handler_instance)
+    registered_endpoint = mock_consumer.register.call_args[0][1]
+
+    result = registered_endpoint(SampleIntegrationEvent(message="test"))
+
+    assert result is None
+    assert not handler_called
+
+
+@pytest.mark.asyncio
+async def test_kafka_post_processor_async_protected_missing_snapshot_skips_handler() -> (
+    None
+):
+    """Protected async Kafka handler is not invoked when snapshot is missing."""
+    handler_called = False
+    application_context = ApplicationContext()
+
+    @EventHandler()
+    class ProtectedAsyncEventHandler:
+        @on_event(SampleIntegrationEvent)
+        @protected
+        async def handle_integration_event(
+            self,
+            event: SampleIntegrationEvent,
+        ) -> None:
+            del event
+            nonlocal handler_called
+            handler_called = True
+
+    mock_consumer = Mock()
+    mock_async_consumer = Mock()
+    handler_instance = ProtectedAsyncEventHandler()
+    mock_container = Mock()
+    mock_container.get.side_effect = lambda t: (
+        mock_consumer
+        if t == IEventConsumer
+        else mock_async_consumer
+        if t == IAsyncEventConsumer
+        else handler_instance
+        if t is type(handler_instance)
+        else None
+    )
+    mock_container.get_or_none.return_value = None
+
+    post_processor = KafkaPostProcessor()
+    post_processor.set_container(mock_container)
+    post_processor.set_application_context(application_context)
+
+    post_processor.post_process(handler_instance)
+    registered_endpoint = mock_async_consumer.register.call_args[0][1]
+
+    result = await registered_endpoint(SampleIntegrationEvent(message="test"))
+
+    assert result is None
+    assert not handler_called
+    mock_async_consumer.register_auth_boundary.assert_called_once_with(
+        registered_endpoint
+    )
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -3167,6 +3167,7 @@ dependencies = [
     { name = "confluent-kafka" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "spakky-auth" },
     { name = "spakky-event" },
     { name = "spakky-tracing" },
 ]
@@ -3183,6 +3184,7 @@ requires-dist = [
     { name = "confluent-kafka", specifier = ">=2.14.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "spakky-auth", editable = "core/spakky-auth" },
     { name = "spakky-event", editable = "core/spakky-event" },
     { name = "spakky-tracing", editable = "core/spakky-tracing" },
 ]


### PR DESCRIPTION
## Summary

- Add Kafka consumer auth snapshot boundary helpers for signed `AuthContextSnapshot` verification and `AuthContext` seeding.
- Route Kafka headers into post-processor endpoints so seeding happens after `clear_context()` and before user handler invocation.
- Preserve trace/payload behavior while mapping CHALLENGE/DENY to handled advance semantics and provider unavailable ERROR to retryable propagation.
- Update spakky-kafka README/API docs and dependency metadata for `spakky-auth`.

## Verification

- `cd plugins/spakky-kafka && uv run --with ruff ruff format .`
- `cd plugins/spakky-kafka && uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- `cd plugins/spakky-kafka && uv run --with ruff ruff check .`
- `cd plugins/spakky-kafka && uv run --with pyrefly pyrefly check src tests`
- `cd plugins/spakky-kafka && uv run --with pytest-cov --with pytest-xdist --with pytest-spec --with pytest-integration-mark --with pytest-asyncio pytest` (100% coverage)

## Acceptance Criteria (자가 grep)

- [x] Issue #295 has no grep/find/rg acceptance lines to execute; acceptance_check: missing.
- [x] Verified by package gate: ruff format, harness validation, ruff check, pyrefly check src tests, pytest with 100% coverage.

Closes #295
