### PR TITLE
Fix default OpenTelemetry OTLP exporter dependency

### DIFF
--- a/plugins/spakky-opentelemetry/pyproject.toml
+++ b/plugins/spakky-opentelemetry/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "spakky-tracing>=6.5.0",
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp>=1.20.0",
     "pydantic-settings>=2.13.1",
 ]
 


### PR DESCRIPTION
Fixes E5presso/spakky-framework#358.

spakky-opentelemetry defaults OpenTelemetryConfig.exporter_type to ExporterType.OTLP, and the default exporter path lazily imports opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter. However, opentelemetry-exporter-otlp was only declared under the optional otlp extra, so a base install of the plugin could fail at runtime with ModuleNotFoundError: No module named 'opentelemetry.exporter'.

This makes the advertised default configuration work by adding opentelemetry-exporter-otlp>=1.20.0 to the base dependencies. The existing otlp extra is left in place for compatibility.

Verification:

Before the fix:

``
python -m venv .venv-otel-repro
.venv-otel-repro/Scripts/python -m pip install -e plugins/spakky-opentelemetry --no-deps
.venv-otel-repro/Scripts/python -m pip install spakky spakky-tracing opentelemetry-api opentelemetry-sdk pydantic-settings
.venv-otel-repro/Scripts/python -c "from spakky.plugins.opentelemetry.config import OpenTelemetryConfig; from spakky.plugins.opentelemetry.post_processor import OTelSetupPostProcessor; OTelSetupPostProcessor._create_exporter(OpenTelemetryConfig())"
# ModuleNotFoundError: No module named 'opentelemetry.exporter'
``

After the fix:

``
python -m venv .venv-otel-fix
.venv-otel-fix/Scripts/python -m pip install -e plugins/spakky-opentelemetry
.venv-otel-fix/Scripts/python -c "from spakky.plugins.opentelemetry.config import OpenTelemetryConfig; from spakky.plugins.opentelemetry.post_processor import OTelSetupPostProcessor; exporter = OTelSetupPostProcessor._create_exporter(OpenTelemetryConfig()); print(type(exporter).__name__)"
git diff --check
``

Result: OTLPSpanExporter; git diff --check passed.