### PR TITLE
docs(opentelemetry): clarify bridge sync usage

### DIFF
--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -152,4 +152,4 @@ export SPAKKY_LOGGING__PACKAGE_LEVELS__uvicorn=30
 
 ## 분산 트레이싱 연동
 
-`spakky-opentelemetry` 플러그인이 함께 로드되면, `LogContextBridge`가 `TraceContext`의 trace/span ID를 `LogContext`에 자동 동기화합니다. 별도 설정 없이 로그에 트레이스 ID가 포함됩니다.
+`spakky-opentelemetry` 플러그인이 함께 로드되면, `LogContextBridge` pod instance의 `sync()`를 호출하여 `TraceContext`의 trace/span ID를 `LogContext`에 동기화할 수 있습니다. 자동으로 호출되는 lifecycle hook은 없으므로, 미들웨어나 Aspect처럼 `TraceContext`를 설정하는 지점에서 `bridge.sync()`를 호출합니다.

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -117,7 +117,7 @@ from spakky.plugins.opentelemetry.propagator import OTelTracePropagator
 
 ## LogContextBridge --- 트레이스-로깅 동기화
 
-`spakky-logging`이 설치되어 있으면, `LogContextBridge`를 사용하여 현재 `TraceContext`의 trace_id/span_id를 `LogContext`에 자동 바인딩할 수 있습니다.
+`spakky-logging`이 설치되어 있으면, `LogContextBridge` pod instance의 `sync()`를 호출하여 현재 `TraceContext`의 trace_id/span_id를 `LogContext`에 바인딩할 수 있습니다.
 
 ```python
 from spakky.plugins.opentelemetry.bridge import LogContextBridge
@@ -137,7 +137,8 @@ if ctx is not None:
     TraceContext.set(ctx.child())
 
 # 로그 컨텍스트에 trace_id/span_id 동기화
-LogContextBridge.sync()
+bridge: LogContextBridge = app.context.get_pod(LogContextBridge)
+bridge.sync()
 # → LogContext.bind(trace_id=ctx.trace_id, span_id=ctx.span_id)
 ```
 

--- a/plugins/spakky-opentelemetry/README.md
+++ b/plugins/spakky-opentelemetry/README.md
@@ -71,13 +71,14 @@ app = (
 
 ### LogContext 브릿지
 
-`spakky-logging`이 설치되어 있으면 `LogContextBridge.sync()`로 trace_id/span_id를 로그 컨텍스트에 바인딩할 수 있습니다. `spakky-logging`이 없으면 no-op으로 동작합니다:
+`spakky-logging`이 설치되어 있으면 `LogContextBridge` pod instance의 `sync()`를 호출하여 trace_id/span_id를 로그 컨텍스트에 바인딩할 수 있습니다. `spakky-logging`이 없으면 no-op으로 동작합니다:
 
 ```python
 from spakky.plugins.opentelemetry.bridge import LogContextBridge
 
 # TraceContext 설정 후
-LogContextBridge.sync()  # LogContext에 trace_id, span_id 자동 바인딩
+bridge: LogContextBridge = app.context.get_pod(LogContextBridge)
+bridge.sync()  # LogContext에 trace_id, span_id 바인딩
 ```
 
 ## 라이선스

--- a/plugins/spakky-opentelemetry/tests/unit/test_docs_contract.py
+++ b/plugins/spakky-opentelemetry/tests/unit/test_docs_contract.py
@@ -1,0 +1,28 @@
+"""Documentation examples should match LogContextBridge behavior."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[4]
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_docs_use_log_context_bridge_instance_sync() -> None:
+    docs = [
+        _read("plugins/spakky-opentelemetry/README.md"),
+        _read("docs/guides/opentelemetry.md"),
+    ]
+
+    for text in docs:
+        assert "bridge.sync()" in text
+        assert "LogContextBridge.sync()" not in text
+
+
+def test_logging_guide_does_not_claim_automatic_bridge_sync() -> None:
+    text = _read("docs/guides/logging.md")
+
+    assert "bridge.sync()" in text
+    assert "자동 동기화" not in text


### PR DESCRIPTION
Fixes #352.

## Summary
- Replace `LogContextBridge.sync()` class-call examples with instance-based `bridge.sync()` examples.
- Clarify that loading the OpenTelemetry plugin does not automatically copy trace/span IDs into `LogContext`; callers should invoke the bridge from middleware/aspects after setting `TraceContext`.
- Add a docs contract test so the invalid class-call examples and automatic-sync wording do not return.

## Verification
- `plugins\spakky-opentelemetry\.venv\Scripts\python.exe -m pytest -o addopts='' plugins\spakky-opentelemetry\tests\unit\test_docs_contract.py plugins\spakky-opentelemetry\tests\unit\test_bridge.py -q`
- `plugins\spakky-opentelemetry\.venv\Scripts\python.exe -m ruff check plugins\spakky-opentelemetry\tests\unit\test_docs_contract.py`
- `plugins\spakky-opentelemetry\.venv\Scripts\python.exe -m pyrefly check plugins\spakky-opentelemetry\tests\unit\test_docs_contract.py`
- `plugins\spakky-opentelemetry\.venv\Scripts\python.exe -m mkdocs build --strict`