### PR TITLE
docs(actuator): warn about public FastAPI routes

### DIFF
--- a/docs/guides/actuator.md
+++ b/docs/guides/actuator.md
@@ -99,11 +99,26 @@ class BuildInfo(IInfoContributor):
 | `GET /actuator/liveness` | `200 OK` | `503 Service Unavailable` |
 | `GET /actuator/info` | `200 OK` | N/A |
 
+!!! warning "Production exposure"
+
+    FastAPI actuator routes are unauthenticated by default. When enabled, they are
+    regular public HTTP routes unless the application places them behind internal networking,
+    an API gateway, a reverse-proxy allowlist, or another explicit access-control layer.
+    Production deployments should disable unneeded endpoints, move the base path under an
+    internal route, and set `ActuatorConfig(include_details=False)` before exposing actuator
+    traffic outside a trusted boundary.
+
 `FastAPIActuatorConfig`로 base path와 endpoint별 노출 여부를 조정합니다.
 
 ```python
 from spakky.core.pod.annotations.pod import Pod
+from spakky.actuator import ActuatorConfig
 from spakky.plugins.fastapi.actuator import FastAPIActuatorConfig
+
+
+@Pod()
+def actuator_config() -> ActuatorConfig:
+    return ActuatorConfig(include_details=False)
 
 
 @Pod()

--- a/plugins/spakky-fastapi/README.md
+++ b/plugins/spakky-fastapi/README.md
@@ -128,13 +128,26 @@ HTTP payload는 transport-neutral core result shape를 그대로 반영합니다
 | `GET /actuator/liveness` | `200 OK` | `503 Service Unavailable` |
 | `GET /actuator/info` | `200 OK` | N/A |
 
+FastAPI actuator routes are unauthenticated by default. In production, expose
+them only behind internal networking, an API gateway, a reverse-proxy allowlist,
+or another explicit access-control layer. Disable unneeded endpoints and set
+`ActuatorConfig(include_details=False)` before allowing actuator traffic outside
+a trusted boundary.
+
 Endpoint 노출과 base path는 `FastAPIActuatorConfig`로 설정합니다.
 Component detail 노출은 `spakky.actuator.ActuatorConfig`로 제어합니다.
 `readiness`는 traffic/work readiness용이며, `liveness`는 process-local check로 남아 외부 의존성 실패와 독립적이어야 합니다.
 
 ```python
 from spakky.core.pod.annotations.pod import Pod
+from spakky.actuator import ActuatorConfig
 from spakky.plugins.fastapi.actuator import FastAPIActuatorConfig
+
+
+@Pod()
+def actuator_config() -> ActuatorConfig:
+    return ActuatorConfig(include_details=False)
+
 
 @Pod()
 def fastapi_actuator_config() -> FastAPIActuatorConfig:

--- a/plugins/spakky-fastapi/tests/test_actuator_docs_contract.py
+++ b/plugins/spakky-fastapi/tests/test_actuator_docs_contract.py
@@ -1,0 +1,15 @@
+"""Documentation contract tests for FastAPI actuator exposure."""
+
+from pathlib import Path
+
+
+def test_fastapi_actuator_docs_expect_security_hardening_warning() -> None:
+    """Docs must warn that FastAPI actuator routes need explicit protection."""
+    guide = Path("docs/guides/actuator.md").read_text(encoding="utf-8")
+    readme = Path("plugins/spakky-fastapi/README.md").read_text(encoding="utf-8")
+
+    for doc in (guide, readme):
+        assert "unauthenticated by default" in doc
+        assert "internal networking" in doc
+        assert "reverse-proxy allowlist" in doc
+        assert "ActuatorConfig(include_details=False)" in doc


### PR DESCRIPTION
## Summary
- Add an explicit production warning that FastAPI actuator routes are unauthenticated by default
- Show hardening guidance: internal networking, gateway/proxy allowlists, disabling unused endpoints, and `ActuatorConfig(include_details=False)`
- Mirror the warning in the FastAPI README and add a docs contract test to keep the security note present

Fixes #350.

## Verification
- `plugins\\spakky-fastapi\\.venv\\Scripts\\python.exe -m pytest -o addopts='' plugins\\spakky-fastapi\\tests\\test_actuator_docs_contract.py plugins\\spakky-fastapi\\tests\\test_actuator.py::test_actuator_routes_registered_when_plugins_loaded -q` (2 passed)
- `plugins\\spakky-fastapi\\.venv\\Scripts\\python.exe -m ruff check plugins\\spakky-fastapi\\tests\\test_actuator_docs_contract.py`
- `plugins\\spakky-fastapi\\.venv\\Scripts\\python.exe -m pyrefly check plugins\\spakky-fastapi\\tests\\test_actuator_docs_contract.py` (0 errors)
- `plugins\\spakky-fastapi\\.venv\\Scripts\\python.exe -m mkdocs build --strict`