### PR TITLE
test: fix contract test paths and formatting

### DIFF
--- a/core/spakky-agent/examples/code_assistant_demo.py
+++ b/core/spakky-agent/examples/code_assistant_demo.py
@@ -370,10 +370,7 @@ class CodeAssistant:
                         idempotency=Idempotency.IDEMPOTENT,
                     ),
                 )
-            elif (
-                event.kind is ModelStreamEventKind.ERROR
-                and event.error is not None
-            ):
+            elif event.kind is ModelStreamEventKind.ERROR and event.error is not None:
                 current_state = self._states.get(state.id)
                 self._states.save(
                     replace(

--- a/plugins/spakky-fastapi/tests/conftest.py
+++ b/plugins/spakky-fastapi/tests/conftest.py
@@ -45,7 +45,6 @@ def get_name_fixture() -> Generator[str, Any, None]:
     yield name
 
 
-@pytest.mark.asyncio
 @pytest.fixture(name="app", scope="function")
 async def get_app_fixture(name: str) -> AsyncGenerator[SpakkyApplication, Any]:
     logger = getLogger("debug")
@@ -82,7 +81,6 @@ async def get_app_fixture(name: str) -> AsyncGenerator[SpakkyApplication, Any]:
     logger.removeHandler(console)
 
 
-@pytest.mark.asyncio
 @pytest.fixture(name="api_without_auth_provider", scope="function")
 async def get_api_without_auth_provider_fixture(
     name: str,
@@ -111,7 +109,6 @@ async def get_api_without_auth_provider_fixture(
     yield app.container.get(type_=FastAPI)
 
 
-@pytest.mark.asyncio
 @pytest.fixture(name="api", scope="function")
 async def get_api_fixture(app: SpakkyApplication) -> AsyncGenerator[FastAPI, Any]:
     yield app.container.get(type_=FastAPI)

--- a/plugins/spakky-fastapi/tests/test_actuator_docs_contract.py
+++ b/plugins/spakky-fastapi/tests/test_actuator_docs_contract.py
@@ -2,11 +2,15 @@
 
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
 
 def test_fastapi_actuator_docs_expect_security_hardening_warning() -> None:
     """Docs must warn that FastAPI actuator routes need explicit protection."""
-    guide = Path("docs/guides/actuator.md").read_text(encoding="utf-8")
-    readme = Path("plugins/spakky-fastapi/README.md").read_text(encoding="utf-8")
+    guide = (REPO_ROOT / "docs/guides/actuator.md").read_text(encoding="utf-8")
+    readme = (REPO_ROOT / "plugins/spakky-fastapi/README.md").read_text(
+        encoding="utf-8"
+    )
 
     for doc in (guide, readme):
         assert "unauthenticated by default" in doc

--- a/plugins/spakky-fastapi/tests/test_readme_contract.py
+++ b/plugins/spakky-fastapi/tests/test_readme_contract.py
@@ -2,12 +2,16 @@
 
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
 
 def test_readme_setup_expect_manual_fastapi_pod_registration() -> None:
     """README must show that applications register the FastAPI Pod."""
-    readme = Path("plugins/spakky-fastapi/README.md").read_text(encoding="utf-8")
+    readme = (REPO_ROOT / "plugins/spakky-fastapi/README.md").read_text(
+        encoding="utf-8"
+    )
 
-    assert "@Pod(name=\"api\")" in readme
+    assert '@Pod(name="api")' in readme
     assert "def get_api() -> FastAPI:" in readme
     assert ".add(get_api)" in readme
     assert "자동 등록합니다" not in readme

--- a/plugins/spakky-typer/tests/test_readme_contract.py
+++ b/plugins/spakky-typer/tests/test_readme_contract.py
@@ -2,10 +2,12 @@
 
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
 
 def test_readme_setup_expect_manual_typer_pod_registration() -> None:
     """README must show that applications register the Typer Pod."""
-    readme = Path("plugins/spakky-typer/README.md").read_text(encoding="utf-8")
+    readme = (REPO_ROOT / "plugins/spakky-typer/README.md").read_text(encoding="utf-8")
 
     assert '@Pod(name="cli")' in readme
     assert "def get_cli() -> Typer:" in readme

--- a/plugins/spakky-vllm/src/spakky/plugins/vllm/model.py
+++ b/plugins/spakky-vllm/src/spakky/plugins/vllm/model.py
@@ -348,9 +348,7 @@ class VllmAgentModel(IAgentModel):
         events = tuple(
             ModelStreamEvent(
                 kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
-                tool_call=tool_buffers[index].to_tool_call(
-                    self, tool_schema_by_name
-                ),
+                tool_call=tool_buffers[index].to_tool_call(self, tool_schema_by_name),
                 metadata={"provider": "vllm"},
             )
             for index in sorted(tool_buffers)


### PR DESCRIPTION
## Summary
- Format files that CI currently rejects in spakky-agent and spakky-vllm
- Resolve FastAPI and Typer README contract tests using repo-root paths instead of package cwd-relative paths
- Remove pytest-asyncio marks from FastAPI async fixtures for pytest 9 compatibility

Part of autopilot recovery issue #376.

## Verification
- In core/spakky-agent: uv run ruff format --check . && uv run ruff check . -> passed
- In plugins/spakky-fastapi: uv run ruff format --check . && uv run ruff check . && uv run pytest tests/test_readme_contract.py tests/test_actuator_docs_contract.py -q -o addopts='' -> 2 passed
- In plugins/spakky-fastapi: uv run python ../../.agents/skills/check/scripts/validate_python_harness.py . -> passed
- In plugins/spakky-typer: uv run ruff format --check . && uv run ruff check . && uv run pytest tests/test_readme_contract.py -q -o addopts='' -> 1 passed
- In plugins/spakky-vllm: uv run ruff format --check . && uv run ruff check . -> passed