### PR TITLE
feat(rabbitmq): add auth snapshot consumer boundary (#294)

### DIFF
--- a/docs/api/plugins/spakky-rabbitmq.md
+++ b/docs/api/plugins/spakky-rabbitmq.md
@@ -20,6 +20,12 @@ show_root_heading: false
 options:
 show_root_heading: false
 
+## 인증 Boundary
+
+::: spakky.plugins.rabbitmq.auth
+options:
+show_root_heading: false
+
 ## 설정
 
 ::: spakky.plugins.rabbitmq.common.config

--- a/docs/guides/rabbitmq.md
+++ b/docs/guides/rabbitmq.md
@@ -40,6 +40,9 @@ export SPAKKY_RABBITMQ__PORT=5672
 export SPAKKY_RABBITMQ__USER=guest
 export SPAKKY_RABBITMQ__PASSWORD=guest
 export SPAKKY_RABBITMQ__EXCHANGE_NAME=my-exchange  # Optional
+export SPAKKY_RABBITMQ__AUTH_CHALLENGE_ACTION=ack
+export SPAKKY_RABBITMQ__AUTH_DENY_ACTION=ack
+export SPAKKY_RABBITMQ__AUTH_ERROR_ACTION=nack_requeue
 ```
 
 | 필드 | 환경변수 | 기본값 | 설명 |
@@ -50,6 +53,11 @@ export SPAKKY_RABBITMQ__EXCHANGE_NAME=my-exchange  # Optional
 | `user` | `SPAKKY_RABBITMQ__USER` | (필수) | 인증 사용자명 |
 | `password` | `SPAKKY_RABBITMQ__PASSWORD` | (필수) | 인증 비밀번호 |
 | `exchange_name` | `SPAKKY_RABBITMQ__EXCHANGE_NAME` | `None` | Exchange 이름 (pub/sub 라우팅) |
+| `auth_challenge_action` | `SPAKKY_RABBITMQ__AUTH_CHALLENGE_ACTION` | `ack` | missing/invalid/expired snapshot 처리 |
+| `auth_deny_action` | `SPAKKY_RABBITMQ__AUTH_DENY_ACTION` | `ack` | protected handler DENY 처리 |
+| `auth_error_action` | `SPAKKY_RABBITMQ__AUTH_ERROR_ACTION` | `nack_requeue` | verifier/provider ERROR 처리 |
+
+`auth_*_action` 값은 `ack`, `nack_requeue`, `nack_drop` 중 하나입니다. 기본 정책은 CHALLENGE/DENY를 ack하여 poison-loop를 피하고, ERROR는 requeue하여 일시적인 verifier/provider 장애를 재시도합니다.
 
 ---
 
@@ -133,7 +141,7 @@ sequenceDiagram
 | 이벤트 이름 | `AbstractIntegrationEvent.event_name` 값, 기본은 클래스명 |
 | 큐 이름 | 수신 핸들러가 등록한 이벤트 클래스명, durable queue로 선언 |
 | payload | Pydantic `TypeAdapter`가 만든 JSON bytes |
-| headers | `ITracePropagator.inject()`가 넣은 trace header |
+| headers | `ITracePropagator.inject()`가 넣은 trace header와 signed `AuthContextSnapshot` metadata |
 | exchange 없음 | 기본 exchange에 큐 이름 routing key로 발행 |
 | exchange 있음 | configured exchange에 이벤트 이름 routing key로 발행하고 큐를 bind |
 
@@ -162,3 +170,20 @@ sequenceDiagram
 - `ITracePropagator`가 컨테이너에 없으면 트레이싱은 비활성 상태로, 별도 에러 없이 동작합니다
 
 별도 설정이나 코드 변경 없이, 플러그인 로드만으로 동작합니다.
+
+---
+
+## 인증/인가 snapshot 수신
+
+`spakky-auth`의 보호 decorator가 붙은 RabbitMQ event handler는 signed `AuthContextSnapshot`을 검증한 뒤 `ApplicationContext` request/context scope에 `AuthContext`를 seed합니다. 이 작업은 `RabbitMQPostProcessor` wrapper가 기존 integration context를 `clear_context()`로 비운 직후, 사용자 handler 호출 전에 수행됩니다.
+
+수신 측은 다음 header를 snapshot envelope로 인식합니다.
+
+| header | 설명 |
+|--------|------|
+| `spakky.auth.context_snapshot` | Event/Outbox transport metadata key |
+| `x-spakky-auth-context-snapshot` | HTTP/gRPC-style snapshot header key |
+
+보호된 handler에서 snapshot이 없거나 invalid/expired이면 `CHALLENGE`로 fail-closed 처리합니다. 정책 evaluator가 `DENY`를 반환해도 handler는 호출되지 않습니다. 검증 provider가 unavailable이면 `ERROR`로 처리하며, 기본 RabbitMQ 정책은 `nack_requeue`입니다.
+
+Payload 직렬화, event name routing, trace header 추출 동작은 snapshot 검증과 독립적으로 유지됩니다.

--- a/plugins/spakky-rabbitmq/README.md
+++ b/plugins/spakky-rabbitmq/README.md
@@ -25,6 +25,9 @@ export SPAKKY_RABBITMQ__PORT="5672"
 export SPAKKY_RABBITMQ__USER="guest"
 export SPAKKY_RABBITMQ__PASSWORD="guest"
 export SPAKKY_RABBITMQ__EXCHANGE_NAME="my-exchange"  # Optional
+export SPAKKY_RABBITMQ__AUTH_CHALLENGE_ACTION="ack"
+export SPAKKY_RABBITMQ__AUTH_DENY_ACTION="ack"
+export SPAKKY_RABBITMQ__AUTH_ERROR_ACTION="nack_requeue"
 ```
 
 ## 사용법
@@ -94,6 +97,26 @@ class AsyncUserService:
 - **소비 측**: 수신 메시지에서 `TraceContext`를 추출하여 자식 스팬을 생성합니다
 - 헤더가 없으면 새로운 루트 트레이스를 시작합니다
 
+## 인증/인가 snapshot 수신
+
+`spakky-auth`의 보호 decorator가 붙은 RabbitMQ event handler는 메시지 header의 signed `AuthContextSnapshot`을 검증한 뒤 `ApplicationContext`에 `AuthContext`를 seed합니다. seed 시점은 handler wrapper가 integration context를 `clear_context()`로 정리한 직후이며, 사용자 handler 호출 전입니다.
+
+- 지원 header: `spakky.auth.context_snapshot`, `x-spakky-auth-context-snapshot`
+- missing, invalid, expired snapshot: `CHALLENGE` decision으로 fail-closed
+- protected handler의 `DENY`: configured ack/nack policy로 fail-closed
+- verifier provider unavailable: `ERROR` decision이며 기본 retryable policy(`nack_requeue`) 적용
+- event payload와 기존 trace header 의미는 변경하지 않습니다
+
+인증 실패 시 message 처리 정책은 다음 환경변수로 조정합니다.
+
+| 필드 | 환경변수 | 기본값 | 설명 |
+|------|---------|--------|------|
+| `auth_challenge_action` | `SPAKKY_RABBITMQ__AUTH_CHALLENGE_ACTION` | `ack` | missing/invalid/expired snapshot 처리 |
+| `auth_deny_action` | `SPAKKY_RABBITMQ__AUTH_DENY_ACTION` | `ack` | protected handler DENY 처리 |
+| `auth_error_action` | `SPAKKY_RABBITMQ__AUTH_ERROR_ACTION` | `nack_requeue` | verifier/provider ERROR 처리 |
+
+가능한 값은 `ack`, `nack_requeue`, `nack_drop`입니다. 기본값은 CHALLENGE/DENY를 ack하여 poison-loop를 피하고, ERROR만 requeue하여 일시적 provider 장애를 재시도합니다.
+
 ## 주요 기능
 
 - **자동 queue 선언**: 이벤트 타입 이름을 기준으로 durable queue 생성
@@ -103,6 +126,7 @@ class AsyncUserService:
 - **Exchange 라우팅**: pub/sub 메시지 패턴을 위한 선택적 exchange
 - **SSL 지원**: AMQPS protocol 기반 보안 연결
 - **분산 트레이싱**: 서비스 간 trace 전파를 위한 `spakky-tracing` 통합
+- **인증/인가 보호 경계**: signed `AuthContextSnapshot` 검증 및 protected handler fail-closed 처리
 
 ## 구성 요소
 
@@ -113,10 +137,12 @@ class AsyncUserService:
 | `RabbitMQEventConsumer` | 동기 event consumer(background service) |
 | `AsyncRabbitMQEventConsumer` | 비동기 event consumer(background service) |
 | `RabbitMQConnectionConfig` | 환경변수 기반 설정 |
+| `RabbitMQAuthBoundary` | signed `AuthContextSnapshot` 검증 및 `AuthContext` seed helper |
 
 ## 에러 처리
 
 - **`InvalidMessageError`**: 필수 metadata(`consumer_tag` 또는 `delivery_tag`)가 없는 message에서 발생
+- 보호된 handler 인증/인가 실패는 handler를 호출하지 않고 ack/nack 정책으로 fail-closed 처리됩니다
 
 ## 라이선스
 

--- a/plugins/spakky-rabbitmq/pyproject.toml
+++ b/plugins/spakky-rabbitmq/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "pika-stubs>=0.1.3",
   "pydantic>=2.12.5",
   "pydantic-settings>=2.13.1",
+  "spakky-auth>=6.5.0",
   "spakky-event>=6.5.0",
   "spakky-tracing>=6.5.0",
 ]
@@ -86,5 +87,6 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
+spakky-auth = { workspace = true }
 spakky-event = { workspace = true }
 spakky-tracing = { workspace = true }

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/auth.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/auth.py
@@ -1,0 +1,136 @@
+"""Auth boundary helpers for RabbitMQ consumer callbacks."""
+
+from collections.abc import Mapping
+from contextvars import ContextVar, Token
+
+from spakky.auth import (
+    AUTH_CONTEXT_SNAPSHOT_HEADER_KEY,
+    AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
+    EXPIRED_SNAPSHOT_DECISION,
+    INVALID_SNAPSHOT_DECISION,
+    MISSING_SNAPSHOT_DECISION,
+    VERIFICATION_PROVIDER_UNAVAILABLE_DECISION,
+    AuthInvocation,
+    AuthInvocationAttribute,
+    AuthRequirementDeniedError,
+    AuthVerificationProviderUnavailableError,
+    ExpiredAuthContextSnapshotError,
+    IAuthContextSnapshotVerifier,
+    InvalidAuthContextSnapshotError,
+    MissingAuthContextSnapshotError,
+    store_auth_context,
+)
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.domain.models.event import AbstractEvent
+
+RABBITMQ_AUTH_BOUNDARY = "rabbitmq"
+"""AuthInvocation boundary value used for RabbitMQ consumer handlers."""
+
+RABBITMQ_EVENT_NAME_ATTRIBUTE = "event_name"
+"""AuthInvocation attribute carrying the integration event name."""
+
+RABBITMQ_SNAPSHOT_ATTRIBUTE = "auth_context_snapshot"
+"""AuthInvocation attribute carrying the signed snapshot envelope."""
+
+_current_message_headers: ContextVar[Mapping[str, str] | None] = ContextVar(
+    "spakky_rabbitmq_message_headers",
+    default=None,
+)
+
+
+def set_current_rabbitmq_message_headers(
+    headers: Mapping[str, str],
+) -> Token[Mapping[str, str] | None]:
+    """Set the message headers visible to the post-processor endpoint."""
+    return _current_message_headers.set(headers)
+
+
+def reset_current_rabbitmq_message_headers(
+    token: Token[Mapping[str, str] | None],
+) -> None:
+    """Restore the previous message header context."""
+    _current_message_headers.reset(token)
+
+
+def current_rabbitmq_message_headers() -> Mapping[str, str]:
+    """Return the active RabbitMQ message headers for this handler invocation."""
+    headers = _current_message_headers.get()
+    if headers is None:
+        return {}
+    return headers
+
+
+class RabbitMQAuthBoundary:
+    """Verify signed snapshots and seed AuthContext for RabbitMQ handlers."""
+
+    _snapshot_verifier: IAuthContextSnapshotVerifier | None
+    _application_context: IApplicationContext
+
+    def __init__(
+        self,
+        application_context: IApplicationContext,
+        snapshot_verifier: IAuthContextSnapshotVerifier | None,
+    ) -> None:
+        self._application_context = application_context
+        self._snapshot_verifier = snapshot_verifier
+
+    def seed_auth_context(
+        self,
+        *,
+        event_type: type[AbstractEvent],
+        operation: str,
+        protected: bool,
+    ) -> None:
+        """Verify the current message snapshot and seed AuthContext when needed."""
+        headers = current_rabbitmq_message_headers()
+        snapshot_envelope = self._snapshot_envelope(headers)
+        if snapshot_envelope is None:
+            if protected:
+                raise AuthRequirementDeniedError(MISSING_SNAPSHOT_DECISION)
+            return
+        verifier = self._snapshot_verifier
+        if verifier is None:
+            raise AuthRequirementDeniedError(VERIFICATION_PROVIDER_UNAVAILABLE_DECISION)
+        try:
+            auth_context = verifier.verify_snapshot(
+                snapshot_envelope,
+                self._invocation(event_type, operation, snapshot_envelope),
+            )
+        except MissingAuthContextSnapshotError as error:
+            raise AuthRequirementDeniedError(MISSING_SNAPSHOT_DECISION) from error
+        except InvalidAuthContextSnapshotError as error:
+            raise AuthRequirementDeniedError(INVALID_SNAPSHOT_DECISION) from error
+        except ExpiredAuthContextSnapshotError as error:
+            raise AuthRequirementDeniedError(EXPIRED_SNAPSHOT_DECISION) from error
+        except AuthVerificationProviderUnavailableError as error:
+            raise AuthRequirementDeniedError(
+                VERIFICATION_PROVIDER_UNAVAILABLE_DECISION
+            ) from error
+        store_auth_context(self._application_context, auth_context)
+
+    def _snapshot_envelope(self, headers: Mapping[str, str]) -> str | None:
+        snapshot = headers.get(AUTH_CONTEXT_SNAPSHOT_METADATA_KEY)
+        if snapshot is not None:
+            return snapshot
+        return headers.get(AUTH_CONTEXT_SNAPSHOT_HEADER_KEY)
+
+    def _invocation(
+        self,
+        event_type: type[AbstractEvent],
+        operation: str,
+        snapshot_envelope: str,
+    ) -> AuthInvocation:
+        return AuthInvocation(
+            boundary=RABBITMQ_AUTH_BOUNDARY,
+            operation=operation,
+            attributes=(
+                AuthInvocationAttribute(
+                    name=RABBITMQ_EVENT_NAME_ATTRIBUTE,
+                    value=event_type.__name__,
+                ),
+                AuthInvocationAttribute(
+                    name=RABBITMQ_SNAPSHOT_ATTRIBUTE,
+                    value=snapshot_envelope,
+                ),
+            ),
+        )

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/common/config.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/common/config.py
@@ -4,12 +4,26 @@ Provides configuration dataclass for RabbitMQ connection parameters including
 host, port, credentials, and exchange settings.
 """
 
+from enum import StrEnum
 from typing import ClassVar
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from spakky.core.stereotype.configuration import Configuration
 
 from spakky.plugins.rabbitmq.common.constants import RABBITMQ_CONFIG_ENV_PREFIX
+
+
+class RabbitMQAuthFailureAction(StrEnum):
+    """Ack/nack action used when a protected RabbitMQ handler fails auth."""
+
+    ACK = "ack"
+    """Acknowledge and drop the message."""
+
+    NACK_REQUEUE = "nack_requeue"
+    """Negative-acknowledge and requeue the message."""
+
+    NACK_DROP = "nack_drop"
+    """Negative-acknowledge without requeueing the message."""
 
 
 @Configuration()
@@ -50,6 +64,17 @@ class RabbitMQConnectionConfig(BaseSettings):
 
     exchange_name: str | None = None
     """Optional exchange name for pub/sub message routing."""
+
+    auth_challenge_action: RabbitMQAuthFailureAction = RabbitMQAuthFailureAction.ACK
+    """Message action for missing, invalid, or expired snapshot decisions."""
+
+    auth_deny_action: RabbitMQAuthFailureAction = RabbitMQAuthFailureAction.ACK
+    """Message action for explicit DENY decisions from protected handlers."""
+
+    auth_error_action: RabbitMQAuthFailureAction = (
+        RabbitMQAuthFailureAction.NACK_REQUEUE
+    )
+    """Message action for retryable provider ERROR decisions."""
 
     @property
     def protocol(self) -> str:

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/consumer.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/consumer.py
@@ -34,8 +34,19 @@ from spakky.event.event_consumer import (
     IAsyncEventConsumer,
     IEventConsumer,
 )
+from spakky.auth import (
+    AuthRequirementDeniedError,
+    AuthorizationDecisionState,
+)
 
-from spakky.plugins.rabbitmq.common.config import RabbitMQConnectionConfig
+from spakky.plugins.rabbitmq.auth import (
+    reset_current_rabbitmq_message_headers,
+    set_current_rabbitmq_message_headers,
+)
+from spakky.plugins.rabbitmq.common.config import (
+    RabbitMQAuthFailureAction,
+    RabbitMQConnectionConfig,
+)
 from spakky.tracing.context import TraceContext
 from spakky.tracing.propagator import ITracePropagator
 
@@ -63,6 +74,9 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
     connection: BlockingConnection
     channel: BlockingChannel
     _propagator: ITracePropagator | None
+    _auth_challenge_action: RabbitMQAuthFailureAction
+    _auth_deny_action: RabbitMQAuthFailureAction
+    _auth_error_action: RabbitMQAuthFailureAction
 
     def __init__(self, config: RabbitMQConnectionConfig) -> None:
         """Initialize the synchronous RabbitMQ event consumer.
@@ -76,6 +90,9 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
         self.type_adapters = {}
         self.handlers = {}
         self._propagator = None
+        self._auth_challenge_action = config.auth_challenge_action
+        self._auth_deny_action = config.auth_deny_action
+        self._auth_error_action = config.auth_error_action
 
     def set_propagator(self, propagator: ITracePropagator) -> None:
         """Set the trace propagator for extracting trace context from messages.
@@ -99,7 +116,7 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
         Returns:
             A dict with string keys and string values.
         """
-        if raw is None:
+        if raw is None or not isinstance(raw, Mapping):
             return {}
         result: dict[str, str] = {}
         for key, value in raw.items():
@@ -123,11 +140,12 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
         """
         if method_frame.consumer_tag is None or method_frame.delivery_tag is None:
             raise InvalidMessageError("Missing consumer tag or delivery tag.")
+        carrier = self._to_string_headers(properties.headers)
         if self._propagator is not None:
-            carrier = self._to_string_headers(properties.headers)
             parent = self._propagator.extract(carrier)
             ctx = parent.child() if parent is not None else TraceContext.new_root()
             TraceContext.set(ctx)
+        token = set_current_rabbitmq_message_headers(carrier)
         try:
             event_type = self.type_lookup[method_frame.consumer_tag]
             handlers = self.handlers[event_type]
@@ -136,9 +154,41 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
             for handler in handlers:
                 handler(event)
             channel.basic_ack(method_frame.delivery_tag)
+        except AuthRequirementDeniedError as error:
+            self._handle_auth_failure(channel, method_frame.delivery_tag, error)
         finally:
+            reset_current_rabbitmq_message_headers(token)
             if self._propagator is not None:
                 TraceContext.clear()
+
+    def _handle_auth_failure(
+        self,
+        channel: BlockingChannel,
+        delivery_tag: int,
+        error: AuthRequirementDeniedError,
+    ) -> None:
+        action = self._auth_failure_action(error)
+        if action is RabbitMQAuthFailureAction.ACK:
+            channel.basic_ack(delivery_tag)
+            return
+        if action is RabbitMQAuthFailureAction.NACK_REQUEUE:
+            channel.basic_nack(delivery_tag, requeue=True)
+            return
+        channel.basic_nack(delivery_tag, requeue=False)
+
+    def _auth_failure_action(
+        self,
+        error: AuthRequirementDeniedError,
+    ) -> RabbitMQAuthFailureAction:
+        decision = error.decision
+        if decision is None:
+            return self._auth_error_action
+        return {
+            AuthorizationDecisionState.ALLOW: self._auth_error_action,
+            AuthorizationDecisionState.CHALLENGE: self._auth_challenge_action,
+            AuthorizationDecisionState.DENY: self._auth_deny_action,
+            AuthorizationDecisionState.ERROR: self._auth_error_action,
+        }[decision.state]
 
     def _check_if_event_set(self) -> None:
         if self._stop_event.is_set():
@@ -226,6 +276,9 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
     handlers: dict[type[AbstractEvent], list[AsyncEventHandlerCallback[Any]]]
     connection: AbstractRobustConnection
     _propagator: ITracePropagator | None
+    _auth_challenge_action: RabbitMQAuthFailureAction
+    _auth_deny_action: RabbitMQAuthFailureAction
+    _auth_error_action: RabbitMQAuthFailureAction
 
     def __init__(self, config: RabbitMQConnectionConfig) -> None:
         """Initialize the asynchronous RabbitMQ event consumer.
@@ -238,6 +291,9 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
         self.type_adapters = {}
         self.handlers = {}
         self._propagator = None
+        self._auth_challenge_action = config.auth_challenge_action
+        self._auth_deny_action = config.auth_deny_action
+        self._auth_error_action = config.auth_error_action
 
     def set_propagator(self, propagator: ITracePropagator) -> None:
         """Set the trace propagator for extracting trace context from messages.
@@ -261,7 +317,7 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
         Returns:
             A dict with string keys and string values.
         """
-        if raw is None:
+        if raw is None or not isinstance(raw, Mapping):
             return {}
         result: dict[str, str] = {}
         for key, value in raw.items():
@@ -279,11 +335,12 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
         """
         if message.consumer_tag is None or message.delivery_tag is None:
             raise InvalidMessageError("Missing consumer tag or delivery tag.")
+        carrier = self._to_string_headers(message.headers)
         if self._propagator is not None:
-            carrier = self._to_string_headers(message.headers)
             parent = self._propagator.extract(carrier)
             ctx = parent.child() if parent is not None else TraceContext.new_root()
             TraceContext.set(ctx)
+        token = set_current_rabbitmq_message_headers(carrier)
         try:
             event_type = self.type_lookup[message.consumer_tag]
             handlers = self.handlers[event_type]
@@ -292,9 +349,40 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
             for handler in handlers:
                 await handler(event)
             await message.ack()
+        except AuthRequirementDeniedError as error:
+            await self._handle_auth_failure(message, error)
         finally:
+            reset_current_rabbitmq_message_headers(token)
             if self._propagator is not None:
                 TraceContext.clear()
+
+    async def _handle_auth_failure(
+        self,
+        message: AbstractIncomingMessage,
+        error: AuthRequirementDeniedError,
+    ) -> None:
+        action = self._auth_failure_action(error)
+        if action is RabbitMQAuthFailureAction.ACK:
+            await message.ack()
+            return
+        if action is RabbitMQAuthFailureAction.NACK_REQUEUE:
+            await message.nack(requeue=True)
+            return
+        await message.nack(requeue=False)
+
+    def _auth_failure_action(
+        self,
+        error: AuthRequirementDeniedError,
+    ) -> RabbitMQAuthFailureAction:
+        decision = error.decision
+        if decision is None:
+            return self._auth_error_action
+        return {
+            AuthorizationDecisionState.ALLOW: self._auth_error_action,
+            AuthorizationDecisionState.CHALLENGE: self._auth_challenge_action,
+            AuthorizationDecisionState.DENY: self._auth_deny_action,
+            AuthorizationDecisionState.ERROR: self._auth_error_action,
+        }[decision.state]
 
     @override
     def register(

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/post_processor.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/post_processor.py
@@ -9,6 +9,7 @@ from inspect import getmembers, iscoroutinefunction, ismethod
 from logging import getLogger
 from typing import Any
 
+from spakky.auth import IAuthContextSnapshotVerifier, get_effective_auth_metadata
 from spakky.core.pod.annotations.order import Order
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.interfaces.application_context import IApplicationContext
@@ -24,6 +25,7 @@ from spakky.event.event_consumer import (
     IEventConsumer,
 )
 from spakky.event.stereotype.event_handler import EventHandler, EventRoute
+from spakky.plugins.rabbitmq.auth import RabbitMQAuthBoundary
 from spakky.tracing.propagator import ITracePropagator
 from typing import override
 
@@ -80,6 +82,10 @@ class RabbitMQPostProcessor(IPostProcessor, IContainerAware, IApplicationContext
         handler: EventHandler = EventHandler.get(pod)
         consumer = self.__container.get(IEventConsumer)
         async_consumer = self.__container.get(IAsyncEventConsumer)
+        auth_boundary = RabbitMQAuthBoundary(
+            self.__application_context,
+            self.__container.get_or_none(IAuthContextSnapshotVerifier),
+        )
         propagator = self.__application_context.get_or_none(ITracePropagator)
         if propagator is not None:
             # 프레임워크 내부: consumer 인터페이스가 선택적 propagator를 지원하는지 확인
@@ -98,6 +104,10 @@ class RabbitMQPostProcessor(IPostProcessor, IContainerAware, IApplicationContext
                 continue
             if not issubclass(route.event_type, AbstractIntegrationEvent):
                 continue
+            auth_metadata = get_effective_auth_metadata(
+                method,
+                owner_type=handler.type_,
+            )
 
             # pylint: disable=line-too-long
             logger.info(
@@ -111,12 +121,19 @@ class RabbitMQPostProcessor(IPostProcessor, IContainerAware, IApplicationContext
                     *args: Any,
                     method_name: str = name,
                     controller_type: type[object] = handler.type_,
+                    event_type: type[AbstractEvent] = route.event_type,
+                    protected: bool = auth_metadata.protected,
                     context: IContainer = self.__container,
                     **kwargs: Any,
                 ) -> Any:
                     # Each message is handled in isolation, so clear the
                     # application context to avoid reusing dependency state.
                     self.__application_context.clear_context()
+                    auth_boundary.seed_auth_context(
+                        event_type=event_type,
+                        operation=f"{controller_type.__module__}.{controller_type.__qualname__}.{method_name}",
+                        protected=protected,
+                    )
                     controller_instance = context.get(controller_type)
                     # 프레임워크 내부: 컨트롤러 메서드 동적 디스패치
                     method_to_call = getattr(  # event handler method lookup
@@ -132,12 +149,19 @@ class RabbitMQPostProcessor(IPostProcessor, IContainerAware, IApplicationContext
                 *args: Any,
                 method_name: str = name,
                 controller_type: type[object] = handler.type_,
+                event_type: type[AbstractEvent] = route.event_type,
+                protected: bool = auth_metadata.protected,
                 context: IContainer = self.__container,
                 **kwargs: Any,
             ) -> Any:
                 # Synchronous consumers share threads, so drop any lingering
                 # scoped data before invoking the handler.
                 self.__application_context.clear_context()
+                auth_boundary.seed_auth_context(
+                    event_type=event_type,
+                    operation=f"{controller_type.__module__}.{controller_type.__qualname__}.{method_name}",
+                    protected=protected,
+                )
                 controller_instance = context.get(controller_type)
                 # 프레임워크 내부: 컨트롤러 메서드 동적 디스패치
                 method_to_call = getattr(  # async event handler method lookup

--- a/plugins/spakky-rabbitmq/tests/unit/test_auth.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_auth.py
@@ -1,0 +1,242 @@
+"""Tests for RabbitMQ auth snapshot boundary helpers."""
+
+from collections.abc import Mapping
+
+import pytest
+from spakky.auth import (
+    AUTH_CONTEXT_SNAPSHOT_HEADER_KEY,
+    AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
+    EXPIRED_SNAPSHOT_DECISION,
+    INVALID_SNAPSHOT_DECISION,
+    MISSING_SNAPSHOT_DECISION,
+    VERIFICATION_PROVIDER_UNAVAILABLE_DECISION,
+    AuthContext,
+    AuthInvocation,
+    AuthRequirementDeniedError,
+    AuthSubject,
+    AuthVerificationProviderUnavailableError,
+    ExpiredAuthContextSnapshotError,
+    IAuthContextSnapshotVerifier,
+    InvalidAuthContextSnapshotError,
+    MissingAuthContextSnapshotError,
+    require_auth_context,
+)
+from spakky.core.application.application_context import ApplicationContext
+from spakky.domain.models.event import AbstractIntegrationEvent
+from typing import override
+
+from spakky.plugins.rabbitmq.auth import (
+    RABBITMQ_AUTH_BOUNDARY,
+    RabbitMQAuthBoundary,
+    current_rabbitmq_message_headers,
+    reset_current_rabbitmq_message_headers,
+    set_current_rabbitmq_message_headers,
+)
+
+
+class SampleIntegrationEvent(AbstractIntegrationEvent):
+    """Sample integration event for auth boundary tests."""
+
+    data: str
+
+
+class RecordingSnapshotVerifier(IAuthContextSnapshotVerifier):
+    """Snapshot verifier stub that records the envelope and invocation."""
+
+    auth_context: AuthContext
+    error: Exception | None
+    envelope: str | None
+    invocation: AuthInvocation | None
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self.auth_context = AuthContext(
+            subject=AuthSubject(id="subject-1"),
+            issuer="issuer-1",
+            scopes=("rabbitmq:consume",),
+        )
+        self.error = error
+        self.envelope = None
+        self.invocation = None
+
+    @override
+    def verify_snapshot(
+        self,
+        snapshot_envelope: str,
+        invocation: AuthInvocation,
+    ) -> AuthContext:
+        self.envelope = snapshot_envelope
+        self.invocation = invocation
+        if self.error is not None:
+            raise self.error
+        return self.auth_context
+
+
+def test_current_headers_default_empty_expect_empty_mapping() -> None:
+    """메시지 헤더 컨텍스트가 없으면 빈 mapping을 반환한다."""
+    assert current_rabbitmq_message_headers() == {}
+
+
+def test_set_and_reset_current_headers_expect_previous_context_restored() -> None:
+    """ContextVar token reset으로 이전 RabbitMQ 헤더 컨텍스트가 복원된다."""
+    outer = set_current_rabbitmq_message_headers({"outer": "1"})
+    inner = set_current_rabbitmq_message_headers({"inner": "2"})
+    try:
+        assert current_rabbitmq_message_headers() == {"inner": "2"}
+        reset_current_rabbitmq_message_headers(inner)
+        assert current_rabbitmq_message_headers() == {"outer": "1"}
+    finally:
+        reset_current_rabbitmq_message_headers(outer)
+
+
+def test_seed_auth_context_with_metadata_key_expect_context_stored() -> None:
+    """metadata key의 signed snapshot을 검증하고 AuthContext를 저장한다."""
+    application_context = ApplicationContext()
+    verifier = RecordingSnapshotVerifier()
+    boundary = RabbitMQAuthBoundary(application_context, verifier)
+    token = set_current_rabbitmq_message_headers(
+        {AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "metadata-snapshot"}
+    )
+    try:
+        boundary.seed_auth_context(
+            event_type=SampleIntegrationEvent,
+            operation="Handler.handle",
+            protected=True,
+        )
+    finally:
+        reset_current_rabbitmq_message_headers(token)
+
+    assert require_auth_context(application_context).subject.id == "subject-1"
+    assert verifier.envelope == "metadata-snapshot"
+    assert verifier.invocation is not None
+    assert verifier.invocation.boundary == RABBITMQ_AUTH_BOUNDARY
+    assert verifier.invocation.operation == "Handler.handle"
+
+
+def test_seed_auth_context_with_header_key_expect_context_stored() -> None:
+    """x-spakky-auth-context-snapshot header를 검증하고 AuthContext를 저장한다."""
+    application_context = ApplicationContext()
+    verifier = RecordingSnapshotVerifier()
+    boundary = RabbitMQAuthBoundary(application_context, verifier)
+    token = set_current_rabbitmq_message_headers(
+        {AUTH_CONTEXT_SNAPSHOT_HEADER_KEY: "header-snapshot"}
+    )
+    try:
+        boundary.seed_auth_context(
+            event_type=SampleIntegrationEvent,
+            operation="Handler.handle",
+            protected=True,
+        )
+    finally:
+        reset_current_rabbitmq_message_headers(token)
+
+    assert require_auth_context(application_context).subject.id == "subject-1"
+    assert verifier.envelope == "header-snapshot"
+
+
+def test_seed_auth_context_unprotected_missing_snapshot_expect_noop() -> None:
+    """보호되지 않은 handler는 snapshot이 없어도 allow-all로 진행한다."""
+    application_context = ApplicationContext()
+    boundary = RabbitMQAuthBoundary(application_context, RecordingSnapshotVerifier())
+
+    boundary.seed_auth_context(
+        event_type=SampleIntegrationEvent,
+        operation="Handler.handle",
+        protected=False,
+    )
+
+    assert application_context.get_context_value("spakky.auth.context") is None
+
+
+def test_seed_auth_context_protected_missing_snapshot_expect_challenge() -> None:
+    """보호된 handler에서 snapshot이 없으면 CHALLENGE로 fail-closed 처리한다."""
+    application_context = ApplicationContext()
+    boundary = RabbitMQAuthBoundary(application_context, RecordingSnapshotVerifier())
+
+    with pytest.raises(AuthRequirementDeniedError) as excinfo:
+        boundary.seed_auth_context(
+            event_type=SampleIntegrationEvent,
+            operation="Handler.handle",
+            protected=True,
+        )
+
+    assert excinfo.value.decision == MISSING_SNAPSHOT_DECISION
+
+
+def test_seed_auth_context_verifier_unavailable_expect_error() -> None:
+    """검증 provider가 없으면 ERROR decision으로 fail-closed 처리한다."""
+    application_context = ApplicationContext()
+    boundary = RabbitMQAuthBoundary(application_context, None)
+    token = set_current_rabbitmq_message_headers(
+        {AUTH_CONTEXT_SNAPSHOT_HEADER_KEY: "header-snapshot"}
+    )
+    try:
+        with pytest.raises(AuthRequirementDeniedError) as excinfo:
+            boundary.seed_auth_context(
+                event_type=SampleIntegrationEvent,
+                operation="Handler.handle",
+                protected=True,
+            )
+    finally:
+        reset_current_rabbitmq_message_headers(token)
+
+    assert excinfo.value.decision == VERIFICATION_PROVIDER_UNAVAILABLE_DECISION
+
+
+@pytest.mark.parametrize(
+    ("error", "decision"),
+    [
+        (MissingAuthContextSnapshotError(), MISSING_SNAPSHOT_DECISION),
+        (InvalidAuthContextSnapshotError(), INVALID_SNAPSHOT_DECISION),
+        (ExpiredAuthContextSnapshotError(), EXPIRED_SNAPSHOT_DECISION),
+        (
+            AuthVerificationProviderUnavailableError(),
+            VERIFICATION_PROVIDER_UNAVAILABLE_DECISION,
+        ),
+    ],
+)
+def test_seed_auth_context_verifier_errors_expect_decision_mapping(
+    error: Exception,
+    decision: object,
+) -> None:
+    """snapshot verifier 오류는 auth decision으로 매핑되어 fail-closed 된다."""
+    application_context = ApplicationContext()
+    boundary = RabbitMQAuthBoundary(
+        application_context,
+        RecordingSnapshotVerifier(error),
+    )
+    token = set_current_rabbitmq_message_headers(
+        {AUTH_CONTEXT_SNAPSHOT_HEADER_KEY: "header-snapshot"}
+    )
+    try:
+        with pytest.raises(AuthRequirementDeniedError) as excinfo:
+            boundary.seed_auth_context(
+                event_type=SampleIntegrationEvent,
+                operation="Handler.handle",
+                protected=True,
+            )
+    finally:
+        reset_current_rabbitmq_message_headers(token)
+
+    assert excinfo.value.decision == decision
+
+
+def test_seed_auth_context_metadata_key_precedes_header_key() -> None:
+    """metadata key와 header key가 모두 있으면 metadata key를 우선한다."""
+    application_context = ApplicationContext()
+    verifier = RecordingSnapshotVerifier()
+    boundary = RabbitMQAuthBoundary(application_context, verifier)
+    headers: Mapping[str, str] = {
+        AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "metadata-snapshot",
+        AUTH_CONTEXT_SNAPSHOT_HEADER_KEY: "header-snapshot",
+    }
+    token = set_current_rabbitmq_message_headers(headers)
+    try:
+        boundary.seed_auth_context(
+            event_type=SampleIntegrationEvent,
+            operation="Handler.handle",
+            protected=True,
+        )
+    finally:
+        reset_current_rabbitmq_message_headers(token)
+
+    assert verifier.envelope == "metadata-snapshot"

--- a/plugins/spakky-rabbitmq/tests/unit/test_config.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_config.py
@@ -9,7 +9,10 @@ from typing import Any, Generator
 
 import pytest
 
-from spakky.plugins.rabbitmq.common.config import RabbitMQConnectionConfig
+from spakky.plugins.rabbitmq.common.config import (
+    RabbitMQAuthFailureAction,
+    RabbitMQConnectionConfig,
+)
 from spakky.plugins.rabbitmq.common.constants import RABBITMQ_CONFIG_ENV_PREFIX
 
 
@@ -23,6 +26,9 @@ def clean_environment_fixture() -> Generator[None, Any, None]:
         f"{RABBITMQ_CONFIG_ENV_PREFIX}USER",
         f"{RABBITMQ_CONFIG_ENV_PREFIX}PASSWORD",
         f"{RABBITMQ_CONFIG_ENV_PREFIX}EXCHANGE_NAME",
+        f"{RABBITMQ_CONFIG_ENV_PREFIX}AUTH_CHALLENGE_ACTION",
+        f"{RABBITMQ_CONFIG_ENV_PREFIX}AUTH_DENY_ACTION",
+        f"{RABBITMQ_CONFIG_ENV_PREFIX}AUTH_ERROR_ACTION",
     ]
     original_values = {}
     for key in keys_to_remove:
@@ -128,6 +134,43 @@ def test_rabbitmq_config_exchange_name_is_optional(clean_env: None) -> None:
     config = RabbitMQConnectionConfig()
 
     assert config.exchange_name is None
+
+
+def test_rabbitmq_config_auth_failure_actions_default_avoid_poison_loop(
+    clean_env: None,
+) -> None:
+    """인증 실패 ack/nack 기본값이 poison-loop를 피하고 ERROR만 재시도함을 검증한다."""
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}USE_SSL"] = "false"
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}HOST"] = "localhost"
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}PORT"] = "5672"
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}USER"] = "guest"
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}PASSWORD"] = "guest"
+
+    config = RabbitMQConnectionConfig()
+
+    assert config.auth_challenge_action is RabbitMQAuthFailureAction.ACK
+    assert config.auth_deny_action is RabbitMQAuthFailureAction.ACK
+    assert config.auth_error_action is RabbitMQAuthFailureAction.NACK_REQUEUE
+
+
+def test_rabbitmq_config_auth_failure_actions_load_from_environment(
+    clean_env: None,
+) -> None:
+    """환경 변수로 인증 실패 ack/nack 정책을 구성할 수 있음을 검증한다."""
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}USE_SSL"] = "false"
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}HOST"] = "localhost"
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}PORT"] = "5672"
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}USER"] = "guest"
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}PASSWORD"] = "guest"
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}AUTH_CHALLENGE_ACTION"] = "nack_drop"
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}AUTH_DENY_ACTION"] = "nack_drop"
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}AUTH_ERROR_ACTION"] = "nack_requeue"
+
+    config = RabbitMQConnectionConfig()
+
+    assert config.auth_challenge_action is RabbitMQAuthFailureAction.NACK_DROP
+    assert config.auth_deny_action is RabbitMQAuthFailureAction.NACK_DROP
+    assert config.auth_error_action is RabbitMQAuthFailureAction.NACK_REQUEUE
 
 
 def test_rabbitmq_config_env_prefix_is_correct() -> None:

--- a/plugins/spakky-rabbitmq/tests/unit/test_consumer.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_consumer.py
@@ -9,10 +9,18 @@ from typing import Any, Generator
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from spakky.auth import (
+    AuthRequirementDeniedError,
+    AuthorizationDecision,
+    AuthorizationReasonCode,
+)
 from spakky.domain.models.event import AbstractIntegrationEvent
 from spakky.event.error import InvalidMessageError
 
-from spakky.plugins.rabbitmq.common.config import RabbitMQConnectionConfig
+from spakky.plugins.rabbitmq.common.config import (
+    RabbitMQAuthFailureAction,
+    RabbitMQConnectionConfig,
+)
 from spakky.plugins.rabbitmq.common.constants import RABBITMQ_CONFIG_ENV_PREFIX
 from spakky.plugins.rabbitmq.event.consumer import (
     AsyncRabbitMQEventConsumer,
@@ -161,6 +169,7 @@ def test_sync_consumer_route_event_handler_success_expect_ack(
     method_frame.consumer_tag = "test_tag"
     method_frame.delivery_tag = 123
     properties = MagicMock()
+    properties.headers = {}
     body = b'{"data": "test"}'
 
     consumer._route_event_handler(channel, method_frame, properties, body)
@@ -189,6 +198,7 @@ def test_sync_consumer_register_multiple_handlers_expect_all_called(
     method_frame.consumer_tag = "test_tag"
     method_frame.delivery_tag = 123
     properties = MagicMock()
+    properties.headers = {}
     body = b'{"data": "test"}'
 
     consumer._route_event_handler(channel, method_frame, properties, body)
@@ -196,6 +206,108 @@ def test_sync_consumer_register_multiple_handlers_expect_all_called(
     handler1.assert_called_once()
     handler2.assert_called_once()
     channel.basic_ack.assert_called_once_with(123)
+
+
+def test_sync_consumer_auth_challenge_default_ack_expect_handler_not_retried(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """CHALLENGE auth failure는 기본적으로 ack되어 poison-loop를 피한다."""
+    consumer = RabbitMQEventConsumer(config)
+
+    def handler(event: SampleIntegrationEvent) -> None:
+        raise AuthRequirementDeniedError(
+            AuthorizationDecision.challenge(AuthorizationReasonCode.SNAPSHOT_MISSING)
+        )
+
+    consumer.register(SampleIntegrationEvent, handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    channel = MagicMock()
+    method_frame = MagicMock()
+    method_frame.consumer_tag = "test_tag"
+    method_frame.delivery_tag = 123
+    properties = MagicMock()
+    properties.headers = {}
+    body = b'{"data": "test"}'
+
+    consumer._route_event_handler(channel, method_frame, properties, body)
+
+    channel.basic_ack.assert_called_once_with(123)
+    channel.basic_nack.assert_not_called()
+
+
+def test_sync_consumer_auth_error_default_nack_requeue_expect_retry(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """ERROR auth failure는 기본적으로 nack requeue로 retryable transport 정책을 따른다."""
+    consumer = RabbitMQEventConsumer(config)
+
+    def handler(event: SampleIntegrationEvent) -> None:
+        raise AuthRequirementDeniedError(
+            AuthorizationDecision.error(
+                AuthorizationReasonCode.VERIFICATION_PROVIDER_UNAVAILABLE
+            )
+        )
+
+    consumer.register(SampleIntegrationEvent, handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    channel = MagicMock()
+    method_frame = MagicMock()
+    method_frame.consumer_tag = "test_tag"
+    method_frame.delivery_tag = 123
+    properties = MagicMock()
+    properties.headers = {}
+    body = b'{"data": "test"}'
+
+    consumer._route_event_handler(channel, method_frame, properties, body)
+
+    channel.basic_ack.assert_not_called()
+    channel.basic_nack.assert_called_once_with(123, requeue=True)
+
+
+def test_sync_consumer_auth_deny_configured_nack_drop_expect_drop(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """DENY auth failure는 설정된 nack-drop 정책을 적용한다."""
+    consumer = RabbitMQEventConsumer(config)
+    consumer._auth_deny_action = RabbitMQAuthFailureAction.NACK_DROP
+    channel = MagicMock()
+
+    consumer._handle_auth_failure(
+        channel,
+        123,
+        AuthRequirementDeniedError(
+            AuthorizationDecision.deny(AuthorizationReasonCode.POLICY_DENIED)
+        ),
+    )
+
+    channel.basic_ack.assert_not_called()
+    channel.basic_nack.assert_called_once_with(123, requeue=False)
+
+
+def test_sync_consumer_auth_decision_none_uses_error_policy(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """decision 없는 auth failure는 ERROR 정책으로 처리한다."""
+    consumer = RabbitMQEventConsumer(config)
+
+    action = consumer._auth_failure_action(AuthRequirementDeniedError())
+
+    assert action is RabbitMQAuthFailureAction.NACK_REQUEUE
+
+
+def test_sync_consumer_auth_allow_decision_uses_error_policy(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """ALLOW decision이 예외로 들어온 불가능 상태는 ERROR 정책으로 처리한다."""
+    consumer = RabbitMQEventConsumer(config)
+
+    action = consumer._auth_failure_action(
+        AuthRequirementDeniedError(AuthorizationDecision.allow())
+    )
+
+    assert action is RabbitMQAuthFailureAction.NACK_REQUEUE
 
 
 @pytest.mark.asyncio
@@ -224,6 +336,106 @@ async def test_async_consumer_register_multiple_handlers_expect_all_called(
     handler1.assert_awaited_once()
     handler2.assert_awaited_once()
     message.ack.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_consumer_auth_challenge_default_ack_expect_handler_not_retried(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """비동기 CHALLENGE auth failure는 기본적으로 ack되어 poison-loop를 피한다."""
+    consumer = AsyncRabbitMQEventConsumer(config)
+
+    async def handler(event: SampleIntegrationEvent) -> None:
+        raise AuthRequirementDeniedError(
+            AuthorizationDecision.challenge(AuthorizationReasonCode.SNAPSHOT_INVALID)
+        )
+
+    consumer.register(SampleIntegrationEvent, handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    message = AsyncMock()
+    message.consumer_tag = "test_tag"
+    message.delivery_tag = 123
+    message.body = b'{"data": "test"}'
+    message.headers = {}
+
+    await consumer._route_event_handler(message)
+
+    message.ack.assert_awaited_once()
+    message.nack.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_consumer_auth_error_default_nack_requeue_expect_retry(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """비동기 ERROR auth failure는 nack requeue로 retryable transport 정책을 따른다."""
+    consumer = AsyncRabbitMQEventConsumer(config)
+
+    async def handler(event: SampleIntegrationEvent) -> None:
+        raise AuthRequirementDeniedError(
+            AuthorizationDecision.error(
+                AuthorizationReasonCode.VERIFICATION_PROVIDER_UNAVAILABLE
+            )
+        )
+
+    consumer.register(SampleIntegrationEvent, handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    message = AsyncMock()
+    message.consumer_tag = "test_tag"
+    message.delivery_tag = 123
+    message.body = b'{"data": "test"}'
+    message.headers = {}
+
+    await consumer._route_event_handler(message)
+
+    message.ack.assert_not_awaited()
+    message.nack.assert_awaited_once_with(requeue=True)
+
+
+@pytest.mark.asyncio
+async def test_async_consumer_auth_deny_configured_nack_drop_expect_drop(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """비동기 DENY auth failure는 설정된 nack-drop 정책을 적용한다."""
+    consumer = AsyncRabbitMQEventConsumer(config)
+    consumer._auth_deny_action = RabbitMQAuthFailureAction.NACK_DROP
+    message = AsyncMock()
+
+    await consumer._handle_auth_failure(
+        message,
+        AuthRequirementDeniedError(
+            AuthorizationDecision.deny(AuthorizationReasonCode.POLICY_DENIED)
+        ),
+    )
+
+    message.ack.assert_not_awaited()
+    message.nack.assert_awaited_once_with(requeue=False)
+
+
+def test_async_consumer_auth_decision_none_uses_error_policy(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """비동기 consumer도 decision 없는 auth failure를 ERROR 정책으로 처리한다."""
+    consumer = AsyncRabbitMQEventConsumer(config)
+
+    action = consumer._auth_failure_action(AuthRequirementDeniedError())
+
+    assert action is RabbitMQAuthFailureAction.NACK_REQUEUE
+
+
+def test_async_consumer_auth_allow_decision_uses_error_policy(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """비동기 consumer도 ALLOW 예외 상태를 ERROR 정책으로 처리한다."""
+    consumer = AsyncRabbitMQEventConsumer(config)
+
+    action = consumer._auth_failure_action(
+        AuthRequirementDeniedError(AuthorizationDecision.allow())
+    )
+
+    assert action is RabbitMQAuthFailureAction.NACK_REQUEUE
 
 
 def test_sync_consumer_check_if_event_set_when_set_expect_stop_consuming(

--- a/plugins/spakky-rabbitmq/tests/unit/test_post_processor.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_post_processor.py
@@ -4,9 +4,19 @@ Tests that the RabbitMQ PostProcessor only registers IntegrationEvent handlers
 and correctly ignores DomainEvent handlers.
 """
 
+from collections.abc import Callable
 from unittest.mock import Mock
 
 import pytest
+from spakky.auth import (
+    AUTH_CONTEXT_SNAPSHOT_HEADER_KEY,
+    AuthContext,
+    AuthInvocation,
+    AuthSubject,
+    IAuthContextSnapshotVerifier,
+    require_auth_context,
+    require_scope,
+)
 from spakky.core.application.application_context import ApplicationContext
 from spakky.core.common.mutability import immutable
 from spakky.domain.models.event import AbstractDomainEvent, AbstractIntegrationEvent
@@ -15,7 +25,12 @@ from spakky.event.event_consumer import (
     IEventConsumer,
 )
 from spakky.event.stereotype.event_handler import EventHandler, on_event
+from spakky.plugins.rabbitmq.auth import (
+    reset_current_rabbitmq_message_headers,
+    set_current_rabbitmq_message_headers,
+)
 from spakky.tracing.propagator import ITracePropagator
+from typing import override
 
 from spakky.plugins.rabbitmq.post_processor import RabbitMQPostProcessor
 
@@ -32,6 +47,31 @@ class SampleDomainEvent(AbstractDomainEvent):
     """Test domain event for testing."""
 
     message: str
+
+
+class RecordingSnapshotVerifier(IAuthContextSnapshotVerifier):
+    """Snapshot verifier stub that records post-processor invocations."""
+
+    envelope: str | None
+    invocation: AuthInvocation | None
+
+    def __init__(self) -> None:
+        self.envelope = None
+        self.invocation = None
+
+    @override
+    def verify_snapshot(
+        self,
+        snapshot_envelope: str,
+        invocation: AuthInvocation,
+    ) -> AuthContext:
+        self.envelope = snapshot_envelope
+        self.invocation = invocation
+        return AuthContext(
+            subject=AuthSubject(id="subject-1"),
+            issuer="issuer-1",
+            scopes=("rabbitmq:consume",),
+        )
 
 
 def test_rabbitmq_post_processor_registers_integration_event_expect_success() -> None:
@@ -309,6 +349,74 @@ def test_rabbitmq_post_processor_sync_endpoint_invocation_expect_handler_called(
     assert handler_called["value"] is True
     assert handler_called["result"] == "handled: test"
     mock_context.clear_context.assert_called_once()
+
+
+def test_rabbitmq_post_processor_protected_sync_endpoint_seeds_auth_after_clear() -> (
+    None
+):
+    """보호된 endpoint는 clear_context 후 handler 호출 전 AuthContext를 seed한다."""
+    application_context = ApplicationContext()
+    verifier = RecordingSnapshotVerifier()
+    handler_called: dict[str, bool | str] = {"value": False, "subject": ""}
+
+    @EventHandler()
+    class SampleEventHandler:
+        @on_event(SampleIntegrationEvent)
+        @require_scope("rabbitmq:consume")
+        def handle_integration_event(self, event: SampleIntegrationEvent) -> None:
+            handler_called["value"] = True
+            handler_called["subject"] = require_auth_context(
+                application_context
+            ).subject.id
+
+    captured_endpoint: dict[
+        str,
+        Callable[[SampleIntegrationEvent], None] | None,
+    ] = {"fn": None}
+
+    def capture_register(
+        event_type: type[SampleIntegrationEvent],
+        endpoint: Callable[[SampleIntegrationEvent], None],
+    ) -> None:
+        captured_endpoint["fn"] = endpoint
+
+    mock_consumer = Mock(spec=IEventConsumer)
+    mock_consumer.register.side_effect = capture_register
+    mock_async_consumer = Mock(spec=IAsyncEventConsumer)
+    handler_instance = SampleEventHandler()
+    mock_container = Mock()
+    mock_container.get.side_effect = lambda t: (
+        mock_consumer
+        if t == IEventConsumer
+        else mock_async_consumer
+        if t == IAsyncEventConsumer
+        else handler_instance
+        if t == SampleEventHandler
+        else None
+    )
+    mock_container.get_or_none.side_effect = lambda t: (
+        verifier if t == IAuthContextSnapshotVerifier else None
+    )
+
+    post_processor = RabbitMQPostProcessor()
+    post_processor.set_container(mock_container)
+    post_processor.set_application_context(application_context)
+    post_processor.post_process(handler_instance)
+
+    token = set_current_rabbitmq_message_headers(
+        {AUTH_CONTEXT_SNAPSHOT_HEADER_KEY: "header-snapshot"}
+    )
+    try:
+        event = SampleIntegrationEvent(message="test")
+        assert captured_endpoint["fn"] is not None
+        captured_endpoint["fn"](event)
+    finally:
+        reset_current_rabbitmq_message_headers(token)
+
+    assert handler_called["value"] is True
+    assert handler_called["subject"] == "subject-1"
+    assert verifier.envelope == "header-snapshot"
+    assert verifier.invocation is not None
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -3336,6 +3336,7 @@ dependencies = [
     { name = "pika-stubs" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "spakky-auth" },
     { name = "spakky-event" },
     { name = "spakky-tracing" },
 ]
@@ -3354,6 +3355,7 @@ requires-dist = [
     { name = "pika-stubs", specifier = ">=0.1.3" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "spakky-auth", editable = "core/spakky-auth" },
     { name = "spakky-event", editable = "core/spakky-event" },
     { name = "spakky-tracing", editable = "core/spakky-tracing" },
 ]


### PR DESCRIPTION
## Summary
- Add RabbitMQ signed AuthContextSnapshot verification and AuthContext seeding before protected event handlers run.
- Apply configurable RabbitMQ ack/nack policy for CHALLENGE, DENY, and ERROR auth failures.
- Preserve trace header extraction and event payload dispatch semantics; update README/API/guide docs.

## Acceptance Criteria
- acceptance_check: missing (issue body contains natural-language acceptance criteria, no literal grep/find/rg lines)
- AuthContext seeding after post_processor clear_context is covered by unit test.
- x-spakky-auth-context-snapshot and spakky.auth.context_snapshot verification paths are covered.
- missing/invalid/expired snapshots map to CHALLENGE fail-closed decisions.
- DENY and ERROR ack/nack policies are covered, with default poison-loop avoidance for CHALLENGE/DENY and retryable requeue for ERROR.
- Existing trace and payload tests remain green.

## Checks
- uv run --project ../.. --group dev ruff check .
- uv run --project ../.. --group dev pyrefly check src tests
- uv run --project ../.. --group dev python ../../.agents/skills/check/scripts/validate_python_harness.py .
- uv run python scripts/run_coverage.py --package spakky-rabbitmq

Closes #294