### PR TITLE
feat(agent): extend AgentExecutionSpec with instructions/output_type/teammates/compaction (#403)

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -28,7 +28,10 @@ pip install spakky-agent spakky-vllm "spakky-sqlalchemy[agent]"
 
 ## 제공하는 public surface
 
-- `Agent`, `AgentExecutionSpec`, `AgentExecutionLimits`: `@UseCase`와 동격인 Pod stereotype과 보조 실행 의미
+- `Agent`, `AgentExecutionSpec`, `AgentExecutionLimits`: `@UseCase`와 동격인 Pod stereotype과 보조 실행 의미. `AgentExecutionSpec`은 이번 변경에서 네 가지 선언 필드를 추가로 제공한다 — `instructions: str | None` (system-level 안내 문자열, 빈 문자열 거부), `output_type: type[object] | None` (구조화 출력 타입 선언; 클래스여야 하며 provider에 중립, pydantic-ai `output_type`과 같은 의미), `teammates: tuple[AgentTeammate, ...]` (협력 agent 선언, 이름 중복 거부), `compaction: AgentCompactionPolicy | None` (컨텍스트 압축 전략 체인 + token threshold 선언). 잘못된 값은 모두 `AgentDefinitionError`로 거부된다.
+- `AgentTeammate`: 이름과 로컬 Pod 타입(`pod`) 또는 원격 AgentCard http(s) URL(`card_url`) 중 정확히 하나를 선언하는 협력 agent 기술자. 둘 다 지정하거나 둘 다 생략하면 `AgentDefinitionError`. 런타임 위임 배선은 후속 태스크 E4에서 구현된다.
+- `CompactionStrategy`: 컨텍스트 압축 전략 열거형(`StrEnum`). 값은 `DROP_OLDEST_EVIDENCE`, `SUMMARIZE_TRANSCRIPT`, `DEDUPLICATE_EVIDENCE`, `OFFLOAD_TO_EXTERNAL_STORE`.
+- `AgentCompactionPolicy`: 압축 전략 체인(`strategies: tuple[CompactionStrategy, ...]`, 비어 있거나 중복 불가)과 트리거 토큰 임계값(`trigger_token_threshold: int`, 양수 필수)을 선언하는 값 타입. 런타임 압축 핸들러는 후속 태스크 C7에서 구현된다.
 - `AgentYield`: `execute()`가 caller에게 흘려보내는 typed stream item
 - `AgentState`: long-running agent execution의 materialized lifecycle state
 - `AgentSignal`: 실행 중 들어오는 user message, approval, cancel 같은 inbound stimulus

--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -76,9 +76,12 @@ from spakky.agent.delegation import (
 )
 from spakky.agent.execution import (
     Agent,
+    AgentCompactionPolicy,
     AgentExecutionLimits,
     AgentExecutionSpec,
     AgentSignalKind,
+    AgentTeammate,
+    CompactionStrategy,
     RecoveryStrategy,
     StreamingExposureMode,
 )
@@ -208,6 +211,7 @@ __all__ = [
     "AgentCancellationCleanupTask",
     "AgentCancellationRequest",
     "AgentCancellationTargetKind",
+    "AgentCompactionPolicy",
     "AgentDelegateTarget",
     "AgentDefinitionError",
     "IAgentDelegate",
@@ -226,6 +230,7 @@ __all__ = [
     "AgentSignalConsumptionBatch",
     "AgentSignalKind",
     "AgentSignalPollPoint",
+    "AgentTeammate",
     "AgentToolBindingError",
     "AgentToolBoundInvocation",
     "AgentToolCatalog",
@@ -258,6 +263,7 @@ __all__ = [
     "ContextRotSymptom",
     "ContextSensitivity",
     "ContextTokenBudget",
+    "CompactionStrategy",
     "CredentialRef",
     "DelegationBudget",
     "DelegationContextSlice",

--- a/core/spakky-agent/src/spakky/agent/execution.py
+++ b/core/spakky-agent/src/spakky/agent/execution.py
@@ -6,11 +6,15 @@ from enum import StrEnum
 from inspect import Parameter, Signature, getattr_static, isclass, signature
 from types import NoneType
 from typing import get_args, get_origin, get_type_hints
+from urllib.parse import urlsplit
 
 from spakky.agent.error import AgentDefinitionError
 from spakky.agent.tooling import AgentToolCatalog, discover_agent_tools
 from spakky.core.pod.annotations.pod import Pod, PodType
 from spakky.core.pod.error import AbstractSpakkyPodError
+
+REMOTE_AGENT_CARD_SCHEMES = ("http", "https")
+"""URL schemes accepted for a remote teammate's AgentCard endpoint."""
 
 
 class RecoveryStrategy(StrEnum):
@@ -55,16 +59,89 @@ class AgentExecutionLimits:
 
 
 @dataclass(frozen=True, slots=True)
+class AgentTeammate:
+    """Declared collaborator an agent may delegate to during execution.
+
+    A teammate is resolved either in-process by a local @Agent Pod type or
+    remotely by an AgentCard endpoint URL. Exactly one binding is declared;
+    the runtime delegation wiring (follow-up E4) consumes this declaration.
+    """
+
+    name: str
+    pod: type[object] | None = None
+    card_url: str | None = None
+
+    def __post_init__(self) -> None:
+        """Reject teammates that cannot resolve to a single delegate target."""
+        if not self.name.strip():
+            raise AgentDefinitionError("Agent teammate name cannot be blank")
+        if (self.pod is None) == (self.card_url is None):
+            raise AgentDefinitionError(
+                "Agent teammate must declare exactly one of a local pod "
+                "or a remote AgentCard url"
+            )
+        if self.pod is not None and not isclass(self.pod):
+            raise AgentDefinitionError("Agent teammate pod must be a class")
+        if self.card_url is not None:
+            parts = urlsplit(self.card_url)
+            if parts.scheme not in REMOTE_AGENT_CARD_SCHEMES or not parts.netloc:
+                raise AgentDefinitionError(
+                    "Agent teammate AgentCard url must be an http(s) endpoint"
+                )
+
+
+class CompactionStrategy(StrEnum):
+    """Ordered context-compaction tactic applied when the threshold trips."""
+
+    DROP_OLDEST_EVIDENCE = "drop_oldest_evidence"
+    SUMMARIZE_TRANSCRIPT = "summarize_transcript"
+    DEDUPLICATE_EVIDENCE = "deduplicate_evidence"
+    OFFLOAD_TO_EXTERNAL_STORE = "offload_to_external_store"
+
+
+@dataclass(frozen=True, slots=True)
+class AgentCompactionPolicy:
+    """Declared compaction chain plus the token threshold that triggers it.
+
+    The strategies form an ordered chain applied in sequence once the
+    running token count crosses ``trigger_token_threshold``. The runtime
+    compaction handler (follow-up C7) consumes this declaration.
+    """
+
+    strategies: tuple[CompactionStrategy, ...]
+    trigger_token_threshold: int
+
+    def __post_init__(self) -> None:
+        """Reject compaction policies that cannot be enforced consistently."""
+        if not self.strategies:
+            raise AgentDefinitionError(
+                "Agent compaction policy requires at least one strategy"
+            )
+        if len(set(self.strategies)) != len(self.strategies):
+            raise AgentDefinitionError(
+                "Agent compaction strategies cannot repeat in the chain"
+            )
+        if self.trigger_token_threshold <= 0:
+            raise AgentDefinitionError(
+                "Agent compaction trigger token threshold must be positive"
+            )
+
+
+@dataclass(frozen=True, slots=True)
 class AgentExecutionSpec:
     """Declarative execution semantics that cannot be inferred from DI alone."""
 
     name: str | None = None
     objective: str | None = None
+    instructions: str | None = None
+    output_type: type[object] | None = None
     accepted_signals: tuple[AgentSignalKind, ...] = ()
     recovery: RecoveryStrategy = RecoveryStrategy.NONE
     streaming_exposure_mode: StreamingExposureMode = StreamingExposureMode.BALANCED
     timeout_seconds: float | None = None
     limits: AgentExecutionLimits = field(default_factory=AgentExecutionLimits)
+    teammates: tuple[AgentTeammate, ...] = ()
+    compaction: AgentCompactionPolicy | None = None
     delegation_allowed: bool = False
     metadata: dict[str, str] = field(default_factory=dict)
 
@@ -74,6 +151,10 @@ class AgentExecutionSpec:
             raise AgentDefinitionError("Agent name cannot be blank")
         if self.objective is not None and not self.objective.strip():
             raise AgentDefinitionError("Agent objective cannot be blank")
+        if self.instructions is not None and not self.instructions.strip():
+            raise AgentDefinitionError("Agent instructions cannot be blank")
+        if self.output_type is not None and not isclass(self.output_type):
+            raise AgentDefinitionError("Agent output type must be a class")
         if self.timeout_seconds is not None and self.timeout_seconds <= 0:
             raise AgentDefinitionError("Agent timeout must be positive")
         if (
@@ -82,6 +163,9 @@ class AgentExecutionSpec:
             and self.timeout_seconds != self.limits.timeout_seconds
         ):
             raise AgentDefinitionError("Agent timeout declarations must match")
+        teammate_names = [teammate.name for teammate in self.teammates]
+        if len(set(teammate_names)) != len(teammate_names):
+            raise AgentDefinitionError("Agent teammate names must be unique")
 
 
 @dataclass(eq=False)

--- a/core/spakky-agent/tests/unit/test_execution.py
+++ b/core/spakky-agent/tests/unit/test_execution.py
@@ -6,15 +6,21 @@ import pytest
 import tests.fixtures.future_agent_app as future_agent_app
 import spakky.agent.execution as execution_module
 
+from pydantic import BaseModel
+
 from spakky.core.pod.annotations.pod import Pod
+
 
 from spakky.agent import (
     Agent,
+    AgentCompactionPolicy,
     AgentDefinitionError,
     AgentExecutionLimits,
     AgentExecutionSpec,
+    AgentTeammate,
     AgentYield,
     AgentYieldKind,
+    CompactionStrategy,
     Final,
     AgentSignalKind,
     RecoveryStrategy,
@@ -29,10 +35,14 @@ def test_agent_execution_spec_expect_defaults_are_non_durable_and_balanced() -> 
     assert spec.accepted_signals == ()
     assert spec.name is None
     assert spec.objective is None
+    assert spec.instructions is None
+    assert spec.output_type is None
     assert spec.recovery == RecoveryStrategy.NONE
     assert spec.streaming_exposure_mode == StreamingExposureMode.BALANCED
     assert spec.timeout_seconds is None
     assert spec.limits == AgentExecutionLimits()
+    assert spec.teammates == ()
+    assert spec.compaction is None
     assert spec.delegation_allowed is False
     assert spec.metadata == {}
 
@@ -379,3 +389,233 @@ def test_agent_expect_rejects_unresolvable_execute_return_annotation(
                     kind=AgentYieldKind.FINAL,
                     payload=Final(output=command, metadata={}),
                 )
+
+
+class _SupportTicketResolution(BaseModel):
+    """Structured output a support agent declares for resolved tickets."""
+
+    ticket_id: str
+    resolved: bool
+
+
+def test_agent_execution_spec_expect_declares_instructions_and_output_type() -> None:
+    """선언형 spec이 시스템 지시와 구조화 출력 타입을 단일 선언점에 담는다."""
+    spec = AgentExecutionSpec(
+        instructions="Resolve support tickets within policy.",
+        output_type=_SupportTicketResolution,
+    )
+
+    assert spec.instructions == "Resolve support tickets within policy."
+    assert spec.output_type is _SupportTicketResolution
+
+
+def test_agent_execution_spec_expect_rejects_blank_instructions() -> None:
+    """instructions는 공백 문자열일 수 없다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentExecutionSpec(instructions="   ")
+
+
+def test_agent_execution_spec_expect_rejects_non_class_output_type() -> None:
+    """output_type은 구조화 출력 타입(class)이어야 한다."""
+    instance_not_class = _SupportTicketResolution(ticket_id="T-1", resolved=True)
+    with pytest.raises(AgentDefinitionError):
+        # pyrefly: ignore - 의도적으로 class가 아닌 instance를 전달해 런타임 가드 검증
+        AgentExecutionSpec(output_type=instance_not_class)
+
+
+def test_agent_execution_spec_expect_declares_local_pod_teammate() -> None:
+    """teammate를 로컬 @Agent Pod 타입으로 선언해 in-process 위임을 표현한다."""
+
+    @Agent()
+    class ResearcherAgent:
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    teammate = AgentTeammate(name="researcher", pod=ResearcherAgent)
+    spec = AgentExecutionSpec(teammates=(teammate,))
+
+    assert spec.teammates == (teammate,)
+    assert spec.teammates[0].pod is ResearcherAgent
+    assert spec.teammates[0].card_url is None
+
+
+def test_agent_teammate_expect_declares_remote_agent_card_url() -> None:
+    """teammate를 원격 AgentCard URL로 선언해 cross-process 위임을 표현한다."""
+    teammate = AgentTeammate(
+        name="billing",
+        card_url="https://billing.internal/.well-known/agent-card.json",
+    )
+
+    assert teammate.pod is None
+    assert teammate.card_url == "https://billing.internal/.well-known/agent-card.json"
+
+
+def test_agent_teammate_expect_rejects_blank_name() -> None:
+    """teammate name은 공백 문자열일 수 없다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentTeammate(name=" ", card_url="https://billing.internal/card")
+
+
+def test_agent_teammate_expect_rejects_declaring_neither_binding() -> None:
+    """teammate는 로컬 pod·원격 url 중 하나를 반드시 선언해야 한다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentTeammate(name="orphan")
+
+
+def test_agent_teammate_expect_rejects_declaring_both_bindings() -> None:
+    """teammate는 로컬 pod와 원격 url을 동시에 선언할 수 없다."""
+
+    @Agent()
+    class LocalAgent:
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    with pytest.raises(AgentDefinitionError):
+        AgentTeammate(
+            name="ambiguous",
+            pod=LocalAgent,
+            card_url="https://peer.internal/card",
+        )
+
+
+def test_agent_teammate_expect_rejects_non_class_pod() -> None:
+    """teammate의 로컬 binding은 class여야 한다."""
+    instance_not_class = object()
+    with pytest.raises(AgentDefinitionError):
+        # pyrefly: ignore - 의도적으로 class가 아닌 instance를 전달해 런타임 가드 검증
+        AgentTeammate(name="bad_pod", pod=instance_not_class)
+
+
+def test_agent_teammate_expect_rejects_non_http_card_url_scheme() -> None:
+    """원격 AgentCard URL은 http(s) 스킴이어야 한다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentTeammate(name="ftp_peer", card_url="ftp://peer.internal/card")
+
+
+def test_agent_teammate_expect_rejects_card_url_without_host() -> None:
+    """원격 AgentCard URL은 호스트(netloc)를 포함해야 한다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentTeammate(name="hostless", card_url="https:///card")
+
+
+def test_agent_execution_spec_expect_rejects_duplicate_teammate_names() -> None:
+    """teammate roster에 같은 이름이 중복되면 거부한다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentExecutionSpec(
+            teammates=(
+                AgentTeammate(name="peer", card_url="https://a.internal/card"),
+                AgentTeammate(name="peer", card_url="https://b.internal/card"),
+            )
+        )
+
+
+def test_agent_execution_spec_expect_declares_compaction_policy() -> None:
+    """spec이 compaction 전략 체인과 임계치 정책을 선언적으로 보유한다."""
+    policy = AgentCompactionPolicy(
+        strategies=(
+            CompactionStrategy.DROP_OLDEST_EVIDENCE,
+            CompactionStrategy.SUMMARIZE_TRANSCRIPT,
+        ),
+        trigger_token_threshold=8000,
+    )
+    spec = AgentExecutionSpec(compaction=policy)
+
+    assert spec.compaction is policy
+    assert spec.compaction.strategies == (
+        CompactionStrategy.DROP_OLDEST_EVIDENCE,
+        CompactionStrategy.SUMMARIZE_TRANSCRIPT,
+    )
+    assert spec.compaction.trigger_token_threshold == 8000
+
+
+def test_agent_compaction_policy_expect_rejects_empty_strategy_chain() -> None:
+    """compaction 정책은 최소 하나의 전략을 요구한다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentCompactionPolicy(strategies=(), trigger_token_threshold=1000)
+
+
+def test_agent_compaction_policy_expect_rejects_duplicate_strategies() -> None:
+    """compaction 전략 체인은 같은 전략을 중복할 수 없다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentCompactionPolicy(
+            strategies=(
+                CompactionStrategy.SUMMARIZE_TRANSCRIPT,
+                CompactionStrategy.SUMMARIZE_TRANSCRIPT,
+            ),
+            trigger_token_threshold=1000,
+        )
+
+
+def test_agent_compaction_policy_expect_rejects_non_positive_threshold() -> None:
+    """compaction trigger 임계치는 양수여야 한다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentCompactionPolicy(
+            strategies=(CompactionStrategy.DEDUPLICATE_EVIDENCE,),
+            trigger_token_threshold=0,
+        )
+
+
+def test_agent_expect_consumes_full_declarative_spec_at_definition() -> None:
+    """@Agent(spec=...)가 instructions·output_type·teammates·compaction을 함께 보존한다."""
+
+    @Agent()
+    class PlannerAgent:
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    spec = AgentExecutionSpec(
+        name="support_agent",
+        instructions="Resolve support tickets within policy.",
+        output_type=_SupportTicketResolution,
+        teammates=(
+            AgentTeammate(name="planner", pod=PlannerAgent),
+            AgentTeammate(name="billing", card_url="https://billing.internal/card"),
+        ),
+        compaction=AgentCompactionPolicy(
+            strategies=(CompactionStrategy.OFFLOAD_TO_EXTERNAL_STORE,),
+            trigger_token_threshold=16000,
+        ),
+    )
+
+    @Agent(spec=spec)
+    class SupportAgent:
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    agent = Agent.get(SupportAgent)
+
+    assert agent.spec is spec
+    assert agent.spec.instructions == "Resolve support tickets within policy."
+    assert agent.spec.output_type is _SupportTicketResolution
+    assert tuple(teammate.name for teammate in agent.spec.teammates) == (
+        "planner",
+        "billing",
+    )
+    assert agent.spec.compaction is not None
+    assert agent.spec.compaction.strategies == (
+        CompactionStrategy.OFFLOAD_TO_EXTERNAL_STORE,
+    )


### PR DESCRIPTION
## 목적

`AgentExecutionSpec`을 선언형 Agent 설정의 단일 선언점으로 확장한다 (issue #403, 마일스톤 #19). 프레임워크가 실행 루프를 소유하는 선언형 Agent 방향에서, instructions·output_type·teammates·compaction을 spec에 선언적으로 보유하고 런타임(본 PR 이후 E4·C7)이 이를 소비한다.

Closes #403

## 변경 내용

`core/spakky-agent`의 `AgentExecutionSpec`에 선언 필드 4개와 공개 value 타입 3개를 추가한다 (기존 필드와 정합, 가산적 변경).

### 신규 spec 필드 (`execution.py`)
- `instructions: str | None` — 시스템 지시. 공백 문자열 거부.
- `output_type: type[object] | None` — 구조화 출력 타입. class만 허용(인스턴스 거부).
- `teammates: tuple[AgentTeammate, ...]` — 위임 협력자 roster. teammate name 중복 거부.
- `compaction: AgentCompactionPolicy | None` — compaction 전략 체인 + 임계치 정책.

### 신규 value 타입
- `AgentTeammate` — `name` + 로컬 Pod 타입(`pod`) XOR 원격 AgentCard http(s) URL(`card_url`) 정확히 하나. 공백 name·둘 다 선언·둘 다 미선언·비-class pod·비-http(s) 스킴·호스트 없는 URL을 모두 `AgentDefinitionError`로 거부.
- `CompactionStrategy` (StrEnum) — `DROP_OLDEST_EVIDENCE`, `SUMMARIZE_TRANSCRIPT`, `DEDUPLICATE_EVIDENCE`, `OFFLOAD_TO_EXTERNAL_STORE`.
- `AgentCompactionPolicy` — `strategies`(비어있지 않은 chain, 중복 불가) + `trigger_token_threshold`(양수).

모든 검증은 빌트인 예외가 아닌 커스텀 `AgentDefinitionError`로 실패한다. `__init__.py` `__all__`에 신규 심볼을 가산적으로 export한다.

## 결정 근거 (PR 폼팩터 회수)

- **`output_type`은 `type[BaseModel]`이 아니라 `type[object]`로 두고 `isclass` 가드만 적용**한다. 참조한 pydantic-ai의 `output_type`은 `BaseModel`뿐 아니라 `str`/`bool` 같은 빌트인 타입과 타입 리스트도 받는다. spec은 provider-neutral 선언점이므로 `BaseModel`로 좁히면 유효한 빌트인 출력 타입을 잘못 거부한다. 실제 footgun(인스턴스 전달)은 `isclass`가 차단한다. (리뷰 Warning에 대한 결정 — 좁히지 않음.)
- **teammate를 `AgentDelegateTarget`(runtime delegation packet)과 별도 타입으로 둔다.** teammates는 선언 시점 roster이고 `AgentDelegateTarget`은 실행 시점 packet target이라 레이어가 다르다. 후속 E4가 roster를 packet으로 배선한다.
- **URL 검증은 `urllib.parse.urlsplit`로 스킴(http/https)·netloc만 확인**한다. regex·외부 의존 없이 stdlib로 명백한 오선언을 차단하고, 도달성 검증은 런타임(E4) 책임으로 남긴다.

## 테스트

`tests/unit/test_execution.py`에 선언→검증→소비 시나리오를 함수 기반 단위 테스트로 추가했다 (DX 관점 happy path + 경계/에러 경로). `@Agent(spec=...)`가 4개 필드를 함께 보존하는 통합 시나리오 포함.

- 패키지 전체 `uv run pytest`: 196 passed, 커버리지 100.00% (`execution.py` 100%).
- format / harness validation / lint(ruff) / type(pyrefly, 0 diagnostics) 통과.

## Acceptance Criteria (자가 grep)

`acceptance_check: missing` — 이슈 본문에 기계적 grep 라인이 박힌 "수용 기준" 섹션이 없다. SC-1("spec 확장 필드의 검증·소비가 단위 테스트로 검증된다, 100% 커버리지")은 위 테스트 + 100% 커버리지로 충족.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
