### PR TITLE
docs(logging): show environment based config

### DIFF
--- a/plugins/spakky-logging/README.md
+++ b/plugins/spakky-logging/README.md
@@ -33,15 +33,14 @@ class UserService:
 
 `LoggingConfig`로 기본값을 override합니다.
 
-```python
-from spakky.plugins.logging import LoggingConfig, LogFormat
+`LoggingConfig` is loaded as a `@Configuration` pod and reads
+`SPAKKY_LOGGING__*` environment variables through `pydantic-settings`.
 
-config = LoggingConfig(
-    level="DEBUG",
-    format=LogFormat.JSON,
-    mask_keys=frozenset({"password", "token", "secret"}),
-    slow_threshold_ms=500,
-)
+```bash
+export SPAKKY_LOGGING__LEVEL=10
+export SPAKKY_LOGGING__FORMAT=json
+export SPAKKY_LOGGING__MASK_KEYS='["password", "token", "secret"]'
+export SPAKKY_LOGGING__SLOW_THRESHOLD_MS=500
 ```
 
 ### 4. LogContext 전파

--- a/plugins/spakky-logging/tests/unit/test_readme_contract.py
+++ b/plugins/spakky-logging/tests/unit/test_readme_contract.py
@@ -1,0 +1,22 @@
+"""README examples should match the public logging configuration API."""
+
+from pathlib import Path
+
+
+README = Path(__file__).resolve().parents[2] / "README.md"
+
+
+def test_readme_uses_environment_variables_for_logging_config() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert "SPAKKY_LOGGING__LEVEL" in readme
+    assert "SPAKKY_LOGGING__FORMAT" in readme
+    assert "SPAKKY_LOGGING__MASK_KEYS" in readme
+    assert "SPAKKY_LOGGING__SLOW_THRESHOLD_MS" in readme
+
+
+def test_readme_does_not_show_keyword_logging_config_constructor() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert "LoggingConfig(" not in readme
+    assert "mask_keys=frozenset" not in readme


### PR DESCRIPTION
Fixes #351.

## Summary
- Replace the invalid `LoggingConfig(...)` keyword-constructor README example with `SPAKKY_LOGGING__*` environment variable configuration.
- Note that `LoggingConfig` is loaded as a `@Configuration` pod via `pydantic-settings`.
- Add a small README contract test so the docs do not drift back to the unsupported constructor pattern.

## Verification
- `plugins\spakky-logging\.venv\Scripts\python.exe -m pytest -o addopts='' plugins\spakky-logging\tests\unit\test_readme_contract.py plugins\spakky-logging\tests\unit\test_config.py -q`
- `plugins\spakky-logging\.venv\Scripts\python.exe -m ruff check plugins\spakky-logging\tests\unit\test_readme_contract.py`
- `plugins\spakky-logging\.venv\Scripts\python.exe -m pyrefly check plugins\spakky-logging\tests\unit\test_readme_contract.py`
- `plugins\spakky-logging\.venv\Scripts\python.exe -m mkdocs build --strict`