### PR TITLE
fix(saga): reject invalid compensation builders

### DIFF
--- a/core/spakky-saga/src/spakky/saga/flow.py
+++ b/core/spakky-saga/src/spakky/saga/flow.py
@@ -34,11 +34,7 @@ class SagaStep[SagaDataT: AbstractSagaData]:
         self,
         compensate: Callable[[SagaDataT], Awaitable[None]] | SagaStep[SagaDataT],
     ) -> Transaction[SagaDataT]:
-        compensate_fn: Callable[[SagaDataT], Awaitable[None]] = (
-            cast(Callable[[SagaDataT], Awaitable[None]], compensate.action)
-            if isinstance(compensate, SagaStep)
-            else compensate
-        )
+        compensate_fn = _resolve_compensate_fn(compensate)
         compensate_auth_boundary = (
             compensate.auth_boundary if isinstance(compensate, SagaStep) else compensate
         )
@@ -178,13 +174,14 @@ def step[SagaDataT: AbstractSagaData](
         on_error if on_error is not None else Compensate()
     )
     if compensate is not None:
+        compensate_fn = _resolve_compensate_fn(compensate)
         return Transaction(
             action=action,
-            compensate=compensate,
+            compensate=compensate_fn,
             on_error=resolved_on_error,
             timeout=timeout,
             action_auth_boundary=action,
-            compensate_auth_boundary=compensate,
+            compensate_auth_boundary=compensate_fn,
         )
     return SagaStep(
         action=action,
@@ -192,6 +189,16 @@ def step[SagaDataT: AbstractSagaData](
         timeout=timeout,
         auth_boundary=action,
     )
+
+
+def _resolve_compensate_fn[SagaDataT: AbstractSagaData](
+    compensate: Callable[[SagaDataT], Awaitable[None]] | SagaStep[SagaDataT],
+) -> Callable[[SagaDataT], Awaitable[None]]:
+    if isinstance(compensate, SagaStep):
+        return cast(Callable[[SagaDataT], Awaitable[None]], compensate.action)
+    if callable(compensate):
+        return compensate
+    raise SagaFlowDefinitionError
 
 
 def parallel[SagaDataT: AbstractSagaData](

--- a/core/spakky-saga/tests/unit/test_builder.py
+++ b/core/spakky-saga/tests/unit/test_builder.py
@@ -62,6 +62,12 @@ def test_step_with_compensate_expect_transaction() -> None:
     assert isinstance(result.on_error, Compensate)
 
 
+def test_step_with_non_callable_compensate_expect_definition_error() -> None:
+    """step() rejects invalid compensation before saga execution."""
+    with pytest.raises(SagaFlowDefinitionError):
+        step(_action, compensate="bad")  # type: ignore[arg-type]
+
+
 def test_step_with_on_error_expect_strategy_applied() -> None:
     """step(action, on_error=)이 에러 전략을 적용하는지 검증한다."""
     result = step(_action, on_error=Skip())
@@ -282,6 +288,21 @@ def test_step_with_compensate_equivalent_to_rshift_expect_same_result() -> None:
     assert via_func.action is via_op.action
     assert via_func.compensate is via_op.compensate
     assert type(via_func.on_error) is type(via_op.on_error)
+
+
+def test_rshift_with_non_callable_compensate_expect_definition_error() -> None:
+    """SagaStep >> rejects invalid compensation before saga execution."""
+    with pytest.raises(SagaFlowDefinitionError):
+        SagaStep(action=_action) >> "bad"  # type: ignore[operator]
+
+
+def test_rshift_with_non_callable_saga_step_compensate_expect_definition_error() -> None:
+    """Builder-created SagaStep >> rejects invalid compensation values."""
+    action_step = step(_action)
+    assert isinstance(action_step, SagaStep)
+
+    with pytest.raises(SagaFlowDefinitionError):
+        action_step >> "bad"  # type: ignore[operator]
 
 
 def test_parallel_func_equivalent_to_and_operator_expect_same_items() -> None:


### PR DESCRIPTION
## Summary
- Validate `step(..., compensate=...)` before returning a `Transaction`
- Validate `SagaStep >> compensate` before composing the transaction
- Add regressions for invalid non-callable compensation values so bad flows fail at definition time instead of during rollback

Fixes #340.

## Verification
- `core\\spakky-saga\\.venv\\Scripts\\python.exe -m pytest -o addopts='' core\\spakky-saga\\tests\\unit\\test_builder.py core\\spakky-saga\\tests\\unit\\test_flow.py -q` (61 passed)
- `core\\spakky-saga\\.venv\\Scripts\\python.exe -m pytest -o addopts='' core\\spakky-saga\\tests\\unit\\test_engine.py::test_step_failure_expect_failed_and_compensated core\\spakky-saga\\tests\\unit\\test_engine.py::test_transaction_failure_expect_compensated core\\spakky-saga\\tests\\unit\\test_engine.py::test_retry_exhausts_then_compensate_expect_failed_and_compensated core\\spakky-saga\\tests\\unit\\test_engine.py::test_parallel_default_compensate_accepted_expect_ok -q` (4 passed)
- `core\\spakky-saga\\.venv\\Scripts\\python.exe -m ruff check core\\spakky-saga\\src\\spakky\\saga\\flow.py core\\spakky-saga\\tests\\unit\\test_builder.py`
- `core\\spakky-saga\\.venv\\Scripts\\python.exe -m pyrefly check core\\spakky-saga\\src\\spakky\\saga\\flow.py core\\spakky-saga\\tests\\unit\\test_builder.py` (0 errors)

Note: `core\\spakky-saga\\.venv\\Scripts\\python.exe -m pytest -o addopts='' core\\spakky-saga\\tests\\unit -q` reached 194 passed / 2 failed on this Windows runner because existing elapsed-time assertions observed `timedelta(0)` for very fast successful saga runs; the failures are unrelated to compensation validation.