### PR TITLE
feat(agent): AgentToolDispatcher 자동 도구 디스패치 (#406)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -48,6 +48,7 @@ pip install spakky-agent spakky-vllm "spakky-sqlalchemy[agent]"
 - `ModelRequest`, `ModelResponse`, `ModelStreamEvent`: provider-neutral model 호출/응답/stream 계약
 - `ToolCallingSpec`, `ModelToolSpec`, `ModelToolCall`: model-facing tool call 요청과 후보 결과
 - `agent_tool`, `AgentToolBoundInvocation`, `AgentToolBindingError`, `ToolEffects`, `ToolRisk`, `ToolApprovalRequirement`, `ToolResumeMetadata`, `EvidenceCapture`: tool binding, risk, approval, idempotency, evidence capture metadata
+- `AgentToolDispatcher`, `AgentToolDispatchError`: model tool-call을 카탈로그 descriptor로 조회·자동 바인딩·실행하는 디스패치 building block과 미등록 도구 에러
 
 ## 의존성 경계
 
@@ -148,6 +149,18 @@ async def lookup_customer(
 ```
 
 Model adapter가 decoded tool-call JSON을 받으면 tool 실행 전에 `descriptor.bind_invocation(payload)`로 Python signature binding을 수행합니다. Payload는 flat keyword object(`{"query": "agent", "limit": 5}`) 또는 structured object(`{"args": ["agent"], "kwargs": {"limit": 5}}`)를 사용할 수 있습니다. Binding은 `inspect.Signature`의 required/default/duplicate/unknown argument semantics를 따르며, 실패 시 tool callable을 실행하지 않고 `AgentToolBindingError`를 발생시킵니다.
+
+`AgentToolDispatcher`는 이 조회·바인딩·실행을 하나의 building block으로 묶어, 소비자가 `if call.name == ...` 같은 이름 문자열 매칭 디스패치를 직접 작성하지 않도록 합니다. `AgentToolDispatcher(target=agent_instance, catalog=Agent.get(MyAgent).tool_catalog).dispatch(call)`은 `ModelToolCall.name`으로 descriptor를 조회하고, `bind_invocation`으로 `call.arguments`를 바인딩한 뒤, descriptor callable을 실행해 결과를 반환합니다. 동기/비동기 tool 모두를 처리하고, `self`/`cls` owner parameter가 없는 descriptor(MCP normalize 등 외부 도구)는 instance 없이 호출합니다. 카탈로그에 없는 이름은 `AgentToolDispatchError`로 실패합니다.
+
+```python
+from spakky.agent import Agent, AgentToolDispatcher
+
+dispatcher = AgentToolDispatcher(
+    target=assistant,
+    catalog=Agent.get(CodeAssistant).tool_catalog,
+)
+result = await dispatcher.dispatch(model_tool_call)
+```
 
 ## Delegation contract
 

--- a/core/spakky-agent/examples/code_assistant_demo.py
+++ b/core/spakky-agent/examples/code_assistant_demo.py
@@ -25,6 +25,7 @@ from spakky.agent import (
     AgentStateReason,
     AgentStateTransition,
     AgentStatus,
+    AgentToolDispatcher,
     AgentYield,
     AgentYieldKind,
     ApprovalDecision,
@@ -62,7 +63,6 @@ from spakky.agent import (
     plan_agent_tool_approval,
     run_agent_cancellation_cleanup,
 )
-from spakky.agent.error import AgentDefinitionError
 from spakky.agent.tooling import AgentToolDescriptor
 
 
@@ -611,7 +611,7 @@ class CodeAssistant:
                 metadata={"call_id": call.call_id or ""},
             ),
         )
-        result = self._invoke_tool(call)
+        result = await self._invoke_tool(call)
         self._append_boundary(
             state.id,
             AgentActionBoundaryCheckpoint.after_tool_call(
@@ -636,34 +636,12 @@ class CodeAssistant:
             payload=Evidence(evidence=evidence),
         )
 
-    def _invoke_tool(self, call: ModelToolCall) -> JsonValue:
-        if call.name == "workspace.read":
-            return _workspace_read_result(
-                self.workspace_read(_text_arg(call, "path")),
-            )
-        if call.name == "workspace.search":
-            return _workspace_search_result(
-                self.workspace_search(
-                    _text_arg(call, "query"),
-                    _optional_text_arg(call, "pattern") or "*",
-                ),
-            )
-        if call.name == "workspace.write":
-            return _workspace_write_result(
-                self.workspace_write(
-                    _text_arg(call, "path"),
-                    _text_arg(call, "content"),
-                ),
-            )
-        if call.name == "shell.command":
-            return _shell_result(self.shell_command(_text_arg(call, "command")))
-        if call.name == "git.status":
-            return _git_json_result(self.git_status())
-        if call.name == "git.diff":
-            return _git_json_result(self.git_diff(_optional_text_arg(call, "path")))
-        if call.name == "git.apply":
-            return _git_json_result(self.git_apply(_text_arg(call, "patch")))
-        raise CodeAssistantDemoError(f"Unknown CodeAssistant tool: {call.name}")
+    async def _invoke_tool(self, call: ModelToolCall) -> JsonValue:
+        result = await AgentToolDispatcher(
+            target=self,
+            catalog=Agent.get(CodeAssistant).tool_catalog,
+        ).dispatch(call)
+        return _tool_result_json(result)
 
     def _append_tool_evidence(
         self,
@@ -810,54 +788,42 @@ def _git_result(operation: str, result: ShellCommandResult) -> GitCommandResult:
     )
 
 
-def _workspace_read_result(result: WorkspaceReadResult) -> dict[str, JsonValue]:
-    return {"path": result.path, "content": result.content}
-
-
-def _workspace_search_result(result: WorkspaceSearchResult) -> dict[str, JsonValue]:
-    return {
-        "query": result.query,
-        "hits": tuple(
-            {"path": hit.path, "line_number": hit.line_number, "line": hit.line}
-            for hit in result.hits
-        ),
-    }
-
-
-def _workspace_write_result(result: WorkspaceWriteResult) -> dict[str, JsonValue]:
-    return {"path": result.path, "bytes_written": result.bytes_written}
-
-
-def _shell_result(result: ShellCommandResult) -> dict[str, JsonValue]:
-    return {
-        "command": result.command,
-        "exit_code": result.exit_code,
-        "stdout": result.stdout,
-        "stderr": result.stderr,
-    }
-
-
-def _git_json_result(result: GitCommandResult) -> dict[str, JsonValue]:
-    return {
-        "operation": result.operation,
-        "exit_code": result.exit_code,
-        "stdout": result.stdout,
-        "stderr": result.stderr,
-    }
-
-
-def _text_arg(call: ModelToolCall, name: str) -> str:
-    value = call.arguments.get(name)
-    if not isinstance(value, str) or not value.strip():
-        raise AgentDefinitionError(f"Model tool argument '{name}' must be text")
-    return value
-
-
-def _optional_text_arg(call: ModelToolCall, name: str) -> str | None:
-    value = call.arguments.get(name)
-    if isinstance(value, str) and value.strip():
-        return value
-    return None
+def _tool_result_json(result: object) -> JsonValue:
+    match result:
+        case WorkspaceReadResult():
+            return {"path": result.path, "content": result.content}
+        case WorkspaceSearchResult():
+            return {
+                "query": result.query,
+                "hits": tuple(
+                    {
+                        "path": hit.path,
+                        "line_number": hit.line_number,
+                        "line": hit.line,
+                    }
+                    for hit in result.hits
+                ),
+            }
+        case WorkspaceWriteResult():
+            return {"path": result.path, "bytes_written": result.bytes_written}
+        case ShellCommandResult():
+            return {
+                "command": result.command,
+                "exit_code": result.exit_code,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        case GitCommandResult():
+            return {
+                "operation": result.operation,
+                "exit_code": result.exit_code,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        case _:
+            raise CodeAssistantDemoError(
+                "CodeAssistant tool returned an unknown result"
+            )
 
 
 def _optional_signal_text(signal: AgentSignal, name: str) -> str | None:

--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -10,7 +10,9 @@ from spakky.agent.error import (
     AgentOutputGuardError,
     AgentPersistenceConfigurationError,
     AgentToolBindingError,
+    AgentToolDispatchError,
 )
+from spakky.agent.dispatcher import AgentToolDispatcher
 from spakky.agent.context import (
     ContextDigest,
     ContextFreshness,
@@ -231,6 +233,8 @@ __all__ = [
     "AgentToolCatalog",
     "AgentToolDefinition",
     "AgentToolDescriptor",
+    "AgentToolDispatchError",
+    "AgentToolDispatcher",
     "AgentToolIdentity",
     "AgentToolMetadata",
     "AgentToolSchemaHandle",

--- a/core/spakky-agent/src/spakky/agent/dispatcher.py
+++ b/core/spakky-agent/src/spakky/agent/dispatcher.py
@@ -1,0 +1,68 @@
+"""Declarative tool dispatch over a discovered agent tool catalog.
+
+ADR-0013 §1 hands the model-call -> tool-invoke step to the framework runner.
+This module removes the developer-written ``if call.name == ...`` chain and the
+manual payload extraction it implied: a model tool call is resolved against the
+catalog, its arguments are bound through the descriptor, and the descriptor's
+callable is invoked. External MCP tools (follow-up F1) normalize into the same
+``AgentToolCatalog`` and therefore dispatch through this identical path.
+"""
+
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from inspect import iscoroutinefunction, signature
+
+from spakky.agent.error import AgentToolDispatchError
+from spakky.agent.interfaces.model import ModelToolCall
+from spakky.agent.tooling import (
+    AgentToolCallable,
+    AgentToolCatalog,
+    AgentToolDescriptor,
+)
+
+_OWNER_PARAMETER_NAMES = ("self", "cls")
+
+
+@dataclass(frozen=True, slots=True)
+class AgentToolDispatcher:
+    """Resolve and invoke a catalog tool from a model tool call.
+
+    The dispatcher binds to a single agent instance whose ``@agent_tool``
+    methods are described by ``catalog``. Catalog descriptors that own no
+    instance parameter (such as MCP-normalized external tools) are invoked
+    without the bound ``target``.
+    """
+
+    target: object
+    catalog: AgentToolCatalog
+
+    def descriptor_for(self, call: ModelToolCall) -> AgentToolDescriptor:
+        """Resolve the catalog descriptor a model tool call targets."""
+        for descriptor in self.catalog.descriptors:
+            if descriptor.schema.name == call.name:
+                return descriptor
+        raise AgentToolDispatchError("Agent tool call names an unregistered tool")
+
+    async def dispatch(self, call: ModelToolCall) -> object:
+        """Bind a model tool call payload and invoke its catalog callable."""
+        descriptor = self.descriptor_for(call)
+        invocation = descriptor.bind_invocation(call.arguments)
+        callable_ = descriptor.callable
+        positional = self._with_owner_prefix(callable_, invocation.args)
+        if iscoroutinefunction(callable_):
+            awaitable: Awaitable[object] = callable_(
+                *positional,
+                **invocation.kwargs,
+            )
+            return await awaitable
+        return callable_(*positional, **invocation.kwargs)
+
+    def _with_owner_prefix(
+        self,
+        callable_: AgentToolCallable,
+        args: tuple[object, ...],
+    ) -> tuple[object, ...]:
+        parameters = tuple(signature(callable_).parameters.values())
+        if parameters and parameters[0].name in _OWNER_PARAMETER_NAMES:
+            return (self.target, *args)
+        return args

--- a/core/spakky-agent/src/spakky/agent/dispatcher.py
+++ b/core/spakky-agent/src/spakky/agent/dispatcher.py
@@ -33,6 +33,7 @@ class AgentToolDispatcher:
     without the bound ``target``.
     """
 
+    # target: any agent instance owning the catalog tools — no common base type.
     target: object
     catalog: AgentToolCatalog
 
@@ -43,6 +44,8 @@ class AgentToolDispatcher:
                 return descriptor
         raise AgentToolDispatchError("Agent tool call names an unregistered tool")
 
+    # Returns object: tool results are heterogeneous per tool — the adapter
+    # owns serialization of the concrete return value into evidence/yield.
     async def dispatch(self, call: ModelToolCall) -> object:
         """Bind a model tool call payload and invoke its catalog callable."""
         descriptor = self.descriptor_for(call)

--- a/core/spakky-agent/src/spakky/agent/error.py
+++ b/core/spakky-agent/src/spakky/agent/error.py
@@ -23,6 +23,12 @@ class AgentToolBindingError(AbstractSpakkyAgentError):
     message = "Agent tool invocation payload is invalid"
 
 
+class AgentToolDispatchError(AbstractSpakkyAgentError):
+    """Raised when a model tool call names a tool absent from the catalog."""
+
+    message = "Agent tool call cannot be dispatched"
+
+
 class AgentBootstrapError(AbstractSpakkyAgentError):
     """Raised when agent bootstrap validation fails."""
 

--- a/core/spakky-agent/tests/unit/test_dispatcher.py
+++ b/core/spakky-agent/tests/unit/test_dispatcher.py
@@ -1,0 +1,177 @@
+"""Tests for declarative agent tool dispatch."""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from spakky.agent import (
+    Agent,
+    AgentExecutionSpec,
+    AgentToolCatalog,
+    AgentToolDescriptor,
+    AgentToolDispatcher,
+    AgentToolDispatchError,
+    AgentToolIdentity,
+    AgentToolSchemaHandle,
+    AgentYield,
+    AgentYieldKind,
+    Final,
+    Idempotency,
+    ModelToolCall,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+
+
+@Agent(spec=AgentExecutionSpec(name="calculator", objective="run arithmetic tools"))
+class CalculatorAgent:
+    """Agent fixture exposing sync and async @agent_tool methods."""
+
+    @agent_tool(
+        schema_name="math.add",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def add(self, left: int, right: int) -> int:
+        """Add two integers."""
+        return left + right
+
+    @agent_tool(
+        schema_name="math.scale",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def scale(self, value: int, factor: int = 2) -> int:
+        """Scale a value by an optional factor."""
+        return value * factor
+
+    @agent_tool(
+        schema_name="math.fetch_remote_sum",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    async def fetch_remote_sum(self, numbers: list[int]) -> int:
+        """Asynchronously sum a list of integers."""
+        return sum(numbers)
+
+    async def execute(
+        self,
+        command: str,
+    ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+        """Satisfy the @Agent execute contract."""
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(output=command, metadata={}),
+        )
+
+
+def _calculator_dispatcher() -> AgentToolDispatcher:
+    target = CalculatorAgent()
+    return AgentToolDispatcher(
+        target=target,
+        catalog=Agent.get(CalculatorAgent).tool_catalog,
+    )
+
+
+async def test_dispatch_flat_payload_expect_sync_tool_invoked_with_bound_args() -> None:
+    """flat keyword 페이로드가 sync 도구로 자동 바인딩·디스패치된다."""
+    dispatcher = _calculator_dispatcher()
+
+    result = await dispatcher.dispatch(
+        ModelToolCall(name="math.add", arguments={"left": 3, "right": 4}),
+    )
+
+    assert result == 7
+
+
+async def test_dispatch_omitted_argument_expect_descriptor_default_applied() -> None:
+    """생략된 인자는 도구 signature default로 채워져 디스패치된다."""
+    dispatcher = _calculator_dispatcher()
+
+    result = await dispatcher.dispatch(
+        ModelToolCall(name="math.scale", arguments={"value": 5}),
+    )
+
+    assert result == 10
+
+
+async def test_dispatch_structured_payload_expect_args_kwargs_binding() -> None:
+    """structured args/kwargs 페이로드가 positional·keyword로 바인딩된다."""
+    dispatcher = _calculator_dispatcher()
+
+    result = await dispatcher.dispatch(
+        ModelToolCall(
+            name="math.scale",
+            arguments={"args": [5], "kwargs": {"factor": 3}},
+        ),
+    )
+
+    assert result == 15
+
+
+async def test_dispatch_async_tool_expect_awaited_result() -> None:
+    """async 도구는 await되어 최종 결과를 반환한다."""
+    dispatcher = _calculator_dispatcher()
+
+    result = await dispatcher.dispatch(
+        ModelToolCall(name="math.fetch_remote_sum", arguments={"numbers": [1, 2, 3]}),
+    )
+
+    assert result == 6
+
+
+async def test_dispatch_unregistered_tool_expect_dispatch_error() -> None:
+    """카탈로그에 없는 도구 호출은 커스텀 디스패치 에러로 실패한다."""
+    dispatcher = _calculator_dispatcher()
+
+    with pytest.raises(AgentToolDispatchError):
+        await dispatcher.dispatch(
+            ModelToolCall(name="math.unknown", arguments={"left": 1}),
+        )
+
+
+def test_descriptor_for_known_tool_expect_matching_descriptor() -> None:
+    """모델 호출 이름으로 카탈로그 디스크립터를 조회한다."""
+    dispatcher = _calculator_dispatcher()
+
+    descriptor = dispatcher.descriptor_for(
+        ModelToolCall(name="math.add", arguments={}),
+    )
+
+    assert descriptor.schema.name == "math.add"
+
+
+async def test_dispatch_external_callable_expect_invoked_without_owner() -> None:
+    """owner parameter가 없는 외부(MCP) 도구는 instance 없이 디스패치된다."""
+
+    def remote_echo(message: str) -> str:
+        return f"echo:{message}"
+
+    descriptor = AgentToolDescriptor(
+        identity=AgentToolIdentity(
+            owner_module="mcp.remote",
+            owner_qualname="RemoteToolset",
+            name="remote.echo",
+        ),
+        owner=object,
+        callable=remote_echo,
+        schema=AgentToolSchemaHandle(
+            name="remote.echo",
+            input_schema_name="remote.echo.input",
+            output_schema_name="remote.echo.output",
+        ),
+    )
+    dispatcher = AgentToolDispatcher(
+        target=object(),
+        catalog=AgentToolCatalog(descriptors=(descriptor,)),
+    )
+
+    result = await dispatcher.dispatch(
+        ModelToolCall(name="remote.echo", arguments={"message": "hi"}),
+    )
+
+    assert result == "echo:hi"


### PR DESCRIPTION
## 목적

모델의 도구 호출(`ModelToolCall`)을 카탈로그 기반으로 자동 디스패치하는 building block `AgentToolDispatcher`를 추가한다. 소비자가 작성하던 `if call.name == ...` 이름 문자열 매칭 디스패치와 수동 파라미터 추출을 제거한다 (ADR-0013 §1, US-1).

## 변경 내용

- **`AgentToolDispatcher`** (`src/spakky/agent/dispatcher.py`): `ModelToolCall` → `AgentToolCatalog`에서 descriptor 조회 → `descriptor.bind_invocation(call.arguments)`로 페이로드 자동 바인딩 → descriptor callable 실행.
  - 타입 안전: 이름 문자열 if/elif 분기 없이 카탈로그 lookup으로 디스패치.
  - 동기/비동기 도구 모두 처리 (`iscoroutinefunction` 분기).
  - `self`/`cls` owner parameter가 없는 descriptor(F1 MCP normalize 등 외부 도구)는 instance 없이 호출 — **외부 도구도 동일 카탈로그 경로로 디스패치** (`_with_owner_prefix`).
  - `descriptor_for(call)`로 디스패치 전 descriptor 조회 가능.
- **`AgentToolDispatchError`** (`src/spakky/agent/error.py`): 카탈로그 미등록 도구 호출 시 발생하는 커스텀 에러 (FR-2).
- **공개 export** (`__init__.py`): `AgentToolDispatcher`, `AgentToolDispatchError` 가산적 추가.
- **CodeAssistant demo 리팩터** (`examples/code_assistant_demo.py`): `_invoke_tool`의 7-branch if/elif 체인 + `_text_arg`/`_optional_text_arg` 수동 추출 + 도구별 result wrapper 5개를 제거. 디스패처로 호출하고 결과 직렬화는 `_tool_result_json` `match`로 분리 (도구 호출 자체와 결과→JSON 변환 관심사 분리).
- **README**: public surface + Tool metadata 섹션에 디스패처 사용법 동기화.

## 설계 결정 근거

- `descriptor.bind_invocation`은 `self`를 drop한 args를 반환하므로, instance method 디스패치 시 `target`을 prepend한다. owner parameter 부재 판정은 카탈로그의 `_drop_owner_parameter`와 동일 규칙(`self`/`cls` 첫 파라미터)을 미러링하여 일관성 유지.
- `dispatch(...) -> object`/`target: object`는 도구별 heterogeneous 결과·공통 베이스 부재로 인한 정당한 사용이며 type-discipline §5 주석으로 명시.
- 결과 직렬화(value object → JSON)는 디스패처가 아닌 어댑터(demo) 책임 — 디스패처는 조회·바인딩·실행만 소유.

## 검증

- `AgentToolDispatcher` 단위 테스트 7건 (`tests/unit/test_dispatcher.py`): flat/structured 페이로드 바인딩, default 인자, async 도구 await, 미등록 도구 에러, descriptor 조회, 외부 MCP-style standalone callable 디스패치 (SC-1).
- 전체 186 테스트 통과, `src/` 브랜치 커버리지 100% (`dispatcher.py` 포함).
- CodeAssistant demo acceptance 3건 통과 — end-to-end 디스패치 경로 검증.

acceptance_check: missing (이슈 본문에 grep 라인 기반 수용 기준 섹션 없음 — SC-1은 단위 테스트로 검증)

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)