### PR TITLE
fix(harness): 워크트리 pre-commit pyrefly가 src·tests를 실제 타입 검사하도록 수정

### DIFF
--- a/core/spakky-actuator/.pre-commit-config.yaml
+++ b/core/spakky-actuator/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-actuator" ]; then cd core/spakky-actuator; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "core/spakky-actuator" ]; then cd core/spakky-actuator; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky-data/.pre-commit-config.yaml
+++ b/core/spakky-data/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-data" ]; then cd core/spakky-data; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "core/spakky-data" ]; then cd core/spakky-data; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky-domain/.pre-commit-config.yaml
+++ b/core/spakky-domain/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-domain" ]; then cd core/spakky-domain; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "core/spakky-domain" ]; then cd core/spakky-domain; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky-event/.pre-commit-config.yaml
+++ b/core/spakky-event/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-event" ]; then cd core/spakky-event; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "core/spakky-event" ]; then cd core/spakky-event; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky-outbox/.pre-commit-config.yaml
+++ b/core/spakky-outbox/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-outbox" ]; then cd core/spakky-outbox; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "core/spakky-outbox" ]; then cd core/spakky-outbox; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky-saga/.pre-commit-config.yaml
+++ b/core/spakky-saga/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-saga" ]; then cd core/spakky-saga; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "core/spakky-saga" ]; then cd core/spakky-saga; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky-task/.pre-commit-config.yaml
+++ b/core/spakky-task/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-task" ]; then cd core/spakky-task; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "core/spakky-task" ]; then cd core/spakky-task; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky-tracing/.pre-commit-config.yaml
+++ b/core/spakky-tracing/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky-tracing" ]; then cd core/spakky-tracing; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "core/spakky-tracing" ]; then cd core/spakky-tracing; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/core/spakky/.pre-commit-config.yaml
+++ b/core/spakky/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "core/spakky" ]; then cd core/spakky; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "core/spakky" ]; then cd core/spakky; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-celery/.pre-commit-config.yaml
+++ b/plugins/spakky-celery/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-celery" ]; then cd plugins/spakky-celery; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "plugins/spakky-celery" ]; then cd plugins/spakky-celery; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-fastapi/.pre-commit-config.yaml
+++ b/plugins/spakky-fastapi/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-fastapi" ]; then cd plugins/spakky-fastapi; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "plugins/spakky-fastapi" ]; then cd plugins/spakky-fastapi; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-grpc/.pre-commit-config.yaml
+++ b/plugins/spakky-grpc/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-grpc" ]; then cd plugins/spakky-grpc; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "plugins/spakky-grpc" ]; then cd plugins/spakky-grpc; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-grpc/pyproject.toml
+++ b/plugins/spakky-grpc/pyproject.toml
@@ -39,11 +39,6 @@ module-name = "spakky.plugins.grpc"
 python-version = "3.12"
 search_path = ["src", "."]
 project_excludes = ["**/__pycache__", "**/*.pyc"]
-# Scope type checking to the package's own sources explicitly. Without an
-# explicit `project_includes`, pyrefly consults the repo's root .gitignore
-# (which lists `.claude/worktrees/`) and skips every file when this package
-# is checked from inside a git-isolation worktree (process-ticket workflow).
-project_includes = ["src", "tests"]
 
 [tool.ruff]
 builtins = ["_"]

--- a/plugins/spakky-kafka/.pre-commit-config.yaml
+++ b/plugins/spakky-kafka/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-kafka" ]; then cd plugins/spakky-kafka; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "plugins/spakky-kafka" ]; then cd plugins/spakky-kafka; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-logging/.pre-commit-config.yaml
+++ b/plugins/spakky-logging/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-logging" ]; then cd plugins/spakky-logging; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "plugins/spakky-logging" ]; then cd plugins/spakky-logging; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-oidc/.pre-commit-config.yaml
+++ b/plugins/spakky-oidc/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-oidc" ]; then cd plugins/spakky-oidc; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "plugins/spakky-oidc" ]; then cd plugins/spakky-oidc; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-opentelemetry/.pre-commit-config.yaml
+++ b/plugins/spakky-opentelemetry/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-opentelemetry" ]; then cd plugins/spakky-opentelemetry; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "plugins/spakky-opentelemetry" ]; then cd plugins/spakky-opentelemetry; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-policy/.pre-commit-config.yaml
+++ b/plugins/spakky-policy/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-policy" ]; then cd plugins/spakky-policy; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "plugins/spakky-policy" ]; then cd plugins/spakky-policy; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-rabbitmq/.pre-commit-config.yaml
+++ b/plugins/spakky-rabbitmq/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-rabbitmq" ]; then cd plugins/spakky-rabbitmq; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "plugins/spakky-rabbitmq" ]; then cd plugins/spakky-rabbitmq; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-sqlalchemy/.pre-commit-config.yaml
+++ b/plugins/spakky-sqlalchemy/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-sqlalchemy" ]; then cd plugins/spakky-sqlalchemy; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "plugins/spakky-sqlalchemy" ]; then cd plugins/spakky-sqlalchemy; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false

--- a/plugins/spakky-typer/.pre-commit-config.yaml
+++ b/plugins/spakky-typer/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "plugins/spakky-typer" ]; then cd plugins/spakky-typer; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+        entry: bash -c 'if [ -d "plugins/spakky-typer" ]; then cd plugins/spakky-typer; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false


### PR DESCRIPTION
## 배경 / 근본 원인

process-ticket 워크트리(`.claude/worktrees/<branch>`) 안에서 패키지 pre-commit의 `pyrefly-typecheck` 훅은 인자 없이 `uv run pyrefly check`를 호출했다. pyrefly는 기본적으로 `.gitignore`를 ignore-file로 존중하는데, 워크트리의 루트 `.gitignore`가 `.claude/worktrees/`를 포함하므로 pyrefly가 패키지 파일을 auto-discovery한 뒤 전부 ignore-file 매치로 skip했다.

증상은 두 가지로 갈렸다:
- `project_includes`/`search_path`로 `src`가 안 잡히는 패키지: `No Python files matched` → exit 1 실패.
- `search_path = ["src", "."]`만 있는 패키지: `src`는 search_path로 검사되지만 `tests`는 ignore-file에 걸려 **조용히 skip**(false-green). 실제로 `core/spakky`는 전체 실패, `spakky-grpc`는 `tests` skip + `0 diagnostics`로 false-green이었다.

이슈 #402는 `spakky-grpc`에 한해 `[tool.pyrefly] project_includes = ["src", "tests"]`를 추가했으나, 이 우회는 `tests`를 여전히 false-green으로 남겼고 다른 모든 패키지에 동일 결함이 잠재했다.

## 수정

pyrefly 문서(`configuration.mdx`, `use-ignore-files`)는 "When explicitly specifying files to check, ignore files are not used"라고 명시한다. 명시 경로를 넘기면 ignore-file skip이 우회된다.

- 20개 패키지의 `.pre-commit-config.yaml` `pyrefly-typecheck` entry를 `uv run pyrefly check ...` → `uv run pyrefly check src tests ...`로 변경. `src`·`tests` 둘 다 명시하여 ignore-file과 무관하게 양쪽을 타입 검사한다.
- `spakky-grpc/pyproject.toml`의 #402 우회(`project_includes = ["src", "tests"]` + 주석)를 revert. 명시 경로 호출이 이를 대체하며, 그 우회는 `tests` false-green을 남겼으므로 제거가 일관 해법이다.

단일 invocation 지점(공유 pre-commit 훅)은 없고 각 패키지가 자기 `.pre-commit-config.yaml`을 소유하므로 20개 파일에 동일 변경을 적용했다.

## CI 보존

CI(`.github/workflows/ci.yml`)는 신규 체크아웃 + root-synced 환경에서 인자 없는 `pyrefly check`를 그대로 실행한다. 신규 체크아웃에는 `.claude/worktrees/` 경로가 없어 root `.gitignore`가 매치되지 않으므로 CI는 영향받지 않고, 이미 `src`·`tests`를 모두 검사한다. CI 파일은 변경하지 않았다.

## 검증 (false-green 재발 방지)

- 20개 패키지 전부 워크트리에서 `pyrefly check src tests` → `0 diagnostics`, `Skipping`/`No Python files` 경고 0건. 여러 패키지가 `(N suppressed)`를 보고하여 `tests`가 실제 검사됨을 확인.
- `spakky-grpc/tests`에 의도적 타입 오류(`x: int = "..."`)를 심자 pre-commit 훅이 **Failed**로 전환(`bad-assignment` 검출) → 이전이라면 skip되어 false-green이었을 케이스가 이제 차단됨을 입증. 확인 후 probe 제거.

Closes #428
