### PR TITLE
fix(fastapi): support sync route handler results

### DIFF
--- a/plugins/spakky-fastapi/src/spakky/plugins/fastapi/post_processors/register_routes.py
+++ b/plugins/spakky-fastapi/src/spakky/plugins/fastapi/post_processors/register_routes.py
@@ -6,7 +6,7 @@ classes, creating FastAPI endpoints with proper dependency injection.
 
 from dataclasses import asdict
 from functools import wraps
-from inspect import getmembers, signature
+from inspect import getmembers, isawaitable, signature
 from logging import getLogger
 from typing import Any
 
@@ -37,6 +37,12 @@ from spakky.plugins.fastapi.routes.websocket import WebSocketRoute
 from spakky.plugins.fastapi.stereotypes.api_controller import ApiController
 
 logger = getLogger(__name__)
+
+
+async def _resolve_route_result(result: Any) -> Any:
+    if isawaitable(result):
+        return await result
+    return result
 
 
 @Order(0)
@@ -147,7 +153,9 @@ class RegisterRoutesPostProcessor(
                             method_to_call
                         ):
                             kwargs[request_name] = auth_request
-                        return await method_to_call(*args, **kwargs)
+                        return await _resolve_route_result(
+                            method_to_call(*args, **kwargs)
+                        )
                     except AbstractSpakkyAuthError as e:
                         auth_boundary.map_http_auth_error(e)
 
@@ -198,7 +206,9 @@ class RegisterRoutesPostProcessor(
                             method_to_call
                         ):
                             kwargs[websocket_name] = websocket
-                        return await method_to_call(*args, **kwargs)
+                        return await _resolve_route_result(
+                            method_to_call(*args, **kwargs)
+                        )
                     except AbstractSpakkyAuthError as e:
                         await auth_boundary.close_websocket_for_auth_error(websocket, e)
                         return None

--- a/plugins/spakky-fastapi/tests/apps/dummy.py
+++ b/plugins/spakky-fastapi/tests/apps/dummy.py
@@ -64,6 +64,10 @@ class DummyController(IApplicationContextAware):
         """This docstring should be ignored since description is provided."""
         return "Named!"
 
+    @get("/sync")
+    def get_sync_dummy(self) -> dict[str, str]:
+        return {"message": "sync ok"}
+
     @get(
         "/file/{name}",
         response_class=FileResponse,

--- a/plugins/spakky-fastapi/tests/test_routing.py
+++ b/plugins/spakky-fastapi/tests/test_routing.py
@@ -43,6 +43,14 @@ def test_get_named_endpoint_with_explicit_name_and_description(api: FastAPI) -> 
         assert response.text == "Named!"
 
 
+def test_sync_route_handler_returns_response(api: FastAPI) -> None:
+    """Ordinary sync route handlers return their result without being awaited."""
+    with TestClient(api) as client:
+        response = client.get("/dummy/sync")
+        assert response.status_code == HTTPStatus.OK
+        assert response.json() == {"message": "sync ok"}
+
+
 def test_post(api: FastAPI) -> None:
     """POST 요청으로 JSON 데이터를 전송하고 응답을 받을 수 있음을 검증한다."""
     with TestClient(api) as client:


### PR DESCRIPTION
## Summary
- resolve FastAPI route handler results only when they are awaitable
- preserve async handler behavior while allowing ordinary sync handlers to return normal response values
- add a sync route regression through the dummy controller

Fixes #342.

## Validation
- `python -m pytest -o addopts="" plugins\spakky-fastapi\tests\test_routing.py::test_sync_route_handler_returns_response -q`
- `python -m pytest -o addopts="" plugins\spakky-fastapi\tests\test_routing.py::test_get plugins\spakky-fastapi\tests\test_routing.py::test_sync_route_handler_returns_response plugins\spakky-fastapi\tests\test_routing.py::test_post plugins\spakky-fastapi\tests\test_routing.py::test_websocket -q`
- `python -m ruff check plugins\spakky-fastapi\src\spakky\plugins\fastapi\post_processors\register_routes.py plugins\spakky-fastapi\tests\apps\dummy.py plugins\spakky-fastapi\tests\test_routing.py`

Notes:
- The new regression failed before the fix with `TypeError("object dict can't be used in 'await' expression")` and now passes.
- Running the full `test_routing.py` from the repository root gives 32 passed and 2 pre-existing file response failures because `tests/apps/dummy.txt` is resolved relative to the root in this local Windows run.
- `pyrefly check` did not execute type checks locally because pyrefly reported the project `**\*.py*` pattern as excluded/ignored in this Windows path.