### PR TITLE
fix(core): resolve startup and qualifier contract gaps

### DIFF
--- a/core/spakky/src/spakky/core/application/application_context.py
+++ b/core/spakky/src/spakky/core/application/application_context.py
@@ -17,6 +17,8 @@ from spakky.core.application.error import AbstractSpakkyApplicationError
 from spakky.core.application.startup_diagnostics import (
     IStartupPhaseRecorder,
     NoOpStartupPhaseRecorder,
+    StartupDiagnosticDetail,
+    StartupDiagnosticDetails,
 )
 from spakky.core.common.constants import CONTEXT_ID, CONTEXT_SCOPE_CACHE
 from spakky.core.common.types import ObjectT, is_optional, remove_none
@@ -206,6 +208,25 @@ class ApplicationContext(IApplicationContext):
             path=dependency_path,
             candidates=candidates,
             resolution_hints=resolution_hints,
+        )
+
+    def __startup_diagnostic_details(
+        self,
+        exception: BaseException,
+    ) -> StartupDiagnosticDetails:
+        """Convert dependency resolution diagnostics into startup report details."""
+        dependency_diagnostic: PodDependencyResolutionDiagnostic | None = None
+        if isinstance(exception, UnexpectedDependencyTypeInjectedError):
+            dependency_diagnostic = exception.dependency_diagnostic
+        if isinstance(exception, NoUniquePodError):
+            dependency_diagnostic = exception.dependency_diagnostic
+        if isinstance(exception, CircularDependencyGraphDetectedError):
+            dependency_diagnostic = exception.dependency_diagnostic
+        if dependency_diagnostic is None:
+            return ()
+        return tuple(
+            StartupDiagnosticDetail(key=key, value=value)
+            for key, value in dependency_diagnostic.as_detail_pairs()
         )
 
     def __candidate_diagnostics(
@@ -672,6 +693,38 @@ class ApplicationContext(IApplicationContext):
         self.__services.clear()
         self.__async_services.clear()
 
+    def __rollback_failed_start(
+        self,
+        original_service_count: int,
+        original_async_service_count: int,
+        started_services: list[IService],
+        started_async_services: list[IAsyncService],
+    ) -> None:
+        event_loop = self.__event_loop
+        event_thread = self.__event_thread
+        for service in reversed(started_services):
+            service.stop()
+        if event_loop is not None and started_async_services:
+
+            async def stop_started_async_services() -> None:
+                for service in reversed(started_async_services):
+                    await service.stop_async()
+
+            run_coroutine_threadsafe(stop_started_async_services(), event_loop).result()
+        if event_loop is not None:
+            event_loop.call_soon_threadsafe(event_loop.stop)  # type: ignore[arg-type]  # stop() is valid callback
+        if event_thread is not None:
+            event_thread.join()
+        self.__event_loop = None
+        self.__event_thread = None
+        with self.__singleton_lock:
+            self.__singleton_cache.clear()
+        self.clear_context()
+        self.__post_processors.clear()
+        del self.__services[original_service_count:]
+        del self.__async_services[original_async_service_count:]
+        self.__is_started = False
+
     def __set_singleton_cache(self, pod: Pod, instance: object) -> None:
         self.__singleton_cache[pod.name] = instance
 
@@ -757,7 +810,11 @@ class ApplicationContext(IApplicationContext):
         loop.run_forever()
         loop.close()
 
-    def __start_services(self) -> None:
+    def __start_services(
+        self,
+        started_services: list[IService],
+        started_async_services: list[IAsyncService],
+    ) -> None:
         """Start all registered sync and async services.
 
         Raises:
@@ -776,39 +833,18 @@ class ApplicationContext(IApplicationContext):
         )
         self.__event_thread.start()
 
-        started_services: list[IService] = []
-        started_async_services: list[IAsyncService] = []
+        for service in self.__services:
+            service.start()
+            started_services.append(service)
 
-        try:
-            for service in self.__services:
-                service.start()
-                started_services.append(service)
+        async def start_async_services() -> None:
+            if self.__event_loop is None:  # pragma: no cover - coverage boundary
+                raise EventLoopThreadNotStartedInApplicationContextError
+            for service in self.__async_services:
+                await service.start_async()
+                started_async_services.append(service)
 
-            async def start_async_services() -> None:
-                if self.__event_loop is None:  # pragma: no cover - coverage boundary
-                    raise EventLoopThreadNotStartedInApplicationContextError
-                for service in self.__async_services:
-                    await service.start_async()
-                    started_async_services.append(service)
-
-            run_coroutine_threadsafe(start_async_services(), self.__event_loop).result()
-        except BaseException:
-            for service in reversed(started_services):
-                service.stop()
-
-            async def stop_started_async_services() -> None:
-                for service in reversed(started_async_services):
-                    await service.stop_async()
-
-            run_coroutine_threadsafe(
-                stop_started_async_services(), self.__event_loop
-            ).result()
-            self.__event_loop.call_soon_threadsafe(self.__event_loop.stop)  # type: ignore[arg-type]  # stop() is valid callback
-            self.__event_thread.join()
-            self.__event_loop = None
-            self.__event_thread = None
-            self.__is_started = False
-            raise
+        run_coroutine_threadsafe(start_async_services(), self.__event_loop).result()
 
     def __stop_services(self) -> None:
         """Stop all services and shutdown event loop.
@@ -973,6 +1009,10 @@ class ApplicationContext(IApplicationContext):
             if startup_phase_recorder is not None
             else NoOpStartupPhaseRecorder()
         )
+        original_service_count = len(self.__services)
+        original_async_service_count = len(self.__async_services)
+        started_services: list[IService] = []
+        started_async_services: list[IAsyncService] = []
         self.__is_started = True
         try:
             with recorder.record_phase(
@@ -992,6 +1032,7 @@ class ApplicationContext(IApplicationContext):
                         elapsed_seconds=startup_metrics.instantiation_elapsed_seconds,
                         exception=e,
                         processed_count=startup_metrics.instantiation_attempt_count,
+                        diagnostic_details=self.__startup_diagnostic_details(e),
                     )
                 else:
                     recorder.record_success(
@@ -1004,6 +1045,9 @@ class ApplicationContext(IApplicationContext):
                         elapsed_seconds=startup_metrics.post_processing_elapsed_seconds,
                         exception=startup_metrics.post_processing_exception,
                         processed_count=startup_metrics.post_processing_application_count,
+                        diagnostic_details=self.__startup_diagnostic_details(
+                            startup_metrics.post_processing_exception
+                        ),
                     )
                 raise
 
@@ -1023,7 +1067,15 @@ class ApplicationContext(IApplicationContext):
                 phase_name=STARTUP_PHASE_SERVICE_START,
                 processed_count=service_start_count,
             ):
-                self.__start_services()
+                self.__start_services(started_services, started_async_services)
+        except BaseException:
+            self.__rollback_failed_start(
+                original_service_count=original_service_count,
+                original_async_service_count=original_async_service_count,
+                started_services=started_services,
+                started_async_services=started_async_services,
+            )
+            raise
         finally:
             self.__startup_metrics = None
 

--- a/core/spakky/src/spakky/core/pod/annotations/pod.py
+++ b/core/spakky/src/spakky/core/pod/annotations/pod.py
@@ -5,11 +5,20 @@ as managed beans in the IoC container, along with dependency resolution logic.
 """
 
 import inspect
+import ast
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from inspect import Parameter, isclass, isfunction
 from types import NoneType
-from typing import Annotated, TypeGuard, TypeVar, get_args, get_origin
+from typing import (
+    Annotated,
+    ForwardRef,
+    TypeGuard,
+    TypeVar,
+    cast,
+    get_args,
+    get_origin,
+)
 from uuid import UUID, uuid4
 
 from spakky.core.common.annotation import Annotation
@@ -118,6 +127,12 @@ class UnexpectedDependencyTypeInjectedError(PodInstantiationFailedError):
         super().__init__(*args)
 
 
+@dataclass(frozen=True)
+class _ResolvedAnnotatedDependency:
+    actual_type: object
+    metadatas: tuple[object, ...]
+
+
 @dataclass(eq=False)
 class Pod(Annotation, IEquatable):
     """Annotation for marking classes and functions as managed Pods in the IoC container.
@@ -158,14 +173,125 @@ class Pod(Annotation, IEquatable):
     dependencies: DependencyMap = field(init=False, default_factory=dict)
     """Map of dependency names to their injection information."""
 
+    def __annotation_globalns(self, obj: PodType) -> dict[str, object]:
+        namespace = cast(Func, obj).__globals__.copy()
+        namespace.setdefault("Annotated", Annotated)
+        namespace.setdefault("Qualifier", Qualifier)
+        return namespace
+
+    def __resolve_parameter_annotation(
+        self,
+        annotation: object,
+        globalns: dict[str, object],
+    ) -> object:
+        if not isinstance(annotation, str):
+            return annotation
+        try:
+            return eval(annotation, globalns)
+        except NameError:
+            return self.__resolve_annotated_forward_annotation(annotation, globalns)
+        except (SyntaxError, TypeError):
+            return annotation
+
+    def __resolve_annotated_forward_annotation(
+        self,
+        annotation: str,
+        globalns: dict[str, object],
+    ) -> object:
+        expression = ast.parse(annotation, mode="eval").body
+        if not self.__is_annotated_expression(expression):
+            return annotation
+        annotation_parts = self.__annotated_expression_parts(expression)
+        if annotation_parts is None:
+            return annotation
+        actual_type_node, metadata_nodes = annotation_parts
+        actual_type = self.__resolve_forward_actual_type(
+            node=actual_type_node,
+            globalns=globalns,
+        )
+        metadatas = self.__resolve_metadata_nodes(
+            nodes=metadata_nodes,
+            globalns=globalns,
+        )
+        if actual_type is None or metadatas is None:
+            return annotation
+        return _ResolvedAnnotatedDependency(
+            actual_type=actual_type,
+            metadatas=metadatas,
+        )
+
+    def __is_annotated_expression(
+        self, expression: ast.expr
+    ) -> TypeGuard[ast.Subscript]:
+        if not isinstance(expression, ast.Subscript):
+            return False
+        value = expression.value
+        if isinstance(value, ast.Name):
+            return value.id == "Annotated"
+        return (
+            isinstance(value, ast.Attribute)
+            and value.attr == "Annotated"
+            and isinstance(value.value, ast.Name)
+            and value.value.id == "typing"
+        )
+
+    def __annotated_expression_parts(
+        self,
+        expression: ast.Subscript,
+    ) -> tuple[ast.expr, tuple[ast.expr, ...]] | None:
+        if not isinstance(expression.slice, ast.Tuple):
+            return None
+        elements = tuple(expression.slice.elts)
+        if len(elements) < 2:
+            return None
+        return elements[0], elements[1:]
+
+    def __resolve_forward_actual_type(
+        self,
+        node: ast.expr,
+        globalns: dict[str, object],
+    ) -> object | None:
+        source = ast.unparse(node)
+        try:
+            return eval(source, globalns)
+        except NameError:
+            if isinstance(node, ast.Name):
+                return node.id
+            return source
+
+    def __resolve_metadata_nodes(
+        self,
+        nodes: tuple[ast.expr, ...],
+        globalns: dict[str, object],
+    ) -> tuple[object, ...] | None:
+        metadatas: list[object] = []
+        for node in nodes:
+            source = ast.unparse(node)
+            try:
+                metadatas.append(eval(source, globalns))
+            except NameError:
+                return None
+            except (SyntaxError, TypeError):
+                return None
+        return tuple(metadatas)
+
     def __normalize_dependency_annotation(
         self, annotation: object
     ) -> tuple[object, list[Qualifier], bool]:
         qualifiers: list[Qualifier] = []
         actual_type = annotation
-        if self.__is_annotated_dependency(annotation):
+        if isinstance(annotation, _ResolvedAnnotatedDependency):
+            actual_type = annotation.actual_type
+            qualifiers = [
+                metadata
+                for metadata in annotation.metadatas
+                if isinstance(metadata, Qualifier)
+            ]
+        elif self.__is_annotated_dependency(annotation):
             actual_type = Qualifier.get_actual_type(annotation)
             qualifiers = Qualifier.all(annotation)
+        if isinstance(actual_type, ForwardRef):
+            actual_type = actual_type.__forward_arg__
         optional = is_optional(actual_type)
         if optional:
             actual_type = remove_none(actual_type)
@@ -279,6 +405,7 @@ class Pod(Annotation, IEquatable):
             # Remove self parameter if obj is an instance method
             parameters = parameters[1:]
 
+        annotation_globalns = self.__annotation_globalns(obj)
         dependencies: DependencyMap = {}
         for parameter in parameters:
             if parameter.kind == Parameter.POSITIONAL_ONLY:
@@ -287,8 +414,12 @@ class Pod(Annotation, IEquatable):
                 raise CannotUseVarArgsInPodError(obj, parameter.name)
             if parameter.annotation == Parameter.empty:
                 raise CannotDeterminePodTypeError(obj, parameter.name)
+            annotation = self.__resolve_parameter_annotation(
+                annotation=parameter.annotation,
+                globalns=annotation_globalns,
+            )
             type_, qualifiers, is_optional_dependency = (
-                self.__normalize_dependency_annotation(parameter.annotation)
+                self.__normalize_dependency_annotation(annotation)
             )
             has_default = parameter.default != Parameter.empty
             collection_dependency = self.__collection_dependency_info(

--- a/core/spakky/tests/application/test_application_context.py
+++ b/core/spakky/tests/application/test_application_context.py
@@ -1,7 +1,7 @@
 import asyncio
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Annotated, Any
+from typing import Annotated, Any, Callable, cast, override
 from uuid import UUID, uuid4
 
 import pytest
@@ -19,6 +19,7 @@ from spakky.core.pod.annotations.pod import (
     Pod,
     PodInstantiationFailedError,
     UnsupportedCollectionDependencyTypeError,
+    UnexpectedDependencyTypeInjectedError,
 )
 from spakky.core.pod.annotations.primary import Primary
 from spakky.core.pod.annotations.qualifier import Qualifier
@@ -29,6 +30,10 @@ from spakky.core.pod.interfaces.container import (
     NoSuchPodBindingTargetError,
 )
 from spakky.core.pod.interfaces.post_processor import IPostProcessor
+from spakky.core.service.interfaces.service import (
+    IAsyncService as LifecycleAsyncService,
+    IService as LifecycleService,
+)
 
 
 def test_application_context_register_expect_success() -> None:
@@ -388,6 +393,68 @@ def test_application_context_start_with_ambiguous_dependency_expect_dependency_d
     ]
     assert ("dependency_parameter", "pod") in diagnostic.as_detail_pairs()
     assert any(key == "candidates" for key, _value in diagnostic.as_detail_pairs())
+
+
+def test_application_context_start_with_postponed_annotated_qualifier_expect_resolution() -> (
+    None
+):
+    """future annotations 문자열의 Annotated Qualifier가 실제 DI 선택에 적용됨을 검증한다."""
+    namespace: dict[str, object] = {
+        "Annotated": Annotated,
+        "ApplicationContext": ApplicationContext,
+        "Pod": Pod,
+        "Primary": Primary,
+        "Qualifier": Qualifier,
+    }
+    exec(
+        """
+from __future__ import annotations
+
+class PaymentGateway:
+    def charge(self) -> str:
+        raise NotImplementedError
+
+@Pod(name="stripe")
+class StripeGateway(PaymentGateway):
+    def charge(self) -> str:
+        return "stripe"
+
+@Primary()
+@Pod(name="sandbox")
+class SandboxGateway(PaymentGateway):
+    def charge(self) -> str:
+        return "sandbox"
+
+@Pod()
+class CheckoutService:
+    def __init__(
+        self,
+        gateway: PaymentGateway,
+        stripe_gateway: Annotated[
+            PaymentGateway, Qualifier(lambda pod: pod.name == "stripe")
+        ],
+    ) -> None:
+        self.gateway = gateway
+        self.stripe_gateway = stripe_gateway
+
+def resolve_charges() -> tuple[str, str]:
+    context = ApplicationContext()
+    context.add(StripeGateway)
+    context.add(SandboxGateway)
+    context.add(CheckoutService)
+    context.start()
+    try:
+        service = context.get(CheckoutService)
+        return service.gateway.charge(), service.stripe_gateway.charge()
+    finally:
+        context.stop()
+""",
+        namespace,
+    )
+
+    resolve_charges = cast(Callable[[], tuple[str, str]], namespace["resolve_charges"])
+
+    assert resolve_charges() == ("sandbox", "stripe")
 
 
 def test_application_context_get_multiple_primary_candidates_expect_primary_diagnostic() -> (
@@ -1653,7 +1720,6 @@ def test_application_context_lazy_pod_not_initialized() -> None:
 
 def test_application_context_initialize_pods_missing_raises_error() -> None:
     """존재하지 않는 의존성으로 Pod 초기화 시 에러가 발생함을 검증한다."""
-    from spakky.core.pod.annotations.pod import UnexpectedDependencyTypeInjectedError
 
     class NonExistentPod:  # noqa: F841
         """Dummy class for type annotation."""
@@ -1676,7 +1742,6 @@ def test_application_context_initialize_pods_missing_raises_error() -> None:
 
 def test_application_context_missing_dependency_expect_structured_diagnostic() -> None:
     """누락된 Pod 의존성 실패가 Pod.dependencies 기반 경로 진단을 포함함을 검증한다."""
-    from spakky.core.pod.annotations.pod import UnexpectedDependencyTypeInjectedError
 
     class MissingDependency:
         """Unregistered dependency type."""
@@ -1711,6 +1776,153 @@ def test_application_context_missing_dependency_expect_structured_diagnostic() -
         ("dependency_parameter", "missing_dep"),
         ("requested_type", "MissingDependency"),
     )
+
+
+def test_application_context_start_failure_expect_retry_without_partial_caches() -> (
+    None
+):
+    """startup 실패 후 started 상태와 부분 singleton/context cache가 재시도를 오염시키지 않음을 검증한다."""
+    singleton_instances: list[object] = []
+    context_instances: list[object] = []
+
+    @Pod()
+    class StableSingleton:
+        def __init__(self) -> None:
+            singleton_instances.append(self)
+
+    @Pod(scope=Pod.Scope.CONTEXT)
+    class StableContextScoped:
+        def __init__(self) -> None:
+            context_instances.append(self)
+
+    @Pod()
+    class MissingDependency:
+        pass
+
+    @Pod()
+    class FailingConsumer:
+        def __init__(
+            self,
+            singleton: StableSingleton,
+            context_scoped: StableContextScoped,
+            missing: MissingDependency,
+        ) -> None:
+            self.singleton = singleton
+            self.context_scoped = context_scoped
+            self.missing = missing
+
+    context = ApplicationContext()
+    context.add(StableSingleton)
+    context.add(StableContextScoped)
+    context.add(FailingConsumer)
+
+    with pytest.raises(UnexpectedDependencyTypeInjectedError):
+        context.start()
+
+    assert context.is_started is False
+    assert len(singleton_instances) == 1
+    assert len(context_instances) == 1
+
+    context.add(MissingDependency)
+    context.start()
+    try:
+        consumer = context.get(FailingConsumer)
+
+        assert context.is_started is True
+        assert len(singleton_instances) == 2
+        assert len(context_instances) == 2
+        assert consumer.singleton is singleton_instances[-1]
+        assert consumer.context_scoped is context_instances[-1]
+    finally:
+        context.stop()
+
+
+def test_application_context_start_service_failure_expect_started_services_stopped() -> (
+    None
+):
+    """service startup 실패 시 이미 시작된 service를 rollback stop한다."""
+    events: list[str] = []
+
+    class StartedService(LifecycleService):
+        @override
+        def set_stop_event(self, stop_event: Any) -> None:
+            self.stop_event = stop_event
+
+        @override
+        def start(self) -> None:
+            events.append("started.start")
+
+        @override
+        def stop(self) -> None:
+            events.append("started.stop")
+
+    class FailingService(LifecycleService):
+        @override
+        def set_stop_event(self, stop_event: Any) -> None:
+            self.stop_event = stop_event
+
+        @override
+        def start(self) -> None:
+            events.append("failing.start")
+            raise RuntimeError("service failed")
+
+        @override
+        def stop(self) -> None:
+            events.append("failing.stop")
+
+    context = ApplicationContext()
+    context.add_service(StartedService())
+    context.add_service(FailingService())
+
+    with pytest.raises(RuntimeError):
+        context.start()
+
+    assert context.is_started is False
+    assert events == ["started.start", "failing.start", "started.stop"]
+
+
+def test_application_context_start_async_service_failure_expect_started_services_stopped() -> (
+    None
+):
+    """async service startup 실패 시 이미 시작된 async service를 rollback stop한다."""
+    events: list[str] = []
+
+    class StartedAsyncService(LifecycleAsyncService):
+        @override
+        def set_stop_event(self, stop_event: Any) -> None:
+            self.stop_event = stop_event
+
+        @override
+        async def start_async(self) -> None:
+            events.append("started.start")
+
+        @override
+        async def stop_async(self) -> None:
+            events.append("started.stop")
+
+    class FailingAsyncService(LifecycleAsyncService):
+        @override
+        def set_stop_event(self, stop_event: Any) -> None:
+            self.stop_event = stop_event
+
+        @override
+        async def start_async(self) -> None:
+            events.append("failing.start")
+            raise RuntimeError("service failed")
+
+        @override
+        async def stop_async(self) -> None:
+            events.append("failing.stop")
+
+    context = ApplicationContext()
+    context.add_service(StartedAsyncService())
+    context.add_service(FailingAsyncService())
+
+    with pytest.raises(RuntimeError):
+        context.start()
+
+    assert context.is_started is False
+    assert events == ["started.start", "failing.start", "started.stop"]
 
 
 def test_set_singleton_cache_with_non_singleton_pod() -> None:
@@ -2037,7 +2249,6 @@ def test_application_context_get_qualified_multiple_candidates_none_match_expect
     None
 ):
     """여러 후보 중 qualifier로 필터링했지만 매치되는 Pod가 없을 때 UnexpectedDependencyTypeInjectedError가 발생함을 검증한다."""
-    from spakky.core.pod.annotations.pod import UnexpectedDependencyTypeInjectedError
 
     class ISamplePod:
         @abstractmethod

--- a/core/spakky/tests/application/test_startup_diagnostics.py
+++ b/core/spakky/tests/application/test_startup_diagnostics.py
@@ -33,7 +33,7 @@ from spakky.core.application.startup_diagnostics import (
     StartupPhaseStatus,
     StartupProcessedCountCannotBeNegativeError,
 )
-from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.annotations.pod import Pod, UnexpectedDependencyTypeInjectedError
 from spakky.core.pod.interfaces.post_processor import IPostProcessor
 from spakky.core.service.interfaces.service import IService
 
@@ -396,6 +396,42 @@ def test_spakky_application_start_failure_expect_recorded_and_propagated() -> No
     finally:
         if context.is_started:
             app.stop()
+
+
+def test_application_context_start_dependency_failure_summary_expect_dependency_details() -> (
+    None
+):
+    """DI startup failure summary가 dependency diagnostic detail을 포함함을 검증한다."""
+
+    class MissingDependency:
+        """Unregistered dependency type."""
+
+    @Pod(name="diagnostic_consumer")
+    class DiagnosticConsumer:
+        def __init__(self, missing: MissingDependency) -> None:
+            self.missing = missing
+
+    context = ApplicationContext()
+    context.add(DiagnosticConsumer)
+    recorder = ActiveStartupPhaseRecorder()
+
+    with pytest.raises(UnexpectedDependencyTypeInjectedError):
+        context.start(recorder)
+
+    failure = recorder.report.records[-1]
+    assert context.is_started is False
+    assert failure.phase_name == STARTUP_PHASE_INSTANTIATION
+    assert failure.status is StartupPhaseStatus.FAILURE
+    assert failure.failure_summary is not None
+
+    details = {
+        detail.key: detail.value
+        for detail in failure.failure_summary.diagnostic_details
+    }
+    assert details["failed_pod"] == "diagnostic_consumer"
+    assert details["dependency_path"] == "DiagnosticConsumer.missing:MissingDependency"
+    assert details["dependency_parameter"] == "missing"
+    assert details["requested_type"] == "MissingDependency"
 
 
 def test_spakky_application_post_processing_failure_expect_phase_failure() -> None:

--- a/core/spakky/tests/pod/test_pod.py
+++ b/core/spakky/tests/pod/test_pod.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from types import GenericAlias
+import typing
 from typing import Annotated, Any, Generic, TypeVar, cast
 from typing import List as LegacyList
 
@@ -499,6 +500,209 @@ def test_pod_with_string_dependency_annotation_expect_metadata() -> None:
     assert dependency.name == "service"
     assert dependency.type_ == "ForwardService"
     assert dependency.collection_kind is None
+
+
+def test_pod_with_postponed_annotated_qualifier_expect_metadata() -> None:
+    """postponed Annotated Qualifier annotation이 qualifier metadata를 보존함을 검증한다."""
+    namespace: dict[str, object] = {
+        "Annotated": Annotated,
+        "Pod": Pod,
+        "Qualifier": Qualifier,
+    }
+    exec(
+        """
+from __future__ import annotations
+
+class PaymentGateway:
+    pass
+
+@Pod(name="stripe")
+class StripeGateway(PaymentGateway):
+    pass
+
+@Pod()
+class CheckoutService:
+    def __init__(
+        self,
+        stripe_gateway: Annotated[
+            PaymentGateway, Qualifier(lambda pod: pod.name == "stripe")
+        ],
+    ) -> None:
+        self.stripe_gateway = stripe_gateway
+""",
+        namespace,
+    )
+
+    checkout_service = cast(type, namespace["CheckoutService"])
+    payment_gateway = cast(type, namespace["PaymentGateway"])
+    stripe_gateway = cast(type, namespace["StripeGateway"])
+    dependency = Pod.get(checkout_service).dependencies["stripe_gateway"]
+
+    assert dependency.type_ is payment_gateway
+    assert len(dependency.qualifiers) == 1
+    assert dependency.qualifiers[0].selector(Pod.get(stripe_gateway)) is True
+
+
+def test_pod_with_postponed_annotated_forward_ref_expect_metadata() -> None:
+    """postponed Annotated 내부 unresolved forward ref는 문자열 타입으로 보존된다."""
+    namespace: dict[str, object] = {
+        "Annotated": Annotated,
+        "Pod": Pod,
+        "Qualifier": Qualifier,
+    }
+    exec(
+        """
+from __future__ import annotations
+
+@Pod(name="forward")
+class ForwardCandidate:
+    pass
+
+@Pod()
+class NeedsForward:
+    def __init__(
+        self,
+        dependency: Annotated[
+            ForwardDependency, Qualifier(lambda pod: pod.name == "forward")
+        ],
+    ) -> None:
+        self.dependency = dependency
+""",
+        namespace,
+    )
+
+    needs_forward = cast(type, namespace["NeedsForward"])
+    forward_candidate = cast(type, namespace["ForwardCandidate"])
+    dependency = Pod.get(needs_forward).dependencies["dependency"]
+
+    assert dependency.type_ == "ForwardDependency"
+    assert len(dependency.qualifiers) == 1
+    assert dependency.qualifiers[0].selector(Pod.get(forward_candidate)) is True
+
+
+def test_pod_with_postponed_annotation_edge_cases_expect_forward_preservation() -> None:
+    """부분 평가할 수 없는 postponed annotation은 기존 문자열 forward ref로 보존된다."""
+
+    def malformed_factory(service) -> object:
+        return service
+
+    malformed_factory.__annotations__["service"] = "list["
+    malformed_factory.__annotations__["return"] = object
+    Pod()(malformed_factory)
+
+    def incomplete_annotated_factory(service) -> object:
+        return service
+
+    incomplete_annotated_factory.__annotations__["service"] = (
+        "Annotated[ForwardDependency]"
+    )
+    incomplete_annotated_factory.__annotations__["return"] = object
+    Pod()(incomplete_annotated_factory)
+
+    def missing_metadata_factory(service) -> object:
+        return service
+
+    missing_metadata_factory.__annotations__["service"] = (
+        "Annotated[ForwardDependency, MissingQualifier]"
+    )
+    missing_metadata_factory.__annotations__["return"] = object
+    Pod()(missing_metadata_factory)
+
+    def unsupported_actual_factory(service) -> object:
+        return service
+
+    unsupported_actual_factory.__annotations__["service"] = (
+        "Annotated[1[0], Qualifier(lambda pod: True)]"
+    )
+    unsupported_actual_factory.__annotations__["return"] = object
+    Pod()(unsupported_actual_factory)
+
+    assert Pod.get(malformed_factory).dependencies["service"].type_ == "list["
+    assert (
+        Pod.get(incomplete_annotated_factory).dependencies["service"].type_
+        == "Annotated[ForwardDependency]"
+    )
+    assert (
+        Pod.get(missing_metadata_factory).dependencies["service"].type_
+        == "Annotated[ForwardDependency, MissingQualifier]"
+    )
+    assert (
+        Pod.get(unsupported_actual_factory).dependencies["service"].type_
+        == "Annotated[1[0], Qualifier(lambda pod: True)]"
+    )
+
+
+def test_pod_with_postponed_typing_annotated_forward_ref_expect_metadata() -> None:
+    """typing.Annotated 형태의 postponed forward ref도 qualifier metadata를 보존한다."""
+    namespace: dict[str, object] = {
+        "Pod": Pod,
+        "Qualifier": Qualifier,
+        "typing": typing,
+    }
+    exec(
+        """
+from __future__ import annotations
+
+@Pod(name="forward")
+class ForwardCandidate:
+    pass
+
+@Pod()
+class NeedsForward:
+    def __init__(
+        self,
+        dependency: typing.Annotated[
+            ForwardDependency, Qualifier(lambda pod: pod.name == "forward")
+        ],
+    ) -> None:
+        self.dependency = dependency
+""",
+        namespace,
+    )
+
+    needs_forward = cast(type, namespace["NeedsForward"])
+    forward_candidate = cast(type, namespace["ForwardCandidate"])
+    dependency = Pod.get(needs_forward).dependencies["dependency"]
+
+    assert dependency.type_ == "ForwardDependency"
+    assert len(dependency.qualifiers) == 1
+    assert dependency.qualifiers[0].selector(Pod.get(forward_candidate)) is True
+
+
+def test_pod_with_postponed_annotated_quoted_forward_ref_expect_metadata() -> None:
+    """문자열 literal forward ref가 Annotated 안에 있을 때도 문자열 타입으로 보존된다."""
+
+    def quoted_forward_factory(service) -> object:
+        return service
+
+    quoted_forward_factory.__annotations__["service"] = (
+        "Annotated['ForwardDependency', Qualifier(lambda pod: True)]"
+    )
+    quoted_forward_factory.__annotations__["return"] = object
+    Pod()(quoted_forward_factory)
+
+    dependency = Pod.get(quoted_forward_factory).dependencies["service"]
+
+    assert dependency.type_ == "ForwardDependency"
+    assert len(dependency.qualifiers) == 1
+
+
+def test_pod_with_postponed_composite_forward_ref_expect_source_preserved() -> None:
+    """복합 unresolved forward ref는 source 문자열을 보존해 기존 forward-ref 경로로 남긴다."""
+
+    def composite_forward_factory(service) -> object:
+        return service
+
+    composite_forward_factory.__annotations__["service"] = (
+        "Annotated[list[ForwardDependency], Qualifier(lambda pod: True)]"
+    )
+    composite_forward_factory.__annotations__["return"] = object
+    Pod()(composite_forward_factory)
+
+    dependency = Pod.get(composite_forward_factory).dependencies["service"]
+
+    assert dependency.type_ == "list[ForwardDependency]"
+    assert len(dependency.qualifiers) == 1
 
 
 def test_pod_equality_with_different_type() -> None:


### PR DESCRIPTION
## Summary
- Resolve future-annotations Qualifier injection cases
- Keep ApplicationContext state consistent after startup failures
- Add dependency diagnostics to startup failure reporting

Fixes #331.
Fixes #332.
Fixes #333.

## Verification
- In core/spakky: uv run --with ruff ruff format --check . -> passed
- In core/spakky: uv run --with ruff ruff check . -> passed
- In core/spakky: uv run --with pyrefly --with pytest pyrefly check -> 0 errors
- In core/spakky: uv run --with pytest --with pytest-asyncio pytest tests/application/test_application_context.py tests/application/test_application_context_errors.py tests/application/test_startup_diagnostics.py tests/pod/test_pod.py -q -o addopts='' -> 147 passed
- In core/spakky: uv run python ../../.agents/skills/check/scripts/validate_python_harness.py . -> passed

Part of autopilot recovery issue #376.