### PR TITLE
fix(agent): surface CodeAssistant model stream errors

### DIFF
--- a/core/spakky-agent/examples/code_assistant_demo.py
+++ b/core/spakky-agent/examples/code_assistant_demo.py
@@ -22,6 +22,7 @@ from spakky.agent import (
     AgentSignal,
     AgentSignalKind,
     AgentState,
+    AgentStateReason,
     AgentStateTransition,
     AgentStatus,
     AgentYield,
@@ -30,6 +31,7 @@ from spakky.agent import (
     Cancel,
     Evidence,
     EvidenceCapture,
+    Error,
     Final,
     Idempotency,
     JsonSchemaConstraint,
@@ -368,6 +370,34 @@ class CodeAssistant:
                         idempotency=Idempotency.IDEMPOTENT,
                     ),
                 )
+            elif (
+                event.kind is ModelStreamEventKind.ERROR
+                and event.error is not None
+            ):
+                current_state = self._states.get(state.id)
+                self._states.save(
+                    replace(
+                        current_state,
+                        status=AgentStatus.FAILED,
+                        transition=AgentStateTransition.FAILED,
+                        reason=AgentStateReason.EXECUTION_FAILED,
+                        current_activity="model stream failed",
+                        metadata={
+                            **current_state.metadata,
+                            "model_error_code": event.error.code,
+                        },
+                    )
+                )
+                yield AgentYield(
+                    kind=AgentYieldKind.ERROR,
+                    payload=Error(
+                        code=event.error.code,
+                        message=event.error.message,
+                        retryable=event.error.retryable,
+                        metadata=event.error.metadata,
+                    ),
+                )
+                return
 
         final_state = self._states.save(
             replace(

--- a/core/spakky-agent/tests/unit/test_code_assistant_demo.py
+++ b/core/spakky-agent/tests/unit/test_code_assistant_demo.py
@@ -35,10 +35,12 @@ from spakky.agent import (
     Approval,
     ApprovalDecision,
     Cancel,
+    Error,
     Evidence,
     Final,
     IAgentModel,
     JsonValue,
+    ModelError,
     ModelRequest,
     ModelResponse,
     ModelStreamEvent,
@@ -216,6 +218,46 @@ async def test_code_assistant_demo_expect_cancellation_reaches_terminal_state() 
     assert AgentEvidenceKind.CANCELLATION in {
         artifact.kind for artifact in evidence.list_by_state("cancel-run")
     }
+
+
+async def test_code_assistant_demo_expect_model_stream_error_fails_state() -> None:
+    """model ERROR events surface to callers instead of completing silently."""
+    states = FakeStateRepository()
+
+    items = await collect_stream(
+        StaticModel(
+            (
+                ModelStreamEvent(
+                    kind=ModelStreamEventKind.ERROR,
+                    error=ModelError(
+                        code="rate_limited",
+                        message="provider rate limit",
+                        retryable=True,
+                        metadata={"provider": "test"},
+                    ),
+                ),
+            )
+        ),
+        FakeWorkspace({}),
+        FakeShell(),
+        FakeGit(),
+        states,
+        FakeSignalRepository(()),
+        FakeEvidenceRepository(),
+        CodeAssistantCommand(state_id="error-run", instruction="trigger model error"),
+    )
+
+    assert [item.kind for item in items] == [
+        AgentYieldKind.PROGRESS,
+        AgentYieldKind.ERROR,
+    ]
+    assert not any(item.kind is AgentYieldKind.FINAL for item in items)
+    error_payload = items[-1].payload
+    assert isinstance(error_payload, Error)
+    assert error_payload.code == "rate_limited"
+    assert error_payload.retryable is True
+    assert error_payload.metadata == {"provider": "test"}
+    assert states.get("error-run").status is AgentStatus.FAILED
 
 
 async def test_code_assistant_demo_expect_restart_resume_uses_persisted_boundaries() -> (


### PR DESCRIPTION
## Summary
- fail CodeAssistant state when the model stream emits an ERROR event
- surface the model error as AgentYieldKind.ERROR instead of continuing to FINAL
- add a regression test covering ERROR without silent completion

Fixes #355.

## Validation
- `python -m pytest -o addopts='' core\spakky-agent\tests\unit\test_code_assistant_demo.py -q`
- `python -m ruff check core\spakky-agent\examples\code_assistant_demo.py core\spakky-agent\tests\unit\test_code_assistant_demo.py`