### PR TITLE
fix(redis): retry stampede lock ownership while waiting

### DIFF
--- a/plugins/spakky-redis/src/spakky/plugins/redis/cache.py
+++ b/plugins/spakky-redis/src/spakky/plugins/redis/cache.py
@@ -534,18 +534,22 @@ class RedisCache[T](
         lock_key = self._lock_key(key)
         token = uuid4().hex.encode()
         if self._client.set_if_absent(lock_key, token, px=self._lock_ttl_ms()):
-            try:
-                second_check = self.get(key)
-                if isinstance(second_check, CacheHit):
-                    return second_check.value
-                value = factory()
-                self.set_with_tags(key, value, tags=tags, ttl=ttl)
-                return value
-            finally:
-                self._client.delete(lock_key)
+            return self._produce_locked_value(
+                key,
+                factory,
+                lock_key=lock_key,
+                ttl=ttl,
+                tags=tags,
+            )
 
         self._stampede_waits += 1
-        return self._wait_for_value(key)
+        return self._wait_for_value_or_reacquire(
+            key,
+            factory,
+            lock_key=lock_key,
+            ttl=ttl,
+            tags=tags,
+        )
 
     @override
     async def get_or_set_async(
@@ -567,18 +571,22 @@ class RedisCache[T](
             token,
             px=self._lock_ttl_ms(),
         ):
-            try:
-                second_check = await self.get_async(key)
-                if isinstance(second_check, CacheHit):
-                    return second_check.value
-                value = await factory()
-                await self.set_with_tags_async(key, value, tags=tags, ttl=ttl)
-                return value
-            finally:
-                await self._async_client.delete(lock_key)
+            return await self._produce_locked_value_async(
+                key,
+                factory,
+                lock_key=lock_key,
+                ttl=ttl,
+                tags=tags,
+            )
 
         self._stampede_waits += 1
-        return await self._wait_for_value_async(key)
+        return await self._wait_for_value_or_reacquire_async(
+            key,
+            factory,
+            lock_key=lock_key,
+            ttl=ttl,
+            tags=tags,
+        )
 
     @override
     def metrics(self) -> CacheMetricsSnapshot:
@@ -710,21 +718,97 @@ class RedisCache[T](
     def _lock_ttl_ms(self) -> int:
         return 30_000
 
-    def _wait_for_value(self, key: str) -> T:
+    def _produce_locked_value(
+        self,
+        key: str,
+        factory: Callable[[], T],
+        *,
+        lock_key: str,
+        ttl: CacheTTL,
+        tags: tuple[str, ...],
+    ) -> T:
+        try:
+            second_check = self.get(key)
+            if isinstance(second_check, CacheHit):
+                return second_check.value
+            value = factory()
+            self.set_with_tags(key, value, tags=tags, ttl=ttl)
+            return value
+        finally:
+            self._client.delete(lock_key)
+
+    async def _produce_locked_value_async(
+        self,
+        key: str,
+        factory: Callable[[], Awaitable[T]],
+        *,
+        lock_key: str,
+        ttl: CacheTTL,
+        tags: tuple[str, ...],
+    ) -> T:
+        try:
+            second_check = await self.get_async(key)
+            if isinstance(second_check, CacheHit):
+                return second_check.value
+            value = await factory()
+            await self.set_with_tags_async(key, value, tags=tags, ttl=ttl)
+            return value
+        finally:
+            await self._async_client.delete(lock_key)
+
+    def _wait_for_value_or_reacquire(
+        self,
+        key: str,
+        factory: Callable[[], T],
+        *,
+        lock_key: str,
+        ttl: CacheTTL,
+        tags: tuple[str, ...],
+    ) -> T:
         deadline = monotonic() + 30.0
         while monotonic() < deadline:
             cached = self.get(key)
             if isinstance(cached, CacheHit):
                 return cached.value
+            token = uuid4().hex.encode()
+            if self._client.set_if_absent(lock_key, token, px=self._lock_ttl_ms()):
+                return self._produce_locked_value(
+                    key,
+                    factory,
+                    lock_key=lock_key,
+                    ttl=ttl,
+                    tags=tags,
+                )
             sleep(0.01)
         raise RedisCacheLockTimeoutError()
 
-    async def _wait_for_value_async(self, key: str) -> T:
+    async def _wait_for_value_or_reacquire_async(
+        self,
+        key: str,
+        factory: Callable[[], Awaitable[T]],
+        *,
+        lock_key: str,
+        ttl: CacheTTL,
+        tags: tuple[str, ...],
+    ) -> T:
         deadline = monotonic() + 30.0
         while monotonic() < deadline:
             cached = await self.get_async(key)
             if isinstance(cached, CacheHit):
                 return cached.value
+            token = uuid4().hex.encode()
+            if await self._async_client.set_if_absent(
+                lock_key,
+                token,
+                px=self._lock_ttl_ms(),
+            ):
+                return await self._produce_locked_value_async(
+                    key,
+                    factory,
+                    lock_key=lock_key,
+                    ttl=ttl,
+                    tags=tags,
+                )
             await async_sleep(0.01)
         raise RedisCacheLockTimeoutError()
 

--- a/plugins/spakky-redis/tests/unit/test_redis_cache.py
+++ b/plugins/spakky-redis/tests/unit/test_redis_cache.py
@@ -301,6 +301,30 @@ class TimeoutSyncClient(ContendedSyncClient):
         return None
 
 
+class ReacquirableSyncClient(ContendedSyncClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.values: dict[str, bytes] = {}
+        self.lock_attempts = 0
+
+    @override
+    def get(self, name: str) -> bytes | None:
+        return self.values.get(name)
+
+    @override
+    def set(self, name: str, value: bytes, *, px: int | None = None) -> None:
+        self.values[name] = value
+
+    @override
+    def set_if_absent(self, name: str, value: bytes, *, px: int) -> bool:
+        self.lock_attempts += 1
+        return self.lock_attempts > 1
+
+    @override
+    def add_set_members(self, name: str, *values: RedisKey) -> int:
+        return len(values)
+
+
 class ContendedAsyncClient(IAsyncRedisClient):
     def __init__(self) -> None:
         self.get_calls = 0
@@ -341,6 +365,30 @@ class TimeoutAsyncClient(ContendedAsyncClient):
     @override
     async def get(self, name: str) -> bytes | None:
         return None
+
+
+class ReacquirableAsyncClient(ContendedAsyncClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.values: dict[str, bytes] = {}
+        self.lock_attempts = 0
+
+    @override
+    async def get(self, name: str) -> bytes | None:
+        return self.values.get(name)
+
+    @override
+    async def set(self, name: str, value: bytes, *, px: int | None = None) -> None:
+        self.values[name] = value
+
+    @override
+    async def set_if_absent(self, name: str, value: bytes, *, px: int) -> bool:
+        self.lock_attempts += 1
+        return self.lock_attempts > 1
+
+    @override
+    async def add_set_members(self, name: str, *values: RedisKey) -> int:
+        return len(values)
 
 
 def _cache(
@@ -559,6 +607,33 @@ def test_get_or_set_contention_expect_waits_for_peer_value() -> None:
     assert cache.metrics().stampede_waits == 1
 
 
+def test_get_or_set_contention_expect_reacquires_abandoned_lock() -> None:
+    """A waiter reacquires ownership when no peer ever publishes the value."""
+    client = ReacquirableSyncClient()
+    cache = RedisCache[str](
+        config=RedisCacheConfig(),
+        client=client,
+        async_client=AsyncRedisAdapter(
+            RedisRawAsyncClient(
+                fakeredis.aioredis.FakeRedis(server=fakeredis.FakeServer())
+            )
+        ),
+    )
+    calls = 0
+
+    def factory() -> str:
+        nonlocal calls
+        calls += 1
+        return "recovered"
+
+    value = cache.get_or_set("item", factory, tags=("items",))
+
+    assert value == "recovered"
+    assert calls == 1
+    assert client.lock_attempts == 2
+    assert cache.metrics().stampede_waits == 1
+
+
 def test_get_or_set_contention_timeout_expect_cache_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -751,6 +826,31 @@ async def test_async_get_or_set_contention_expect_waits_for_peer_value() -> None
     value = await cache.get_or_set_async("item", factory)
 
     assert value == "ready"
+    assert cache.metrics().stampede_waits == 1
+
+
+async def test_async_get_or_set_contention_expect_reacquires_abandoned_lock() -> None:
+    """A waiter reacquires ownership when no peer ever publishes the value."""
+    client = ReacquirableAsyncClient()
+    cache = RedisCache[str](
+        config=RedisCacheConfig(),
+        client=SyncRedisAdapter(
+            RedisRawSyncClient(fakeredis.FakeRedis(server=fakeredis.FakeServer()))
+        ),
+        async_client=client,
+    )
+    calls = 0
+
+    async def factory() -> str:
+        nonlocal calls
+        calls += 1
+        return "recovered"
+
+    value = await cache.get_or_set_async("item", factory, tags=("items",))
+
+    assert value == "recovered"
+    assert calls == 1
+    assert client.lock_attempts == 2
     assert cache.metrics().stampede_waits == 1
 
 


### PR DESCRIPTION
## Summary
- Refactor Redis get_or_set lock-owned production into shared sync/async helpers
- Let stampede waiters retry lock ownership while polling for the peer value
- Add sync and async regressions for abandoned lock/no published cache value

Fixes #349.

## Verification
- `plugins\spakky-redis\.venv\Scripts\python.exe -m pytest -o addopts='' plugins\spakky-redis\tests\unit\test_redis_cache.py -q` (35 passed)
- `plugins\spakky-redis\.venv\Scripts\python.exe -m ruff check plugins\spakky-redis\src\spakky\plugins\redis\cache.py plugins\spakky-redis\tests\unit\test_redis_cache.py`
- `plugins\spakky-redis\.venv\Scripts\python.exe -m pyrefly check plugins\spakky-redis\src\spakky\plugins\redis\cache.py plugins\spakky-redis\tests\unit\test_redis_cache.py`