### PR TITLE
feat(celery): add auth snapshot task boundary (#292)

### DIFF
--- a/docs/api/plugins/spakky-celery.md
+++ b/docs/api/plugins/spakky-celery.md
@@ -14,6 +14,12 @@ show_root_heading: false
 options:
 show_root_heading: false
 
+## Auth
+
+::: spakky.plugins.celery.auth
+options:
+show_root_heading: false
+
 ## 설정
 
 ::: spakky.plugins.celery.common.config

--- a/docs/guides/celery.md
+++ b/docs/guides/celery.md
@@ -165,6 +165,31 @@ value = result.get()
 
 ---
 
+## 보호된 태스크와 AuthContextSnapshot
+
+`spakky-auth` snapshot propagation을 활성화하면 Celery dispatch 경계는 현재 `AuthContext`를 signed snapshot으로 전파합니다.
+
+```python
+from spakky.auth import AuthSnapshotPropagationConfig, require_scope
+from spakky.task import TaskHandler, task
+
+app.add(lambda: AuthSnapshotPropagationConfig(enabled=True))
+
+@TaskHandler()
+class ReportTasks:
+    @task
+    @require_scope("reports:generate")
+    def generate(self, report_id: str) -> None:
+        ...
+```
+
+- dispatch aspect는 Celery task header `spakky.auth.context_snapshot`에 signed `AuthContextSnapshot` envelope를 저장합니다.
+- worker endpoint는 `clear_context()` 후 Celery task context key를 설정하고, 보호된 task 실행 전에 snapshot을 검증해 `AuthContext`를 seed합니다.
+- snapshot missing / invalid / expired는 `CHALLENGE` task failure, requirement `DENY`는 task failure, verifier/provider unavailable `ERROR`는 Celery retryable task error로 처리됩니다.
+- raw bearer token은 task header로 전파하지 않습니다.
+
+---
+
 ## 자동 등록 확인
 
 `CeleryPostProcessor`가 `@TaskHandler`를 감지하면 자동으로 Celery에 등록합니다.

--- a/plugins/spakky-celery/README.md
+++ b/plugins/spakky-celery/README.md
@@ -21,6 +21,7 @@ pip install spakky-celery
 - **Worker context 감지**: context key로 worker 내부 재dispatch 방지
 - **자동 등록**: `@TaskHandler` pod를 스캔해 Celery task로 자동 등록합니다.
 - **전체 설정**: broker URL, serializer, timezone 등을 환경변수로 설정
+- **AuthContextSnapshot 전파**: `spakky-auth` snapshot propagation이 활성화되면 raw bearer token 대신 signed snapshot을 task header에 담아 보호된 worker task를 fail-closed로 실행합니다.
 
 ## 설정
 
@@ -129,6 +130,20 @@ AOP aspect가 호출을 가로채 Celery로 자동 라우팅합니다.
 - **디스패치 측**: `@task` 호출 시 현재 `TraceContext`를 Celery 메시지 헤더에 주입합니다
 - **워커 측**: 수신 태스크에서 `TraceContext`를 추출하여 자식 스팬을 생성합니다
 - 헤더가 없으면 새로운 루트 트레이스를 시작합니다
+
+## 인증/인가 스냅샷 전파
+
+`spakky-auth`의 `AuthSnapshotPropagationConfig(enabled=True)`와 `IAuthContextSnapshotSigner` / `IAuthContextSnapshotVerifier` provider가 등록되어 있으면, `CeleryTaskDispatchAspect`와 `AsyncCeleryTaskDispatchAspect`는 현재 request/context scope의 `AuthContext`를 signed `AuthContextSnapshot`으로 직렬화해 Celery task header `spakky.auth.context_snapshot`에 저장합니다.
+
+Worker endpoint는 task 실행 시작 시 `ApplicationContext.clear_context()` 후 `spakky.plugins.celery.task_context`를 설정하고, 보호된 task metadata가 있으면 snapshot을 검증해 `AuthContext`를 다시 seed합니다. 이후 `@protected`, `@require_scope`, `@require_role`, `@require_permission`, `@require_policy`, `@require_relation` requirement를 worker boundary에서 fail-closed로 평가합니다.
+
+| 상황 | 결과 |
+|------|------|
+| snapshot missing / invalid / expired | `CHALLENGE` decision을 담은 task failure |
+| requirement `DENY` | retry 없이 task failure |
+| verifier 또는 auth provider unavailable `ERROR` | Celery retryable task error |
+
+Raw bearer token은 task/broker header로 전파하지 않습니다. 같은 worker process 안에서 재호출되는 task는 기존 Celery task context를 감지해 재dispatch하지 않고 직접 실행합니다.
 
 ## 관련 패키지
 

--- a/plugins/spakky-celery/src/spakky/plugins/celery/aspects/task_dispatch.py
+++ b/plugins/spakky-celery/src/spakky/plugins/celery/aspects/task_dispatch.py
@@ -4,6 +4,7 @@ from inspect import iscoroutinefunction
 from logging import getLogger
 from typing import Any
 
+from spakky.auth import AuthSnapshotPropagationConfig, IAuthContextSnapshotSigner
 from spakky.core.aop.aspect import Aspect, AsyncAspect
 from spakky.core.aop.interfaces.aspect import IAspect, IAsyncAspect
 from spakky.core.aop.pointcut import Around
@@ -19,6 +20,7 @@ from spakky.tracing.propagator import ITracePropagator
 from typing import override
 
 from celery import Celery
+from spakky.plugins.celery.auth import inject_auth_context_snapshot
 from spakky.plugins.celery.common.constants import CELERY_TASK_CONTEXT_KEY
 from spakky.plugins.celery.common.task_result import CeleryTaskResult
 
@@ -37,11 +39,22 @@ class CeleryTaskDispatchAspect(IAspect, IApplicationContextAware):
     _celery: Celery
     _application_context: IApplicationContext
     _propagator: ITracePropagator | None
+    _auth_snapshot_signer: IAuthContextSnapshotSigner | None
+    _auth_snapshot_propagation_config: AuthSnapshotPropagationConfig
 
-    def __init__(self, celery: Celery) -> None:
+    def __init__(
+        self,
+        celery: Celery,
+        auth_snapshot_signer: IAuthContextSnapshotSigner | None = None,
+        auth_snapshot_propagation_config: AuthSnapshotPropagationConfig | None = None,
+    ) -> None:
         """Initialize with the Celery application instance."""
         self._celery = celery
         self._propagator = None
+        self._auth_snapshot_signer = auth_snapshot_signer
+        self._auth_snapshot_propagation_config = (
+            auth_snapshot_propagation_config or AuthSnapshotPropagationConfig()
+        )
 
     @override
     def set_application_context(self, application_context: IApplicationContext) -> None:
@@ -62,6 +75,12 @@ class CeleryTaskDispatchAspect(IAspect, IApplicationContextAware):
         task_headers: dict[str, str] = {}
         if self._propagator is not None:
             self._propagator.inject(task_headers)
+        inject_auth_context_snapshot(
+            task_headers,
+            application_context=self._application_context,
+            auth_snapshot_signer=self._auth_snapshot_signer,
+            auth_snapshot_propagation_config=self._auth_snapshot_propagation_config,
+        )
         async_result = self._celery.send_task(
             task_name,
             args=args,
@@ -84,11 +103,22 @@ class AsyncCeleryTaskDispatchAspect(IAsyncAspect, IApplicationContextAware):
     _celery: Celery
     _application_context: IApplicationContext
     _propagator: ITracePropagator | None
+    _auth_snapshot_signer: IAuthContextSnapshotSigner | None
+    _auth_snapshot_propagation_config: AuthSnapshotPropagationConfig
 
-    def __init__(self, celery: Celery) -> None:
+    def __init__(
+        self,
+        celery: Celery,
+        auth_snapshot_signer: IAuthContextSnapshotSigner | None = None,
+        auth_snapshot_propagation_config: AuthSnapshotPropagationConfig | None = None,
+    ) -> None:
         """Initialize with the Celery application instance."""
         self._celery = celery
         self._propagator = None
+        self._auth_snapshot_signer = auth_snapshot_signer
+        self._auth_snapshot_propagation_config = (
+            auth_snapshot_propagation_config or AuthSnapshotPropagationConfig()
+        )
 
     @override
     def set_application_context(self, application_context: IApplicationContext) -> None:
@@ -111,6 +141,12 @@ class AsyncCeleryTaskDispatchAspect(IAsyncAspect, IApplicationContextAware):
         task_headers: dict[str, str] = {}
         if self._propagator is not None:
             self._propagator.inject(task_headers)
+        inject_auth_context_snapshot(
+            task_headers,
+            application_context=self._application_context,
+            auth_snapshot_signer=self._auth_snapshot_signer,
+            auth_snapshot_propagation_config=self._auth_snapshot_propagation_config,
+        )
         async_result = self._celery.send_task(
             task_name,
             args=args,

--- a/plugins/spakky-celery/src/spakky/plugins/celery/auth.py
+++ b/plugins/spakky-celery/src/spakky/plugins/celery/auth.py
@@ -1,0 +1,222 @@
+"""Auth snapshot propagation and enforcement for Celery task boundaries."""
+
+from spakky.auth import (
+    AUTH_CONTEXT_CONTEXT_KEY,
+    AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
+    EXPIRED_SNAPSHOT_DECISION,
+    INVALID_SNAPSHOT_DECISION,
+    MISSING_SNAPSHOT_DECISION,
+    VERIFICATION_PROVIDER_UNAVAILABLE_DECISION,
+    AuthContext,
+    AuthInvocation,
+    AuthInvocationAttribute,
+    AuthRequirementDeniedError,
+    AuthSnapshotPropagationConfig,
+    AuthVerificationProviderUnavailableError,
+    AuthorizationDecision,
+    AuthorizationDecisionState,
+    AuthorizationReasonCode,
+    AuthorizationRequest,
+    ExpiredAuthContextSnapshotError,
+    IAuthContextSnapshotSigner,
+    IAuthContextSnapshotVerifier,
+    IAuthorizationPolicyEvaluator,
+    IPermissionChecker,
+    IRelationChecker,
+    IRoleChecker,
+    IScopeChecker,
+    InvalidAuthContextSnapshotError,
+    InvalidAuthContextValueError,
+    MissingAuthContextSnapshotError,
+    PermissionCheckRequest,
+    RelationCheckRequest,
+    RoleCheckRequest,
+    ScopeCheckRequest,
+    SnapshotSignRequest,
+    store_auth_context,
+)
+from spakky.core.pod.interfaces.application_context import IApplicationContext
+from spakky.task.stereotype.task_handler import (
+    TaskAuthMetadata,
+    TaskAuthRequirementMetadata,
+)
+
+from spakky.plugins.celery.error import AuthSnapshotPropagationSignerUnavailableError
+
+CELERY_AUTH_BOUNDARY = "task"
+"""AuthInvocation boundary value used for Celery task workers."""
+
+
+def inject_auth_context_snapshot(
+    headers: dict[str, str],
+    *,
+    application_context: IApplicationContext,
+    auth_snapshot_signer: IAuthContextSnapshotSigner | None,
+    auth_snapshot_propagation_config: AuthSnapshotPropagationConfig,
+) -> None:
+    """Inject a signed AuthContextSnapshot into Celery task headers."""
+    if not auth_snapshot_propagation_config.enabled:
+        return
+    value = application_context.get_context_value(AUTH_CONTEXT_CONTEXT_KEY)
+    if value is None:
+        return
+    if not isinstance(value, AuthContext):
+        raise InvalidAuthContextValueError()
+    if auth_snapshot_signer is None:
+        raise AuthSnapshotPropagationSignerUnavailableError()
+    snapshot = auth_snapshot_signer.sign_snapshot(
+        SnapshotSignRequest(auth_context=value)
+    )
+    headers[AUTH_CONTEXT_SNAPSHOT_METADATA_KEY] = snapshot.base64url_canonical_json()
+
+
+def seed_and_authorize_celery_task(
+    *,
+    application_context: IApplicationContext,
+    task_name: str,
+    headers: dict[str, str],
+    auth_metadata: TaskAuthMetadata,
+    snapshot_verifier: IAuthContextSnapshotVerifier | None,
+    authorization_policy_evaluator: IAuthorizationPolicyEvaluator | None,
+    permission_checker: IPermissionChecker | None,
+    relation_checker: IRelationChecker | None,
+    role_checker: IRoleChecker | None,
+    scope_checker: IScopeChecker | None,
+) -> None:
+    """Verify a worker snapshot, seed AuthContext, and enforce task metadata."""
+    if not auth_metadata.protected:
+        return
+    invocation = AuthInvocation(
+        boundary=CELERY_AUTH_BOUNDARY,
+        operation=task_name,
+        attributes=(
+            AuthInvocationAttribute(
+                name="auth_context_snapshot",
+                value=headers.get(AUTH_CONTEXT_SNAPSHOT_METADATA_KEY),
+            ),
+        ),
+    )
+    auth_context = _verify_snapshot(
+        headers.get(AUTH_CONTEXT_SNAPSHOT_METADATA_KEY),
+        invocation,
+        snapshot_verifier,
+    )
+    store_auth_context(application_context, auth_context)
+    for requirement in auth_metadata.requirements:
+        decision = _evaluate_requirement(
+            requirement,
+            auth_context,
+            authorization_policy_evaluator=authorization_policy_evaluator,
+            permission_checker=permission_checker,
+            relation_checker=relation_checker,
+            role_checker=role_checker,
+            scope_checker=scope_checker,
+        )
+        if decision.state is not AuthorizationDecisionState.ALLOW:
+            raise AuthRequirementDeniedError(decision)
+
+
+def is_retryable_auth_failure(error: AuthRequirementDeniedError) -> bool:
+    """Return whether a task auth failure should use Celery retry semantics."""
+    return (
+        error.decision is not None
+        and error.decision.state is AuthorizationDecisionState.ERROR
+    )
+
+
+def _verify_snapshot(
+    snapshot_envelope: str | None,
+    invocation: AuthInvocation,
+    snapshot_verifier: IAuthContextSnapshotVerifier | None,
+) -> AuthContext:
+    if snapshot_envelope is None or snapshot_envelope == "":
+        raise AuthRequirementDeniedError(MISSING_SNAPSHOT_DECISION)
+    if snapshot_verifier is None:
+        raise AuthRequirementDeniedError(VERIFICATION_PROVIDER_UNAVAILABLE_DECISION)
+    try:
+        return snapshot_verifier.verify_snapshot(snapshot_envelope, invocation)
+    except MissingAuthContextSnapshotError as error:
+        raise AuthRequirementDeniedError(MISSING_SNAPSHOT_DECISION) from error
+    except InvalidAuthContextSnapshotError as error:
+        raise AuthRequirementDeniedError(INVALID_SNAPSHOT_DECISION) from error
+    except ExpiredAuthContextSnapshotError as error:
+        raise AuthRequirementDeniedError(EXPIRED_SNAPSHOT_DECISION) from error
+    except AuthVerificationProviderUnavailableError as error:
+        raise AuthRequirementDeniedError(
+            VERIFICATION_PROVIDER_UNAVAILABLE_DECISION
+        ) from error
+
+
+def _evaluate_requirement(
+    requirement: TaskAuthRequirementMetadata,
+    auth_context: AuthContext,
+    *,
+    authorization_policy_evaluator: IAuthorizationPolicyEvaluator | None,
+    permission_checker: IPermissionChecker | None,
+    relation_checker: IRelationChecker | None,
+    role_checker: IRoleChecker | None,
+    scope_checker: IScopeChecker | None,
+) -> AuthorizationDecision:
+    if requirement.kind == "AUTHENTICATED":
+        return AuthorizationDecision.allow()
+    if requirement.kind == "PERMISSION":
+        if permission_checker is None:
+            return _provider_unavailable_decision()
+        return permission_checker.check_permission(
+            PermissionCheckRequest(
+                auth_context=auth_context,
+                permission=requirement.ref,
+                resource=requirement.resource,
+                tenant=requirement.tenant,
+            )
+        )
+    if requirement.kind == "POLICY":
+        if (
+            authorization_policy_evaluator is None
+            or requirement.resource is None
+            or requirement.action is None
+        ):
+            return _provider_unavailable_decision()
+        return authorization_policy_evaluator.evaluate_policy(
+            AuthorizationRequest(
+                auth_context=auth_context,
+                resource=requirement.resource,
+                action=requirement.action,
+                tenant=requirement.tenant,
+            )
+        )
+    if requirement.kind == "RELATION":
+        if relation_checker is None or requirement.resource is None:
+            return _provider_unavailable_decision()
+        return relation_checker.check_relation(
+            RelationCheckRequest(
+                auth_context=auth_context,
+                relation=requirement.ref,
+                resource=requirement.resource,
+                tenant=requirement.tenant,
+            )
+        )
+    if requirement.kind == "ROLE":
+        if role_checker is None:
+            return _provider_unavailable_decision()
+        return role_checker.check_role(
+            RoleCheckRequest(
+                auth_context=auth_context,
+                role=requirement.ref,
+                tenant=requirement.tenant,
+            )
+        )
+    if requirement.kind == "SCOPE":
+        if scope_checker is None:
+            return _provider_unavailable_decision()
+        return scope_checker.check_scope(
+            ScopeCheckRequest(auth_context=auth_context, scope=requirement.ref)
+        )
+    return _provider_unavailable_decision()
+
+
+def _provider_unavailable_decision() -> AuthorizationDecision:
+    return AuthorizationDecision.error(
+        AuthorizationReasonCode.INTERNAL_ERROR,
+        reason="Celery task auth provider is unavailable",
+    )

--- a/plugins/spakky-celery/src/spakky/plugins/celery/error.py
+++ b/plugins/spakky-celery/src/spakky/plugins/celery/error.py
@@ -21,3 +21,9 @@ class InvalidScheduleRouteError(AbstractSpakkyCeleryError):
     """Raised when a ScheduleRoute has no valid schedule specification."""
 
     message = "ScheduleRoute has no schedule specification"
+
+
+class AuthSnapshotPropagationSignerUnavailableError(AbstractSpakkyCeleryError):
+    """Raised when signed task snapshot propagation has no signer provider."""
+
+    message = "Auth context snapshot signer is unavailable"

--- a/plugins/spakky-celery/src/spakky/plugins/celery/post_processor.py
+++ b/plugins/spakky-celery/src/spakky/plugins/celery/post_processor.py
@@ -6,6 +6,16 @@ from inspect import getmembers, iscoroutinefunction, isfunction
 from logging import getLogger
 from typing import Any, Callable
 
+from celery.exceptions import Retry
+from spakky.auth import (
+    AuthRequirementDeniedError,
+    IAuthContextSnapshotVerifier,
+    IAuthorizationPolicyEvaluator,
+    IPermissionChecker,
+    IRelationChecker,
+    IRoleChecker,
+    IScopeChecker,
+)
 from spakky.core.pod.annotations.order import Order
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.pod.interfaces.application_context import IApplicationContext
@@ -16,7 +26,11 @@ from spakky.core.pod.interfaces.post_processor import IPostProcessor
 from spakky.core.utils.inspection import get_fully_qualified_name
 from spakky.task.stereotype.crontab import Crontab, Month, Weekday
 from spakky.task.stereotype.schedule import ScheduleRoute
-from spakky.task.stereotype.task_handler import TaskHandler, TaskRoute
+from spakky.task.stereotype.task_handler import (
+    TaskHandler,
+    TaskRoute,
+    collect_task_auth_metadata,
+)
 from spakky.tracing.context import TraceContext
 from spakky.tracing.propagator import ITracePropagator
 from typing import override
@@ -27,6 +41,10 @@ from celery.schedules import schedule as celery_schedule
 from spakky.plugins.celery.aspects.task_dispatch import (
     AsyncCeleryTaskDispatchAspect,
     CeleryTaskDispatchAspect,
+)
+from spakky.plugins.celery.auth import (
+    is_retryable_auth_failure,
+    seed_and_authorize_celery_task,
 )
 from spakky.plugins.celery.common.constants import CELERY_TASK_CONTEXT_KEY
 from spakky.plugins.celery.error import InvalidScheduleRouteError
@@ -40,6 +58,28 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
     """Post-processor that registers TaskHandler-annotated Pods as Celery tasks."""
 
     __application_context: IApplicationContext
+    __auth_snapshot_verifier: IAuthContextSnapshotVerifier | None
+    __authorization_policy_evaluator: IAuthorizationPolicyEvaluator | None
+    __permission_checker: IPermissionChecker | None
+    __relation_checker: IRelationChecker | None
+    __role_checker: IRoleChecker | None
+    __scope_checker: IScopeChecker | None
+
+    def __init__(
+        self,
+        auth_snapshot_verifier: IAuthContextSnapshotVerifier | None = None,
+        authorization_policy_evaluator: IAuthorizationPolicyEvaluator | None = None,
+        permission_checker: IPermissionChecker | None = None,
+        relation_checker: IRelationChecker | None = None,
+        role_checker: IRoleChecker | None = None,
+        scope_checker: IScopeChecker | None = None,
+    ) -> None:
+        self.__auth_snapshot_verifier = auth_snapshot_verifier
+        self.__authorization_policy_evaluator = authorization_policy_evaluator
+        self.__permission_checker = permission_checker
+        self.__relation_checker = relation_checker
+        self.__role_checker = role_checker
+        self.__scope_checker = scope_checker
 
     @override
     def set_application_context(self, application_context: IApplicationContext) -> None:
@@ -58,10 +98,10 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
         def endpoint(*args: Any, **kwargs: Any) -> Any:
             self.__application_context.clear_context()
             self.__application_context.set_context_value(CELERY_TASK_CONTEXT_KEY, True)
+            task_name = get_fully_qualified_name(method)
+            raw_headers = self._current_task_headers()
+            self._seed_and_authorize_task(task_name, method, handler_type, raw_headers)
             if propagator is not None:
-                raw_headers: dict[str, object] = (
-                    current_task.request.get("headers") or {}
-                )
                 carrier: dict[str, str] = {
                     k: v for k, v in raw_headers.items() if isinstance(v, str)
                 }
@@ -94,10 +134,10 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
             """Async wrapper that sets context and invokes handler method."""
             self.__application_context.clear_context()
             self.__application_context.set_context_value(CELERY_TASK_CONTEXT_KEY, True)
+            task_name = get_fully_qualified_name(method)
+            raw_headers = self._current_task_headers()
+            self._seed_and_authorize_task(task_name, method, handler_type, raw_headers)
             if propagator is not None:
-                raw_headers: dict[str, object] = (
-                    current_task.request.get("headers") or {}
-                )
                 carrier: dict[str, str] = {
                     k: v for k, v in raw_headers.items() if isinstance(v, str)
                 }
@@ -165,6 +205,53 @@ class CeleryPostProcessor(IPostProcessor, IApplicationContextAware):
         task_name = get_fully_qualified_name(method)
         celery.task(name=task_name)(endpoint)
         return task_name
+
+    def _current_task_headers(self) -> dict[str, object]:
+        try:
+            request = current_task.request
+        except AttributeError:
+            return {}
+        raw_headers = request.get("headers") or {}
+        if isinstance(raw_headers, dict):
+            return raw_headers
+        return {}
+
+    def _seed_and_authorize_task(
+        self,
+        task_name: str,
+        method: Callable[..., Any],
+        handler_type: type[object],
+        raw_headers: dict[str, object],
+    ) -> None:
+        route = TaskRoute.get_or_none(method)
+        if route is None:
+            return
+        route.auth_metadata = collect_task_auth_metadata(
+            method,
+            owner_type=handler_type,
+        )
+        headers = {k: v for k, v in raw_headers.items() if isinstance(v, str)}
+        try:
+            seed_and_authorize_celery_task(
+                application_context=self.__application_context,
+                task_name=task_name,
+                headers=headers,
+                auth_metadata=route.auth_metadata,
+                snapshot_verifier=self.__auth_snapshot_verifier,
+                authorization_policy_evaluator=self.__authorization_policy_evaluator,
+                permission_checker=self.__permission_checker,
+                relation_checker=self.__relation_checker,
+                role_checker=self.__role_checker,
+                scope_checker=self.__scope_checker,
+            )
+        except AuthRequirementDeniedError as error:
+            if not is_retryable_auth_failure(error):
+                raise
+            try:
+                current_task.retry(exc=error)
+            except Retry as retry:
+                raise retry from error
+            raise
 
     @override
     def post_process(self, pod: object) -> object:

--- a/plugins/spakky-celery/tests/unit/test_auth.py
+++ b/plugins/spakky-celery/tests/unit/test_auth.py
@@ -1,0 +1,358 @@
+"""Tests for Celery auth snapshot propagation helpers."""
+
+from datetime import UTC, datetime
+from typing import override
+from unittest.mock import MagicMock
+
+import pytest
+from spakky.auth import (
+    AUTH_CONTEXT_CONTEXT_KEY,
+    AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
+    AuthContext,
+    AuthContextSnapshot,
+    AuthContextSnapshotSignature,
+    AuthInvocation,
+    AuthRequirementDeniedError,
+    AuthSnapshotPropagationConfig,
+    AuthSubject,
+    AuthVerificationProviderUnavailableError,
+    AuthorizationDecision,
+    AuthorizationDecisionState,
+    AuthorizationReasonCode,
+    AuthorizationRequest,
+    ExpiredAuthContextSnapshotError,
+    IAuthContextSnapshotSigner,
+    IAuthContextSnapshotVerifier,
+    IAuthorizationPolicyEvaluator,
+    IPermissionChecker,
+    IRelationChecker,
+    IRoleChecker,
+    IScopeChecker,
+    InvalidAuthContextSnapshotError,
+    InvalidAuthContextValueError,
+    MissingAuthContextSnapshotError,
+    PermissionCheckRequest,
+    RelationCheckRequest,
+    RoleCheckRequest,
+    ScopeCheckRequest,
+    SnapshotSignRequest,
+)
+from spakky.task.stereotype.task_handler import (
+    TaskAuthMetadata,
+    TaskAuthRequirementMetadata,
+)
+
+from spakky.plugins.celery.auth import (
+    inject_auth_context_snapshot,
+    is_retryable_auth_failure,
+    seed_and_authorize_celery_task,
+)
+from spakky.plugins.celery.error import AuthSnapshotPropagationSignerUnavailableError
+
+
+def _auth_context() -> AuthContext:
+    return AuthContext(subject=AuthSubject(id="subject-1"), issuer="issuer-1")
+
+
+class SnapshotSigner(IAuthContextSnapshotSigner):
+    @override
+    def sign_snapshot(self, request: SnapshotSignRequest) -> AuthContextSnapshot:
+        return AuthContextSnapshot(
+            subject=request.auth_context.subject,
+            issuer=request.auth_context.issuer,
+            issued_at=datetime(2026, 5, 15, 1, 2, 3, tzinfo=UTC),
+            expires_at=datetime(2026, 5, 15, 1, 7, 3, tzinfo=UTC),
+            signature=AuthContextSnapshotSignature(
+                key_id="key:test",
+                algorithm="HS256",
+                signature="signature-1",
+            ),
+        )
+
+
+class SnapshotVerifier(IAuthContextSnapshotVerifier):
+    error: Exception | None
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+
+    @override
+    def verify_snapshot(
+        self,
+        snapshot_envelope: str,
+        invocation: AuthInvocation,
+    ) -> AuthContext:
+        if self.error is not None:
+            raise self.error
+        return _auth_context()
+
+
+class PolicyEvaluator(IAuthorizationPolicyEvaluator):
+    @override
+    def evaluate_policy(self, request: AuthorizationRequest) -> AuthorizationDecision:
+        return AuthorizationDecision.allow()
+
+
+class PermissionChecker(IPermissionChecker):
+    @override
+    def check_permission(
+        self, request: PermissionCheckRequest
+    ) -> AuthorizationDecision:
+        return AuthorizationDecision.allow()
+
+
+class RelationChecker(IRelationChecker):
+    @override
+    def check_relation(self, request: RelationCheckRequest) -> AuthorizationDecision:
+        return AuthorizationDecision.allow()
+
+
+class RoleChecker(IRoleChecker):
+    @override
+    def check_role(self, request: RoleCheckRequest) -> AuthorizationDecision:
+        return AuthorizationDecision.allow()
+
+
+class ScopeChecker(IScopeChecker):
+    @override
+    def check_scope(self, request: ScopeCheckRequest) -> AuthorizationDecision:
+        return AuthorizationDecision.allow()
+
+
+def _application_context_with(value: object | None) -> MagicMock:
+    application_context = MagicMock()
+    application_context.get_context_value.return_value = value
+    return application_context
+
+
+def test_inject_auth_snapshot_skips_disabled_config_and_missing_context() -> None:
+    """disabled config 또는 missing AuthContext는 snapshot header를 만들지 않는다."""
+    headers: dict[str, str] = {}
+    disabled_context = _application_context_with(_auth_context())
+
+    inject_auth_context_snapshot(
+        headers,
+        application_context=disabled_context,
+        auth_snapshot_signer=SnapshotSigner(),
+        auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(enabled=False),
+    )
+
+    assert headers == {}
+    disabled_context.get_context_value.assert_not_called()
+
+    inject_auth_context_snapshot(
+        headers,
+        application_context=_application_context_with(None),
+        auth_snapshot_signer=SnapshotSigner(),
+        auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(enabled=True),
+    )
+
+    assert headers == {}
+
+
+def test_inject_auth_snapshot_rejects_invalid_context_value() -> None:
+    """AuthContext가 아닌 context value는 invalid context 오류로 실패한다."""
+    with pytest.raises(InvalidAuthContextValueError):
+        inject_auth_context_snapshot(
+            {},
+            application_context=_application_context_with("not-auth-context"),
+            auth_snapshot_signer=SnapshotSigner(),
+            auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(
+                enabled=True
+            ),
+        )
+
+
+def test_inject_auth_snapshot_requires_signer_when_context_exists() -> None:
+    """enabled propagation + AuthContext 조합은 signer provider를 요구한다."""
+    with pytest.raises(AuthSnapshotPropagationSignerUnavailableError):
+        inject_auth_context_snapshot(
+            {},
+            application_context=_application_context_with(_auth_context()),
+            auth_snapshot_signer=None,
+            auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(
+                enabled=True
+            ),
+        )
+
+
+def test_seed_auth_skips_unprotected_task() -> None:
+    """unprotected task metadata는 snapshot verifier 없이 통과한다."""
+    application_context = MagicMock()
+
+    seed_and_authorize_celery_task(
+        application_context=application_context,
+        task_name="tasks.public",
+        headers={},
+        auth_metadata=TaskAuthMetadata(),
+        snapshot_verifier=None,
+        authorization_policy_evaluator=None,
+        permission_checker=None,
+        relation_checker=None,
+        role_checker=None,
+        scope_checker=None,
+    )
+
+    application_context.set_context_value.assert_not_called()
+
+
+def test_seed_auth_requires_snapshot_verifier_for_protected_task() -> None:
+    """protected task는 snapshot verifier provider가 없으면 ERROR decision으로 실패한다."""
+    with pytest.raises(AuthRequirementDeniedError) as excinfo:
+        seed_and_authorize_celery_task(
+            application_context=MagicMock(),
+            task_name="tasks.protected",
+            headers={AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "snapshot-envelope"},
+            auth_metadata=TaskAuthMetadata(
+                requirements=(
+                    TaskAuthRequirementMetadata(kind="AUTHENTICATED", ref="auth"),
+                )
+            ),
+            snapshot_verifier=None,
+            authorization_policy_evaluator=None,
+            permission_checker=None,
+            relation_checker=None,
+            role_checker=None,
+            scope_checker=None,
+        )
+
+    assert excinfo.value.decision is not None
+    assert excinfo.value.decision.state is AuthorizationDecisionState.ERROR
+
+
+@pytest.mark.parametrize(
+    ("verifier_error", "expected_state"),
+    [
+        (MissingAuthContextSnapshotError(), AuthorizationDecisionState.CHALLENGE),
+        (InvalidAuthContextSnapshotError(), AuthorizationDecisionState.CHALLENGE),
+        (ExpiredAuthContextSnapshotError(), AuthorizationDecisionState.CHALLENGE),
+        (
+            AuthVerificationProviderUnavailableError(),
+            AuthorizationDecisionState.ERROR,
+        ),
+    ],
+)
+def test_seed_auth_maps_snapshot_verifier_errors(
+    verifier_error: Exception,
+    expected_state: AuthorizationDecisionState,
+) -> None:
+    """snapshot verifier 오류는 task failure decision으로 매핑된다."""
+    with pytest.raises(AuthRequirementDeniedError) as excinfo:
+        seed_and_authorize_celery_task(
+            application_context=MagicMock(),
+            task_name="tasks.protected",
+            headers={AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "snapshot-envelope"},
+            auth_metadata=TaskAuthMetadata(
+                requirements=(
+                    TaskAuthRequirementMetadata(kind="AUTHENTICATED", ref="auth"),
+                )
+            ),
+            snapshot_verifier=SnapshotVerifier(verifier_error),
+            authorization_policy_evaluator=None,
+            permission_checker=None,
+            relation_checker=None,
+            role_checker=None,
+            scope_checker=None,
+        )
+
+    assert excinfo.value.decision is not None
+    assert excinfo.value.decision.state is expected_state
+
+
+def test_seed_auth_all_requirement_kinds_allow() -> None:
+    """모든 task auth requirement kind가 provider decision으로 평가된다."""
+    application_context = MagicMock()
+
+    seed_and_authorize_celery_task(
+        application_context=application_context,
+        task_name="tasks.protected",
+        headers={AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "snapshot-envelope"},
+        auth_metadata=TaskAuthMetadata(
+            requirements=(
+                TaskAuthRequirementMetadata(kind="AUTHENTICATED", ref="auth"),
+                TaskAuthRequirementMetadata(kind="PERMISSION", ref="documents:read"),
+                TaskAuthRequirementMetadata(
+                    kind="POLICY",
+                    ref="document-policy",
+                    resource="document:1",
+                    action="read",
+                ),
+                TaskAuthRequirementMetadata(
+                    kind="RELATION",
+                    ref="owner",
+                    resource="document:1",
+                ),
+                TaskAuthRequirementMetadata(kind="ROLE", ref="role:admin"),
+                TaskAuthRequirementMetadata(kind="SCOPE", ref="documents:read"),
+            )
+        ),
+        snapshot_verifier=SnapshotVerifier(),
+        authorization_policy_evaluator=PolicyEvaluator(),
+        permission_checker=PermissionChecker(),
+        relation_checker=RelationChecker(),
+        role_checker=RoleChecker(),
+        scope_checker=ScopeChecker(),
+    )
+
+    application_context.set_context_value.assert_called_once_with(
+        AUTH_CONTEXT_CONTEXT_KEY,
+        _auth_context(),
+    )
+
+
+@pytest.mark.parametrize(
+    "requirement",
+    [
+        TaskAuthRequirementMetadata(kind="PERMISSION", ref="documents:read"),
+        TaskAuthRequirementMetadata(kind="POLICY", ref="policy"),
+        TaskAuthRequirementMetadata(kind="RELATION", ref="owner"),
+        TaskAuthRequirementMetadata(kind="ROLE", ref="role:admin"),
+        TaskAuthRequirementMetadata(kind="SCOPE", ref="documents:read"),
+        TaskAuthRequirementMetadata(kind="UNKNOWN", ref="unknown"),
+    ],
+)
+def test_seed_auth_provider_unavailable_branches_are_error(
+    requirement: TaskAuthRequirementMetadata,
+) -> None:
+    """provider가 없거나 metadata가 불충분한 requirement는 ERROR decision이 된다."""
+    with pytest.raises(AuthRequirementDeniedError) as excinfo:
+        seed_and_authorize_celery_task(
+            application_context=MagicMock(),
+            task_name="tasks.protected",
+            headers={AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "snapshot-envelope"},
+            auth_metadata=TaskAuthMetadata(requirements=(requirement,)),
+            snapshot_verifier=SnapshotVerifier(),
+            authorization_policy_evaluator=None,
+            permission_checker=None,
+            relation_checker=None,
+            role_checker=None,
+            scope_checker=None,
+        )
+
+    assert excinfo.value.decision is not None
+    assert excinfo.value.decision.state is AuthorizationDecisionState.ERROR
+
+
+def test_retryable_auth_failure_requires_error_decision() -> None:
+    """Celery retry는 ERROR decision이 있는 AuthRequirementDeniedError에만 적용된다."""
+    assert is_retryable_auth_failure(AuthRequirementDeniedError()) is False
+    assert (
+        is_retryable_auth_failure(
+            AuthRequirementDeniedError(
+                AuthorizationDecision.challenge(
+                    reason_code=AuthorizationReasonCode.SNAPSHOT_MISSING
+                )
+            )
+        )
+        is False
+    )
+    assert (
+        is_retryable_auth_failure(
+            AuthRequirementDeniedError(
+                AuthorizationDecision.error(
+                    reason_code=AuthorizationReasonCode.INTERNAL_ERROR
+                )
+            )
+        )
+        is True
+    )

--- a/plugins/spakky-celery/tests/unit/test_dispatcher.py
+++ b/plugins/spakky-celery/tests/unit/test_dispatcher.py
@@ -1,19 +1,26 @@
 """Tests for CeleryTaskDispatchAspect and AsyncCeleryTaskDispatchAspect."""
 
 from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from spakky.auth import (
+    AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
     AuthContext,
+    AuthContextSnapshot,
+    AuthContextSnapshotSignature,
     AuthRequirementDeniedError,
+    AuthSnapshotPropagationConfig,
     AuthSubject,
     AuthorizationDecision,
     AuthorizationDecisionState,
     AuthorizationReasonCode,
+    IAuthContextSnapshotSigner,
     IScopeChecker,
     ScopeCheckRequest,
+    SnapshotSignRequest,
     require_auth_context,
     require_scope,
     store_auth_context,
@@ -76,6 +83,31 @@ class ConfigurableScopeChecker(IScopeChecker):
         return self.decision
 
 
+class RecordingSnapshotSigner(IAuthContextSnapshotSigner):
+    requests: list[SnapshotSignRequest]
+
+    def __init__(self) -> None:
+        self.requests = []
+
+    @override
+    def sign_snapshot(self, request: SnapshotSignRequest) -> AuthContextSnapshot:
+        self.requests.append(request)
+        return AuthContextSnapshot(
+            subject=request.auth_context.subject,
+            issuer=request.auth_context.issuer,
+            issued_at=datetime(2026, 5, 15, 1, 2, 3, tzinfo=UTC),
+            expires_at=datetime(2026, 5, 15, 1, 7, 3, tzinfo=UTC),
+            signature=AuthContextSnapshotSignature(
+                key_id="key:test",
+                algorithm="HS256",
+                signature="signature-1",
+            ),
+            tenant=request.auth_context.tenant,
+            roles=request.auth_context.roles,
+            scopes=request.auth_context.scopes,
+        )
+
+
 def _create_direct_task_context() -> ApplicationContext:
     context = ApplicationContext()
     context.set_context_value(CELERY_TASK_CONTEXT_KEY, True)
@@ -87,6 +119,14 @@ def _create_direct_task_context() -> ApplicationContext:
         ),
     )
     return context
+
+
+def _auth_context() -> AuthContext:
+    return AuthContext(
+        subject=AuthSubject(id="subject-1"),
+        issuer="issuer-1",
+        scopes=("tasks:run",),
+    )
 
 
 def _run_sync_task_aspect_chain(
@@ -215,6 +255,29 @@ def test_around_injects_traceparent_expect_headers_contain_traceparent() -> None
     headers = call_kwargs.kwargs["headers"]
     assert "traceparent" in headers
     assert headers["traceparent"] == SAMPLE_TRACEPARENT
+
+
+def test_around_injects_signed_auth_snapshot_expect_header() -> None:
+    """snapshot propagation enabled이면 signed AuthContextSnapshot이 task header로 전파된다."""
+    celery = _create_mock_celery()
+    signer = RecordingSnapshotSigner()
+    application_context = ApplicationContext()
+    store_auth_context(application_context, _auth_context())
+    aspect = CeleryTaskDispatchAspect(
+        celery,
+        auth_snapshot_signer=signer,
+        auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(enabled=True),
+    )
+    aspect.set_application_context(application_context)
+    joinpoint = _create_joinpoint("send_email")
+
+    aspect.around(joinpoint)
+
+    call_kwargs = celery.send_task.call_args
+    headers = call_kwargs.kwargs["headers"]
+    assert AUTH_CONTEXT_SNAPSHOT_METADATA_KEY in headers
+    assert len(signer.requests) == 1
+    assert signer.requests[0].auth_context == _auth_context()
 
 
 def test_around_sends_empty_headers_when_propagator_none_expect_no_traceparent() -> (
@@ -383,6 +446,30 @@ async def test_async_around_injects_traceparent_expect_headers_contain_tracepare
     headers = call_kwargs.kwargs["headers"]
     assert "traceparent" in headers
     assert headers["traceparent"] == SAMPLE_TRACEPARENT
+
+
+@pytest.mark.asyncio
+async def test_async_around_injects_signed_auth_snapshot_expect_header() -> None:
+    """async dispatch도 signed AuthContextSnapshot을 task header로 전파한다."""
+    celery = _create_mock_celery()
+    signer = RecordingSnapshotSigner()
+    application_context = ApplicationContext()
+    store_auth_context(application_context, _auth_context())
+    aspect = AsyncCeleryTaskDispatchAspect(
+        celery,
+        auth_snapshot_signer=signer,
+        auth_snapshot_propagation_config=AuthSnapshotPropagationConfig(enabled=True),
+    )
+    aspect.set_application_context(application_context)
+    joinpoint = _create_async_joinpoint("async_send_email")
+
+    await aspect.around_async(joinpoint)
+
+    call_kwargs = celery.send_task.call_args
+    headers = call_kwargs.kwargs["headers"]
+    assert AUTH_CONTEXT_SNAPSHOT_METADATA_KEY in headers
+    assert len(signer.requests) == 1
+    assert signer.requests[0].auth_context == _auth_context()
 
 
 @pytest.mark.asyncio

--- a/plugins/spakky-celery/tests/unit/test_post_processor.py
+++ b/plugins/spakky-celery/tests/unit/test_post_processor.py
@@ -1,12 +1,33 @@
 """Tests for CeleryPostProcessor."""
 
+from collections.abc import Callable
 from datetime import time, timedelta
+from typing import override
 from unittest.mock import MagicMock, patch
 
 import pytest
 from celery import Celery
+from celery.exceptions import Retry
 from celery.schedules import crontab as celery_crontab
 from celery.schedules import schedule as celery_schedule
+from spakky.auth import (
+    AUTH_CONTEXT_CONTEXT_KEY,
+    AUTH_CONTEXT_SNAPSHOT_METADATA_KEY,
+    AuthContext,
+    AuthInvocation,
+    AuthRequirementDeniedError,
+    AuthSubject,
+    AuthVerificationProviderUnavailableError,
+    AuthorizationDecision,
+    AuthorizationDecisionState,
+    AuthorizationReasonCode,
+    ExpiredAuthContextSnapshotError,
+    IAuthContextSnapshotVerifier,
+    IScopeChecker,
+    InvalidAuthContextSnapshotError,
+    ScopeCheckRequest,
+    require_scope,
+)
 from spakky.core.utils.inspection import get_fully_qualified_name
 from spakky.task.stereotype.crontab import Crontab, Weekday
 from spakky.task.stereotype.schedule import schedule
@@ -31,6 +52,48 @@ class _SampleTaskHandler:
     @task
     def process_data(self, data: str) -> None:
         pass
+
+
+def _auth_context() -> AuthContext:
+    return AuthContext(
+        subject=AuthSubject(id="subject-1"),
+        issuer="issuer-1",
+        scopes=("tasks:run",),
+    )
+
+
+class SnapshotVerifier(IAuthContextSnapshotVerifier):
+    error: Exception | None
+    calls: list[tuple[str, AuthInvocation]]
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls = []
+
+    @override
+    def verify_snapshot(
+        self,
+        snapshot_envelope: str,
+        invocation: AuthInvocation,
+    ) -> AuthContext:
+        self.calls.append((snapshot_envelope, invocation))
+        if self.error is not None:
+            raise self.error
+        return _auth_context()
+
+
+class ScopeChecker(IScopeChecker):
+    decision: AuthorizationDecision
+    requests: list[ScopeCheckRequest]
+
+    def __init__(self, decision: AuthorizationDecision) -> None:
+        self.decision = decision
+        self.requests = []
+
+    @override
+    def check_scope(self, request: ScopeCheckRequest) -> AuthorizationDecision:
+        self.requests.append(request)
+        return self.decision
 
 
 def _create_celery() -> Celery:
@@ -194,6 +257,218 @@ def test_celery_post_processor_registers_async_tasks() -> None:
     application_context_mock.clear_context.assert_called_once()
     assert async_handler.calls == ["async_payload"]
     assert result == "async: async_payload"
+
+
+def _registered_endpoint_for_handler(
+    handler_type: type[object],
+    handler: object,
+    *,
+    snapshot_verifier: IAuthContextSnapshotVerifier | None,
+    scope_checker: IScopeChecker | None,
+) -> tuple[Callable[..., object], MagicMock]:
+    celery_mock = MagicMock()
+    application_context_mock = MagicMock()
+
+    def get_from_context(type_: type[object]) -> object:
+        if type_ is Celery:
+            return celery_mock
+        if type_ is handler_type:
+            return handler
+        raise AssertionError(f"Unexpected dependency lookup: {type_}")
+
+    application_context_mock.get.side_effect = get_from_context
+    application_context_mock.get_or_none.return_value = None
+
+    post_processor = CeleryPostProcessor(
+        auth_snapshot_verifier=snapshot_verifier,
+        scope_checker=scope_checker,
+    )
+    post_processor.set_application_context(application_context_mock)
+    post_processor.post_process(handler)
+
+    endpoint = celery_mock.task.return_value.call_args_list[0].args[0]
+    return endpoint, application_context_mock
+
+
+def test_protected_sync_endpoint_verifies_snapshot_and_seeds_auth_context() -> None:
+    """protected worker task는 snapshot 검증 후 AuthContext를 seed하고 실행한다."""
+
+    @TaskHandler()
+    class ProtectedHandler:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        @task
+        @require_scope("tasks:run")
+        def protected_task(self, value: str) -> str:
+            self.calls.append(value)
+            return value
+
+    handler = ProtectedHandler()
+    verifier = SnapshotVerifier()
+    checker = ScopeChecker(AuthorizationDecision.allow())
+    endpoint, application_context_mock = _registered_endpoint_for_handler(
+        ProtectedHandler,
+        handler,
+        snapshot_verifier=verifier,
+        scope_checker=checker,
+    )
+    mock_request = MagicMock()
+    mock_request.get.return_value = {
+        AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "snapshot-envelope"
+    }
+
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        result = endpoint("payload")
+
+    assert result == "payload"
+    assert handler.calls == ["payload"]
+    assert verifier.calls[0][0] == "snapshot-envelope"
+    assert checker.requests[0].auth_context == _auth_context()
+    application_context_mock.set_context_value.assert_any_call(
+        AUTH_CONTEXT_CONTEXT_KEY,
+        _auth_context(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("headers", "verifier_error", "expected_reason"),
+    [
+        ({}, None, AuthorizationReasonCode.SNAPSHOT_MISSING),
+        (
+            {AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "invalid-envelope"},
+            InvalidAuthContextSnapshotError(),
+            AuthorizationReasonCode.SNAPSHOT_INVALID,
+        ),
+        (
+            {AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "expired-envelope"},
+            ExpiredAuthContextSnapshotError(),
+            AuthorizationReasonCode.SNAPSHOT_EXPIRED,
+        ),
+    ],
+)
+def test_protected_sync_endpoint_snapshot_challenge_fails_closed(
+    headers: dict[str, str],
+    verifier_error: Exception | None,
+    expected_reason: AuthorizationReasonCode,
+) -> None:
+    """missing/invalid/expired snapshot은 CHALLENGE task failure로 닫힌다."""
+
+    @TaskHandler()
+    class ProtectedHandler:
+        def __init__(self) -> None:
+            self.called = False
+
+        @task
+        @require_scope("tasks:run")
+        def protected_task(self) -> None:
+            self.called = True
+
+    handler = ProtectedHandler()
+    endpoint, _ = _registered_endpoint_for_handler(
+        ProtectedHandler,
+        handler,
+        snapshot_verifier=SnapshotVerifier(verifier_error),
+        scope_checker=ScopeChecker(AuthorizationDecision.allow()),
+    )
+    mock_request = MagicMock()
+    mock_request.get.return_value = headers
+
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        with pytest.raises(AuthRequirementDeniedError) as excinfo:
+            endpoint()
+
+    assert excinfo.value.decision is not None
+    assert excinfo.value.decision.state is AuthorizationDecisionState.CHALLENGE
+    assert excinfo.value.decision.reason_code is expected_reason
+    assert not handler.called
+    mock_current_task.retry.assert_not_called()
+
+
+def test_protected_sync_endpoint_deny_fails_task_without_retry() -> None:
+    """authorization DENY decision은 retry 없이 task failure가 된다."""
+
+    @TaskHandler()
+    class ProtectedHandler:
+        def __init__(self) -> None:
+            self.called = False
+
+        @task
+        @require_scope("tasks:run")
+        def protected_task(self) -> None:
+            self.called = True
+
+    handler = ProtectedHandler()
+    endpoint, _ = _registered_endpoint_for_handler(
+        ProtectedHandler,
+        handler,
+        snapshot_verifier=SnapshotVerifier(),
+        scope_checker=ScopeChecker(
+            AuthorizationDecision.deny(AuthorizationReasonCode.INSUFFICIENT_SCOPE)
+        ),
+    )
+    mock_request = MagicMock()
+    mock_request.get.return_value = {
+        AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "snapshot-envelope"
+    }
+
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        with pytest.raises(AuthRequirementDeniedError) as excinfo:
+            endpoint()
+
+    assert excinfo.value.decision is not None
+    assert excinfo.value.decision.state is AuthorizationDecisionState.DENY
+    assert not handler.called
+    mock_current_task.retry.assert_not_called()
+
+
+def test_protected_sync_endpoint_verification_error_uses_celery_retry() -> None:
+    """verification provider unavailable ERROR는 Celery retryable task 오류로 매핑된다."""
+
+    @TaskHandler()
+    class ProtectedHandler:
+        def __init__(self) -> None:
+            self.called = False
+
+        @task
+        @require_scope("tasks:run")
+        def protected_task(self) -> None:
+            self.called = True
+
+    handler = ProtectedHandler()
+    endpoint, _ = _registered_endpoint_for_handler(
+        ProtectedHandler,
+        handler,
+        snapshot_verifier=SnapshotVerifier(AuthVerificationProviderUnavailableError()),
+        scope_checker=ScopeChecker(AuthorizationDecision.allow()),
+    )
+    mock_request = MagicMock()
+    mock_request.get.return_value = {
+        AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "snapshot-envelope"
+    }
+
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        mock_current_task.retry.side_effect = Retry()
+        with pytest.raises(Retry):
+            endpoint()
+
+    retry_error = mock_current_task.retry.call_args.kwargs["exc"]
+    assert isinstance(retry_error, AuthRequirementDeniedError)
+    assert retry_error.decision is not None
+    assert retry_error.decision.state is AuthorizationDecisionState.ERROR
+    assert not handler.called
 
 
 # =============================================================================
@@ -494,6 +769,19 @@ def test_sync_endpoint_no_trace_when_propagator_none_expect_context_unset() -> N
     endpoint()
 
     assert handler.captured_ctx is None
+
+
+def test_current_task_headers_non_dict_expect_empty() -> None:
+    """current_task headers가 dict가 아니면 빈 header carrier로 처리한다."""
+    post_processor = CeleryPostProcessor()
+    mock_request = MagicMock()
+    mock_request.get.return_value = ["not", "headers"]
+
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        assert post_processor._current_task_headers() == {}
 
 
 def test_async_endpoint_extracts_trace_context_expect_child_span() -> None:


### PR DESCRIPTION
## Summary
- Add signed AuthContextSnapshot propagation to sync/async Celery task dispatch headers.
- Verify worker snapshots, seed AuthContext, and fail closed for protected task invocation.
- Map missing/invalid/expired snapshots to CHALLENGE failures, DENY to task failure, and provider ERROR to Celery retry.
- Update Celery README/API/guide docs and add full auth boundary test coverage.

## Tests
- `uv run --with ruff ruff format .`
- `uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- `uv run --with ruff ruff check .`
- `uv run --with pyrefly pyrefly check src tests --config pyproject.toml --search-path src --search-path ../../core/spakky/src --search-path ../../core/spakky-auth/src --search-path ../../core/spakky-task/src --search-path ../../core/spakky-tracing/src`
- `uv run --with pytest-cov --with pytest-xdist --with pytest-spec pytest`

## Acceptance Criteria (자가 grep)

acceptance_check: missing

이슈 본문에 실행 가능한 grep/find/rg acceptance line 없음.

Closes #292
