### PR TITLE
test(saga): document invalid type ignores

### DIFF
--- a/core/spakky-saga/tests/unit/test_builder.py
+++ b/core/spakky-saga/tests/unit/test_builder.py
@@ -65,7 +65,7 @@ def test_step_with_compensate_expect_transaction() -> None:
 def test_step_with_non_callable_compensate_expect_definition_error() -> None:
     """step() rejects invalid compensation before saga execution."""
     with pytest.raises(SagaFlowDefinitionError):
-        step(_action, compensate="bad")  # type: ignore[arg-type]
+        step(_action, compensate="bad")  # type: ignore[arg-type] - intentional invalid compensate for test
 
 
 def test_step_with_on_error_expect_strategy_applied() -> None:
@@ -293,16 +293,18 @@ def test_step_with_compensate_equivalent_to_rshift_expect_same_result() -> None:
 def test_rshift_with_non_callable_compensate_expect_definition_error() -> None:
     """SagaStep >> rejects invalid compensation before saga execution."""
     with pytest.raises(SagaFlowDefinitionError):
-        SagaStep(action=_action) >> "bad"  # type: ignore[operator]
+        SagaStep(action=_action) >> "bad"  # type: ignore[operator] - intentional invalid compensate for test
 
 
-def test_rshift_with_non_callable_saga_step_compensate_expect_definition_error() -> None:
+def test_rshift_with_non_callable_saga_step_compensate_expect_definition_error() -> (
+    None
+):
     """Builder-created SagaStep >> rejects invalid compensation values."""
     action_step = step(_action)
     assert isinstance(action_step, SagaStep)
 
     with pytest.raises(SagaFlowDefinitionError):
-        action_step >> "bad"  # type: ignore[operator]
+        action_step >> "bad"  # type: ignore[operator] - intentional invalid compensate for test
 
 
 def test_parallel_func_equivalent_to_and_operator_expect_same_items() -> None:


### PR DESCRIPTION
## Summary
- Add required inline reasons to saga tests that intentionally pass invalid compensation values
- Keep the existing negative tests intact while satisfying the Python harness opt-out rule

Part of autopilot recovery issue #376.

## Verification
- In core/spakky-saga: uv run python ../../.agents/skills/check/scripts/validate_python_harness.py . -> passed
- In core/spakky-saga: uv run --with ruff ruff check . -> passed
- In core/spakky-saga: uv run --with ruff ruff format --check . -> passed after formatting
- In core/spakky-saga: uv run --with pytest pytest tests/unit/test_builder.py -q -o addopts='' -> 32 passed