### PR TITLE
test(grpc): migrate echo example to zero-config protobuf + README quick-start (#409)

### DIFF
--- a/plugins/spakky-grpc/README.md
+++ b/plugins/spakky-grpc/README.md
@@ -20,26 +20,24 @@ export SPAKKY_GRPC_BIND_ADDRESSES='["127.0.0.1:50051"]'
 ```
 
 ```python
-from typing import Annotated
-
 from pydantic import BaseModel
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
 
 import spakky.plugins.grpc
-from spakky.plugins.grpc.annotations.field import ProtoField
 from spakky.plugins.grpc.decorators.rpc import rpc
 from spakky.plugins.grpc.stereotypes.grpc_controller import GrpcController
 
 import apps  # `@GrpcController`-decorated classes live in your own package
 
 
+# ProtoField 없이 — 필드 번호는 필드 이름 해시로 자동 결정됩니다.
 class HelloRequest(BaseModel):
-    name: Annotated[str, ProtoField(number=1)]
+    name: str
 
 
 class HelloReply(BaseModel):
-    message: Annotated[str, ProtoField(number=1)]
+    message: str
 
 
 @GrpcController(package="example.hello")

--- a/plugins/spakky-grpc/tests/integration/apps/echo.py
+++ b/plugins/spakky-grpc/tests/integration/apps/echo.py
@@ -26,37 +26,67 @@ from spakky.plugins.grpc.stereotypes.grpc_controller import GrpcController
 
 
 class EchoRequest(BaseModel):
-    """Single-field request used by unary and streaming echo methods."""
+    """Single-field request used by unary and streaming echo methods.
 
-    text: Annotated[str, ProtoField(number=1)]
+    Declared without ``ProtoField`` — the field number is derived from the
+    field name hash (zero-config code-first protobuf).
+    """
+
+    text: str
 
 
 class EchoReply(BaseModel):
-    """Single-field reply mirroring the request text."""
+    """Single-field reply mirroring the request text (zero-config numbering)."""
 
-    text: Annotated[str, ProtoField(number=1)]
+    text: str
 
 
 class CountRequest(BaseModel):
     """Controls how many messages the server should emit/aggregate."""
 
-    count: Annotated[int, ProtoField(number=1)]
+    count: int
 
 
 class CountReply(BaseModel):
     """Aggregated count reply for client-streaming tests."""
 
-    total: Annotated[int, ProtoField(number=1)]
+    total: int
+
+
+class ProfileRequest(BaseModel):
+    """Multi-field, mixed-type zero-config request.
+
+    Exercises the zero-config DX path with more than one field: every field
+    number is derived from the field name hash, so the client and server
+    agree on the wire layout without any ``ProtoField`` annotation.
+    """
+
+    nickname: str
+    age: int
+    verified: bool
+
+
+class ProfileReply(BaseModel):
+    """Multi-field zero-config reply mirroring the request fields."""
+
+    nickname: str
+    age: int
+    verified: bool
 
 
 class ErrorRequest(BaseModel):
     """Identifies which error the controller should raise."""
 
-    code: Annotated[str, ProtoField(number=1)]
+    code: str
 
 
 class TraceReply(BaseModel):
-    """Returns the captured server-side trace context."""
+    """Returns the captured server-side trace context.
+
+    Retains explicit ``ProtoField`` overrides so the integration suite
+    keeps exercising the explicit-numbering path alongside the zero-config
+    messages above.
+    """
 
     trace_id: Annotated[str, ProtoField(number=1)]
     parent_span_id: Annotated[str, ProtoField(number=2)]
@@ -130,6 +160,15 @@ class EchoController:
         """Echo every inbound request back to the client."""
         async for item in requests:
             yield EchoReply(text=item.text)
+
+    @rpc()
+    async def echo_profile(self, request: ProfileRequest) -> ProfileReply:
+        """Return a multi-field zero-config reply mirroring the request."""
+        return ProfileReply(
+            nickname=request.nickname,
+            age=request.age,
+            verified=request.verified,
+        )
 
     @rpc()
     async def raise_error(self, request: ErrorRequest) -> EchoReply:

--- a/plugins/spakky-grpc/tests/integration/test_unary.py
+++ b/plugins/spakky-grpc/tests/integration/test_unary.py
@@ -5,10 +5,16 @@ import pytest
 
 from spakky.plugins.grpc.schema.registry import DescriptorRegistry
 from tests.integration._client import deserializer_for, serializer_for
-from tests.integration.apps.echo import EchoReply, EchoRequest
+from tests.integration.apps.echo import (
+    EchoReply,
+    EchoRequest,
+    ProfileReply,
+    ProfileRequest,
+)
 
 PACKAGE = "test.echo"
 SERVICE_METHOD = "/test.echo.EchoController/unary_echo"
+PROFILE_METHOD = "/test.echo.EchoController/echo_profile"
 
 
 @pytest.mark.asyncio
@@ -45,3 +51,29 @@ async def test_unary_echo_with_empty_text_expect_empty_reply(
 
     assert isinstance(reply, EchoReply)
     assert reply.text == ""
+
+
+@pytest.mark.asyncio
+async def test_echo_profile_zero_config_multi_field_expect_roundtrip(
+    channel: grpc.aio.Channel, registry: DescriptorRegistry
+) -> None:
+    """A multi-field zero-config message should roundtrip every field intact.
+
+    ``ProfileRequest``/``ProfileReply`` carry no ``ProtoField`` annotations,
+    so client and server derive each field number from the field name hash.
+    A correct roundtrip across distinct types (str/int/bool) proves the
+    derived numbering is symmetric on both sides of the wire.
+    """
+    call = channel.unary_unary(
+        PROFILE_METHOD,
+        request_serializer=serializer_for(registry, f"{PACKAGE}.ProfileRequest"),
+        response_deserializer=deserializer_for(
+            registry, f"{PACKAGE}.ProfileReply", ProfileReply
+        ),
+    )
+    reply = await call(ProfileRequest(nickname="spakky", age=7, verified=True))
+
+    assert isinstance(reply, ProfileReply)
+    assert reply.nickname == "spakky"
+    assert reply.age == 7
+    assert reply.verified is True


### PR DESCRIPTION
## 개요

#402(이름 해시 안정 번호 변환 엔진)·#427(ProtoField 선택화)로 도입된 무설정 protobuf 변환을 echo 예제·통합 테스트·README에 반영한다 (#409).

## 변경 사항

### 예제·통합 테스트 마이그레이션 (FR-1)
- `tests/integration/apps/echo.py`: `EchoRequest`/`EchoReply`/`CountRequest`/`CountReply`/`ErrorRequest`를 `ProtoField` 없는 무설정 형태로 마이그레이션. 필드 번호는 필드 이름 해시로 자동 부여된다.
- `TraceReply`는 명시 `ProtoField(number=...)` 오버라이드를 **검증용 1개 케이스로 보존** — 무설정 경로와 명시 오버라이드 경로를 통합 스위트가 함께 커버한다.
- 다중 필드·혼합 타입 `ProfileRequest`/`ProfileReply` + `echo_profile` RPC 추가. `test_echo_profile_zero_config_multi_field_expect_roundtrip`이 str/int/bool 라운드트립을 실서버로 검증하여 **이름 파생 번호가 클라이언트/서버 양쪽에서 대칭**임을 입증한다 (실사용 DX 테스트).

### 문서 동기화 (FR-2)
- `README.md` 빠른 시작 예제를 무설정 형태로 변경(`HelloRequest`/`HelloReply`에서 `ProtoField` 제거). `ProtoField`는 "필드 번호 할당" 섹션의 선택적 오버라이드로만 등장한다.
- `docs/guides/grpc.md` 사용자 가이드는 #425/#427에서 이미 무설정 변환 + 이름 해시 번호 안정성으로 갱신되어 있어 추가 변경 불필요.

## 검증 (SC-1)
- `uv run pytest` (plugins/spakky-grpc): **218 passed, 100% coverage**
- `ruff format`/`ruff check`: clean
- `pyrefly check`: 0 errors
- 통합 테스트가 무설정 형태로 동작하며, 문서의 코드 예시가 실제 동작과 일치한다.

## Acceptance Criteria (자가 grep)
acceptance_check: missing (이슈 본문에 grep 라인 없음)

## 결정 근거
- echo 예제는 모든 RPC 패턴을 커버하는 정본 fixture이므로 여기서의 무설정 마이그레이션이 곧 사용자 학습 경로의 SSOT가 된다.
- `TraceReply` 오버라이드 보존: 무설정이 기본이지만 명시 오버라이드 경로 회귀를 통합 테스트로 계속 검증해야 하므로 1개 케이스를 의도적으로 남겼다.

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)