### PR TITLE
docs: 정보구조(IA) 재설계 — nav·기초/심화 골격·도식 표준 (#401)

### DIFF
--- a/docs/contributing/diagram-standard.md
+++ b/docs/contributing/diagram-standard.md
@@ -1,0 +1,108 @@
+# 도식(Mermaid) 사용 표준
+
+> Spakky 문서의 도식은 모두 [Mermaid](https://mermaid.js.org/)로 작성합니다. 이 문서는 **어떤 설명에 어떤 다이어그램을 쓰고, 어떻게 그릴지**의 표준을 정의합니다. 후속 가이드는 이 표준을 따릅니다.
+
+문서의 도식은 글로 설명하기 어려운 **구조·흐름·관계**를 한눈에 보여 주기 위한 것입니다. 장식이 아니라 본문의 한 문단을 대신하는 그림이므로, 아래 선택 기준과 작성 규칙을 지킵니다.
+
+## 1. 어떤 설명에 어떤 다이어그램을 쓰나
+
+| 설명하려는 것 | 다이어그램 | 예시 상황 |
+| --- | --- | --- |
+| 모듈/패키지/레이어 간 **의존 방향** | `graph TD` (Top-Down flowchart) | DI 컨테이너가 Pod를 스캔해 주입하는 구조, 플러그인이 코어에 의존하는 방향 |
+| 컴포넌트 간 **호출/데이터 흐름** | `graph LR` (Left-Right flowchart) | 요청이 Adapter → UseCase → Repository로 흐르는 경로 |
+| 시간 순서가 있는 **상호작용** | `sequenceDiagram` | Agent 실행 루프의 모델 호출 → 도구 호출 → 승인(HITL) → 재개 |
+| 객체가 거치는 **상태 전이** | `stateDiagram-v2` | Saga 단계 전이, Outbox 메시지 상태(pending → published) |
+| 도메인 모델의 **구조와 관계** | `classDiagram` | Aggregate ↔ Entity ↔ Value Object 관계 |
+
+선택이 애매하면 **의존 방향은 `graph TD`, 처리 흐름은 `graph LR`**를 기본값으로 씁니다 (`.agents/rules/mermaid.md`).
+
+## 2. 작성 규칙
+
+`.agents/rules/mermaid.md`의 가이드라인을 문서 도식에 그대로 적용합니다.
+
+- **`graph TD` 기본**: 의존성 흐름은 위→아래(Top-Down)로 그립니다.
+- **중첩 서브그래프**: 관련 노드를 상위 컨테이너 + 하위 카테고리로 그룹핑합니다.
+- **인라인 엣지**: 서브그래프 내부 엣지는 노드 선언과 함께 인라인으로 작성합니다.
+- **크로스 엣지 분리**: 서브그래프 사이를 잇는 엣지는 서브그래프 블록 **밖에** 별도로 선언합니다.
+- **노드 색상 구분**: 역할(코어/플러그인/사용자 코드/외부 시스템)별로 `fill`·`stroke`·`color`를 지정합니다.
+
+### 역할별 색상 팔레트
+
+문서 전체에서 노드 역할을 일관된 색으로 구분합니다. 새 도식은 아래 `classDef`를 재사용합니다.
+
+| 역할 | classDef 이름 | 색상 의미 |
+| --- | --- | --- |
+| 사용자 코드 (애플리케이션) | `app` | 사용자가 작성하는 비즈니스 코드 |
+| 프레임워크 코어 | `core` | `spakky` 코어 컴포넌트(DI·AOP·도메인·이벤트) |
+| 플러그인 | `plugin` | `spakky-*` 플러그인(FastAPI·SQLAlchemy 등) |
+| 외부 시스템 | `external` | DB·브로커·LLM 등 프레임워크 밖 시스템 |
+
+## 3. 표준 예시
+
+아래는 코어와 플러그인, 외부 시스템을 색으로 구분하고 중첩 서브그래프로 그룹핑한 `graph TD` 예시입니다. 새 도식의 출발점으로 복사해 쓰세요.
+
+```mermaid
+graph TD
+  App[애플리케이션 코드]:::app
+
+  subgraph Framework[Spakky Framework]
+    subgraph Core[코어]
+      DI[DI / Pod]:::core
+      AOP[AOP]:::core
+      Domain[도메인 모델]:::core
+      Event[이벤트]:::core
+    end
+    subgraph Plugins[플러그인]
+      Web[spakky-fastapi]:::plugin
+      Data[spakky-sqlalchemy]:::plugin
+      Broker[spakky-kafka]:::plugin
+    end
+  end
+
+  subgraph Outside[외부 시스템]
+    DB[(데이터베이스)]:::external
+    MQ[Kafka 브로커]:::external
+  end
+
+  App --> DI
+  DI --> AOP
+  DI --> Domain
+  Domain --> Event
+  DI --> Web
+  DI --> Data
+  Event --> Broker
+  Data --> DB
+  Broker --> MQ
+
+  classDef app fill:#E3F2FD,stroke:#1565C0,color:#0D47A1
+  classDef core fill:#E8F5E9,stroke:#2E7D32,color:#1B5E20
+  classDef plugin fill:#FFF3E0,stroke:#EF6C00,color:#E65100
+  classDef external fill:#ECEFF1,stroke:#546E7A,color:#263238
+```
+
+상호작용 순서를 보일 때는 `sequenceDiagram`을 씁니다.
+
+```mermaid
+sequenceDiagram
+  participant Adapter as Inbound Adapter
+  participant UseCase
+  participant Repo as Repository
+  participant DB as 데이터베이스
+
+  Adapter->>UseCase: execute(command)
+  UseCase->>Repo: save(aggregate)
+  Repo->>DB: INSERT
+  DB-->>Repo: ok
+  Repo-->>UseCase: aggregate
+  UseCase-->>Adapter: result
+```
+
+## 4. 체크리스트
+
+도식을 추가하기 전에 다음을 확인합니다.
+
+- [ ] 설명하려는 것(구조/흐름/순서/상태/관계)에 맞는 다이어그램 종류를 §1 기준으로 골랐다.
+- [ ] 의존 방향 도식이면 `graph TD`로 위→아래를 지켰다.
+- [ ] 노드 역할을 §2 팔레트(`app`/`core`/`plugin`/`external`)로 색 구분했다.
+- [ ] 서브그래프 사이 엣지를 블록 밖에 별도 선언했다.
+- [ ] 도식이 본문 문단 하나를 실제로 대신한다(장식용이 아니다).

--- a/docs/contributing/ia-map.md
+++ b/docs/contributing/ia-map.md
@@ -1,0 +1,77 @@
+# 정보구조(IA) 지도
+
+> Spakky 사용자 문서의 정보구조 골격입니다. 후속 문서 작업은 이 지도가 정한 채널·기초/심화 위치를 따릅니다. 새 페이지를 추가할 때 "이 페이지가 어느 채널의 기초인가 심화인가"를 먼저 정한 뒤 nav에 배치합니다.
+
+## 골격 원칙
+
+- **채널/기능 축**: nav는 사용자가 만들려는 것(핵심·경계·메시징·보안·운영·Agent)을 기준으로 나뉩니다.
+- **기초/심화 2단**: 각 채널은 *기초*(입문 가이드)와 *심화*(설계·내부·확장)로 나뉩니다.
+- **채널 랜딩 페이지**: 각 채널은 진입점 페이지(`sections/<채널>.md`)를 가지며, 그 채널의 기초/심화 문서를 표로 안내합니다.
+- **도식 표준**: 모든 도식은 [도식(Mermaid) 사용 표준](diagram-standard.md)을 따릅니다.
+
+## 채널 구성
+
+| 채널 | 랜딩 페이지 | 기초 | 심화 |
+| --- | --- | --- | --- |
+| 핵심 (Core) | `sections/core.md` | DI & Pod, AOP, 도메인 모델링, 이벤트 시스템, 태스크 & 스케줄링 | DI/IoC 컨테이너, DI & Pod 심화, AOP 가이드, 이벤트 시스템(심화) |
+| 애플리케이션 경계 | `sections/boundaries.md` | FastAPI, CLI(Typer), gRPC, 데이터베이스(SQLAlchemy) | gRPC 심화 |
+| 메시징과 워크플로우 | `sections/messaging.md` | Celery, RabbitMQ, Kafka, Outbox, 사가 | 사가 심화 |
+| 보안 | `sections/security.md` | 보안 | 보안 심화, 인증/인가 전환, 마일스톤 스펙 |
+| 운영 | `sections/operations.md` | 로깅, 트레이싱, OpenTelemetry, Actuator, 캐시 | — |
+| Agent | `sections/agent.md` | AI Agent 개발, CodeAssistant 예제 | AI Agent 심화 (+ 프로토콜 어댑터: AG-UI·A2A·MCP) |
+
+## 기존 페이지의 새 위치 (이동 계획)
+
+기존 문서 파일은 mkdocstrings·기존 링크 호환을 위해 **현재 경로를 그대로 유지**하고, nav 위계만 채널/기능 축 + 기초/심화로 재편했습니다. 아래는 각 페이지가 새 nav에서 차지하는 위치입니다.
+
+| 페이지 파일 | 이전 nav 위치 | 새 nav 위치 |
+| --- | --- | --- |
+| `guides/dependency-injection.md` | 가이드 > 시작하기 | 핵심 > 기초 |
+| `guides/aop.md` | 가이드 > 시작하기 | 핵심 > 기초 |
+| `guides/domain-modeling.md` | 가이드 > 시작하기 | 핵심 > 기초 |
+| `guides/events.md` | 가이드 > 시작하기 | 핵심 > 기초 |
+| `guides/tasks.md` | 가이드 > 시작하기 | 핵심 > 기초 |
+| `di-container.md` | 심화 가이드 | 핵심 > 심화 |
+| `guides/dependency-injection-advanced.md` | 심화 가이드 | 핵심 > 심화 |
+| `aop-guide.md` | 심화 가이드 | 핵심 > 심화 |
+| `event-system.md` | 심화 가이드 | 핵심 > 심화 |
+| `guides/fastapi.md` | 가이드 > 애플리케이션 경계 | 애플리케이션 경계 > 기초 |
+| `guides/typer.md` | 가이드 > 애플리케이션 경계 | 애플리케이션 경계 > 기초 |
+| `guides/grpc.md` | 가이드 > 애플리케이션 경계 | 애플리케이션 경계 > 기초 |
+| `guides/sqlalchemy.md` | 가이드 > 애플리케이션 경계 | 애플리케이션 경계 > 기초 |
+| `guides/grpc-advanced.md` | 심화 가이드 | 애플리케이션 경계 > 심화 |
+| `guides/celery.md` | 가이드 > 메시징과 워크플로우 | 메시징과 워크플로우 > 기초 |
+| `guides/rabbitmq.md` | 가이드 > 메시징과 워크플로우 | 메시징과 워크플로우 > 기초 |
+| `guides/kafka.md` | 가이드 > 메시징과 워크플로우 | 메시징과 워크플로우 > 기초 |
+| `guides/outbox.md` | 가이드 > 메시징과 워크플로우 | 메시징과 워크플로우 > 기초 |
+| `guides/saga.md` | 가이드 > 메시징과 워크플로우 | 메시징과 워크플로우 > 기초 |
+| `guides/saga-advanced.md` | 심화 가이드 | 메시징과 워크플로우 > 심화 |
+| `guides/security.md` | 가이드 > 운영 | 보안 > 기초 |
+| `guides/security-advanced.md` | 심화 가이드 | 보안 > 심화 |
+| `guides/auth-migration.md` | 심화 가이드 | 보안 > 심화 |
+| `planning/auth-authorization-milestone-scope.md` | 심화 가이드 | 보안 > 심화 |
+| `guides/logging.md` | 가이드 > 운영 | 운영 > 기초 |
+| `guides/tracing.md` | 가이드 > 운영 | 운영 > 기초 |
+| `guides/opentelemetry.md` | 가이드 > 운영 | 운영 > 기초 |
+| `guides/actuator.md` | 가이드 > 운영 | 운영 > 기초 |
+| `guides/cache.md` | 가이드 > 운영 | 운영 > 기초 |
+| `guides/agents.md` | 가이드 > Agent | Agent > 기초 |
+| `guides/agent-code-assistant.md` | 가이드 > Agent | Agent > 기초 |
+| `guides/agents-advanced.md` | 심화 가이드 | Agent > 심화 |
+| `plugin-api.md` | 심화 가이드 | 참조 |
+
+## 신규 스캐폴딩 페이지
+
+| 페이지 파일 | 채널 위치 | 상태 |
+| --- | --- | --- |
+| `sections/core.md` | 핵심 랜딩 | 작성 완료 |
+| `sections/boundaries.md` | 애플리케이션 경계 랜딩 | 작성 완료 |
+| `sections/messaging.md` | 메시징과 워크플로우 랜딩 | 작성 완료 |
+| `sections/security.md` | 보안 랜딩 | 작성 완료 |
+| `sections/operations.md` | 운영 랜딩 | 작성 완료 |
+| `sections/agent.md` | Agent 랜딩 | 작성 완료 |
+| `contributing/diagram-standard.md` | 기여 | 작성 완료 |
+| `contributing/ia-map.md` | 기여 | 작성 완료 (이 문서) |
+| `guides/agent-ag-ui.md` | Agent > 프로토콜 어댑터 | 빈 페이지(후속 태스크) |
+| `guides/agent-a2a.md` | Agent > 프로토콜 어댑터 | 빈 페이지(후속 태스크) |
+| `guides/agent-mcp.md` | Agent > 프로토콜 어댑터 | 빈 페이지(후속 태스크) |

--- a/docs/guides/agent-a2a.md
+++ b/docs/guides/agent-a2a.md
@@ -1,0 +1,6 @@
+# A2A 어댑터
+
+> 선언형 Agent를 A2A(Agent-to-Agent) 프로토콜로 연동해, 다른 Agent와 협업하도록 노출하는 어댑터 가이드입니다.
+
+!!! note "작성 예정"
+    이 페이지는 정보구조(IA) 재설계에서 마련한 자리입니다. 선언형 Agent 어댑터 기능이 추가되면 후속 문서 태스크가 내용을 채웁니다. 지금은 [AI Agent 개발](agents.md)과 [AI Agent 심화](agents-advanced.md)를 참고하세요.

--- a/docs/guides/agent-ag-ui.md
+++ b/docs/guides/agent-ag-ui.md
@@ -1,0 +1,6 @@
+# AG-UI 어댑터
+
+> 선언형 Agent를 AG-UI 프로토콜로 노출해, Agent 실행 이벤트를 UI에 스트리밍하는 어댑터 가이드입니다.
+
+!!! note "작성 예정"
+    이 페이지는 정보구조(IA) 재설계에서 마련한 자리입니다. 선언형 Agent 어댑터 기능이 추가되면 후속 문서 태스크가 내용을 채웁니다. 지금은 [AI Agent 개발](agents.md)과 [AI Agent 심화](agents-advanced.md)를 참고하세요.

--- a/docs/guides/agent-mcp.md
+++ b/docs/guides/agent-mcp.md
@@ -1,0 +1,6 @@
+# MCP 어댑터
+
+> 선언형 Agent의 도구를 MCP(Model Context Protocol) 서버로 노출해, MCP 호환 클라이언트가 호출하도록 하는 어댑터 가이드입니다.
+
+!!! note "작성 예정"
+    이 페이지는 정보구조(IA) 재설계에서 마련한 자리입니다. 선언형 Agent 어댑터 기능이 추가되면 후속 문서 태스크가 내용을 채웁니다. 지금은 [AI Agent 개발](agents.md)과 [AI Agent 심화](agents-advanced.md)를 참고하세요.

--- a/docs/sections/agent.md
+++ b/docs/sections/agent.md
@@ -1,0 +1,28 @@
+# Agent
+
+> `spakky-agent`으로 LLM 실행과 도구 호출을 Spakky 애플리케이션 안에 넣는 채널입니다. Agent는 외부 런타임이 아니라 하나의 애플리케이션 컴포넌트로 다뤄집니다.
+
+처음이라면 [AI Agent 개발](../guides/agents.md)로 시작하세요. 운영형 Agent로 확장할 때 필요한 도구·승인·durable 실행은 [AI Agent 심화](../guides/agents-advanced.md)에서 다룹니다. 프로토콜별 어댑터(AG-UI·A2A·MCP)는 **프로토콜 어댑터** 항목에서 이어집니다.
+
+## 기초
+
+| 문서 | 무엇을 배우나요 |
+| --- | --- |
+| [AI Agent 개발](../guides/agents.md) | `@Agent`·`execute()`·`AgentYield`로 Agent 만들기 |
+| [CodeAssistant 에이전트 예제](../guides/agent-code-assistant.md) | 실제 Agent 흐름을 예제로 따라가기 |
+
+## 심화
+
+| 문서 | 무엇을 배우나요 |
+| --- | --- |
+| [AI Agent 심화](../guides/agents-advanced.md) | tool catalog·approval·durable 실행·transport adapter |
+
+## 프로토콜 어댑터
+
+선언형 Agent는 프로토콜 중립 코어 위에 어댑터를 붙여 여러 전송 프로토콜로 노출됩니다. 각 어댑터 가이드는 후속 문서 태스크가 채웁니다.
+
+| 문서 | 무엇을 다루나요 |
+| --- | --- |
+| [AG-UI 어댑터](../guides/agent-ag-ui.md) | AG-UI 프로토콜로 Agent 실행을 UI에 스트리밍 |
+| [A2A 어댑터](../guides/agent-a2a.md) | A2A(Agent-to-Agent) 프로토콜 연동 |
+| [MCP 어댑터](../guides/agent-mcp.md) | MCP(Model Context Protocol) 서버로 도구 노출 |

--- a/docs/sections/boundaries.md
+++ b/docs/sections/boundaries.md
@@ -1,0 +1,20 @@
+# 애플리케이션 경계
+
+> 외부 세계(HTTP·CLI·gRPC)와 데이터베이스를 Spakky 컴포넌트 모델에 붙이는 입출력 경계입니다. 코어에서 만든 UseCase를 어떤 채널로 노출할지 여기서 고릅니다.
+
+만들려는 앱의 경계가 정해졌다면 해당 채널의 **기초**부터 보세요.
+
+## 기초
+
+| 문서 | 무엇을 배우나요 |
+| --- | --- |
+| [FastAPI 통합](../guides/fastapi.md) | HTTP API를 FastAPI 위에 올리기 |
+| [CLI (Typer)](../guides/typer.md) | Typer 기반 CLI 애플리케이션 만들기 |
+| [gRPC 통합](../guides/grpc.md) | code-first gRPC 서비스 정의하기 |
+| [데이터베이스 (SQLAlchemy)](../guides/sqlalchemy.md) | 데이터베이스와 트랜잭션 붙이기 |
+
+## 심화
+
+| 문서 | 무엇을 배우나요 |
+| --- | --- |
+| [gRPC 심화](../guides/grpc-advanced.md) | 무설정 변환·스트리밍·인터셉터 |

--- a/docs/sections/core.md
+++ b/docs/sections/core.md
@@ -1,0 +1,24 @@
+# 핵심 (Core)
+
+> 의존성 주입, AOP, 도메인 모델, 이벤트, 태스크 — Spakky 애플리케이션의 기본 문법입니다. 어떤 경계(HTTP·CLI·메시징·Agent)를 붙이든 이 다섯 개념 위에서 출발합니다.
+
+처음이라면 **기초**를 위에서부터 차례로 읽으세요. 이미 기본기를 익혔다면 **심화**에서 스코프·순환 참조·이벤트 시스템 내부 설계로 넘어가면 됩니다.
+
+## 기초
+
+| 문서 | 무엇을 배우나요 |
+| --- | --- |
+| [DI & Pod](../guides/dependency-injection.md) | `@Pod()`로 컴포넌트를 등록하고 생성자 타입 힌트로 주입받기 |
+| [AOP](../guides/aop.md) | 로깅·트랜잭션 같은 공통 관심사를 Aspect로 분리하기 |
+| [도메인 모델링](../guides/domain-modeling.md) | Aggregate·Entity·Value Object로 도메인 모델 만들기 |
+| [이벤트 시스템](../guides/events.md) | UseCase 성공 뒤 이벤트를 발행하고 처리하기 |
+| [태스크 & 스케줄링](../guides/tasks.md) | 백그라운드 태스크와 주기 실행 선언하기 |
+
+## 심화
+
+| 문서 | 무엇을 배우나요 |
+| --- | --- |
+| [DI/IoC 컨테이너](../di-container.md) | 컨테이너 내부, Pod 스코프, 순환 참조 해결 |
+| [DI & Pod 심화](../guides/dependency-injection-advanced.md) | 다중 구현 해소, 조건부 등록, 한정자 |
+| [AOP 가이드](../aop-guide.md) | Aspect·Pointcut·Advice 작성 상세 |
+| [이벤트 시스템(심화)](../event-system.md) | DomainEvent·IntegrationEvent·EventHandler 설계 |

--- a/docs/sections/messaging.md
+++ b/docs/sections/messaging.md
@@ -1,0 +1,21 @@
+# 메시징과 워크플로우
+
+> 비동기 태스크, 메시지 브로커, 분산 트랜잭션 — 서비스 사이의 메시지 흐름과 장기 워크플로우를 다룹니다.
+
+이벤트를 외부로 내보내거나, 여러 서비스에 걸친 트랜잭션을 조율해야 할 때 이 채널을 봅니다.
+
+## 기초
+
+| 문서 | 무엇을 배우나요 |
+| --- | --- |
+| [Celery 태스크](../guides/celery.md) | Celery worker로 백그라운드 태스크 실행하기 |
+| [RabbitMQ 통합](../guides/rabbitmq.md) | RabbitMQ로 이벤트 주고받기 |
+| [Kafka 통합](../guides/kafka.md) | Kafka로 이벤트 스트리밍하기 |
+| [Transactional Outbox](../guides/outbox.md) | 이벤트 발행과 DB 트랜잭션을 원자적으로 묶기 |
+| [사가 오케스트레이션](../guides/saga.md) | 분산 트랜잭션을 보상 단계로 조율하기 |
+
+## 심화
+
+| 문서 | 무엇을 배우나요 |
+| --- | --- |
+| [사가 심화](../guides/saga-advanced.md) | 보상 설계, 상태 전이, 실패 복구 |

--- a/docs/sections/operations.md
+++ b/docs/sections/operations.md
@@ -1,0 +1,13 @@
+# 운영 (Operations)
+
+> 로깅·트레이싱·헬스 체크·캐시 — 애플리케이션을 운영 환경에서 관측하고 안정적으로 굴리기 위한 기능들입니다.
+
+## 기초
+
+| 문서 | 무엇을 배우나요 |
+| --- | --- |
+| [구조화 로깅](../guides/logging.md) | 구조화된 로그 출력 설정하기 |
+| [분산 트레이싱](../guides/tracing.md) | 요청 흐름을 trace로 추적하기 |
+| [OpenTelemetry 통합](../guides/opentelemetry.md) | OpenTelemetry로 관측 데이터 내보내기 |
+| [Actuator 상태 확인](../guides/actuator.md) | 헬스 체크·상태 엔드포인트 노출하기 |
+| [애플리케이션 데이터 캐시](../guides/cache.md) | Redis 기반 캐시 붙이기 |

--- a/docs/sections/security.md
+++ b/docs/sections/security.md
@@ -1,0 +1,17 @@
+# 보안 (인증/인가)
+
+> 인증·인가 요구사항을 특정 provider에 묶이지 않게 선언하는 채널입니다. OIDC·정책 기반 인가·OpenFGA 같은 구현은 어댑터로 갈아 끼웁니다.
+
+## 기초
+
+| 문서 | 무엇을 배우나요 |
+| --- | --- |
+| [보안](../guides/security.md) | 인증/인가 요구사항을 provider 중립으로 선언하기 |
+
+## 심화
+
+| 문서 | 무엇을 배우나요 |
+| --- | --- |
+| [인증/인가 심화](../guides/security-advanced.md) | 정책·토큰·provider 어댑터 상세 |
+| [인증/인가 전환](../guides/auth-migration.md) | 기존 인증 구조에서 옮겨오기 |
+| [인증/인가 마일스톤 스펙](../planning/auth-authorization-milestone-scope.md) | 인증/인가 범위 설계 기록 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,49 +112,72 @@ plugins:
 
 nav:
   - Home: index.md
-  - 가이드:
-      - 시작하기:
+  - 핵심:
+      - 개요: sections/core.md
+      - 기초:
           - DI & Pod: guides/dependency-injection.md
           - AOP: guides/aop.md
           - 도메인 모델링: guides/domain-modeling.md
           - 이벤트 시스템: guides/events.md
           - 태스크 & 스케줄링: guides/tasks.md
-      - 애플리케이션 경계:
+      - 심화:
+          - DI/IoC 컨테이너: di-container.md
+          - DI & Pod 심화: guides/dependency-injection-advanced.md
+          - AOP 가이드: aop-guide.md
+          - 이벤트 시스템 심화: event-system.md
+  - 애플리케이션 경계:
+      - 개요: sections/boundaries.md
+      - 기초:
           - FastAPI 통합: guides/fastapi.md
           - CLI (Typer): guides/typer.md
           - gRPC 통합: guides/grpc.md
           - 데이터베이스 (SQLAlchemy): guides/sqlalchemy.md
-      - 메시징과 워크플로우:
+      - 심화:
+          - gRPC 심화: guides/grpc-advanced.md
+  - 메시징과 워크플로우:
+      - 개요: sections/messaging.md
+      - 기초:
           - Celery 태스크: guides/celery.md
           - RabbitMQ 통합: guides/rabbitmq.md
           - Kafka 통합: guides/kafka.md
           - Transactional Outbox: guides/outbox.md
           - 사가 오케스트레이션: guides/saga.md
-      - 운영:
+      - 심화:
+          - 사가 심화: guides/saga-advanced.md
+  - 보안:
+      - 개요: sections/security.md
+      - 기초:
           - 보안: guides/security.md
+      - 심화:
+          - 인증/인가 심화: guides/security-advanced.md
+          - 인증/인가 전환: guides/auth-migration.md
+          - 인증/인가 마일스톤 스펙: planning/auth-authorization-milestone-scope.md
+  - 운영:
+      - 개요: sections/operations.md
+      - 기초:
           - 구조화 로깅: guides/logging.md
           - 분산 트레이싱: guides/tracing.md
           - OpenTelemetry 통합: guides/opentelemetry.md
           - Actuator 상태 확인: guides/actuator.md
           - 애플리케이션 데이터 캐시: guides/cache.md
-      - Agent:
+  - Agent:
+      - 개요: sections/agent.md
+      - 기초:
           - AI Agent 개발: guides/agents.md
           - CodeAssistant 에이전트 예제: guides/agent-code-assistant.md
-  - 심화 가이드:
-      - DI/IoC 컨테이너: di-container.md
-      - DI & Pod 심화: guides/dependency-injection-advanced.md
-      - AOP 가이드: aop-guide.md
-      - 이벤트 시스템: event-system.md
-      - gRPC 심화: guides/grpc-advanced.md
-      - AI Agent 심화: guides/agents-advanced.md
-      - 인증/인가 심화: guides/security-advanced.md
-      - 사가 심화: guides/saga-advanced.md
-      - 플러그인 API: plugin-api.md
-      - 인증/인가 전환: guides/auth-migration.md
-      - 인증/인가 마일스톤 스펙: planning/auth-authorization-milestone-scope.md
+      - 심화:
+          - AI Agent 심화: guides/agents-advanced.md
+      - 프로토콜 어댑터:
+          - AG-UI 어댑터: guides/agent-ag-ui.md
+          - A2A 어댑터: guides/agent-a2a.md
+          - MCP 어댑터: guides/agent-mcp.md
   - 참조:
       - 용어 사전: glossary.md
       - 에러 계층 구조: error-hierarchy.md
+      - 플러그인 API: plugin-api.md
+  - 기여:
+      - 도식(Mermaid) 표준: contributing/diagram-standard.md
+      - 정보구조(IA) 지도: contributing/ia-map.md
   - API Reference:
       - 개요: api/index.md
       - Core:


### PR DESCRIPTION
## 목적

문서 전체의 정보구조(IA)를 채널/기능 축으로 재편하고, 각 채널을 기초/심화 2단 위계로 분리하는 골격을 확립합니다. 이후 모든 사용자 문서 작업(A2·A3, 각 기능 그룹 가이드)이 이 골격을 채웁니다. 골격을 먼저 고정해 후속 문서 태스크의 쓰기 충돌을 막는 것이 본 PR의 핵심입니다. (#401, 마일스톤 #19)

## 변경 내용

### nav 재편 (mkdocs.yml)
- 기존 `가이드`(채널 혼재) + `심화 가이드`(평면 dump) 구조를 채널/기능 축으로 분리:
  핵심 · 애플리케이션 경계 · 메시징과 워크플로우 · 보안 · 운영 · Agent.
- 각 채널을 `개요(랜딩)` + `기초` + `심화` 위계로 분리.

### 채널 랜딩 페이지 (`docs/sections/`)
- `core.md`, `boundaries.md`, `messaging.md`, `security.md`, `operations.md`, `agent.md` —
  각 채널 진입점에서 그 채널의 기초/심화 문서를 표로 안내.

### 도식 표준 (`docs/contributing/diagram-standard.md`)
- 어떤 설명(구조/흐름/순서/상태/관계)에 어떤 다이어그램을 쓸지 선택 기준 정의.
- `.agents/rules/mermaid.md` 가이드라인 적용 — `graph TD` 기본, 중첩 서브그래프, 크로스 엣지 분리, 역할별 색상 팔레트(app/core/plugin/external), 표준 예시 + 체크리스트.

### IA 지도 / 이동 계획 (`docs/contributing/ia-map.md`)
- 채널 구성 표 + 기존 페이지의 새 nav 위치 매핑 + 신규 스캐폴딩 페이지 목록.

### Agent 프로토콜 어댑터 스캐폴딩 (`docs/guides/agent-{ag-ui,a2a,mcp}.md`)
- 선언형 Agent 어댑터(AG-UI·A2A·MCP)의 nav 자리와 "작성 예정" 빈 페이지.
  상세 내용은 각 기능 그룹의 문서 동기화 태스크가 채웁니다(본 태스크 범위 밖).

## 결정 근거

- **기존 파일 경로 유지**: 문서 파일을 물리적으로 이동하지 않고 nav 위계만 재편했습니다. mkdocstrings 핸들러 경로·기존 내부 링크 호환을 깨지 않기 위함이며, 이동 계획은 `ia-map.md`에 명시했습니다.
- **플러그인 API는 참조로 이동**: 채널 가이드가 아니라 확장 레퍼런스 성격이므로 `참조` 섹션에 배치.

## 성공 기준

- SC-1: `mkdocs build --strict` 통과 (EXIT=0) + nav에 기초/심화 2단 구조가 채널별로 반영됨. ✅

## 검증

```
$ uv run mkdocs build --strict --quiet
EXIT=0
```

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)