### PR TITLE
fix(messaging): align event routing and RabbitMQ ack handling

### DIFF
--- a/docs/guides/kafka.md
+++ b/docs/guides/kafka.md
@@ -1,7 +1,7 @@
 # Kafka 통합
 
 > `spakky-kafka`는 `IEventTransport` 인터페이스를 통해 Integration Event를 Apache Kafka로 전송하고, 백그라운드 Consumer로 수신합니다.
-> 이벤트 클래스 이름을 Kafka topic으로 사용하므로 발행자와 소비자가 같은 이벤트 타입 계약을 공유해야 합니다.
+> `AbstractIntegrationEvent.event_name` 값을 Kafka topic으로 사용하므로 발행자와 소비자가 같은 이벤트 타입 계약을 공유해야 합니다.
 
 ---
 
@@ -16,16 +16,21 @@
 ## 설정
 
 `KafkaConnectionConfig`는 `@Configuration`이므로 환경변수에서 자동 로딩됩니다.
+발행 예제는 `IAsyncEventPublisher`와 event bus를 사용하므로 `spakky-kafka`와 함께 `spakky-event`를 설치하고 로드해야 합니다. Kafka만 쓴다면 `pip install "spakky[events-kafka]"`가 가장 가볍습니다. RabbitMQ, Kafka, Outbox를 한 번에 실험하려면 `pip install "spakky[event-driven]"`를 사용하세요.
 
 ```python
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
+import spakky.event
 import spakky.plugins.kafka
 import apps
 
 app = (
     SpakkyApplication(ApplicationContext())
-    .load_plugins(include={spakky.plugins.kafka.PLUGIN_NAME})
+    .load_plugins(include={
+        spakky.event.PLUGIN_NAME,
+        spakky.plugins.kafka.PLUGIN_NAME,
+    })
     .scan(apps)
     .start()
 )
@@ -104,7 +109,7 @@ class OrderEventHandler:
         print(f"주문 접수: {event.order_id}, 금액: {event.total_amount}")
 ```
 
-토픽 이름은 이벤트 클래스의 `__name__`(예: `OrderPlacedEvent`)으로 자동 결정됩니다. 토픽이 존재하지 않으면 `number_of_partitions`와 `replication_factor` 설정값으로 자동 생성합니다.
+토픽 이름은 이벤트 인스턴스의 `event_name`과 같은 값으로 자동 결정됩니다. 기본값은 이벤트 클래스명(예: `OrderPlacedEvent`)이며, custom `event_name` property를 오버라이드하면 발행 topic과 소비 topic이 함께 그 값을 사용합니다. 토픽이 존재하지 않으면 `number_of_partitions`와 `replication_factor` 설정값으로 자동 생성합니다.
 
 ---
 

--- a/docs/guides/rabbitmq.md
+++ b/docs/guides/rabbitmq.md
@@ -1,7 +1,7 @@
 # RabbitMQ 통합
 
 > `spakky-rabbitmq`는 `IEventTransport` 인터페이스를 통해 Integration Event를 RabbitMQ로 전송하고, 백그라운드 Consumer로 수신합니다.
-> 이벤트 클래스 이름을 큐/라우팅 키로 사용하므로 발행자와 소비자가 같은 이벤트 타입 계약을 공유해야 합니다.
+> `AbstractIntegrationEvent.event_name` 값을 큐/라우팅 키로 사용하므로 발행자와 소비자가 같은 이벤트 타입 계약을 공유해야 합니다.
 
 ---
 
@@ -16,16 +16,21 @@
 ## 설정
 
 `RabbitMQConnectionConfig`는 `@Configuration`이므로 환경변수에서 자동 로딩됩니다.
+발행 예제는 `IAsyncEventPublisher`와 event bus를 사용하므로 `spakky-rabbitmq`와 함께 `spakky-event`를 설치하고 로드해야 합니다. RabbitMQ만 쓴다면 `pip install "spakky[events-rabbitmq]"`가 가장 가볍습니다. RabbitMQ, Kafka, Outbox를 한 번에 실험하려면 `pip install "spakky[event-driven]"`를 사용하세요.
 
 ```python
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
+import spakky.event
 import spakky.plugins.rabbitmq
 import apps
 
 app = (
     SpakkyApplication(ApplicationContext())
-    .load_plugins(include={spakky.plugins.rabbitmq.PLUGIN_NAME})
+    .load_plugins(include={
+        spakky.event.PLUGIN_NAME,
+        spakky.plugins.rabbitmq.PLUGIN_NAME,
+    })
     .scan(apps)
     .start()
 )
@@ -43,6 +48,7 @@ export SPAKKY_RABBITMQ__EXCHANGE_NAME=my-exchange  # Optional
 export SPAKKY_RABBITMQ__AUTH_CHALLENGE_ACTION=ack
 export SPAKKY_RABBITMQ__AUTH_DENY_ACTION=ack
 export SPAKKY_RABBITMQ__AUTH_ERROR_ACTION=nack_requeue
+export SPAKKY_RABBITMQ__MALFORMED_PAYLOAD_ACTION=ack
 ```
 
 | 필드 | 환경변수 | 기본값 | 설명 |
@@ -56,8 +62,9 @@ export SPAKKY_RABBITMQ__AUTH_ERROR_ACTION=nack_requeue
 | `auth_challenge_action` | `SPAKKY_RABBITMQ__AUTH_CHALLENGE_ACTION` | `ack` | missing/invalid/expired snapshot 처리 |
 | `auth_deny_action` | `SPAKKY_RABBITMQ__AUTH_DENY_ACTION` | `ack` | protected handler DENY 처리 |
 | `auth_error_action` | `SPAKKY_RABBITMQ__AUTH_ERROR_ACTION` | `nack_requeue` | verifier/provider ERROR 처리 |
+| `malformed_payload_action` | `SPAKKY_RABBITMQ__MALFORMED_PAYLOAD_ACTION` | `ack` | JSON/스키마 오류 poison message 처리 |
 
-`auth_*_action` 값은 `ack`, `nack_requeue`, `nack_drop` 중 하나입니다. 기본 정책은 CHALLENGE/DENY를 ack하여 poison-loop를 피하고, ERROR는 requeue하여 일시적인 verifier/provider 장애를 재시도합니다.
+`*_action` 값은 `ack`, `nack_requeue`, `nack_drop` 중 하나입니다. 기본 정책은 CHALLENGE/DENY와 malformed payload를 ack하여 poison-loop를 피하고, ERROR는 requeue하여 일시적인 verifier/provider 장애를 재시도합니다.
 
 ---
 
@@ -108,7 +115,7 @@ class OrderEventHandler:
         print(f"주문 접수: {event.order_id}, 금액: {event.total_amount}")
 ```
 
-큐 이름은 이벤트 클래스의 `__name__`(예: `OrderPlacedEvent`)으로 자동 결정됩니다.
+큐 이름은 이벤트 인스턴스의 `event_name`과 같은 값으로 자동 결정됩니다. 기본값은 이벤트 클래스명(예: `OrderPlacedEvent`)이며, custom `event_name` property를 오버라이드하면 발행 routing key와 소비 queue 이름이 함께 그 값을 사용합니다.
 
 ---
 
@@ -139,7 +146,7 @@ sequenceDiagram
 | 항목 | 규칙 |
 |------|------|
 | 이벤트 이름 | `AbstractIntegrationEvent.event_name` 값, 기본은 클래스명 |
-| 큐 이름 | 수신 핸들러가 등록한 이벤트 클래스명, durable queue로 선언 |
+| 큐 이름 | 수신 핸들러가 등록한 이벤트의 `event_name`, durable queue로 선언 |
 | payload | Pydantic `TypeAdapter`가 만든 JSON bytes |
 | headers | `ITracePropagator.inject()`가 넣은 trace header와 signed `AuthContextSnapshot` metadata |
 | exchange 없음 | 기본 exchange에 큐 이름 routing key로 발행 |
@@ -186,4 +193,4 @@ sequenceDiagram
 
 보호된 handler에서 snapshot이 없거나 invalid/expired이면 `CHALLENGE`로 fail-closed 처리합니다. 정책 evaluator가 `DENY`를 반환해도 handler는 호출되지 않습니다. 검증 provider가 unavailable이면 `ERROR`로 처리하며, 기본 RabbitMQ 정책은 `nack_requeue`입니다.
 
-Payload 직렬화, event name routing, trace header 추출 동작은 snapshot 검증과 독립적으로 유지됩니다.
+Payload 직렬화, event name routing, trace header 추출 동작은 snapshot 검증과 독립적으로 유지됩니다. JSON 파싱이나 이벤트 스키마 검증에 실패한 malformed payload는 handler 호출 전 poison message로 분류되며, 기본 정책은 `ack`로 drop합니다. 이 정책은 `SPAKKY_RABBITMQ__MALFORMED_PAYLOAD_ACTION`으로 조정할 수 있습니다.

--- a/plugins/spakky-kafka/README.md
+++ b/plugins/spakky-kafka/README.md
@@ -14,6 +14,9 @@ pip install spakky-kafka
 pip install spakky[kafka]
 ```
 
+`IAsyncEventPublisher`와 함께 쓰는 Kafka 이벤트 서비스라면 event core까지 포함하는
+`spakky[events-kafka]`를 권장합니다.
+
 ## 설정
 
 `SPAKKY_KAFKA__` prefix를 가진 환경변수를 설정합니다:

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/event/consumer.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/event/consumer.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from typing import Any
+from typing import Any, cast
 
 from spakky.auth import (
     AuthContextNotFoundError,
@@ -32,6 +32,14 @@ from spakky.plugins.kafka.auth import KAFKA_AUTH_HEADERS_PARAMETER
 from spakky.plugins.kafka.common.config import KafkaConnectionConfig
 
 logger = getLogger(__name__)
+
+
+def _event_routing_name(event: type[AbstractEvent]) -> str:
+    descriptor = event.__dict__.get("event_name")
+    if isinstance(descriptor, property):
+        probe = object.__new__(event)
+        return cast(str, descriptor.__get__(probe, event))
+    return event.__name__
 
 
 @Pod()
@@ -174,13 +182,15 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
         if event not in self.handlers:
             self.handlers[event] = []
             self.type_adapters[event] = TypeAdapter(event)
-            self.type_lookup[event.__name__] = event
+            self.type_lookup[_event_routing_name(event)] = event
         self.handlers[event].append(handler)
 
     @override
     def initialize(self) -> None:
         """Create Kafka topics and subscribe the consumer."""
-        topics: list[str] = [event_type.__name__ for event_type in self.handlers.keys()]
+        topics: list[str] = [
+            _event_routing_name(event_type) for event_type in self.handlers.keys()
+        ]
         self._create_topics(topics=topics)
         self.consumer.subscribe(topics=topics)
 
@@ -342,14 +352,16 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
         if event not in self.handlers:
             self.handlers[event] = []
             self.type_adapters[event] = TypeAdapter(event)
-            self.type_lookup[event.__name__] = event
+            self.type_lookup[_event_routing_name(event)] = event
         self.handlers[event].append(handler)
 
     @override
     async def initialize_async(self) -> None:
         """Create Kafka topics and subscribe the async consumer."""
         self.consumer = AIOConsumer(self.config.configuration_dict)
-        topics: list[str] = [event_type.__name__ for event_type in self.handlers.keys()]
+        topics: list[str] = [
+            _event_routing_name(event_type) for event_type in self.handlers.keys()
+        ]
         self._create_topics(topics=topics)
         await self.consumer.subscribe(topics=topics)
 

--- a/plugins/spakky-kafka/tests/unit/test_consumer.py
+++ b/plugins/spakky-kafka/tests/unit/test_consumer.py
@@ -5,7 +5,7 @@ for both synchronous and asynchronous Kafka event consumers.
 """
 
 import threading
-from typing import Any, Generator
+from typing import Any, Generator, override
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -38,6 +38,18 @@ class AnotherEvent(AbstractIntegrationEvent):
     """Another test integration event."""
 
     value: int
+
+
+@immutable
+class RenamedEvent(AbstractIntegrationEvent):
+    """Integration event with custom outbound topic identity."""
+
+    data: str
+
+    @property
+    @override
+    def event_name(self) -> str:
+        return "external.renamed.v1"
 
 
 @pytest.fixture(name="config")
@@ -104,6 +116,23 @@ def test_sync_consumer_register_expect_handler_stored(
 
 @patch("spakky.plugins.kafka.event.consumer.Consumer")
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_register_custom_event_name_expect_topic_lookup(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """Custom event_name 등록은 class name 대신 outbound topic과 일치한다."""
+    consumer = KafkaEventConsumer(config)
+    handler = MagicMock()
+
+    consumer.register(RenamedEvent, handler)
+
+    assert consumer.type_lookup["external.renamed.v1"] is RenamedEvent
+    assert "RenamedEvent" not in consumer.type_lookup
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
 def test_sync_consumer_register_multiple_handlers_expect_all_stored(
     mock_admin_cls: MagicMock,
     mock_consumer_cls: MagicMock,
@@ -166,6 +195,31 @@ def test_sync_consumer_initialize_expect_subscribe(
 
 @patch("spakky.plugins.kafka.event.consumer.Consumer")
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_initialize_custom_event_name_expect_subscribe_to_event_name(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """Custom event_name topic을 생성하고 구독한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = set()
+    mock_admin_cls.return_value = mock_admin
+
+    mock_inner_consumer = MagicMock()
+    mock_consumer_cls.return_value = mock_inner_consumer
+
+    consumer = KafkaEventConsumer(config)
+    consumer.register(RenamedEvent, MagicMock())
+
+    consumer.initialize()
+
+    mock_inner_consumer.subscribe.assert_called_once_with(
+        topics=["external.renamed.v1"]
+    )
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
 def test_sync_consumer_route_event_handler_expect_handler_called(
     mock_admin_cls: MagicMock,
     mock_consumer_cls: MagicMock,
@@ -179,6 +233,30 @@ def test_sync_consumer_route_event_handler_expect_handler_called(
     mock_message = MagicMock()
     mock_message.error.return_value = None
     mock_message.topic.return_value = "SampleEvent"
+    mock_message.value.return_value = b'{"data": "hello"}'
+
+    consumer._route_event_handler(mock_message)
+
+    handler.assert_called_once()
+    event_arg = handler.call_args[0][0]
+    assert event_arg.data == "hello"
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_route_custom_event_name_expect_handler_called(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """Custom event_name topic 수신이 class name mismatch 없이 handler로 라우팅된다."""
+    consumer = KafkaEventConsumer(config)
+    handler = MagicMock()
+    consumer.register(RenamedEvent, handler)
+
+    mock_message = MagicMock()
+    mock_message.error.return_value = None
+    mock_message.topic.return_value = "external.renamed.v1"
     mock_message.value.return_value = b'{"data": "hello"}'
 
     consumer._route_event_handler(mock_message)
@@ -393,6 +471,21 @@ def test_async_consumer_register_expect_handler_stored(
 
 
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_async_consumer_register_custom_event_name_expect_topic_lookup(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """Async custom event_name 등록도 outbound topic identity를 사용한다."""
+    consumer = AsyncKafkaEventConsumer(config)
+    handler = AsyncMock()
+
+    consumer.register(RenamedEvent, handler)
+
+    assert consumer.type_lookup["external.renamed.v1"] is RenamedEvent
+    assert "RenamedEvent" not in consumer.type_lookup
+
+
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
 def test_async_consumer_register_multiple_handlers_expect_all_stored(
     mock_admin_cls: MagicMock,
     config: KafkaConnectionConfig,
@@ -462,6 +555,30 @@ async def test_async_consumer_initialize_async_expect_subscribe(
     await consumer.initialize_async()
 
     mock_aio_consumer.subscribe.assert_awaited_once_with(topics=["SampleEvent"])
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AIOConsumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_initialize_custom_event_name_expect_subscribe_to_event_name(
+    mock_admin_cls: MagicMock,
+    mock_aio_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """Async consumer도 custom event_name topic을 생성하고 구독한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = set()
+    mock_admin_cls.return_value = mock_admin
+
+    mock_aio_consumer = AsyncMock()
+    mock_aio_consumer_cls.return_value = mock_aio_consumer
+
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.register(RenamedEvent, AsyncMock())
+
+    await consumer.initialize_async()
+
+    mock_aio_consumer.subscribe.assert_awaited_once_with(topics=["external.renamed.v1"])
 
 
 @pytest.mark.asyncio

--- a/plugins/spakky-rabbitmq/README.md
+++ b/plugins/spakky-rabbitmq/README.md
@@ -14,6 +14,9 @@ pip install spakky-rabbitmq
 pip install spakky[rabbitmq]
 ```
 
+`IAsyncEventPublisher`와 함께 쓰는 RabbitMQ 이벤트 서비스라면 event core까지 포함하는
+`spakky[events-rabbitmq]`를 권장합니다.
+
 ## 설정
 
 `SPAKKY_RABBITMQ__` prefix를 가진 환경변수를 설정합니다:

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/common/config.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/common/config.py
@@ -76,6 +76,9 @@ class RabbitMQConnectionConfig(BaseSettings):
     )
     """Message action for retryable provider ERROR decisions."""
 
+    malformed_payload_action: RabbitMQAuthFailureAction = RabbitMQAuthFailureAction.ACK
+    """Message action for malformed payloads that cannot be deserialized."""
+
     @property
     def protocol(self) -> str:
         """Determine protocol based on SSL usage.

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/consumer.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/consumer.py
@@ -6,7 +6,7 @@ to registered handlers.
 """
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 from typing import override
 
@@ -17,7 +17,7 @@ from aio_pika.abc import AbstractIncomingMessage, AbstractRobustConnection
 from pika import URLParameters
 from pika.adapters.blocking_connection import BlockingChannel, BlockingConnection
 from pika.spec import Basic, BasicProperties
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.service.background import (
     AbstractAsyncBackgroundService,
@@ -51,6 +51,14 @@ from spakky.tracing.context import TraceContext
 from spakky.tracing.propagator import ITracePropagator
 
 
+def _event_routing_name(event: type[AbstractEvent]) -> str:
+    descriptor = event.__dict__.get("event_name")
+    if isinstance(descriptor, property):
+        probe = object.__new__(event)
+        return cast(str, descriptor.__get__(probe, event))
+    return event.__name__
+
+
 @Pod()
 class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
     """Synchronous RabbitMQ event consumer.
@@ -77,6 +85,7 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
     _auth_challenge_action: RabbitMQAuthFailureAction
     _auth_deny_action: RabbitMQAuthFailureAction
     _auth_error_action: RabbitMQAuthFailureAction
+    _malformed_payload_action: RabbitMQAuthFailureAction
 
     def __init__(self, config: RabbitMQConnectionConfig) -> None:
         """Initialize the synchronous RabbitMQ event consumer.
@@ -93,6 +102,7 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
         self._auth_challenge_action = config.auth_challenge_action
         self._auth_deny_action = config.auth_deny_action
         self._auth_error_action = config.auth_error_action
+        self._malformed_payload_action = config.malformed_payload_action
 
     def set_propagator(self, propagator: ITracePropagator) -> None:
         """Set the trace propagator for extracting trace context from messages.
@@ -154,6 +164,8 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
             for handler in handlers:
                 handler(event)
             channel.basic_ack(method_frame.delivery_tag)
+        except ValidationError:
+            self._handle_malformed_payload(channel, method_frame.delivery_tag)
         except AuthRequirementDeniedError as error:
             self._handle_auth_failure(channel, method_frame.delivery_tag, error)
         finally:
@@ -168,6 +180,21 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
         error: AuthRequirementDeniedError,
     ) -> None:
         action = self._auth_failure_action(error)
+        self._apply_action(channel, delivery_tag, action)
+
+    def _handle_malformed_payload(
+        self,
+        channel: BlockingChannel,
+        delivery_tag: int,
+    ) -> None:
+        self._apply_action(channel, delivery_tag, self._malformed_payload_action)
+
+    @staticmethod
+    def _apply_action(
+        channel: BlockingChannel,
+        delivery_tag: int,
+        action: RabbitMQAuthFailureAction,
+    ) -> None:
         if action is RabbitMQAuthFailureAction.ACK:
             channel.basic_ack(delivery_tag)
             return
@@ -227,9 +254,10 @@ class RabbitMQEventConsumer(IEventConsumer, AbstractBackgroundService):
         self.channel = self.connection.channel()
 
         for event_type in self.handlers:
-            self.channel.queue_declare(event_type.__name__, durable=True)
+            routing_name = _event_routing_name(event_type)
+            self.channel.queue_declare(routing_name, durable=True)
             consumer_tag = self.channel.basic_consume(
-                event_type.__name__,
+                routing_name,
                 self._route_event_handler,
             )
             self.type_lookup[consumer_tag] = event_type
@@ -279,6 +307,7 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
     _auth_challenge_action: RabbitMQAuthFailureAction
     _auth_deny_action: RabbitMQAuthFailureAction
     _auth_error_action: RabbitMQAuthFailureAction
+    _malformed_payload_action: RabbitMQAuthFailureAction
 
     def __init__(self, config: RabbitMQConnectionConfig) -> None:
         """Initialize the asynchronous RabbitMQ event consumer.
@@ -294,6 +323,7 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
         self._auth_challenge_action = config.auth_challenge_action
         self._auth_deny_action = config.auth_deny_action
         self._auth_error_action = config.auth_error_action
+        self._malformed_payload_action = config.malformed_payload_action
 
     def set_propagator(self, propagator: ITracePropagator) -> None:
         """Set the trace propagator for extracting trace context from messages.
@@ -349,6 +379,8 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
             for handler in handlers:
                 await handler(event)
             await message.ack()
+        except ValidationError:
+            await self._handle_malformed_payload(message)
         except AuthRequirementDeniedError as error:
             await self._handle_auth_failure(message, error)
         finally:
@@ -362,6 +394,19 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
         error: AuthRequirementDeniedError,
     ) -> None:
         action = self._auth_failure_action(error)
+        await self._apply_action(message, action)
+
+    async def _handle_malformed_payload(
+        self,
+        message: AbstractIncomingMessage,
+    ) -> None:
+        await self._apply_action(message, self._malformed_payload_action)
+
+    @staticmethod
+    async def _apply_action(
+        message: AbstractIncomingMessage,
+        action: RabbitMQAuthFailureAction,
+    ) -> None:
         if action is RabbitMQAuthFailureAction.ACK:
             await message.ack()
             return
@@ -414,7 +459,8 @@ class AsyncRabbitMQEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundSer
         self.channel = await self.connection.channel()
 
         for event_type in self.handlers:
-            queue = await self.channel.declare_queue(event_type.__name__, durable=True)
+            routing_name = _event_routing_name(event_type)
+            queue = await self.channel.declare_queue(routing_name, durable=True)
             consumer_tag = await queue.consume(self._route_event_handler)
             self.type_lookup[consumer_tag] = event_type
 

--- a/plugins/spakky-rabbitmq/tests/unit/test_config.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_config.py
@@ -29,6 +29,7 @@ def clean_environment_fixture() -> Generator[None, Any, None]:
         f"{RABBITMQ_CONFIG_ENV_PREFIX}AUTH_CHALLENGE_ACTION",
         f"{RABBITMQ_CONFIG_ENV_PREFIX}AUTH_DENY_ACTION",
         f"{RABBITMQ_CONFIG_ENV_PREFIX}AUTH_ERROR_ACTION",
+        f"{RABBITMQ_CONFIG_ENV_PREFIX}MALFORMED_PAYLOAD_ACTION",
     ]
     original_values = {}
     for key in keys_to_remove:
@@ -151,6 +152,7 @@ def test_rabbitmq_config_auth_failure_actions_default_avoid_poison_loop(
     assert config.auth_challenge_action is RabbitMQAuthFailureAction.ACK
     assert config.auth_deny_action is RabbitMQAuthFailureAction.ACK
     assert config.auth_error_action is RabbitMQAuthFailureAction.NACK_REQUEUE
+    assert config.malformed_payload_action is RabbitMQAuthFailureAction.ACK
 
 
 def test_rabbitmq_config_auth_failure_actions_load_from_environment(
@@ -165,12 +167,14 @@ def test_rabbitmq_config_auth_failure_actions_load_from_environment(
     environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}AUTH_CHALLENGE_ACTION"] = "nack_drop"
     environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}AUTH_DENY_ACTION"] = "nack_drop"
     environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}AUTH_ERROR_ACTION"] = "nack_requeue"
+    environ[f"{RABBITMQ_CONFIG_ENV_PREFIX}MALFORMED_PAYLOAD_ACTION"] = "nack_drop"
 
     config = RabbitMQConnectionConfig()
 
     assert config.auth_challenge_action is RabbitMQAuthFailureAction.NACK_DROP
     assert config.auth_deny_action is RabbitMQAuthFailureAction.NACK_DROP
     assert config.auth_error_action is RabbitMQAuthFailureAction.NACK_REQUEUE
+    assert config.malformed_payload_action is RabbitMQAuthFailureAction.NACK_DROP
 
 
 def test_rabbitmq_config_env_prefix_is_correct() -> None:

--- a/plugins/spakky-rabbitmq/tests/unit/test_consumer.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_consumer.py
@@ -5,7 +5,7 @@ particularly the InvalidMessageError conditions.
 """
 
 from os import environ
-from typing import Any, Generator
+from typing import Any, Generator, override
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -34,6 +34,17 @@ class SampleIntegrationEvent(AbstractIntegrationEvent):
     """Sample integration event for testing."""
 
     data: str
+
+
+class RenamedIntegrationEvent(AbstractIntegrationEvent):
+    """Integration event with custom outbound routing identity."""
+
+    data: str
+
+    @property
+    @override
+    def event_name(self) -> str:
+        return "external.renamed.v1"
 
 
 @pytest.fixture(name="config")
@@ -176,6 +187,29 @@ def test_sync_consumer_route_event_handler_success_expect_ack(
 
     handler.assert_called_once()
     channel.basic_ack.assert_called_once_with(123)
+
+
+def test_sync_consumer_malformed_payload_default_ack_expect_handler_not_called(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """Malformed payload는 기본 poison 정책에 따라 ack/drop되고 handler를 호출하지 않는다."""
+    consumer = RabbitMQEventConsumer(config)
+    handler = MagicMock()
+    consumer.register(SampleIntegrationEvent, handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    channel = MagicMock()
+    method_frame = MagicMock()
+    method_frame.consumer_tag = "test_tag"
+    method_frame.delivery_tag = 123
+    properties = MagicMock()
+    properties.headers = {}
+
+    consumer._route_event_handler(channel, method_frame, properties, b'{"data":')
+
+    handler.assert_not_called()
+    channel.basic_ack.assert_called_once_with(123)
+    channel.basic_nack.assert_not_called()
 
 
 def test_sync_consumer_register_multiple_handlers_expect_all_called(
@@ -336,6 +370,29 @@ async def test_async_consumer_register_multiple_handlers_expect_all_called(
     handler1.assert_awaited_once()
     handler2.assert_awaited_once()
     message.ack.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_consumer_malformed_payload_default_ack_expect_handler_not_called(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """비동기 malformed payload도 ack/drop되어 poison-loop를 만들지 않는다."""
+    consumer = AsyncRabbitMQEventConsumer(config)
+    handler = AsyncMock()
+    consumer.register(SampleIntegrationEvent, handler)
+    consumer.type_lookup["test_tag"] = SampleIntegrationEvent
+
+    message = AsyncMock()
+    message.consumer_tag = "test_tag"
+    message.delivery_tag = 123
+    message.body = b'{"data":'
+    message.headers = {}
+
+    await consumer._route_event_handler(message)
+
+    handler.assert_not_awaited()
+    message.ack.assert_awaited_once()
+    message.nack.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -500,6 +557,36 @@ def test_sync_consumer_initialize_expect_connection_and_channel_created(
     assert consumer.type_lookup["consumer_tag_1"] == SampleIntegrationEvent
 
 
+def test_sync_consumer_initialize_custom_event_name_expect_queue_matches_routing(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """Custom event_name을 가진 consumer queue가 outbound routing key와 일치한다."""
+    from unittest.mock import patch
+
+    consumer = RabbitMQEventConsumer(config)
+    consumer.register(RenamedIntegrationEvent, MagicMock())
+
+    mock_channel = MagicMock()
+    mock_channel.basic_consume.return_value = "consumer_tag_1"
+    mock_connection = MagicMock()
+    mock_connection.channel.return_value = mock_channel
+
+    with patch(
+        "spakky.plugins.rabbitmq.event.consumer.BlockingConnection",
+        return_value=mock_connection,
+    ):
+        consumer.initialize()
+
+    mock_channel.queue_declare.assert_called_once_with(
+        "external.renamed.v1", durable=True
+    )
+    mock_channel.basic_consume.assert_called_once_with(
+        "external.renamed.v1",
+        consumer._route_event_handler,
+    )
+    assert consumer.type_lookup["consumer_tag_1"] == RenamedIntegrationEvent
+
+
 def test_sync_consumer_dispose_expect_channel_and_connection_closed(
     config: RabbitMQConnectionConfig,
 ) -> None:
@@ -557,6 +644,37 @@ async def test_async_consumer_initialize_async_expect_connection_and_channel_cre
     )
     mock_queue.consume.assert_called_once()
     assert consumer.type_lookup["consumer_tag_1"] == SampleIntegrationEvent
+
+
+@pytest.mark.asyncio
+async def test_async_consumer_initialize_custom_event_name_expect_queue_matches_routing(
+    config: RabbitMQConnectionConfig,
+) -> None:
+    """비동기 consumer도 custom event_name queue를 선언한다."""
+    from unittest.mock import patch
+
+    consumer = AsyncRabbitMQEventConsumer(config)
+    consumer.register(RenamedIntegrationEvent, AsyncMock())
+
+    mock_queue = AsyncMock()
+    mock_queue.consume.return_value = "consumer_tag_1"
+    mock_channel = AsyncMock()
+    mock_channel.declare_queue.return_value = mock_queue
+    mock_connection = AsyncMock()
+    mock_connection.channel.return_value = mock_channel
+
+    with patch(
+        "spakky.plugins.rabbitmq.event.consumer.connect_robust",
+        new_callable=AsyncMock,
+        return_value=mock_connection,
+    ):
+        await consumer.initialize_async()
+
+    mock_channel.declare_queue.assert_awaited_once_with(
+        "external.renamed.v1", durable=True
+    )
+    mock_queue.consume.assert_awaited_once()
+    assert consumer.type_lookup["consumer_tag_1"] == RenamedIntegrationEvent
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Document that RabbitMQ/Kafka event consumers require spakky-event to be loaded
- Align custom event_name routing behavior for RabbitMQ and Kafka consumers
- Ensure malformed RabbitMQ payload handling follows ack/nack configuration instead of escaping without a decision

Fixes #334.
Fixes #335.
Fixes #336.

## Verification
- In plugins/spakky-kafka: uv run --with ruff ruff format --check . && uv run --with ruff ruff check . && uv run --with pyrefly --with pytest pyrefly check && uv run --with pytest pytest tests/unit/test_consumer.py -q -o addopts='' -> 42 passed
- In plugins/spakky-rabbitmq: uv run --with ruff ruff format --check . && uv run --with ruff ruff check . && uv run --with pyrefly --with pytest pyrefly check && uv run --with pytest pytest tests/unit/test_config.py tests/unit/test_consumer.py -q -o addopts='' -> 53 passed
- uv run mkdocs build --strict -> passed

Part of autopilot recovery issue #376.