### PR TITLE
docs(typer): show manual Typer pod setup

### DIFF
--- a/plugins/spakky-typer/README.md
+++ b/plugins/spakky-typer/README.md
@@ -108,14 +108,36 @@ class DatabaseCliController:
 ```python
 from typer import Typer
 from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.annotations.pod import Pod
+
+import apps
+import spakky.plugins.typer
+
+
+@Pod(name="cli")
+def get_cli() -> Typer:
+    return Typer()
+
+
+application = (
+    SpakkyApplication(ApplicationContext())
+    .load_plugins(include={spakky.plugins.typer.PLUGIN_NAME})
+    .scan(apps)
+    .add(get_cli)
+    .start()
+)
 
 # application.start() 이후
-typer_app = application.container.get(Typer)
+typer_app: Typer = application.container.get(Typer)
 
 # CLI 실행
 if __name__ == "__main__":
     typer_app()
 ```
+
+`spakky-typer`는 command registration post-processor를 등록하지만
+`Typer` 인스턴스 자체는 애플리케이션에서 Pod로 등록해야 합니다.
 
 ### Auth boundary
 
@@ -185,13 +207,21 @@ Typer adapter는 플러그인별 상세 check를 자동 등록하지 않습니�
 ```python
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.annotations.pod import Pod
 from typer import Typer
 import my_cli_module
+
+
+@Pod(name="cli")
+def get_cli() -> Typer:
+    return Typer()
+
 
 app = (
     SpakkyApplication(ApplicationContext())
     .load_plugins()
     .scan(my_cli_module)
+    .add(get_cli)
     .start()
 )
 

--- a/plugins/spakky-typer/tests/test_readme_contract.py
+++ b/plugins/spakky-typer/tests/test_readme_contract.py
@@ -1,0 +1,13 @@
+"""README contract tests for Typer setup snippets."""
+
+from pathlib import Path
+
+
+def test_readme_setup_expect_manual_typer_pod_registration() -> None:
+    """README must show that applications register the Typer Pod."""
+    readme = Path("plugins/spakky-typer/README.md").read_text(encoding="utf-8")
+
+    assert '@Pod(name="cli")' in readme
+    assert "def get_cli() -> Typer:" in readme
+    assert ".add(get_cli)" in readme
+    assert "Typer` 인스턴스 자체는 애플리케이션에서 Pod로 등록해야 합니다" in readme


### PR DESCRIPTION
## Summary
- Update the Typer README setup snippets to register a `Typer` Pod explicitly
- Add `.add(get_cli)` before startup so the README matches the guide and real test fixture
- Add a README contract test to prevent the setup from drifting again

Fixes #346.

## Verification
- `plugins\\spakky-typer\\.venv\\Scripts\\python.exe -m pytest -o addopts='' plugins\\spakky-typer\\tests\\test_readme_contract.py plugins\\spakky-typer\\tests\\test_command.py::test_first_command -q` (2 passed)
- `plugins\\spakky-typer\\.venv\\Scripts\\python.exe -m pytest -o addopts='' plugins\\spakky-typer\\tests\\test_readme_contract.py -q` (1 passed)
- `plugins\\spakky-typer\\.venv\\Scripts\\python.exe -m ruff check plugins\\spakky-typer\\tests\\test_readme_contract.py`
- `plugins\\spakky-typer\\.venv\\Scripts\\python.exe -m pyrefly check plugins\\spakky-typer\\tests\\test_readme_contract.py` (0 errors)
- `plugins\\spakky-typer\\.venv\\Scripts\\python.exe -m mkdocs build --strict`