### PR TITLE
docs(event): load event plugin in broker guides

### DIFF
--- a/docs/guides/kafka.md
+++ b/docs/guides/kafka.md
@@ -20,16 +20,26 @@
 ```python
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
+import spakky.event
 import spakky.plugins.kafka
 import apps
 
 app = (
     SpakkyApplication(ApplicationContext())
-    .load_plugins(include={spakky.plugins.kafka.PLUGIN_NAME})
+    .load_plugins(include={
+        spakky.event.PLUGIN_NAME,
+        spakky.plugins.kafka.PLUGIN_NAME,
+    })
     .scan(apps)
     .start()
 )
 ```
+
+`IEventPublisher`, `IAsyncEventPublisher`, and the default event bus are
+registered by `spakky-event`; `spakky-kafka` provides the Kafka transport and
+consumer integration. Installing `spakky[event-driven]` includes both plugins,
+so explicit loading should include both plugin names when using the publishing
+examples below.
 
 환경변수 예시:
 

--- a/docs/guides/rabbitmq.md
+++ b/docs/guides/rabbitmq.md
@@ -20,16 +20,26 @@
 ```python
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
+import spakky.event
 import spakky.plugins.rabbitmq
 import apps
 
 app = (
     SpakkyApplication(ApplicationContext())
-    .load_plugins(include={spakky.plugins.rabbitmq.PLUGIN_NAME})
+    .load_plugins(include={
+        spakky.event.PLUGIN_NAME,
+        spakky.plugins.rabbitmq.PLUGIN_NAME,
+    })
     .scan(apps)
     .start()
 )
 ```
+
+`IEventPublisher`, `IAsyncEventPublisher`, and the default event bus are
+registered by `spakky-event`; `spakky-rabbitmq` provides the RabbitMQ
+transport and consumer integration. Installing `spakky[event-driven]` includes
+both plugins, so explicit loading should include both plugin names when using
+the publishing examples below.
 
 환경변수 예시:
 

--- a/tests/test_event_transport_docs_contract.py
+++ b/tests/test_event_transport_docs_contract.py
@@ -1,0 +1,30 @@
+"""Messaging guide setup examples should load the event core plugin."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_rabbitmq_guide_loads_event_and_transport_plugins() -> None:
+    text = _read("docs/guides/rabbitmq.md")
+
+    assert "import spakky.event" in text
+    assert "spakky.event.PLUGIN_NAME" in text
+    assert "spakky.plugins.rabbitmq.PLUGIN_NAME" in text
+    assert "IAsyncEventPublisher" in text
+    assert "`spakky[event-driven]` includes" in text
+
+
+def test_kafka_guide_loads_event_and_transport_plugins() -> None:
+    text = _read("docs/guides/kafka.md")
+
+    assert "import spakky.event" in text
+    assert "spakky.event.PLUGIN_NAME" in text
+    assert "spakky.plugins.kafka.PLUGIN_NAME" in text
+    assert "IAsyncEventPublisher" in text
+    assert "`spakky[event-driven]` includes" in text


### PR DESCRIPTION
Fixes #334.

## Summary
- Update the RabbitMQ and Kafka guide setup examples to load `spakky.event.PLUGIN_NAME` alongside the transport plugin.
- Clarify that `IEventPublisher`, `IAsyncEventPublisher`, and the default event bus come from `spakky-event`, while RabbitMQ/Kafka provide the transport and consumer integration.
- Add a docs contract test that keeps the broker guides aligned with the `spakky[event-driven]` plugin combination.

## Verification
- `plugins\spakky-opentelemetry\.venv\Scripts\python.exe -m pytest -o addopts='' tests\test_event_transport_docs_contract.py -q`
- `plugins\spakky-opentelemetry\.venv\Scripts\python.exe -m ruff check tests\test_event_transport_docs_contract.py`
- `plugins\spakky-opentelemetry\.venv\Scripts\python.exe -m pyrefly check tests\test_event_transport_docs_contract.py`
- `plugins\spakky-opentelemetry\.venv\Scripts\python.exe -m mkdocs build --strict`