### PR TITLE
fix: rollback started services on startup failure

### DIFF
--- a/core/spakky/src/spakky/core/application/application_context.py
+++ b/core/spakky/src/spakky/core/application/application_context.py
@@ -776,16 +776,39 @@ class ApplicationContext(IApplicationContext):
         )
         self.__event_thread.start()
 
-        for service in self.__services:
-            service.start()
+        started_services: list[IService] = []
+        started_async_services: list[IAsyncService] = []
 
-        async def start_async_services() -> None:
-            if self.__event_loop is None:  # pragma: no cover - coverage boundary
-                raise EventLoopThreadNotStartedInApplicationContextError
-            for service in self.__async_services:
-                await service.start_async()
+        try:
+            for service in self.__services:
+                service.start()
+                started_services.append(service)
 
-        run_coroutine_threadsafe(start_async_services(), self.__event_loop).result()
+            async def start_async_services() -> None:
+                if self.__event_loop is None:  # pragma: no cover - coverage boundary
+                    raise EventLoopThreadNotStartedInApplicationContextError
+                for service in self.__async_services:
+                    await service.start_async()
+                    started_async_services.append(service)
+
+            run_coroutine_threadsafe(start_async_services(), self.__event_loop).result()
+        except BaseException:
+            for service in reversed(started_services):
+                service.stop()
+
+            async def stop_started_async_services() -> None:
+                for service in reversed(started_async_services):
+                    await service.stop_async()
+
+            run_coroutine_threadsafe(
+                stop_started_async_services(), self.__event_loop
+            ).result()
+            self.__event_loop.call_soon_threadsafe(self.__event_loop.stop)  # type: ignore[arg-type]  # stop() is valid callback
+            self.__event_thread.join()
+            self.__event_loop = None
+            self.__event_thread = None
+            self.__is_started = False
+            raise
 
     def __stop_services(self) -> None:
         """Stop all services and shutdown event loop.

--- a/core/spakky/tests/application/test_application_context_errors.py
+++ b/core/spakky/tests/application/test_application_context_errors.py
@@ -84,6 +84,80 @@ def test_application_context_with_services() -> None:
     assert async_service.stopped
 
 
+def test_application_context_start_failure_stops_started_sync_services() -> None:
+    """Services started before a startup failure are stopped during rollback."""
+
+    events: list[str] = []
+
+    class StartedService(IService):
+        def set_stop_event(self, stop_event: Event) -> None:
+            self.stop_event = stop_event
+
+        def start(self) -> None:
+            events.append("started.start")
+
+        def stop(self) -> None:
+            events.append("started.stop")
+
+    class FailingService(IService):
+        def set_stop_event(self, stop_event: Event) -> None:
+            self.stop_event = stop_event
+
+        def start(self) -> None:
+            events.append("failing.start")
+            raise RuntimeError("service failed")
+
+        def stop(self) -> None:
+            events.append("failing.stop")
+
+    context = ApplicationContext()
+    context.add_service(StartedService())
+    context.add_service(FailingService())
+
+    with pytest.raises(RuntimeError, match="service failed"):
+        context.start()
+
+    assert events == ["started.start", "failing.start", "started.stop"]
+    assert not context.is_started
+
+
+def test_application_context_start_failure_stops_started_async_services() -> None:
+    """Async services started before a startup failure are stopped during rollback."""
+
+    events: list[str] = []
+
+    class StartedAsyncService(IAsyncService):
+        def set_stop_event(self, stop_event: locks.Event) -> None:
+            self.stop_event = stop_event
+
+        async def start_async(self) -> None:
+            events.append("started.start")
+
+        async def stop_async(self) -> None:
+            events.append("started.stop")
+
+    class FailingAsyncService(IAsyncService):
+        def set_stop_event(self, stop_event: locks.Event) -> None:
+            self.stop_event = stop_event
+
+        async def start_async(self) -> None:
+            events.append("failing.start")
+            raise RuntimeError("async service failed")
+
+        async def stop_async(self) -> None:
+            events.append("failing.stop")
+
+    context = ApplicationContext()
+    context.add_service(StartedAsyncService())
+    context.add_service(FailingAsyncService())
+
+    with pytest.raises(RuntimeError, match="async service failed"):
+        context.start()
+
+    assert events == ["started.start", "failing.start", "started.stop"]
+    assert not context.is_started
+
+
 def test_event_loop_error_when_not_started() -> None:
     """컷텍스트가 시작되지 않은 상태에서 stop 호출 시 에러가 발생함을 검증한다."""
     context = ApplicationContext()


### PR DESCRIPTION
Closes #360.

This fixes ApplicationContext startup rollback when a service fails after earlier services have already started.

Changes:
- track sync services that successfully started and stop them in reverse order if a later sync startup fails
- track async services that successfully started and stop them in reverse order if a later async startup fails
- shut down the startup event loop and reset the started state so the context is not left half-started
- add regression coverage for sync and async service startup rollback

Verification:
```text
PYTHONUTF8=1 PYTHONIOENCODING=utf-8 python -m pytest core/spakky/tests/application/test_application_context_errors.py -q -o addopts=""
# 7 passed

PYTHONUTF8=1 PYTHONIOENCODING=utf-8 python -m pytest core/spakky/tests/application/test_application_context_errors.py::test_application_context_start_failure_stops_started_sync_services core/spakky/tests/application/test_application_context_errors.py::test_application_context_start_failure_stops_started_async_services -q -o addopts=""
# 2 passed

python -m compileall -q core/spakky/src/spakky/core/application/application_context.py core/spakky/tests/application/test_application_context_errors.py
```