### PR TITLE
fix(grpc): unwrap streaming RPC type hints

### DIFF
--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/decorators/rpc.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/decorators/rpc.py
@@ -4,10 +4,11 @@ Provides the @rpc decorator for marking controller methods as gRPC service
 methods with support for all four gRPC streaming patterns.
 """
 
+from collections.abc import AsyncIterator as AsyncIteratorABC
 from dataclasses import dataclass
 from enum import StrEnum, auto
 from inspect import signature
-from typing import Callable, get_type_hints
+from typing import Callable, get_args, get_origin, get_type_hints
 
 from spakky.core.common.annotation import FunctionAnnotation
 from spakky.core.common.types import AnyT
@@ -27,6 +28,18 @@ class RpcMethodType(StrEnum):
     SERVER_STREAMING = auto()
     CLIENT_STREAMING = auto()
     BIDI_STREAMING = auto()
+
+
+def _unwrap_streaming_type(annotation: object | None) -> type | None:
+    """Return the message type inside supported streaming annotations."""
+    candidate = annotation
+    if get_origin(annotation) is AsyncIteratorABC:
+        args = get_args(annotation)
+        if args:
+            candidate = args[0]
+    if isinstance(candidate, type):
+        return candidate
+    return None
 
 
 @dataclass
@@ -75,9 +88,11 @@ class Rpc(FunctionAnnotation):
             params = list(signature(obj).parameters.values())
             non_self_params = [p for p in params if p.name != "self"]
             if non_self_params:
-                self.request_type = hints.get(non_self_params[0].name)
+                request_hint = hints.get(non_self_params[0].name)
+                self.request_type = _unwrap_streaming_type(request_hint)
         if self.response_type is None:
-            self.response_type = hints.get("return")
+            response_hint = hints.get("return")
+            self.response_type = _unwrap_streaming_type(response_hint)
 
 
 def rpc(

--- a/plugins/spakky-grpc/tests/unit/test_descriptor_builder.py
+++ b/plugins/spakky-grpc/tests/unit/test_descriptor_builder.py
@@ -1,6 +1,6 @@
 """Unit tests for descriptor_builder module."""
 
-from typing import Annotated
+from typing import Annotated, AsyncIterator
 
 from google.protobuf.descriptor_pb2 import FieldDescriptorProto
 from pydantic import BaseModel
@@ -177,6 +177,47 @@ def test_build_service_descriptor_sets_streaming_flags() -> None:
     assert not methods["client_streaming"].server_streaming
     assert methods["bidi_streaming"].client_streaming
     assert methods["bidi_streaming"].server_streaming
+
+
+def test_build_file_descriptor_unwraps_streaming_type_hints() -> None:
+    """Documented AsyncIterator[T] signatures generate T descriptors."""
+
+    @GrpcController(package="test.v1")
+    class StreamingHintService:
+        """Controller using documented streaming type hints."""
+
+        @rpc(method_type=RpcMethodType.SERVER_STREAMING)
+        async def server_streaming(
+            self, request: HelloRequest
+        ) -> AsyncIterator[HelloResponse]:
+            """Server-streaming method."""
+            ...
+
+        @rpc(method_type=RpcMethodType.CLIENT_STREAMING)
+        async def client_streaming(
+            self, requests: AsyncIterator[HelloRequest]
+        ) -> HelloResponse:
+            """Client-streaming method."""
+            ...
+
+        @rpc(method_type=RpcMethodType.BIDI_STREAMING)
+        async def bidi_streaming(
+            self, requests: AsyncIterator[HelloRequest]
+        ) -> AsyncIterator[HelloResponse]:
+            """Bidirectional-streaming method."""
+            ...
+
+    file_desc = build_file_descriptor(StreamingHintService)
+    methods = {method.name: method for method in file_desc.service[0].method}
+    message_names = {message.name for message in file_desc.message_type}
+
+    assert methods["server_streaming"].input_type == ".test.v1.HelloRequest"
+    assert methods["server_streaming"].output_type == ".test.v1.HelloResponse"
+    assert methods["client_streaming"].input_type == ".test.v1.HelloRequest"
+    assert methods["client_streaming"].output_type == ".test.v1.HelloResponse"
+    assert methods["bidi_streaming"].input_type == ".test.v1.HelloRequest"
+    assert methods["bidi_streaming"].output_type == ".test.v1.HelloResponse"
+    assert message_names == {"HelloRequest", "HelloResponse"}
 
 
 def test_build_file_descriptor_complete() -> None:

--- a/plugins/spakky-grpc/tests/unit/test_rpc.py
+++ b/plugins/spakky-grpc/tests/unit/test_rpc.py
@@ -42,6 +42,8 @@ def test_rpc_server_streaming_method_type() -> None:
 
     annotation = Rpc.get(list_features)
     assert annotation.method_type == RpcMethodType.SERVER_STREAMING
+    assert annotation.request_type is HelloRequest
+    assert annotation.response_type is HelloResponse
 
 
 def test_rpc_client_streaming_method_type() -> None:
@@ -56,6 +58,8 @@ def test_rpc_client_streaming_method_type() -> None:
 
     annotation = Rpc.get(record_route)
     assert annotation.method_type == RpcMethodType.CLIENT_STREAMING
+    assert annotation.request_type is HelloRequest
+    assert annotation.response_type is HelloResponse
 
 
 def test_rpc_bidi_streaming_method_type() -> None:
@@ -70,6 +74,21 @@ def test_rpc_bidi_streaming_method_type() -> None:
 
     annotation = Rpc.get(route_chat)
     assert annotation.method_type == RpcMethodType.BIDI_STREAMING
+    assert annotation.request_type is HelloRequest
+    assert annotation.response_type is HelloResponse
+
+
+def test_rpc_streaming_hint_without_type_arg_returns_none() -> None:
+    """Bare AsyncIterator hints should not be treated as message types."""
+
+    @rpc(method_type=RpcMethodType.CLIENT_STREAMING)
+    async def record_route(self: object, requests: AsyncIterator) -> HelloResponse:
+        """Record route."""
+        ...
+
+    annotation = Rpc.get(record_route)
+    assert annotation.request_type is None
+    assert annotation.response_type is HelloResponse
 
 
 def test_rpc_extracts_request_type_from_hints() -> None:


### PR DESCRIPTION
## Summary
- Unwrap documented AsyncIterator[T] RPC type hints to the underlying protobuf message type
- Preserve generated descriptor streaming flags after #365
- Cover typed and bare AsyncIterator hints so descriptor generation does not treat AsyncIterator as a protobuf model

Fixes #343.

## Verification
- In plugins/spakky-grpc: uv run --with ruff ruff format --check . -> passed after formatting
- In plugins/spakky-grpc: uv run --with ruff ruff check . -> passed
- In plugins/spakky-grpc: uv run --with pyrefly pyrefly check -> 0 errors
- In plugins/spakky-grpc: uv run pytest -q -> 203 passed, coverage 100%
- In plugins/spakky-grpc: uv run python ../../.agents/skills/check/scripts/validate_python_harness.py . -> passed

Autopilot recovery note: this replaces cross-repository PR #366, whose fork head could not be updated from this recovery session.