### PR TITLE
Fix spakky-sqlalchemy missing pydantic-settings dependency

### DIFF
--- a/plugins/spakky-sqlalchemy/pyproject.toml
+++ b/plugins/spakky-sqlalchemy/pyproject.toml
@@ -8,6 +8,7 @@ license = { text = "MIT" }
 authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
 dependencies = [
     "spakky-data>=6.5.0",
+    "pydantic-settings>=2.13.1",
     "sqlalchemy>=2.0.49",
 ]
 


### PR DESCRIPTION
Fixes E5presso/spakky-framework#357.

spakky.plugins.sqlalchemy.common.config imports pydantic_settings at plugin import time, but plugins/spakky-sqlalchemy/pyproject.toml only declared spakky-data and sqlalchemy as base dependencies. A fresh spakky-sqlalchemy install can therefore fail importing spakky.plugins.sqlalchemy.main with ModuleNotFoundError: No module named 'pydantic_settings'.

This adds pydantic-settings>=2.13.1, matching the dependency style already used by other Spakky plugins that define BaseSettings configs.

Verification:

Before the fix, a minimal install reproduced the issue:

``
python -m venv .venv-sqlalchemy-repro
.venv-sqlalchemy-repro/Scripts/python -m pip install -e plugins/spakky-sqlalchemy --no-deps
.venv-sqlalchemy-repro/Scripts/python -m pip install spakky-data sqlalchemy
.venv-sqlalchemy-repro/Scripts/python -c "import importlib; importlib.import_module('spakky.plugins.sqlalchemy.main')"
# ModuleNotFoundError: No module named 'pydantic_settings'
``

After the fix:

``
python -m venv .venv-sqlalchemy-fix
.venv-sqlalchemy-fix/Scripts/python -m pip install -e plugins/spakky-sqlalchemy
.venv-sqlalchemy-fix/Scripts/python -c "import importlib; importlib.import_module('spakky.plugins.sqlalchemy.main'); print('sqlalchemy plugin import ok')"
git diff --check
``

Result: sqlalchemy plugin import ok; git diff --check passed.