### PR TITLE
fix(sqlalchemy): declare pydantic-settings dependency

### DIFF
--- a/plugins/spakky-sqlalchemy/pyproject.toml
+++ b/plugins/spakky-sqlalchemy/pyproject.toml
@@ -8,6 +8,7 @@ license = { text = "MIT" }
 authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
 dependencies = [
     "spakky-data>=6.5.0",
+    "pydantic-settings>=2.13.1",
     "sqlalchemy>=2.0.49",
 ]
 

--- a/plugins/spakky-sqlalchemy/tests/unit/test_package_metadata.py
+++ b/plugins/spakky-sqlalchemy/tests/unit/test_package_metadata.py
@@ -1,0 +1,16 @@
+"""Tests for SQLAlchemy package metadata."""
+
+from pathlib import Path
+import tomllib
+
+
+def test_base_dependencies_include_pydantic_settings_for_config_import() -> None:
+    """Base package install includes SQLAlchemyConnectionConfig runtime dependency."""
+    pyproject = Path(__file__).parents[2] / "pyproject.toml"
+
+    metadata = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+
+    assert any(
+        dependency.startswith("pydantic-settings")
+        for dependency in metadata["project"]["dependencies"]
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -3597,6 +3597,7 @@ name = "spakky-sqlalchemy"
 version = "6.5.0"
 source = { editable = "plugins/spakky-sqlalchemy" }
 dependencies = [
+    { name = "pydantic-settings" },
     { name = "spakky-data" },
     { name = "sqlalchemy" },
 ]
@@ -3622,6 +3623,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "spakky-agent", marker = "extra == 'agent'", editable = "core/spakky-agent" },
     { name = "spakky-data", editable = "core/spakky-data" },
     { name = "spakky-outbox", marker = "extra == 'outbox'", editable = "core/spakky-outbox" },


### PR DESCRIPTION
## Summary
- add `pydantic-settings` to the base `spakky-sqlalchemy` dependencies
- sync the editable package entry in `uv.lock`
- add a package metadata regression test so the runtime config import dependency stays declared

Fixes #357.

## Validation
- `python -m pytest -o addopts="" plugins\spakky-sqlalchemy\tests\unit\test_package_metadata.py plugins\spakky-sqlalchemy\tests\unit\test_main.py plugins\spakky-sqlalchemy\tests\unit\test_entry_points.py -q`
- `python -m ruff check plugins\spakky-sqlalchemy\tests\unit\test_package_metadata.py`
- `python -c "from importlib.metadata import requires; reqs = requires('spakky-sqlalchemy') or []; assert any(r.lower().startswith('pydantic-settings') for r in reqs)"`

Note: `uv` is not installed in my local environment, so I updated the lockfile package stanza to match the new dependency and validated with pip editable installs on Python 3.12.