### PR TITLE
docs: split FastAPI·CLI boundary guides into basic/advanced with flow diagrams (#407)

### DIFF
--- a/docs/guides/fastapi-advanced.md
+++ b/docs/guides/fastapi-advanced.md
@@ -1,0 +1,168 @@
+# FastAPI 심화
+
+> `spakky-fastapi`의 라우트 등록 내부 동작과, 운영에서 필요한 커스텀 인스턴스·미들웨어·WebSocket·분산 트레이싱·Agent stream 노출을 다룹니다.
+
+이 문서는 [FastAPI 통합](fastapi.md)의 기초(컨트롤러·라우팅·에러 매핑)를 읽은 뒤 확인하는 심화 가이드입니다. 기본 문서가 "동작하는 컨트롤러"에 집중한다면, 여기서는 등록 과정에서 무슨 일이 일어나는지와 채널 경계에서 자주 마주치는 고급 요구사항을 설명합니다.
+
+## 라우트 등록 내부 동작 { #route-registration }
+
+`app.start()`가 끝나기 전, `RegisterRoutesPostProcessor`가 모든 Pod를 순회하며 `@ApiController`가 붙은 Pod를 찾습니다. 컨트롤러 하나마다 `APIRouter`를 만들고, route 메서드를 `add_api_route()`로 등록한 뒤, 컨테이너에 등록된 모든 `FastAPI` 앱에 `include_router()`로 붙입니다.
+
+```mermaid
+sequenceDiagram
+  participant Start as app.start()
+  participant RR as RegisterRoutesPostProcessor
+  participant Router as APIRouter
+  participant App as FastAPI
+
+  Start->>RR: post_process(pod)
+  Note over RR: @ApiController가 아니면 그대로 반환
+  RR->>Router: APIRouter(prefix, tags)
+  loop route 메서드마다
+    Note over RR: name 미지정 → 메서드명 Capitalize
+    Note over RR: description 미지정 → docstring
+    Note over RR: response_model 미지정 → 반환 타입 추론
+    RR->>Router: add_api_route(endpoint, ...)
+  end
+  RR->>App: include_router(router)
+```
+
+`response_model`이 비어 있으면 메서드의 반환 타입 annotation으로 `create_model_field("", return_annotation)`을 시도합니다. FastAPI가 모델 필드를 만들 수 없는 타입(`str`·`dict` 등)이면 `FastAPIError`가 발생하고, 이 경우 `response_model` 없이 등록합니다. 따라서 응답 스키마를 OpenAPI에 노출하려면 반환 타입을 Pydantic 모델로 선언합니다.
+
+등록된 endpoint는 요청마다 `ApplicationContext.clear_context()`를 호출해 CONTEXT scope Pod가 이전 요청과 섞이지 않도록 정리하고, 컨테이너에서 컨트롤러 인스턴스를 다시 resolve해 실제 메서드를 호출합니다. `spakky-auth`를 함께 쓰면 이 경계에서 인증 컨텍스트를 seed하고, `AbstractSpakkyAuthError`를 HTTP 응답으로 매핑합니다.
+
+## 커스텀 FastAPI 인스턴스 { #custom-instance }
+
+기본 앱 대신 직접 만든 `FastAPI` 인스턴스를 쓰려면 플러그인 로드 전에 Pod로 등록합니다. 플러그인은 컨테이너에 이미 `FastAPI` Pod가 있으면 기본 앱을 중복 등록하지 않습니다.
+
+```python
+from fastapi import FastAPI
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.annotations.pod import Pod
+
+import apps
+import spakky.plugins.fastapi
+
+
+@Pod()
+def custom_fastapi() -> FastAPI:
+    return FastAPI(title="Orders API", version="1.0.0")
+
+
+spakky_app = (
+    SpakkyApplication(ApplicationContext())
+    .add(custom_fastapi)
+    .load_plugins(include={spakky.plugins.fastapi.PLUGIN_NAME})
+    .scan(apps)
+    .start()
+)
+```
+
+`RegisterRoutesPostProcessor`는 컨테이너에 등록된 **모든** `FastAPI` Pod에 라우터를 붙이므로, 여러 `FastAPI` 인스턴스를 등록하면 동일 컨트롤러가 각 앱에 등록됩니다.
+
+## 미들웨어와 에러 처리 { #middleware-error }
+
+`AddBuiltInMiddlewaresPostProcessor`가 `FastAPI` Pod에 기본 미들웨어를 주입합니다. `add_middleware`는 가장 나중에 추가한 미들웨어가 가장 바깥에서 실행되므로, 실행 순서(바깥쪽 우선)는 다음과 같습니다.
+
+1. `TracingMiddleware` — W3C Trace Context 추출/주입 (트레이싱 propagator가 있을 때만)
+2. `ErrorHandlingMiddleware` — 예외를 JSON 응답으로 변환
+
+`ErrorHandlingMiddleware`는 `AbstractSpakkyFastAPIError`를 잡아 `to_response()`로 변환하고, 그 외 예외는 로그를 남긴 뒤 `InternalServerError`(500)로 응답합니다. `FastAPI(debug=True)`(또는 `SPAKKY_FASTAPI_DEBUG=true`)이면 500 응답에 traceback이 포함됩니다.
+
+기본 에러로 표현되지 않는 상태 코드가 필요하면 `AbstractSpakkyFastAPIError`를 상속해 `status_code`와 `message`를 선언합니다.
+
+```python
+from typing import ClassVar
+
+from fastapi import status
+from spakky.plugins.fastapi.error import AbstractSpakkyFastAPIError
+
+
+class PaymentRequired(AbstractSpakkyFastAPIError):
+    message = "Payment Required"
+    status_code: ClassVar[int] = status.HTTP_402_PAYMENT_REQUIRED
+```
+
+`message`는 클래스 속성으로 정의하고, 추가 컨텍스트가 필요 없으면 `__init__`을 오버라이드하지 않습니다.
+
+## WebSocket
+
+`@websocket` 데코레이터로 WebSocket 엔드포인트를 선언합니다. HTTP route와 마찬가지로 컨트롤러 메서드로 등록되며, 각 연결마다 컨텍스트가 격리됩니다.
+
+```python
+from fastapi import WebSocket
+from spakky.plugins.fastapi.routes import websocket
+from spakky.plugins.fastapi.stereotypes.api_controller import ApiController
+
+
+@ApiController("/chat")
+class ChatController:
+    @websocket("/ws")
+    async def chat(self, socket: WebSocket) -> None:
+        """WebSocket /chat/ws"""
+        await socket.accept()
+        while True:
+            message = await socket.receive_text()
+            await socket.send_text(f"Echo: {message}")
+```
+
+## 분산 트레이싱 { #tracing }
+
+`spakky-tracing`은 `spakky-fastapi`의 필수 의존성입니다. 컨테이너에 `ITracePropagator`가 등록되어 있으면 `AddBuiltInMiddlewaresPostProcessor`가 `get_or_none(ITracePropagator)`로 propagator를 조회해 `TracingMiddleware`를 자동 등록합니다.
+
+- 수신 요청의 `traceparent` 헤더에서 `TraceContext`를 추출하여 자식 스팬을 생성합니다
+- 헤더가 없으면 새로운 루트 트레이스를 시작합니다
+- 응답 헤더에 `traceparent`를 자동 주입합니다
+- 요청 완료 후 `TraceContext`를 자동으로 정리합니다
+
+별도 설정이나 코드 변경 없이, 플러그인 로드만으로 동작합니다.
+
+## AgentYield stream 노출 { #agent-stream }
+
+`@Agent`는 inbound adapter에서 `@UseCase`처럼 container로 resolve한 뒤 `execute()`를 호출합니다. Agent 전용 FastAPI plugin package를 만들 필요는 없습니다. CodeAssistant demo의 WebSocket 예제는 `core/spakky-agent/examples/inbound_adapter_examples.py`에 있습니다.
+
+```python
+from examples.code_assistant_demo import CodeAssistant
+from examples.inbound_adapter_examples import (
+    agent_signal_from_json,
+    agent_yield_to_event,
+    code_assistant_command_from_json,
+)
+from fastapi import WebSocket
+from spakky.agent import IAgentSignalRepository
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.plugins.fastapi.routes import websocket
+from spakky.plugins.fastapi.stereotypes.api_controller import ApiController
+
+
+@ApiController("/agents")
+class AgentController(IContainerAware):
+    _container: IContainer
+
+    def set_container(self, container: IContainer) -> None:
+        self._container = container
+
+    @websocket("/code/ws")
+    async def code(self, socket: WebSocket) -> None:
+        await socket.accept()
+        command = code_assistant_command_from_json(await socket.receive_json())
+        agent = self._container.get(CodeAssistant)
+        signals = self._container.get(IAgentSignalRepository)
+
+        async for item in agent.execute(command):
+            await socket.send_json(agent_yield_to_event(item))
+            if item.kind.value == "approval":
+                signals.append(
+                    agent_signal_from_json(
+                        command.state_id,
+                        await socket.receive_json(),
+                        approval=item.payload,
+                    )
+                )
+```
+
+실제 예제는 inbound JSON을 `CodeAssistantCommand`와 `AgentSignal`로 변환합니다. 핵심은 WebSocket이 transport 변환만 담당하고, agent business workflow는 container에서 얻은 `CodeAssistant.execute()` 안에 남긴다는 점입니다.
+
+SSE나 AG-UI/CopilotKit 연동이 필요하면 [AI Agent 개발](agents.md)의 SSE 및 AG-UI adapter 예제를 사용합니다. Spakky-native SSE는 `AgentYield`를 `data: {"kind": ...}` frame으로 보내고, CopilotKit용 endpoint는 AG-UI `data: {"type": ...}` event stream으로 별도 변환해야 합니다.

--- a/docs/guides/fastapi.md
+++ b/docs/guides/fastapi.md
@@ -3,6 +3,49 @@
 > `spakky-fastapi`는 FastAPI 엔드포인트를 `@ApiController` 클래스로 구조화합니다.
 > Controller Pod를 스캔하면 route decorator가 붙은 메서드를 FastAPI 라우터에 자동 등록합니다.
 
+이 문서는 **처음 HTTP API를 붙일 때 필요한 기초**만 다룹니다. WebSocket·분산 트레이싱 자동 등록·커스텀 FastAPI 인스턴스·라우트 등록 내부 동작 같은 심화 주제는 [FastAPI 심화](fastapi-advanced.md)를 참고하세요.
+
+---
+
+## 요청 처리 흐름
+
+`@ApiController` Pod의 route 메서드 하나가 HTTP 요청을 받기까지의 경로입니다. 사용자 코드(Controller)는 프레임워크 코어(DI/Pod)와 플러그인(`spakky-fastapi`)을 거쳐 ASGI 서버에 연결됩니다.
+
+```mermaid
+graph TD
+  Client[HTTP 클라이언트]:::external
+
+  subgraph App[애플리케이션 코드]
+    Controller["@ApiController"]:::app
+    UseCase["@UseCase"]:::app
+  end
+
+  subgraph Framework[Spakky Framework]
+    DI[DI / Pod 컨테이너]:::core
+    subgraph Plugin[spakky-fastapi]
+      RR[RegisterRoutesPostProcessor]:::plugin
+      Router[FastAPI 라우터]:::plugin
+    end
+  end
+
+  ASGI[ASGI 서버 uvicorn]:::external
+
+  Client --> ASGI
+  ASGI --> Router
+  Router --> Controller
+  Controller --> UseCase
+  DI --> Controller
+  DI --> UseCase
+  RR --> Router
+
+  classDef app fill:#E3F2FD,stroke:#1565C0,color:#0D47A1
+  classDef core fill:#E8F5E9,stroke:#2E7D32,color:#1B5E20
+  classDef plugin fill:#FFF3E0,stroke:#EF6C00,color:#E65100
+  classDef external fill:#ECEFF1,stroke:#546E7A,color:#263238
+```
+
+`app.start()` 시점에 `RegisterRoutesPostProcessor`가 `@ApiController` Pod를 찾아 route 메서드를 `FastAPI` 라우터에 등록합니다. 요청이 들어오면 ASGI 서버 → 라우터 → Controller 메서드 → UseCase 순으로 흐르고, Controller·UseCase 인스턴스는 DI 컨테이너가 제공합니다.
+
 ---
 
 ## 기본 설정
@@ -50,33 +93,9 @@ export SPAKKY_FASTAPI_TITLE="Orders API"
 uvicorn main:api --reload
 ```
 
+기본 앱의 `title`·`description`·`version`·`debug`는 `FastAPIConfig`(`@Configuration`)가 `SPAKKY_FASTAPI_` 접두사 환경변수에서 읽습니다. 위처럼 `SPAKKY_FASTAPI_TITLE`을 설정하면 OpenAPI 문서 제목이 바뀝니다.
+
 FastAPI lifespan은 `BindLifespanPostProcessor`가 감싸므로, ASGI 서버가 종료될 때 `ApplicationContext.stop()`이 호출되어 `IService`/`IAsyncService` 리소스가 정리됩니다.
-
-커스텀 `FastAPI` 인스턴스가 필요하면 플러그인 로드 전에 Pod로 등록합니다. 이 경우 플러그인은 기본 앱을 중복 등록하지 않습니다.
-
-```python
-from fastapi import FastAPI
-from spakky.core.application.application import SpakkyApplication
-from spakky.core.application.application_context import ApplicationContext
-from spakky.core.pod.annotations.pod import Pod
-
-import apps
-import spakky.plugins.fastapi
-
-
-@Pod()
-def custom_fastapi() -> FastAPI:
-    return FastAPI(title="Orders API", version="1.0.0")
-
-
-spakky_app = (
-    SpakkyApplication(ApplicationContext())
-    .add(custom_fastapi)
-    .load_plugins(include={spakky.plugins.fastapi.PLUGIN_NAME})
-    .scan(apps)
-    .start()
-)
-```
 
 ---
 
@@ -84,12 +103,13 @@ spakky_app = (
 
 ### HTTP 메서드 데코레이터
 
+`@ApiController(prefix)`는 클래스를 REST 컨트롤러로 등록하고, `prefix`를 모든 route 앞에 붙입니다. 메서드에는 `spakky.plugins.fastapi.routes`의 `get`·`post`·`put`·`patch`·`delete`·`head`·`options`·`websocket` 데코레이터를 사용합니다.
+
 ```python
 from pydantic import BaseModel
-from fastapi import WebSocket
 from fastapi.responses import PlainTextResponse
 from spakky.plugins.fastapi.routes import (
-    get, post, put, patch, delete, head, options, websocket,
+    get, post, put, patch, delete, head, options,
 )
 from spakky.plugins.fastapi.stereotypes.api_controller import ApiController
 
@@ -154,6 +174,8 @@ class UserController:
         return "GET, POST, PUT, PATCH, DELETE"
 ```
 
+반환 타입이 Pydantic 모델이면 `RegisterRoutesPostProcessor`가 `response_model`을 자동 추론합니다. 메서드 docstring은 route `description`으로, 메서드명은 route `name`(예: `list_users` → `List Users`)으로 자동 채워집니다. 이 추론·등록의 내부 동작은 [FastAPI 심화](fastapi-advanced.md#route-registration)에서 다룹니다.
+
 ### UseCase와 에러 매핑
 
 Controller에는 Repository를 직접 주입하지 말고 `@UseCase()` Pod를 주입합니다. 예상 가능한 HTTP 실패는 `spakky.plugins.fastapi.error`의 에러 클래스로 변환하면 `ErrorHandlingMiddleware`가 JSON 응답으로 바꿉니다.
@@ -204,85 +226,20 @@ class OrderController:
         return OrderResponse(order_id=str(order.uid), status=order.status.value)
 ```
 
-`@post(..., status_code=201)`처럼 route decorator에 전달한 옵션은 내부 `Route` annotation에 저장되고 그대로 `FastAPI.add_api_route()`에 전달됩니다. 반환 타입이 Pydantic 모델이면 `RegisterRoutesPostProcessor`가 `response_model`을 자동 추론합니다.
+`@post(..., status_code=201)`처럼 route decorator에 전달한 옵션은 내부 `Route` annotation에 저장되고 그대로 `FastAPI.add_api_route()`에 전달됩니다.
 
-### WebSocket
+`spakky.plugins.fastapi.error`가 제공하는 기본 에러 클래스는 다음과 같습니다. 모두 `AbstractSpakkyFastAPIError`를 상속하며 `to_response()`로 JSON 응답으로 변환됩니다.
 
-```python
-@ApiController("/chat")
-class ChatController:
-    @websocket("/ws")
-    async def chat(self, socket: WebSocket) -> None:
-        """WebSocket /chat/ws"""
-        await socket.accept()
-        while True:
-            message = await socket.receive_text()
-            await socket.send_text(f"Echo: {message}")
-```
+| 에러 클래스 | HTTP 상태 코드 |
+| --- | --- |
+| `BadRequest` | 400 |
+| `Unauthorized` | 401 |
+| `Forbidden` | 403 |
+| `NotFound` | 404 |
+| `Conflict` | 409 |
+| `InternalServerError` | 500 |
 
-### AgentYield stream 노출
-
-`@Agent`는 inbound adapter에서 `@UseCase`처럼 container로 resolve한 뒤 `execute()`를 호출합니다. Agent 전용 FastAPI plugin package를 만들 필요는 없습니다. CodeAssistant demo의 WebSocket 예제는 `core/spakky-agent/examples/inbound_adapter_examples.py`에 있습니다.
-
-```python
-from examples.code_assistant_demo import CodeAssistant
-from examples.inbound_adapter_examples import (
-    agent_signal_from_json,
-    agent_yield_to_event,
-    code_assistant_command_from_json,
-)
-from fastapi import WebSocket
-from spakky.agent import IAgentSignalRepository
-from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
-from spakky.core.pod.interfaces.container import IContainer
-from spakky.plugins.fastapi.routes import websocket
-from spakky.plugins.fastapi.stereotypes.api_controller import ApiController
-
-
-@ApiController("/agents")
-class AgentController(IContainerAware):
-    _container: IContainer
-
-    def set_container(self, container: IContainer) -> None:
-        self._container = container
-
-    @websocket("/code/ws")
-    async def code(self, socket: WebSocket) -> None:
-        await socket.accept()
-        command = code_assistant_command_from_json(await socket.receive_json())
-        agent = self._container.get(CodeAssistant)
-        signals = self._container.get(IAgentSignalRepository)
-
-        async for item in agent.execute(command):
-            await socket.send_json(agent_yield_to_event(item))
-            if item.kind.value == "approval":
-                signals.append(
-                    agent_signal_from_json(
-                        command.state_id,
-                        await socket.receive_json(),
-                        approval=item.payload,
-                    )
-                )
-```
-
-실제 예제는 inbound JSON을 `CodeAssistantCommand`와 `AgentSignal`로 변환합니다. 핵심은 WebSocket이 transport 변환만 담당하고, agent business workflow는 container에서 얻은 `CodeAssistant.execute()` 안에 남긴다는 점입니다.
-
-SSE나 AG-UI/CopilotKit 연동이 필요하면 [AI Agent 개발](agents.md)의 SSE 및 AG-UI adapter 예제를 사용합니다. Spakky-native SSE는 `AgentYield`를 `data: {"kind": ...}` frame으로 보내고, CopilotKit용 endpoint는 AG-UI `data: {"type": ...}` event stream으로 별도 변환해야 합니다.
-
----
-
-## 분산 트레이싱
-
-`spakky-tracing`은 `spakky-fastapi`의 필수 의존성입니다. 컨테이너에 `ITracePropagator`가 등록되어 있으면 `TracingMiddleware`가 자동으로 등록되어 모든 HTTP 요청에 대해 W3C `TraceContext`를 전파합니다.
-
-`AddBuiltInMiddlewaresPostProcessor`가 컨테이너에서 `get_or_none(ITracePropagator)`로 propagator를 조회하고, 있으면 `TracingMiddleware`를 FastAPI에 자동 추가합니다.
-
-- 수신 요청의 `traceparent` 헤더에서 `TraceContext`를 추출하여 자식 스팬을 생성합니다
-- 헤더가 없으면 새로운 루트 트레이스를 시작합니다
-- 응답 헤더에 `traceparent`를 자동 주입합니다
-- 요청 완료 후 `TraceContext`를 자동으로 정리합니다
-
-별도 설정이나 코드 변경 없이, 플러그인 로드만으로 동작합니다.
+미들웨어 실행 순서와 커스텀 에러 정의는 [FastAPI 심화](fastapi-advanced.md#middleware-error)에서 다룹니다.
 
 ---
 
@@ -304,3 +261,16 @@ class FileController:
     async def download(self, filename: str) -> str:
         return f"storage/{filename}"
 ```
+
+---
+
+## 다음 단계
+
+| 주제 | 문서 |
+| --- | --- |
+| 라우트 등록 내부 동작·`response_model` 추론 | [FastAPI 심화](fastapi-advanced.md#route-registration) |
+| 커스텀 FastAPI 인스턴스 | [FastAPI 심화](fastapi-advanced.md#custom-instance) |
+| 미들웨어 순서·커스텀 에러 | [FastAPI 심화](fastapi-advanced.md#middleware-error) |
+| WebSocket | [FastAPI 심화](fastapi-advanced.md#websocket) |
+| 분산 트레이싱 자동 등록 | [FastAPI 심화](fastapi-advanced.md#tracing) |
+| Agent stream 노출 | [FastAPI 심화](fastapi-advanced.md#agent-stream) |

--- a/docs/guides/typer-advanced.md
+++ b/docs/guides/typer-advanced.md
@@ -1,0 +1,121 @@
+# CLI 심화 (Typer)
+
+> `spakky-typer`의 명령 등록 내부 동작과, 운영에서 필요한 비동기 명령·컨텍스트 정리·인증 경계·Agent stream 노출을 다룹니다.
+
+이 문서는 [CLI 애플리케이션 (Typer)](typer.md)의 기초(컨트롤러·명령 그룹·DI 주입)를 읽은 뒤 확인하는 심화 가이드입니다. 기본 문서가 "동작하는 명령"에 집중한다면, 여기서는 명령이 등록·호출되는 과정에서 일어나는 컨텍스트 정리, async 지원, 인증 경계 처리를 설명합니다.
+
+## 명령 등록 내부 동작 { #command-registration }
+
+`app.start()` 동안 `TyperCLIPostProcessor`가 모든 Pod를 순회하며 `@CliController` Pod를 찾습니다. 컨트롤러 하나마다 하위 `Typer` 그룹을 만들고, `@command()` 메서드를 등록한 뒤, 기본 `Typer` 앱에 `add_typer()`로 붙입니다.
+
+```mermaid
+sequenceDiagram
+  participant Start as app.start()
+  participant PP as TyperCLIPostProcessor
+  participant Group as Typer(하위 그룹)
+  participant App as Typer(기본 앱)
+
+  Start->>PP: post_process(pod)
+  Note over PP: @CliController가 아니면 그대로 반환
+  PP->>Group: Typer(name=group_name)
+  loop @command 메서드마다
+    Note over PP: auth metadata 수집
+    Note over PP: async면 run_async로 래핑
+    PP->>Group: command(name, help, ...)(endpoint)
+  end
+  PP->>App: add_typer(group)
+```
+
+등록된 endpoint는 호출 시점에 컨테이너에서 컨트롤러 인스턴스를 다시 resolve해 실제 메서드를 호출합니다. 코루틴 함수면 `run_async()`로 감싸 동기 호출 모델에서 실행하고, 매 명령 실행 전에 `ApplicationContext.clear_context()`를 호출해 이전 명령의 CONTEXT scope Pod를 정리합니다.
+
+## 비동기 명령과 컨텍스트 정리 { #async-context }
+
+`TyperCLIPostProcessor`는 command 메서드가 coroutine function이면 내부에서 `run_async()`로 감싸 Typer의 동기 호출 모델에서 실행합니다. 또한 각 명령 호출 전에 `ApplicationContext.clear_context()`를 호출하여 CONTEXT scope Pod가 이전 명령과 섞이지 않도록 정리합니다 — 같은 인터프리터 세션에서 여러 명령이 연이어 실행될 때 컨텍스트 누수를 방지합니다.
+
+```python
+from spakky.plugins.typer.stereotypes.cli_controller import CliController, command
+
+
+@CliController("orders")
+class OrderCLI:
+    def __init__(self, import_orders: ImportOrdersUseCase) -> None:
+        self._import_orders = import_orders
+
+    @command("import", help="Import orders from a JSON file")
+    async def import_orders(self, path: str) -> None:
+        count = await self._import_orders.execute(path)
+        print(f"{count} orders imported")
+```
+
+위 예시는 `python main.py orders import --path ./orders.json`처럼 호출합니다. `@command(name=None)`이면 메서드명이 Typer command 이름이 되고, 그룹 이름은 `@CliController("orders")` 또는 클래스명 kebab-case로 정해집니다.
+
+## Auth boundary 통합 { #auth-boundary }
+
+`spakky-auth`를 함께 사용하면 CLI command method에 `@protected`, `@require_scope`, `@require_role`, `@require_permission`, `@require_policy`, `@require_relation` metadata를 선언할 수 있습니다. Typer adapter는 command 실행 직전에 `--auth-token` option을 먼저 읽고, 없으면 `SPAKKY_AUTH_TOKEN` env var를 읽어 `CredentialCarrier(location=CLI_OPTION)`로 provider에 전달합니다. stdin은 auth 전달체가 아닙니다.
+
+```python
+from spakky.auth import require_scope
+from spakky.plugins.typer.stereotypes.cli_controller import CliController, command
+
+
+@CliController("documents")
+class DocumentCLI:
+    @command("read")
+    @require_scope("documents:read")
+    def read_document(self, document_id: str) -> None:
+        print(f"reading {document_id}")
+```
+
+```bash
+python main.py documents read --document-id doc-1 --auth-token "$TOKEN"
+SPAKKY_AUTH_TOKEN="$TOKEN" python main.py documents read --document-id doc-1
+```
+
+Decorator가 없는 command는 auth provider 없이도 allow all입니다. Protected command는 token, authentication provider, `AuthContext`, authorization checker 중 필요한 요소가 없거나 decision이 `ALLOW`가 아니면 fail closed 됩니다. CLI 출력은 reason code 기반이며 exit code는 다음처럼 고정됩니다.
+
+| Decision | Exit code | 예시 reason code |
+|----------|-----------|------------------|
+| `CHALLENGE` | `2` | `MISSING_CREDENTIAL`, `INVALID_CREDENTIAL` |
+| `DENY` | `3` | `INSUFFICIENT_SCOPE`, `POLICY_DENIED` |
+| `ERROR` | `1` | `VERIFICATION_PROVIDER_UNAVAILABLE` |
+
+## AgentYield stream CLI { #agent-stream-cli }
+
+`@Agent`도 CLI adapter에서는 UseCase와 같은 방식으로 다룹니다. Typer 전용 agent plugin을 만들지 않고, `@CliController` command가 container에서 agent Pod를 resolve한 뒤 `execute()`를 순회하면 됩니다. CodeAssistant demo의 CLI 예제는 `core/spakky-agent/examples/inbound_adapter_examples.py`에 있습니다.
+
+```python
+from examples.code_assistant_demo import CodeAssistant, CodeAssistantCommand
+from examples.inbound_adapter_examples import agent_signal_from_json, agent_yield_to_event
+from spakky.agent import IAgentSignalRepository
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.plugins.typer.stereotypes.cli_controller import CliController, command
+
+
+@CliController("agents")
+class AgentCLI(IContainerAware):
+    _container: IContainer
+
+    def set_container(self, container: IContainer) -> None:
+        self._container = container
+
+    @command("code")
+    async def code(self, state_id: str, instruction: str) -> None:
+        command_dto = CodeAssistantCommand(state_id=state_id, instruction=instruction)
+        agent = self._container.get(CodeAssistant)
+        signals = self._container.get(IAgentSignalRepository)
+
+        async for item in agent.execute(command_dto):
+            event = agent_yield_to_event(item)
+            print(event["payload"].get("text", ""), end="")
+            if item.kind.value == "approval":
+                signals.append(
+                    agent_signal_from_json(
+                        state_id,
+                        {"kind": "approval_decision", "decision": "approve"},
+                        approval=item.payload,
+                    )
+                )
+```
+
+실제 예제 command는 `token`을 stdout에 즉시 쓰고, 다른 `AgentYield`는 줄 단위 event로 출력합니다. `--read-stdin-signal` 옵션을 켜면 stdin JSON line을 `AgentSignalKind.USER_MESSAGE` 또는 `AgentSignalKind.APPROVAL_DECISION`으로 변환해 repository에 append합니다.

--- a/docs/guides/typer.md
+++ b/docs/guides/typer.md
@@ -3,6 +3,48 @@
 > `spakky-typer`는 Typer CLI 앱을 `@CliController` 클래스로 구조화합니다.
 > CLI Controller Pod를 스캔하면 `@command()` 메서드가 Typer 하위 명령으로 자동 등록됩니다.
 
+이 문서는 **처음 CLI를 만들 때 필요한 기초**만 다룹니다. 비동기 명령·컨텍스트 정리·인증 경계·Agent stream 같은 심화 주제는 [CLI 심화](typer-advanced.md)를 참고하세요.
+
+---
+
+## 명령 등록 흐름
+
+`@CliController` Pod의 `@command()` 메서드가 Typer 하위 명령으로 노출되기까지의 경로입니다. 사용자 코드(Controller)는 DI 컨테이너와 `spakky-typer` 플러그인을 거쳐 Typer 앱에 연결되고, 최종 실행 파일에서 `cli()`로 호출됩니다.
+
+```mermaid
+graph TD
+  User[터미널 사용자]:::external
+
+  subgraph App[애플리케이션 코드]
+    Controller["@CliController"]:::app
+    Command["@command 메서드"]:::app
+    UseCase["@UseCase"]:::app
+  end
+
+  subgraph Framework[Spakky Framework]
+    DI[DI / Pod 컨테이너]:::core
+    subgraph Plugin[spakky-typer]
+      PP[TyperCLIPostProcessor]:::plugin
+      Typer[Typer 앱]:::plugin
+    end
+  end
+
+  User --> Typer
+  Typer --> Command
+  Controller --> Command
+  Command --> UseCase
+  DI --> Controller
+  DI --> UseCase
+  PP --> Typer
+
+  classDef app fill:#E3F2FD,stroke:#1565C0,color:#0D47A1
+  classDef core fill:#E8F5E9,stroke:#2E7D32,color:#1B5E20
+  classDef plugin fill:#FFF3E0,stroke:#EF6C00,color:#E65100
+  classDef external fill:#ECEFF1,stroke:#546E7A,color:#263238
+```
+
+`app.start()` 이후 `TyperCLIPostProcessor`가 `@CliController` Pod마다 하위 `Typer` 그룹을 만들고 `@command()` 메서드를 명령으로 등록한 뒤, 기본 `Typer` 앱에 `add_typer()`로 붙입니다. 사용자가 명령을 입력하면 Typer 앱 → 명령 → UseCase 순으로 흐르고, 컨트롤러·UseCase 인스턴스는 DI 컨테이너가 제공합니다.
+
 ---
 
 ## 기본 설정
@@ -61,8 +103,8 @@ python main.py users create --name "John" --email "john@example.com"
 
 ## @CliController — CLI 명령 그룹
 
-`@CliController`는 클래스를 CLI 명령 그룹으로 등록합니다. `group_name`을 생략하면 클래스명에서 자동으로 kebab-case 이름이 생성됩니다.
-메서드에는 독립 함수인 `@command()`를 사용합니다.
+`@CliController`는 클래스를 CLI 명령 그룹으로 등록합니다. `group_name`을 생략하면 클래스명에서 자동으로 kebab-case 이름이 생성됩니다(`pascal_to_kebab`, 예: `UserController` → `user-controller`).
+메서드에는 독립 함수인 `@command()`를 사용합니다. `@command(name=...)`을 생략하면 메서드명이 명령 이름이 됩니다.
 
 ```python
 from spakky.plugins.typer.stereotypes.cli_controller import CliController, command
@@ -101,6 +143,8 @@ python main.py users list
 python main.py users delete --user-id "user-123"
 ```
 
+`@command()`에는 Typer의 명령 옵션을 그대로 전달할 수 있습니다 — `help`, `short_help`, `epilog`, `hidden`, `deprecated`, `rich_help_panel` 등이 `TyperCommand` annotation에 저장되어 Typer에 그대로 넘어갑니다.
+
 ---
 
 ## 여러 컨트롤러
@@ -129,7 +173,7 @@ class DatabaseCLI:
 
 ## DI 주입
 
-일반 `@Pod`처럼 생성자 주입이 동작합니다.
+일반 `@Pod`처럼 생성자 주입이 동작합니다. 명령은 컨테이너에서 resolve한 컨트롤러 인스턴스 위에서 실행되므로, UseCase·Service를 생성자로 받아 그대로 사용할 수 있습니다.
 
 ```python
 from spakky.core.stereotype.usecase import UseCase
@@ -154,94 +198,15 @@ class DataCLI:
         print(f"{count}건 임포트 완료")
 ```
 
-## 비동기 명령과 컨텍스트 정리
+명령 옵션 이름은 Typer의 기본 규칙을 따릅니다. 위 예시는 `python main.py data import --path ./data.json`처럼 호출합니다.
 
-`TyperCLIPostProcessor`는 command 메서드가 coroutine function이면 내부에서 `run_async()`로 감싸 Typer의 동기 호출 모델에서 실행합니다. 또한 각 명령 호출 전에 `ApplicationContext.clear_context()`를 호출하여 CONTEXT scope Pod가 이전 명령과 섞이지 않도록 정리합니다.
+---
 
-```python
-from spakky.plugins.typer.stereotypes.cli_controller import CliController, command
+## 다음 단계
 
-
-@CliController("orders")
-class OrderCLI:
-    def __init__(self, import_orders: ImportOrdersUseCase) -> None:
-        self._import_orders = import_orders
-
-    @command("import", help="Import orders from a JSON file")
-    async def import_orders(self, path: str) -> None:
-        count = await self._import_orders.execute(path)
-        print(f"{count} orders imported")
-```
-
-명령 옵션 이름은 Typer의 기본 규칙을 따릅니다. 위 예시는 `python main.py orders import --path ./orders.json`처럼 호출합니다. `@command(name=None)`이면 메서드명이 Typer command 이름이 되고, 그룹 이름은 `@CliController("orders")` 또는 클래스명 kebab-case로 정해집니다.
-
-## Auth boundary 통합
-
-`spakky-auth`를 함께 사용하면 CLI command method에 `@protected`, `@require_scope`, `@require_role`, `@require_permission`, `@require_policy`, `@require_relation` metadata를 선언할 수 있습니다. Typer adapter는 command 실행 직전에 `--auth-token` option을 먼저 읽고, 없으면 `SPAKKY_AUTH_TOKEN` env var를 읽어 `CredentialCarrier(location=CLI_OPTION)`로 provider에 전달합니다. stdin은 auth 전달체가 아닙니다.
-
-```python
-from spakky.auth import require_scope
-from spakky.plugins.typer.stereotypes.cli_controller import CliController, command
-
-
-@CliController("documents")
-class DocumentCLI:
-    @command("read")
-    @require_scope("documents:read")
-    def read_document(self, document_id: str) -> None:
-        print(f"reading {document_id}")
-```
-
-```bash
-python main.py documents read --document-id doc-1 --auth-token "$TOKEN"
-SPAKKY_AUTH_TOKEN="$TOKEN" python main.py documents read --document-id doc-1
-```
-
-Decorator가 없는 command는 auth provider 없이도 allow all입니다. Protected command는 token, authentication provider, `AuthContext`, authorization checker 중 필요한 요소가 없거나 decision이 `ALLOW`가 아니면 fail closed 됩니다. CLI 출력은 reason code 기반이며 exit code는 다음처럼 고정됩니다.
-
-| Decision | Exit code | 예시 reason code |
-|----------|-----------|------------------|
-| `CHALLENGE` | `2` | `MISSING_CREDENTIAL`, `INVALID_CREDENTIAL` |
-| `DENY` | `3` | `INSUFFICIENT_SCOPE`, `POLICY_DENIED` |
-| `ERROR` | `1` | `VERIFICATION_PROVIDER_UNAVAILABLE` |
-
-## AgentYield stream CLI
-
-`@Agent`도 CLI adapter에서는 UseCase와 같은 방식으로 다룹니다. Typer 전용 agent plugin을 만들지 않고, `@CliController` command가 container에서 agent Pod를 resolve한 뒤 `execute()`를 순회하면 됩니다. CodeAssistant demo의 CLI 예제는 `core/spakky-agent/examples/inbound_adapter_examples.py`에 있습니다.
-
-```python
-from examples.code_assistant_demo import CodeAssistant, CodeAssistantCommand
-from examples.inbound_adapter_examples import agent_signal_from_json, agent_yield_to_event
-from spakky.agent import IAgentSignalRepository
-from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
-from spakky.core.pod.interfaces.container import IContainer
-from spakky.plugins.typer.stereotypes.cli_controller import CliController, command
-
-
-@CliController("agents")
-class AgentCLI(IContainerAware):
-    _container: IContainer
-
-    def set_container(self, container: IContainer) -> None:
-        self._container = container
-
-    @command("code")
-    async def code(self, state_id: str, instruction: str) -> None:
-        command_dto = CodeAssistantCommand(state_id=state_id, instruction=instruction)
-        agent = self._container.get(CodeAssistant)
-        signals = self._container.get(IAgentSignalRepository)
-
-        async for item in agent.execute(command_dto):
-            event = agent_yield_to_event(item)
-            print(event["payload"].get("text", ""), end="")
-            if item.kind.value == "approval":
-                signals.append(
-                    agent_signal_from_json(
-                        state_id,
-                        {"kind": "approval_decision", "decision": "approve"},
-                        approval=item.payload,
-                    )
-                )
-```
-
-실제 예제 command는 `token`을 stdout에 즉시 쓰고, 다른 `AgentYield`는 줄 단위 event로 출력합니다. `--read-stdin-signal` 옵션을 켜면 stdin JSON line을 `AgentSignalKind.USER_MESSAGE` 또는 `AgentSignalKind.APPROVAL_DECISION`으로 변환해 repository에 append합니다.
+| 주제 | 문서 |
+| --- | --- |
+| 명령 등록 내부 동작 | [CLI 심화](typer-advanced.md#command-registration) |
+| 비동기 명령·컨텍스트 정리 | [CLI 심화](typer-advanced.md#async-context) |
+| 인증/인가 경계 통합 | [CLI 심화](typer-advanced.md#auth-boundary) |
+| Agent stream CLI | [CLI 심화](typer-advanced.md#agent-stream-cli) |

--- a/docs/sections/boundaries.md
+++ b/docs/sections/boundaries.md
@@ -17,4 +17,6 @@
 
 | 문서 | 무엇을 배우나요 |
 | --- | --- |
+| [FastAPI 심화](../guides/fastapi-advanced.md) | 라우트 등록 내부 동작·커스텀 인스턴스·미들웨어·WebSocket·트레이싱·Agent stream |
+| [CLI (Typer) 심화](../guides/typer-advanced.md) | 명령 등록 내부 동작·비동기 명령·컨텍스트 정리·인증 경계·Agent stream |
 | [gRPC 심화](../guides/grpc-advanced.md) | 무설정 변환·스트리밍·인터셉터 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,8 @@ nav:
           - gRPC 통합: guides/grpc.md
           - 데이터베이스 (SQLAlchemy): guides/sqlalchemy.md
       - 심화:
+          - FastAPI 심화: guides/fastapi-advanced.md
+          - CLI (Typer) 심화: guides/typer-advanced.md
           - gRPC 심화: guides/grpc-advanced.md
   - 메시징과 워크플로우:
       - 개요: sections/messaging.md


### PR DESCRIPTION
## 목적

애플리케이션 경계 채널(FastAPI·CLI)의 가이드를 기초/심화로 분리하고, 기능 설명을 보강하며 흐름 도식을 추가한다. 선행 #401(문서 IA 재설계)이 만든 채널별 개요+기초+심화 위계와 `docs/contributing/diagram-standard.md` 도식 표준을 따른다.

Closes #407

## 변경 내용

### 기초/심화 분리 (FR-1)
- `docs/guides/fastapi.md` (기초): 기본 설정, `@ApiController` HTTP 메서드 데코레이터, UseCase+에러 매핑, 라우트 옵션에 집중. 중급/고급 블록 제거 후 "다음 단계" 표로 심화 링크 안내.
- `docs/guides/fastapi-advanced.md` (신규, 심화): 라우트 등록 내부 동작·`response_model` 추론, 커스텀 FastAPI 인스턴스, 미들웨어 순서·커스텀 에러, WebSocket, 분산 트레이싱 자동 등록, AgentYield stream 노출.
- `docs/guides/typer.md` (기초): 기본 설정, `@CliController` 명령 그룹, 여러 컨트롤러, DI 주입에 집중. 비동기/컨텍스트 정리 섹션은 심화로 이동.
- `docs/guides/typer-advanced.md` (신규, 심화): 명령 등록 내부 동작, 비동기 명령·컨텍스트 정리, 인증(Auth) 경계 통합(exit code 매핑), AgentYield stream CLI.

### 흐름 도식 추가 (FR-2)
각 채널 핵심 흐름에 `diagram-standard.md` 준수 mermaid 도식 1개 이상:
- FastAPI: 요청 처리 흐름(`graph TD`, app/core/plugin/external 팔레트) + 라우트 등록 내부 동작(`sequenceDiagram`).
- CLI: 명령 등록 흐름(`graph TD`) + 명령 등록 내부 동작(`sequenceDiagram`).

### nav·색인 등록
- `mkdocs.yml`: 애플리케이션 경계 > 심화에 "FastAPI 심화", "CLI (Typer) 심화" 추가.
- `docs/sections/boundaries.md`: 심화 표에 두 문서 항목 추가.

## 결정 근거 (구현 단계 자율 결정)
- 심화 문서 헤딩에 `attr_list` 명시 앵커(`{ #route-registration }` 등)를 부여했다. mkdocs slugify가 순수 한국어 헤딩을 `_1`/`_2`로 축약해 기초→심화 교차 링크가 불안정해지는 문제를 안정 슬러그로 차단하기 위함.
- 도식 종류 선택은 표준 §1을 따랐다 — 의존/요청 흐름은 `graph TD`, 시간순 등록 동작은 `sequenceDiagram`.

## 검증

- `uv run --group dev mkdocs build --strict` → EXIT=0 (SC-1 빌드 통과). 교차 링크 앵커 12개 모두 resolve.
- code-first: 문서의 모든 심볼·import 경로·환경변수·동작을 `spakky-fastapi`/`spakky-typer` 소스로 대조 (환각 0건).
- `/review-code` 외부 게이트: Critical 0개 수렴.

## Acceptance Criteria (자가 grep)
- [x] FR-1: FastAPI·CLI 각각 기초/심화 문서 분리 (`fastapi.md`+`fastapi-advanced.md`, `typer.md`+`typer-advanced.md`)
- [x] FR-2: 각 채널 핵심 흐름 도식 1개 이상 (채널당 2개)
- [x] SC-1: `mkdocs build --strict` 통과 + 기초 문서에 중급/고급 주제 잔존 없음 (심화로 이동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)