### PR TITLE
Set generated gRPC descriptor streaming flags

### DIFF
--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/schema/descriptor_builder.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/schema/descriptor_builder.py
@@ -17,7 +17,7 @@ from google.protobuf.descriptor_pb2 import (
     ServiceDescriptorProto,
 )
 from pydantic import BaseModel
-from spakky.plugins.grpc.decorators.rpc import Rpc
+from spakky.plugins.grpc.decorators.rpc import Rpc, RpcMethodType
 from spakky.plugins.grpc.schema.type_map import (
     extract_proto_field,
     resolve_type,
@@ -130,6 +130,10 @@ def build_service_descriptor(
             name=method_name,
             input_type=input_type,
             output_type=output_type,
+            client_streaming=rpc_annotation.method_type
+            in {RpcMethodType.CLIENT_STREAMING, RpcMethodType.BIDI_STREAMING},
+            server_streaming=rpc_annotation.method_type
+            in {RpcMethodType.SERVER_STREAMING, RpcMethodType.BIDI_STREAMING},
         )
 
         service.method.append(method_desc)

--- a/plugins/spakky-grpc/tests/unit/test_descriptor_builder.py
+++ b/plugins/spakky-grpc/tests/unit/test_descriptor_builder.py
@@ -6,7 +6,7 @@ from google.protobuf.descriptor_pb2 import FieldDescriptorProto
 from pydantic import BaseModel
 
 from spakky.plugins.grpc.annotations.field import ProtoField
-from spakky.plugins.grpc.decorators.rpc import rpc
+from spakky.plugins.grpc.decorators.rpc import RpcMethodType, rpc
 from spakky.plugins.grpc.schema.descriptor_builder import (
     build_file_descriptor,
     build_message_descriptor,
@@ -119,6 +119,64 @@ def test_build_service_descriptor_unary() -> None:
 
     assert "HelloRequest" in collected
     assert "HelloResponse" in collected
+
+
+def test_build_service_descriptor_sets_streaming_flags() -> None:
+    """Descriptor methods expose the streaming mode selected by @rpc."""
+
+    @GrpcController(package="test.v1")
+    class StreamingService:
+        """Service with all four RPC streaming modes."""
+
+        @rpc(
+            method_type=RpcMethodType.UNARY,
+            request_type=HelloRequest,
+            response_type=HelloResponse,
+        )
+        async def unary(self, request: HelloRequest) -> HelloResponse:
+            """Unary method."""
+            ...
+
+        @rpc(
+            method_type=RpcMethodType.SERVER_STREAMING,
+            request_type=HelloRequest,
+            response_type=HelloResponse,
+        )
+        async def server_streaming(self, request: HelloRequest) -> HelloResponse:
+            """Server-streaming method."""
+            ...
+
+        @rpc(
+            method_type=RpcMethodType.CLIENT_STREAMING,
+            request_type=HelloRequest,
+            response_type=HelloResponse,
+        )
+        async def client_streaming(self, request: HelloRequest) -> HelloResponse:
+            """Client-streaming method."""
+            ...
+
+        @rpc(
+            method_type=RpcMethodType.BIDI_STREAMING,
+            request_type=HelloRequest,
+            response_type=HelloResponse,
+        )
+        async def bidi_streaming(self, request: HelloRequest) -> HelloResponse:
+            """Bidirectional-streaming method."""
+            ...
+
+    service = build_service_descriptor(
+        StreamingService, "test.v1", "StreamingService", {}
+    )
+    methods = {method.name: method for method in service.method}
+
+    assert not methods["unary"].client_streaming
+    assert not methods["unary"].server_streaming
+    assert not methods["server_streaming"].client_streaming
+    assert methods["server_streaming"].server_streaming
+    assert methods["client_streaming"].client_streaming
+    assert not methods["client_streaming"].server_streaming
+    assert methods["bidi_streaming"].client_streaming
+    assert methods["bidi_streaming"].server_streaming
 
 
 def test_build_file_descriptor_complete() -> None:


### PR DESCRIPTION
## Summary
- Populate generated `MethodDescriptorProto.client_streaming` and `server_streaming` from `RpcMethodType`
- Cover unary, server-streaming, client-streaming, and bidi-streaming descriptor flags in unit tests

Fixes #344.

## Verification
- `python -m pytest tests/unit/test_descriptor_builder.py -q -o addopts=""` -> 12 passed
- `python -m pytest tests/unit/test_descriptor_builder.py tests/unit/test_handler.py -q -o addopts=""` -> 38 passed
- `python -m ruff check src tests` -> passed
- `python -m ruff format --check src tests` -> passed

Note: `uv` is not available in my local Windows environment, so I verified with a local Python 3.12 venv using editable installs for `spakky`, `spakky-auth`, `spakky-tracing`, and `spakky-grpc`.