### PR TITLE
Unwrap AsyncIterator RPC type hints for descriptors

### DIFF
--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/decorators/rpc.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/decorators/rpc.py
@@ -4,10 +4,11 @@ Provides the @rpc decorator for marking controller methods as gRPC service
 methods with support for all four gRPC streaming patterns.
 """
 
+from collections.abc import AsyncIterator as AsyncIteratorABC
 from dataclasses import dataclass
 from enum import StrEnum, auto
 from inspect import signature
-from typing import Callable, get_type_hints
+from typing import Callable, get_args, get_origin, get_type_hints
 
 from spakky.core.common.annotation import FunctionAnnotation
 from spakky.core.common.types import AnyT
@@ -27,6 +28,15 @@ class RpcMethodType(StrEnum):
     SERVER_STREAMING = auto()
     CLIENT_STREAMING = auto()
     BIDI_STREAMING = auto()
+
+
+def _unwrap_streaming_type(annotation: object) -> object:
+    """Return the message type inside supported streaming annotations."""
+    if get_origin(annotation) is AsyncIteratorABC:
+        args = get_args(annotation)
+        if args:
+            return args[0]
+    return annotation
 
 
 @dataclass
@@ -75,9 +85,11 @@ class Rpc(FunctionAnnotation):
             params = list(signature(obj).parameters.values())
             non_self_params = [p for p in params if p.name != "self"]
             if non_self_params:
-                self.request_type = hints.get(non_self_params[0].name)
+                request_hint = hints.get(non_self_params[0].name)
+                self.request_type = _unwrap_streaming_type(request_hint)
         if self.response_type is None:
-            self.response_type = hints.get("return")
+            response_hint = hints.get("return")
+            self.response_type = _unwrap_streaming_type(response_hint)
 
 
 def rpc(

--- a/plugins/spakky-grpc/tests/unit/test_descriptor_builder.py
+++ b/plugins/spakky-grpc/tests/unit/test_descriptor_builder.py
@@ -1,12 +1,12 @@
 """Unit tests for descriptor_builder module."""
 
-from typing import Annotated
+from typing import Annotated, AsyncIterator
 
 from google.protobuf.descriptor_pb2 import FieldDescriptorProto
 from pydantic import BaseModel
 
 from spakky.plugins.grpc.annotations.field import ProtoField
-from spakky.plugins.grpc.decorators.rpc import rpc
+from spakky.plugins.grpc.decorators.rpc import RpcMethodType, rpc
 from spakky.plugins.grpc.schema.descriptor_builder import (
     build_file_descriptor,
     build_message_descriptor,
@@ -119,6 +119,47 @@ def test_build_service_descriptor_unary() -> None:
 
     assert "HelloRequest" in collected
     assert "HelloResponse" in collected
+
+
+def test_build_file_descriptor_unwraps_streaming_type_hints() -> None:
+    """Documented AsyncIterator[T] signatures generate T descriptors."""
+
+    @GrpcController(package="test.v1")
+    class StreamingHintService:
+        """Controller using documented streaming type hints."""
+
+        @rpc(method_type=RpcMethodType.SERVER_STREAMING)
+        async def server_streaming(
+            self, request: HelloRequest
+        ) -> AsyncIterator[HelloResponse]:
+            """Server-streaming method."""
+            ...
+
+        @rpc(method_type=RpcMethodType.CLIENT_STREAMING)
+        async def client_streaming(
+            self, requests: AsyncIterator[HelloRequest]
+        ) -> HelloResponse:
+            """Client-streaming method."""
+            ...
+
+        @rpc(method_type=RpcMethodType.BIDI_STREAMING)
+        async def bidi_streaming(
+            self, requests: AsyncIterator[HelloRequest]
+        ) -> AsyncIterator[HelloResponse]:
+            """Bidirectional-streaming method."""
+            ...
+
+    file_desc = build_file_descriptor(StreamingHintService)
+    methods = {method.name: method for method in file_desc.service[0].method}
+    message_names = {message.name for message in file_desc.message_type}
+
+    assert methods["server_streaming"].input_type == ".test.v1.HelloRequest"
+    assert methods["server_streaming"].output_type == ".test.v1.HelloResponse"
+    assert methods["client_streaming"].input_type == ".test.v1.HelloRequest"
+    assert methods["client_streaming"].output_type == ".test.v1.HelloResponse"
+    assert methods["bidi_streaming"].input_type == ".test.v1.HelloRequest"
+    assert methods["bidi_streaming"].output_type == ".test.v1.HelloResponse"
+    assert message_names == {"HelloRequest", "HelloResponse"}
 
 
 def test_build_file_descriptor_complete() -> None:

--- a/plugins/spakky-grpc/tests/unit/test_rpc.py
+++ b/plugins/spakky-grpc/tests/unit/test_rpc.py
@@ -42,6 +42,8 @@ def test_rpc_server_streaming_method_type() -> None:
 
     annotation = Rpc.get(list_features)
     assert annotation.method_type == RpcMethodType.SERVER_STREAMING
+    assert annotation.request_type is HelloRequest
+    assert annotation.response_type is HelloResponse
 
 
 def test_rpc_client_streaming_method_type() -> None:
@@ -56,6 +58,8 @@ def test_rpc_client_streaming_method_type() -> None:
 
     annotation = Rpc.get(record_route)
     assert annotation.method_type == RpcMethodType.CLIENT_STREAMING
+    assert annotation.request_type is HelloRequest
+    assert annotation.response_type is HelloResponse
 
 
 def test_rpc_bidi_streaming_method_type() -> None:
@@ -70,6 +74,8 @@ def test_rpc_bidi_streaming_method_type() -> None:
 
     annotation = Rpc.get(route_chat)
     assert annotation.method_type == RpcMethodType.BIDI_STREAMING
+    assert annotation.request_type is HelloRequest
+    assert annotation.response_type is HelloResponse
 
 
 def test_rpc_extracts_request_type_from_hints() -> None:


### PR DESCRIPTION
## Summary
- Unwrap documented `AsyncIterator[T]` RPC type hints to the underlying protobuf message type
- Cover server-streaming, client-streaming, and bidi-streaming type inference in `@rpc`
- Add descriptor coverage proving streaming signatures generate `T` message descriptors instead of treating `AsyncIterator` as a model

Fixes #343.

## Verification
- `python -m pytest tests/unit/test_rpc.py tests/unit/test_descriptor_builder.py -q -o addopts=""` -> 23 passed
- `python -m pytest tests/unit/test_rpc.py tests/unit/test_descriptor_builder.py tests/unit/test_handler.py -q -o addopts=""` -> 49 passed
- `python -m ruff check src tests` -> passed
- `python -m ruff format --check src tests` -> passed

Note: `uv` is not available in my local Windows environment, so I verified with a local Python 3.12 venv using editable installs for `spakky`, `spakky-auth`, `spakky-tracing`, and `spakky-grpc`.