### PR TITLE
docs: 이벤트 기반 아키텍처 통합 가이드 — 개념/사용법 분리 + 도식 (#408)

### DIFF
--- a/docs/guides/event-driven.md
+++ b/docs/guides/event-driven.md
@@ -1,0 +1,247 @@
+# 이벤트 기반 아키텍처 통합 가이드
+
+> 이벤트 시스템·Transactional Outbox·사가가 **하나의 분산 워크플로우**로 맞물려 동작하는 방식을 개념과 사용법으로 나누어 설명합니다.
+
+이벤트 시스템(`spakky-event`), Outbox(`spakky-outbox`), 사가(`spakky-saga`)는 각각 독립된 가이드가 있지만, 실제 분산 워크플로우는 셋을 함께 씁니다. 이 문서는 세 컴포넌트를 **개념 → 사용법** 순서로 한 번에 연결해, "이벤트로 분산 워크플로우를 어떻게 구성하는가"를 끝까지 따라갈 수 있게 합니다.
+
+개별 컴포넌트의 전체 API는 [이벤트 시스템](events.md) · [Transactional Outbox](outbox.md) · [사가 오케스트레이션](saga.md)을 참고하세요.
+
+---
+
+## 개념
+
+### 세 컴포넌트의 역할 분담
+
+| 컴포넌트 | 책임 | 경계 |
+| --- | --- | --- |
+| 이벤트 시스템 | 상태 변경을 이벤트로 발행하고 핸들러로 처리 | 같은 프로세스 안(DomainEvent) + 외부 발행 진입점(IntegrationEvent) |
+| Outbox | Integration Event를 DB 트랜잭션과 원자적으로 묶어 at-least-once 전달 보장 | 발행 시점 ↔ 브로커 전송 시점 분리 |
+| 사가 | 여러 서비스/트랜잭션에 걸친 흐름을 보상 기반으로 오케스트레이션 | 복수 UseCase 호출 + 실패 시 역순 보상 |
+
+이벤트 시스템은 "무엇이 일어났는가"를 알리고, Outbox는 그 알림이 "유실 없이" 외부로 나가도록 보장하며, 사가는 여러 단계의 흐름이 "전부 성공하거나 전부 되돌려지도록" 조율합니다.
+
+### 발행에서 전송, 보상까지의 전체 그림
+
+아래는 주문 사가가 진행되는 동안 세 컴포넌트가 어떻게 연결되는지를 보여 줍니다. 사용자 코드(UseCase·Saga)는 프레임워크 코어(이벤트·Outbox 코어)와 플러그인(SQLAlchemy·Kafka)을 거쳐 외부 시스템(DB·브로커)에 닿습니다.
+
+```mermaid
+graph TD
+  Saga["@Saga 오케스트레이터"]:::app
+
+  subgraph App[애플리케이션 코드]
+    UseCase["@UseCase + @Transactional"]:::app
+    Handler["@EventHandler"]:::app
+  end
+
+  subgraph Framework[Spakky Framework]
+    subgraph Core[코어]
+      Publisher["IAsyncEventPublisher"]:::core
+      Bus["IAsyncEventBus<br/>(OutboxEventBus @Primary)"]:::core
+      Mediator["EventMediator"]:::core
+      Relay["OutboxRelayBackgroundService"]:::core
+    end
+    subgraph Plugins[플러그인]
+      Storage["SqlAlchemyOutboxStorage"]:::plugin
+      Transport["KafkaEventTransport"]:::plugin
+    end
+  end
+
+  subgraph Outside[외부 시스템]
+    DB[(Outbox 테이블)]:::external
+    MQ[Kafka 브로커]:::external
+  end
+
+  Saga --> UseCase
+  UseCase --> Publisher
+  Publisher -->|"DomainEvent"| Mediator
+  Mediator --> Handler
+  Publisher -->|"IntegrationEvent"| Bus
+  Bus --> Storage
+  Storage --> DB
+  Relay --> Storage
+  Relay --> Transport
+  Transport --> MQ
+
+  classDef app fill:#E3F2FD,stroke:#1565C0,color:#0D47A1
+  classDef core fill:#E8F5E9,stroke:#2E7D32,color:#1B5E20
+  classDef plugin fill:#FFF3E0,stroke:#EF6C00,color:#E65100
+  classDef external fill:#ECEFF1,stroke:#546E7A,color:#263238
+```
+
+핵심은 `OutboxEventBus`가 `@Primary`로 기본 `IAsyncEventBus`를 대체한다는 점입니다. 사가 step 안의 UseCase가 `publisher.publish()`로 Integration Event를 발행하면, 이벤트가 브로커로 바로 나가지 않고 **같은 트랜잭션 안에서 Outbox 테이블에 저장**됩니다. 트랜잭션이 commit되어야 메시지도 함께 남고, rollback되면 비즈니스 데이터와 메시지가 함께 사라집니다. 실제 브로커 전송은 `OutboxRelayBackgroundService`가 별도로 폴링하며 수행합니다.
+
+### 왜 세 컴포넌트를 함께 쓰나
+
+단일 Aggregate 내부 변경이라면 이벤트 시스템만으로 충분합니다. 외부로 Integration Event를 내보내는 순간 "DB는 commit됐는데 브로커 전송은 실패"하는 이중 쓰기 문제가 생기고, 이때 Outbox가 필요합니다. 여기에 더해 흐름이 여러 서비스를 가로지르고 중간 실패 시 앞 단계를 되돌려야 하면 사가로 승격합니다. 즉, 세 컴포넌트는 **요구사항이 커질수록 차례로 추가**되는 계층이지, 항상 함께 켜야 하는 묶음이 아닙니다.
+
+---
+
+## 사용법
+
+### 1단계 — 플러그인 로드
+
+세 컴포넌트를 함께 쓰려면 이벤트·Outbox 코어와 저장소·전송 플러그인을 함께 로드합니다. 사가는 `Pod` 스캔만으로 동작하므로 별도 post-processor가 없습니다.
+
+```python
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+import spakky.data
+import spakky.event
+import spakky.outbox
+import spakky.saga
+import spakky.plugins.sqlalchemy  # Outbox storage 제공
+import spakky.plugins.kafka       # Transport 제공
+import apps
+
+app = (
+    SpakkyApplication(ApplicationContext())
+    .load_plugins(include={
+        spakky.data.PLUGIN_NAME,
+        spakky.event.PLUGIN_NAME,
+        spakky.outbox.PLUGIN_NAME,
+        spakky.saga.PLUGIN_NAME,
+        spakky.plugins.sqlalchemy.PLUGIN_NAME,
+        spakky.plugins.kafka.PLUGIN_NAME,
+    })
+    .scan(apps)
+    .start()
+)
+```
+
+### 2단계 — UseCase에서 트랜잭션 + 이벤트 발행
+
+각 사가 step의 실체는 `@UseCase()` + `@Transactional()` 메서드입니다. UseCase 안에서 Aggregate를 저장하고 Integration Event를 발행하면, Outbox가 로드돼 있을 때 메시지가 같은 트랜잭션 안에서 Outbox 테이블에 저장됩니다.
+
+```python
+from dataclasses import replace
+from uuid import UUID
+
+from spakky.core.stereotype.usecase import UseCase
+from spakky.data.aspects.transactional import Transactional
+from spakky.event.event_publisher import IAsyncEventPublisher
+
+
+@UseCase()
+class CreateOrderUseCase:
+    def __init__(
+        self,
+        order_repo: OrderRepository,
+        publisher: IAsyncEventPublisher,
+    ) -> None:
+        self._order_repo = order_repo
+        self._publisher = publisher
+
+    @Transactional()
+    async def execute(self, customer_id: UUID, total_amount: float) -> UUID:
+        order = Order.create_pending(customer_id, total_amount)
+        saved = await self._order_repo.save(order)
+        # OutboxEventBus가 @Primary로 IAsyncEventBus를 대체 →
+        # 이 발행은 브로커로 즉시 나가지 않고 같은 트랜잭션 안에서 Outbox 테이블에 저장된다.
+        await self._publisher.publish(
+            OrderPendingCreated(order_id=saved.uid, total_amount=total_amount)
+        )
+        return saved.uid
+```
+
+### 3단계 — 사가로 흐름과 보상 묶기
+
+사가는 UseCase들을 DI로 주입받아 step으로 호출하고, `>>`로 action과 보상 UseCase를 묶습니다. 중간 step이 실패하면 엔진이 이미 commit된 step의 보상 UseCase를 **역순으로** 호출합니다.
+
+```python
+from spakky.saga import AbstractSaga, Saga, SagaFlow, saga_flow, saga_step
+
+
+@Saga()
+class OrderSaga(AbstractSaga[OrderSagaData]):
+    def __init__(
+        self,
+        create_order: CreateOrderUseCase,
+        cancel_order: CancelOrderUseCase,
+        reserve_stock: ReserveStockUseCase,
+        release_stock: ReleaseStockUseCase,
+        process_payment: ProcessPaymentUseCase,
+        refund_payment: RefundPaymentUseCase,
+    ) -> None:
+        self._create_order = create_order
+        self._cancel_order = cancel_order
+        self._reserve_stock = reserve_stock
+        self._release_stock = release_stock
+        self._process_payment = process_payment
+        self._refund_payment = refund_payment
+
+    @saga_step
+    async def create_order(self, data: OrderSagaData) -> OrderSagaData:
+        order_id = await self._create_order.execute(data.customer_id, data.total_amount)
+        return replace(data, order_id=order_id)
+
+    @saga_step
+    async def cancel_order(self, data: OrderSagaData) -> None:
+        await self._cancel_order.execute(require_order_id(data))
+
+    @saga_step
+    async def reserve_stock(self, data: OrderSagaData) -> OrderSagaData:
+        reservation_id = await self._reserve_stock.execute(require_order_id(data))
+        return replace(data, reservation_id=reservation_id)
+
+    @saga_step
+    async def release_stock(self, data: OrderSagaData) -> None:
+        await self._release_stock.execute(require_reservation_id(data))
+
+    @saga_step
+    async def process_payment(self, data: OrderSagaData) -> OrderSagaData:
+        payment_id = await self._process_payment.execute(
+            require_order_id(data), data.total_amount
+        )
+        return replace(data, payment_id=payment_id)
+
+    @saga_step
+    async def refund_payment(self, data: OrderSagaData) -> None:
+        await self._refund_payment.execute(require_payment_id(data))
+
+    def flow(self) -> SagaFlow[OrderSagaData]:
+        return saga_flow(
+            self.create_order >> self.cancel_order,
+            self.reserve_stock >> self.release_stock,
+            self.process_payment >> self.refund_payment,
+        )
+```
+
+`OrderSagaData`와 `require_*` 식별자 검증 헬퍼의 전체 정의는 [사가 오케스트레이션](saga.md)의 "사가 정의"를 참고하세요.
+
+### 보상 흐름
+
+결제 step이 실패하면 사가 엔진이 이미 commit된 재고 예약·주문 생성을 역순으로 보상합니다. 각 보상은 "rollback SQL"이 아니라 `release()`·`cancel()` 같은 명시적 도메인 상태 전이를 수행하는 새 트랜잭션입니다.
+
+```mermaid
+sequenceDiagram
+  participant Saga as OrderSaga
+  participant Create as CreateOrderUseCase
+  participant Stock as ReserveStockUseCase
+  participant Pay as ProcessPaymentUseCase
+
+  Saga->>Create: create_order 실행
+  Create-->>Saga: 주문 생성 commit (order_id)
+  Saga->>Stock: reserve_stock 실행
+  Stock-->>Saga: 재고 예약 commit (reservation_id)
+  Saga->>Pay: process_payment 실행
+  Pay--xSaga: 결제 실패
+  Note over Saga: 역순 보상 시작
+  Saga->>Stock: release_stock 보상
+  Saga->>Create: cancel_order 보상
+  Saga-->>Saga: SagaResult(status=FAILED)
+```
+
+보상이 끝나면 `execute()`는 예외 대신 `SagaResult(status=SagaStatus.FAILED)`를 반환합니다. Controller는 이 상태로 응답을 분기합니다. 보상 자체가 실패하는 경우(`SagaCompensationFailedError`)와 에스컬레이션 핸들러는 [사가 심화 — 타임아웃과 보상 실패](saga-advanced.md)에서 다룹니다.
+
+### Outbox 전송 시점
+
+UseCase가 발행한 Integration Event는 트랜잭션 commit 시점에 Outbox 테이블에 남고, 실제 브로커 전송은 `OutboxRelayBackgroundService`가 폴링으로 따로 처리합니다. 발행 트랜잭션과 전송이 분리돼 있어 at-least-once가 보장됩니다. 폴링 주기·배치 크기·재시도 설정과 전송 상태 전이 도식은 [Transactional Outbox](outbox.md)의 "폴링 → 전송 흐름"에서 다룹니다.
+
+---
+
+## 다음 단계
+
+- [이벤트 시스템](events.md) — DomainEvent/IntegrationEvent 발행과 핸들러 등록
+- [Transactional Outbox](outbox.md) — at-least-once 전달 보장과 Relay 설정
+- [사가 오케스트레이션](saga.md) — 보상 기반 분산 트랜잭션 정의
+- [사가 심화](saga-advanced.md) — DSL, 에러 전략, 타임아웃, Semantic Lock

--- a/docs/guides/events.md
+++ b/docs/guides/events.md
@@ -1,16 +1,66 @@
 # 이벤트 시스템
 
-> 도메인 이벤트와 통합 이벤트를 발행하고 handler로 처리하는 기본 흐름을 설명합니다.
+> 도메인 이벤트와 통합 이벤트를 발행하고 handler로 처리하는 기본 흐름을, 개념과 사용법으로 나누어 설명합니다.
 
-도메인 이벤트를 자동으로 발행하고 핸들러에서 처리하는 이벤트 기반 아키텍처를 구축합니다.
+도메인 이벤트를 자동으로 발행하고 핸들러에서 처리하는 이벤트 기반 아키텍처를 구축합니다. events·outbox·saga가 하나의 분산 워크플로우로 맞물리는 전체 그림은 [이벤트 기반 아키텍처 통합 가이드](event-driven.md)를 참고하세요.
 
 ---
 
-## 이벤트 핸들러 정의
+## 개념
+
+### 두 가지 이벤트 타입
+
+| 이벤트 타입 | 전달 경로 | 용도 |
+| --- | --- | --- |
+| `AbstractDomainEvent` | 인프로세스 (`EventMediator`) | 같은 바운디드 컨텍스트 내 상태 변경 알림 |
+| `AbstractIntegrationEvent` | 메시지 브로커 (`IEventBus` → RabbitMQ/Kafka) | 서비스/컨텍스트 간 통신 |
+
+두 타입은 모두 `spakky.domain.models.event`에 정의되어 있고, `event_id: UUID`와 `timestamp: datetime`을 자동으로 가집니다. 정의 방법과 공통 속성, AggregateRoot의 이벤트 수집은 [이벤트 시스템 심화](../event-system.md)에서 다룹니다.
+
+### 발행 라우팅
+
+`IEventPublisher.publish()`는 단일 발행 진입점입니다. 이벤트 타입에 따라 인프로세스 핸들러(`EventMediator`)와 브로커(`IEventBus`)로 자동 라우팅합니다. 사용자 코드는 `publish()` 한 번만 호출하면 됩니다.
+
+```mermaid
+graph TD
+  UseCase["@UseCase + @Transactional"]:::app
+  Handler["@EventHandler"]:::app
+
+  subgraph Framework[Spakky Framework]
+    subgraph Core[코어]
+      Publisher["IEventPublisher"]:::core
+      Mediator["EventMediator"]:::core
+      Bus["IEventBus"]:::core
+    end
+    Transport["EventTransport (플러그인)"]:::plugin
+  end
+
+  Broker[메시지 브로커]:::external
+
+  UseCase --> Publisher
+  Publisher -->|"DomainEvent"| Mediator
+  Mediator --> Handler
+  Publisher -->|"IntegrationEvent"| Bus
+  Bus --> Transport
+  Transport --> Broker
+
+  classDef app fill:#E3F2FD,stroke:#1565C0,color:#0D47A1
+  classDef core fill:#E8F5E9,stroke:#2E7D32,color:#1B5E20
+  classDef plugin fill:#FFF3E0,stroke:#EF6C00,color:#E65100
+  classDef external fill:#ECEFF1,stroke:#546E7A,color:#263238
+```
+
+`@on_event` 핸들러는 `AbstractDomainEvent` 서브클래스에 대해서만 자동 등록됩니다. Integration Event는 핸들러 자동 등록 대상이 아니라, 브로커에서 수신해 transport consumer가 처리합니다.
+
+---
+
+## 사용법
+
+### 이벤트 핸들러 정의
 
 `@EventHandler`와 `@on_event`로 이벤트 핸들러를 선언합니다.
 
-### 동기 핸들러
+#### 동기 핸들러
 
 ```python
 from spakky.event.stereotype.event_handler import EventHandler, on_event
@@ -26,7 +76,7 @@ class OrderEventHandler:
         print(f"아이템 추가: {event.item_name}")
 ```
 
-### 비동기 핸들러
+#### 비동기 핸들러
 
 ```python
 @EventHandler()
@@ -40,7 +90,7 @@ class AsyncOrderEventHandler:
         await update_inventory(event.item_name)
 ```
 
-### 같은 이벤트, 여러 핸들러
+#### 같은 이벤트, 여러 핸들러
 
 하나의 이벤트에 여러 핸들러를 등록할 수 있습니다. 도메인 이벤트와 통합 이벤트 모두 동일합니다.
 
@@ -58,11 +108,7 @@ class AnalyticsHandler:
         await analytics.track("order_created", event.total_amount)
 ```
 
----
-
-## 이벤트 발행 흐름
-
-### 트랜잭션과 연동
+### 트랜잭션과 연동해 발행
 
 `@Transactional`과 함께 사용하면, 트랜잭션 커밋 후 이벤트가 자동 발행됩니다.
 
@@ -92,16 +138,7 @@ class CreateOrderUseCase:
         # 4. @Transactional 완료 시 → commit → 이벤트 자동 발행
 ```
 
----
-
-## 이벤트 라우팅
-
-`EventPublisher`는 이벤트 타입에 따라 자동으로 라우팅합니다.
-
-| 이벤트 타입                | 라우팅 대상                         | 용도                    |
-| -------------------------- | ----------------------------------- | ----------------------- |
-| `AbstractDomainEvent`      | `EventDispatcher` → `EventMediator` | 같은 프로세스 내 핸들러 |
-| `AbstractIntegrationEvent` | `EventBus` (RabbitMQ, Kafka 등)     | 외부 서비스 통신        |
+### 타입별 발행 호출
 
 ```python
 from spakky.event.publisher.domain_event_publisher import EventPublisher
@@ -115,9 +152,7 @@ integration_event = OrderConfirmed(order_id="ORD-001", total_amount=5000)
 publisher.publish(integration_event)  # RabbitMQ/Kafka로 전달
 ```
 
----
-
-## 애플리케이션 설정
+### 애플리케이션 설정
 
 ```python
 import apps
@@ -138,4 +173,12 @@ app = (
 ```
 
 !!! info "자동 등록"
-`app.start()` 시점에 `EventHandlerRegistrationPostProcessor`가 `@EventHandler` 클래스를 스캔하여 `@on_event` 메서드를 이벤트 타입별로 자동 등록합니다.
+    `app.start()` 시점에 `EventHandlerRegistrationPostProcessor`가 `@EventHandler` 클래스를 스캔하여 `@on_event` 메서드를 이벤트 타입별로 자동 등록합니다.
+
+---
+
+## 다음 단계
+
+- [이벤트 기반 아키텍처 통합 가이드](event-driven.md) — events·outbox·saga를 함께 쓰는 분산 워크플로우
+- [이벤트 시스템 심화](../event-system.md) — 이벤트 정의, AggregateRoot 이벤트 수집, 인터페이스 구조
+- [Transactional Outbox](outbox.md) — Integration Event의 at-least-once 전달 보장

--- a/docs/guides/outbox.md
+++ b/docs/guides/outbox.md
@@ -1,22 +1,73 @@
 # Transactional Outbox
 
-> `spakky-outbox`로 transaction 이후 Integration Event를 at-least-once로 전달하는 흐름을 설명합니다.
+> `spakky-outbox`로 transaction 이후 Integration Event를 at-least-once로 전달하는 흐름을, 개념과 사용법으로 나누어 설명합니다.
 
-`spakky-outbox`는 Transactional Outbox 패턴을 구현하여 Integration Event의 at-least-once 전달을 보장합니다.
-
----
-
-## 동작 원리
-
-1. `OutboxEventBus`가 `@Primary`로 기본 `IEventBus`를 대체
-2. Integration Event 발행 시 메시지 브로커 대신 Outbox 테이블에 저장 (트랜잭션 내)
-3. `OutboxRelayBackgroundService`가 주기적으로 Outbox 테이블을 폴링
-4. 미전송 메시지를 `IEventTransport` (Kafka/RabbitMQ)를 통해 실제 전송
-5. 전송 성공 시 메시지를 published 처리, 실패 시 재시도 카운트 증가
+`spakky-outbox`는 Transactional Outbox 패턴을 구현하여 Integration Event의 at-least-once 전달을 보장합니다. events·outbox·saga가 함께 동작하는 전체 그림은 [이벤트 기반 아키텍처 통합 가이드](event-driven.md)를 참고하세요.
 
 ---
 
-## 설정
+## 개념
+
+### 해결하는 문제 — 이중 쓰기
+
+DB 트랜잭션을 commit한 뒤 별도로 브로커에 이벤트를 전송하면, 트랜잭션은 성공했는데 브로커 전송만 실패하는 순간 이벤트가 영구히 유실됩니다. 반대로 브로커 먼저 보내면 트랜잭션 rollback 시 "일어나지 않은 일"이 외부에 알려집니다. 두 저장소(DB·브로커)를 하나의 원자적 연산으로 묶을 수 없는 것이 이중 쓰기 문제입니다.
+
+Outbox는 이벤트를 **비즈니스 데이터와 같은 DB 트랜잭션 안에서 Outbox 테이블에 저장**하고, 브로커 전송은 별도 폴링 프로세스로 분리해 이 문제를 해결합니다. DB commit 하나에 비즈니스 변경과 이벤트가 함께 남으므로 유실 구간이 사라집니다.
+
+### 동작 원리
+
+1. `OutboxEventBus`가 `@Primary`로 기본 `IEventBus`를 대체합니다.
+2. Integration Event 발행 시 메시지 브로커 대신 Outbox 테이블에 저장합니다 (트랜잭션 내).
+3. `OutboxRelayBackgroundService`가 주기적으로 Outbox 테이블을 폴링합니다.
+4. 미전송 메시지를 `IEventTransport`(Kafka/RabbitMQ)를 통해 실제 전송합니다.
+5. 전송 성공 시 메시지를 published 처리, 실패 시 재시도 카운트를 증가시킵니다.
+
+### 폴링 → 전송 흐름
+
+발행 측(UseCase 트랜잭션)과 전송 측(Relay 폴링)이 시간적으로 분리됩니다. Relay는 `fetch_pending`으로 미전송 메시지를 원자적으로 claim한 뒤 전송하고, 성공·실패에 따라 상태를 갱신합니다.
+
+```mermaid
+sequenceDiagram
+  participant UseCase as "@Transactional UseCase"
+  participant Bus as OutboxEventBus
+  participant Storage as IOutboxStorage
+  participant Relay as OutboxRelayBackgroundService
+  participant Transport as IEventTransport
+  participant Broker as 메시지 브로커
+
+  UseCase->>Bus: publish(IntegrationEvent)
+  Bus->>Storage: save(OutboxMessage)
+  Note over UseCase,Storage: 같은 트랜잭션에서 commit
+  loop polling_interval_seconds 주기
+    Relay->>Storage: fetch_pending(batch_size, max_retry)
+    Storage-->>Relay: 미전송 메시지 (claim)
+    Relay->>Transport: send(event_name, payload, headers)
+    alt 전송 성공
+      Transport->>Broker: 메시지 전달
+      Relay->>Storage: mark_published(id)
+    else 전송 실패
+      Relay->>Storage: increment_retry(id)
+    end
+  end
+```
+
+`OutboxMessage`는 이 흐름을 거치며 상태가 전이됩니다. `claimed_at`은 폴링이 메시지를 가져갈 때 잠금으로 찍히며, `claim_timeout_seconds`가 지나면 다른 폴링 사이클이 다시 claim할 수 있어(크래시 복구) 전송이 멈추지 않습니다.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Pending: save (트랜잭션 commit)
+  Pending --> Claimed: fetch_pending (claimed_at 기록)
+  Claimed --> Published: 전송 성공 → mark_published
+  Claimed --> Pending: 전송 실패 → increment_retry
+  Claimed --> Pending: claim_timeout 초과 (크래시 복구)
+  Published --> [*]
+```
+
+---
+
+## 사용법
+
+### 설정
 
 `OutboxConfig`는 `@Configuration`이므로 환경변수에서 자동 로딩됩니다.
 
@@ -56,11 +107,31 @@ export SPAKKY_OUTBOX__CLAIM_TIMEOUT_SECONDS=300.0
 | `max_retry_count` | `SPAKKY_OUTBOX__MAX_RETRY_COUNT` | `5` | 최대 재시도 횟수 |
 | `claim_timeout_seconds` | `SPAKKY_OUTBOX__CLAIM_TIMEOUT_SECONDS` | `300.0` | 메시지 잠금 타임아웃 (초) |
 
----
+### 이벤트 발행
 
-## 핵심 컴포넌트
+코드 변경 없이 플러그인 로드만으로 동작합니다. 기존 `IAsyncEventPublisher.publish()` 호출이 그대로 Outbox를 통하게 됩니다.
 
-### OutboxEventBus
+```python
+from spakky.core.stereotype.usecase import UseCase
+from spakky.event.event_publisher import IAsyncEventPublisher
+
+@UseCase()
+class PlaceOrderUseCase:
+    _publisher: IAsyncEventPublisher
+
+    def __init__(self, publisher: IAsyncEventPublisher) -> None:
+        self._publisher = publisher
+
+    async def execute(self, order_id: UUID, total: float) -> None:
+        event = OrderPlacedEvent(order_id=order_id, total_amount=total)
+        await self._publisher.publish(event)
+        # → OutboxEventBus가 Outbox 테이블에 저장 (트랜잭션 내)
+        # → Relay가 주기적으로 Kafka/RabbitMQ로 전송
+```
+
+### 핵심 컴포넌트
+
+#### OutboxEventBus
 
 `@Primary`로 등록되어 기본 `IEventBus` / `IAsyncEventBus`를 대체합니다. `send()` 호출 시 메시지를 직접 브로커로 전송하지 않고 `IOutboxStorage`에 저장합니다.
 
@@ -68,7 +139,7 @@ export SPAKKY_OUTBOX__CLAIM_TIMEOUT_SECONDS=300.0
 from spakky.outbox.bus.outbox_event_bus import OutboxEventBus, AsyncOutboxEventBus
 ```
 
-### OutboxRelayBackgroundService
+#### OutboxRelayBackgroundService
 
 백그라운드 서비스로 실행되며, Outbox 테이블에서 미전송 메시지를 주기적으로 가져와 `IEventTransport`로 전송합니다.
 
@@ -79,7 +150,7 @@ from spakky.outbox.relay.relay import (
 )
 ```
 
-### IOutboxStorage
+#### IOutboxStorage
 
 Outbox 메시지의 저장/조회/상태 변경을 담당하는 포트 인터페이스입니다.
 `spakky-sqlalchemy`는 `spakky.contributions.spakky.outbox` contribution으로
@@ -96,7 +167,7 @@ from spakky.outbox.ports.storage import IOutboxStorage, IAsyncOutboxStorage
 | `mark_published(message_id)` | 메시지를 전송 완료 처리 |
 | `increment_retry(message_id)` | 재시도 카운트 증가 |
 
-### OutboxMessage
+#### OutboxMessage
 
 영속성에 독립적인 Outbox 메시지 모델입니다.
 
@@ -117,30 +188,6 @@ from spakky.outbox.common.message import OutboxMessage
 
 ---
 
-## 사용 흐름
-
-코드 변경 없이 플러그인 로드만으로 동작합니다.
-
-```python
-from spakky.core.stereotype.usecase import UseCase
-from spakky.event.event_publisher import IAsyncEventPublisher
-
-@UseCase()
-class PlaceOrderUseCase:
-    _publisher: IAsyncEventPublisher
-
-    def __init__(self, publisher: IAsyncEventPublisher) -> None:
-        self._publisher = publisher
-
-    async def execute(self, order_id: UUID, total: float) -> None:
-        event = OrderPlacedEvent(order_id=order_id, total_amount=total)
-        await self._publisher.publish(event)
-        # → OutboxEventBus가 Outbox 테이블에 저장 (트랜잭션 내)
-        # → Relay가 주기적으로 Kafka/RabbitMQ로 전송
-```
-
----
-
 ## 분산 트레이싱
 
 `spakky-tracing`이 설치되면 `OutboxEventBus`가 현재 `TraceContext`를 메시지 헤더에 자동 주입합니다. Relay가 전송할 때 해당 헤더가 그대로 브로커 메시지에 포함되므로, 수신 측에서 트레이스 컨텍스트가 복원됩니다.
@@ -148,3 +195,11 @@ class PlaceOrderUseCase:
 ## 인증 컨텍스트 전파
 
 `SPAKKY_AUTH_SNAPSHOT_PROPAGATION_ENABLED=true`가 설정되어 있고 현재 request/context scope에 `AuthContext`가 있으면 `OutboxEventBus` / `AsyncOutboxEventBus`는 Outbox message headers에 `spakky.auth.context_snapshot` metadata를 저장합니다. 이 값은 `IAuthContextSnapshotSigner`가 만든 signed `AuthContextSnapshot` envelope이며, raw bearer token은 저장하지 않습니다. 기존 `traceparent` header는 함께 보존됩니다.
+
+---
+
+## 다음 단계
+
+- [이벤트 기반 아키텍처 통합 가이드](event-driven.md) — events·outbox·saga를 함께 쓰는 분산 워크플로우
+- [이벤트 시스템](events.md) — 도메인/통합 이벤트 발행과 핸들러 등록
+- [사가 오케스트레이션](saga.md) — 보상 기반 분산 트랜잭션과 Outbox 조합

--- a/docs/guides/saga.md
+++ b/docs/guides/saga.md
@@ -3,9 +3,13 @@
 > `spakky-saga`는 분산 트랜잭션의 보상(compensation) 기반 롤백을 오케스트레이션합니다.
 > `SagaFlow`, `SagaStep`, `Transaction`, `Parallel`을 조합하여 비즈니스 프로세스를 선언적으로 모델링합니다.
 
+이 문서는 사가의 **개념**(언제·왜 쓰는가)과 **사용법**(어떻게 정의하고 호출하는가)을 나누어 설명합니다. events·outbox·saga가 함께 동작하는 전체 그림은 [이벤트 기반 아키텍처 통합 가이드](event-driven.md)를 참고하세요.
+
 ---
 
-## 동작 원리
+## 개념
+
+### 동작 원리
 
 1. `@Saga` 스테레오타입으로 사가 오케스트레이터 클래스를 DI 컨테이너에 등록
 2. `@saga_step` 데코레이터로 사가 step 메서드를 `SagaStep` 디스크립터로 감쌈
@@ -13,28 +17,34 @@
 4. `AbstractSaga.execute(data)` 또는 `run_saga_flow(flow, data)`가 흐름을 실행하고 `SagaResult`를 반환
 5. step 실패 시 `ErrorStrategy`(Compensate/Skip/Retry)에 따라 분기하고, 필요 시 commit된 step을 역순으로 보상
 
----
-
-## Saga의 아키텍처 위치
+### Saga의 아키텍처 위치
 
 `@Saga()`는 `@UseCase()`와 **동급**의 application layer 스테레오타입입니다. 두 스테레오타입 모두 `Pod`을 상속하므로 DI 컨테이너가 동일한 방식으로 관리하며, Controller가 둘 중 어느 것이든 직접 주입받아 호출할 수 있습니다.
 
 ```mermaid
-flowchart TD
-  Controller["Controller"] --> UseCase["UseCase<br/>단일 Aggregate, 로컬 @Transactional"]
-  Controller --> Saga["Saga<br/>복수 서비스/프로세스, 분산 트랜잭션 오케스트레이션"]
-  Saga --> InternalUseCase["UseCase 호출<br/>내부 서비스 위임"]
-  Saga --> Command["Command 발행<br/>외부 서비스"]
-  InternalUseCase --> Repository["Repository / AggregateRoot<br/>UseCase 내부에서만"]
+graph TD
+  Controller["Controller"]:::app
+  UseCase["UseCase<br/>단일 Aggregate, 로컬 @Transactional"]:::app
+  Saga["Saga<br/>복수 서비스/프로세스, 분산 트랜잭션 오케스트레이션"]:::app
+  InternalUseCase["UseCase 호출<br/>내부 서비스 위임"]:::app
+  Command["Command 발행<br/>외부 서비스"]:::external
+  Repository["Repository / AggregateRoot<br/>UseCase 내부에서만"]:::app
+
+  Controller --> UseCase
+  Controller --> Saga
+  Saga --> InternalUseCase
+  Saga --> Command
+  InternalUseCase --> Repository
+
+  classDef app fill:#E3F2FD,stroke:#1565C0,color:#0D47A1
+  classDef external fill:#ECEFF1,stroke:#546E7A,color:#263238
 ```
 
 Saga는 **흐름 제어기(flow orchestrator)** 역할만 담당합니다. Repository 접근·Aggregate 조작·트랜잭션 경계·비즈니스 규칙 판단은 **호출되는 UseCase**에서 수행합니다. 이 경계는 다음 절의 "역할 제한"으로 강제됩니다.
 
 > ADR-0007 §아키텍처 위치 참조.
 
----
-
-## UseCase vs Saga
+### UseCase vs Saga
 
 구현하려는 오퍼레이션이 아래 중 어느 쪽에 가까운지를 기준으로 선택합니다.
 
@@ -48,9 +58,7 @@ Saga는 **흐름 제어기(flow orchestrator)** 역할만 담당합니다. Repos
 
 단일 Aggregate 내부 변경이면 `@UseCase()` + `@Transactional`로 충분합니다. 복수 서비스를 가로지르며 보상이 필요한 순간에만 `@Saga()`로 승격합니다.
 
----
-
-## Saga의 역할 제한 (순수 흐름 제어기)
+### Saga의 역할 제한 (순수 흐름 제어기)
 
 Saga는 "흐름을 짠다"는 하나의 관심사만 책임집니다. 아래 범주를 넘어가면 Saga가 아니라 UseCase/Aggregate로 옮겨야 합니다.
 
@@ -67,7 +75,9 @@ Saga는 "흐름을 짠다"는 하나의 관심사만 책임집니다. 아래 범
 
 ---
 
-## 설정
+## 사용법
+
+### 설정
 
 `spakky-saga`는 `spakky`와 `spakky-domain`에 의존합니다.
 
@@ -93,9 +103,9 @@ app = (
 
 ---
 
-## 사가 정의
+### 사가 정의
 
-### AbstractSagaData
+#### AbstractSagaData
 
 사가 비즈니스 데이터 모델은 `AbstractSagaData`를 상속합니다. `@immutable` + `AbstractDomainModel` 기반이며, 각 step에는 읽기 전용으로 전달됩니다. `saga_id: UUID` 필드가 기본 제공됩니다.
 
@@ -117,7 +127,7 @@ class OrderSagaData(AbstractSagaData):
 
 Saga가 식별자(`order_id`, `reservation_id`, `payment_id`)를 **흐름 진행 중에 발급**하기 때문에 이들 필드는 `None` 기본값을 가진 optional로 선언합니다. 각 step은 `dataclasses.replace(data, ...)`로 새 인스턴스를 반환하여 이후 step에 전달합니다.
 
-### @Saga + AbstractSaga + @saga_step
+#### @Saga + AbstractSaga + @saga_step
 
 `@Saga()`는 DI 컨테이너에 사가 클래스를 등록하는 스테레오타입입니다. `AbstractSaga[SagaDataT]`를 상속하여 `flow()`를 구현하면 `execute(data)`가 정의된 흐름을 실행합니다.
 
@@ -212,14 +222,14 @@ class OrderSaga(AbstractSaga[OrderSagaData]):
         )
 ```
 
-### UseCase 주입 패턴
+#### UseCase 주입 패턴
 
 - `__init__`에서 필요한 UseCase를 **타입 기반 DI**로 주입받습니다. Saga도 `Pod`이므로 컨테이너가 자동으로 해결합니다.
 - 각 step은 주입받은 UseCase의 `execute()`를 **한 줄**로 호출합니다.
 - `@Transactional`은 UseCase 쪽에 붙입니다. Saga 자체는 트랜잭션 경계를 관리하지 않습니다.
 - Repository/Aggregate를 Saga에 직접 주입하지 않습니다. 직접 주입이 필요하다고 느껴지면 그 로직은 UseCase로 승격되어야 한다는 신호입니다.
 
-### @Transactional UseCase를 Saga step으로 묶기
+#### @Transactional UseCase를 Saga step으로 묶기
 
 실무에서 Saga step의 action/compensate는 대부분 `@UseCase()` 클래스의 `@Transactional()` 메서드입니다. 로컬 DB 트랜잭션은 각 UseCase 안에서 시작하고 끝나며, Saga 엔진은 이미 commit된 step 목록만 기억했다가 이후 step 실패 시 보상 UseCase를 역순으로 호출합니다.
 
@@ -264,7 +274,7 @@ Saga compensation은 DB rollback과 다릅니다.
 
 마지막 확정 step 전까지는 Semantic Lock 패턴을 적용해 `PENDING` 주문을 외부 확정 주문으로 취급하지 않습니다. 보상 UseCase는 "rollback SQL"이 아니라 `cancel()`, `release()`, `refund()` 같은 명시적 도메인 상태 전이를 수행해야 합니다.
 
-### step 시그니처 규약
+#### step 시그니처 규약
 
 | 역할 | 시그니처 | 반환값 |
 |------|---------|--------|
@@ -275,11 +285,11 @@ action이 새 `AbstractSagaData` 인스턴스를 반환하면 엔진이 이후 s
 
 ---
 
-## SagaFlow DSL과 실행 세부사항
+### SagaFlow DSL과 실행 세부사항
 
 기본 흐름은 `self.create_order >> self.cancel_order`처럼 action과 compensation을 묶는 방식으로 충분합니다. 병렬 실행, `Retry`/`Skip`, step timeout, `run_saga_flow`, `SagaResult.history`, 보상 실패 에스컬레이션처럼 운영에서 필요한 세부 주제는 [사가 심화](saga-advanced.md)에 정리했습니다.
 
-## Controller에서 Saga 호출
+### Controller에서 Saga 호출
 
 Controller는 Saga를 다른 Pod와 동일하게 DI로 주입받아 `execute()`를 호출하고, `SagaResult.status`로 응답을 분기합니다. 예외는 발생하지 않으므로 `try/except`가 아니라 **상태 분기**로 제어 흐름을 짭니다.
 

--- a/docs/sections/messaging.md
+++ b/docs/sections/messaging.md
@@ -14,6 +14,12 @@
 | [Transactional Outbox](../guides/outbox.md) | 이벤트 발행과 DB 트랜잭션을 원자적으로 묶기 |
 | [사가 오케스트레이션](../guides/saga.md) | 분산 트랜잭션을 보상 단계로 조율하기 |
 
+## 이벤트 기반 아키텍처
+
+| 문서 | 무엇을 배우나요 |
+| --- | --- |
+| [이벤트 기반 아키텍처 통합 가이드](../guides/event-driven.md) | events·outbox·saga를 하나의 분산 워크플로우로 엮기 (개념 → 사용법 + 도식) |
+
 ## 심화
 
 | 문서 | 무엇을 배우나요 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,8 @@ nav:
           - Kafka 통합: guides/kafka.md
           - Transactional Outbox: guides/outbox.md
           - 사가 오케스트레이션: guides/saga.md
+      - 이벤트 기반 아키텍처:
+          - 통합 가이드: guides/event-driven.md
       - 심화:
           - 사가 심화: guides/saga-advanced.md
   - 보안:


### PR DESCRIPTION
## 요약

이벤트 시스템·Transactional Outbox·사가를 하나의 "이벤트 기반 아키텍처"로 묶고, 각 가이드에서 **개념 설명과 사용법(how-to)을 명확히 분리**한다. 세 컴포넌트가 함께 작동하는 통합 워크플로우 가이드를 신설하고 핵심 흐름에 mermaid 도식을 추가한다. (#408)

## 변경 내용

- **`docs/guides/event-driven.md` (신설)** — events→outbox→saga 분산 워크플로우를 `## 개념`(역할 분담·전체 발행/전송 구조·왜 함께 쓰나) → `## 사용법`(플러그인 로드·트랜잭션 발행·사가 보상·Outbox 전송 시점) 순으로 연결. 전체 구조 `graph TD` + 보상 흐름 `sequenceDiagram` 도식 포함.
- **`docs/guides/events.md`** — `## 개념`(이벤트 타입·발행 라우팅 + 발행 흐름 `graph TD`)과 `## 사용법`(핸들러 정의·트랜잭션 연동 발행·설정)을 별도 소제목으로 분리.
- **`docs/guides/outbox.md`** — `## 개념`(이중 쓰기 문제·동작 원리 + 폴링→전송 `sequenceDiagram`·메시지 상태 전이 `stateDiagram-v2`)과 `## 사용법`(설정·발행·핵심 컴포넌트)을 분리.
- **`docs/guides/saga.md`** — `## 개념`(동작 원리·아키텍처 위치·UseCase vs Saga·역할 제한)과 `## 사용법`(설정·사가 정의·DSL·Controller 호출)을 `##` 소제목으로 명시 분리. 아키텍처 도식을 `flowchart TD` → diagram-standard 팔레트(`graph TD` + `classDef`)로 맞춤.
- **`docs/sections/messaging.md` · `mkdocs.yml`** — 통합 가이드를 메시징 채널 nav에 "이벤트 기반 아키텍처" 그룹으로 추가.

## 도식

추가/정비한 도식은 모두 `docs/contributing/diagram-standard.md` 표준을 따른다.

- 발행 흐름 — `graph TD` + 역할별 `classDef` 팔레트 (events.md, event-driven.md)
- Outbox 폴링→전송 — `sequenceDiagram` (outbox.md, event-driven.md)
- Outbox 메시지 상태 전이 — `stateDiagram-v2` (outbox.md)
- Saga 보상 흐름 — `sequenceDiagram` (event-driven.md)
- Saga 아키텍처 위치 — `graph TD` 팔레트 정비 (saga.md)

## 결정 근거

- "이벤트 기반 아키텍처" 섹션은 기존 "메시징과 워크플로우" 채널을 재사용하고, 통합 가이드를 그 안의 별도 nav 그룹으로 둔다 — 신규 채널을 만들지 않고 #401 IA 골격을 보존하기 위함.
- 각 컴포넌트 가이드는 `## 개념` / `## 사용법` 2단 구조로 통일했다. saga.md는 이미 내용이 풍부했으나 개념/사용법이 평면 나열돼 있어 소제목 위계만 재편(내용 보존).
- 모든 API·import 경로·환경변수·메서드 시그니처는 실제 소스(`spakky.event`/`spakky.outbox`/`spakky.saga` 및 `spakky-sqlalchemy` outbox contribution)로 검증했다. 환각 없음.

## 검증

- `mkdocs build --strict` 통과 (exit 0).
- 코드 무변경 (문서 전용 PR).

Closes #408
