### PR TITLE
Reject all-zero W3C traceparent identifiers

### DIFF
--- a/core/spakky-tracing/src/spakky/tracing/context.py
+++ b/core/spakky-tracing/src/spakky/tracing/context.py
@@ -30,6 +30,8 @@ class TraceContext:
     _TRACE_ID_BYTES: ClassVar[int] = 16
     _SPAN_ID_BYTES: ClassVar[int] = 8
     _HEX_BASE: ClassVar[int] = 16
+    _ZERO_TRACE_ID: ClassVar[str] = "0" * 32
+    _ZERO_SPAN_ID: ClassVar[str] = "0" * 16
 
     trace_id: str
     span_id: str
@@ -74,6 +76,8 @@ class TraceContext:
         if match is None:
             raise InvalidTraceparentError()
         _version, trace_id, span_id, flags_hex = match.groups()
+        if trace_id == cls._ZERO_TRACE_ID or span_id == cls._ZERO_SPAN_ID:
+            raise InvalidTraceparentError()
         return cls(
             trace_id=trace_id,
             span_id=span_id,

--- a/core/spakky-tracing/tests/unit/test_trace_context.py
+++ b/core/spakky-tracing/tests/unit/test_trace_context.py
@@ -97,6 +97,22 @@ def test_roundtrip_traceparent_expect_identity() -> None:
     assert restored.trace_flags == original.trace_flags
 
 
+def test_from_traceparent_zero_trace_id_expect_error() -> None:
+    """from_traceparent() rejects the W3C-forbidden all-zero trace ID."""
+    with pytest.raises(InvalidTraceparentError):
+        TraceContext.from_traceparent(
+            "00-00000000000000000000000000000000-b7ad6b7169203331-01"
+        )
+
+
+def test_from_traceparent_zero_span_id_expect_error() -> None:
+    """from_traceparent() rejects the W3C-forbidden all-zero span ID."""
+    with pytest.raises(InvalidTraceparentError):
+        TraceContext.from_traceparent(
+            "00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01"
+        )
+
+
 def test_get_set_clear_expect_contextvar_lifecycle() -> None:
     """get()/set()/clear()가 contextvars 기반 생명주기를 올바르게 관리하는지 검증한다."""
     assert TraceContext.get() is None

--- a/core/spakky-tracing/tests/unit/test_w3c_propagator.py
+++ b/core/spakky-tracing/tests/unit/test_w3c_propagator.py
@@ -70,6 +70,30 @@ def test_extract_invalid_header_expect_none() -> None:
     assert ctx is None
 
 
+def test_extract_zero_trace_id_expect_none() -> None:
+    """extract() ignores W3C-forbidden all-zero trace IDs."""
+    propagator = W3CTracePropagator()
+    carrier = {
+        TRACEPARENT_HEADER: "00-00000000000000000000000000000000-b7ad6b7169203331-01",
+    }
+
+    ctx = propagator.extract(carrier)
+
+    assert ctx is None
+
+
+def test_extract_zero_span_id_expect_none() -> None:
+    """extract() ignores W3C-forbidden all-zero span IDs."""
+    propagator = W3CTracePropagator()
+    carrier = {
+        TRACEPARENT_HEADER: "00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01",
+    }
+
+    ctx = propagator.extract(carrier)
+
+    assert ctx is None
+
+
 def test_fields_expect_traceparent() -> None:
     """fields()가 ["traceparent"]를 반환하는지 검증한다."""
     propagator = W3CTracePropagator()


### PR DESCRIPTION
## Summary
- Reject W3C-forbidden all-zero `trace_id` and `span_id` values in `TraceContext.from_traceparent()`
- Keep `W3CTracePropagator.extract()` fail-closed by returning `None` for those invalid traceparent headers
- Add hostile regressions for zero trace and span identifiers

Fixes #348.

## Verification
- `python -m pytest tests/unit/test_trace_context.py tests/unit/test_w3c_propagator.py -q -o addopts=""` -> 23 passed
- `python -m ruff check src tests` -> passed
- `python -m ruff format --check src tests` -> passed

Note: `uv` was not available in my local Windows environment, so I verified with a local Python 3.12 venv using editable installs for `spakky` and `spakky-tracing`.