### PR TITLE
feat(grpc): 명시 ProtoField 번호 유효성 검증 (예약범위·범위·중복 조기 차단)

### DIFF
--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/error.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/error.py
@@ -142,3 +142,50 @@ class ProtoFieldNumberConflictError(AbstractSpakkyGrpcError):
         self.explicit_field_name = explicit_field_name
         self.derived_field_name = derived_field_name
         self.number = number
+
+
+class InvalidProtoFieldNumberError(AbstractSpakkyGrpcError):
+    """Raised when an explicit ProtoField number is not a valid protobuf number.
+
+    An explicit ``ProtoField(number=N)`` must fall in the assignable protobuf
+    range: ``1`` .. ``536_870_911`` (``2**29 - 1``) and outside the protobuf
+    reserved band ``19_000`` .. ``19_999``. The auto-numbering path already
+    honors these constraints deterministically, but an explicit override
+    bypassed them and only failed later at descriptor-pool build time with an
+    opaque protobuf message. This error surfaces the violation at schema-build
+    time with the offending field and number so the author corrects it.
+    """
+
+    message = "Explicit ProtoField number is outside the valid protobuf range"
+
+    def __init__(self, model_type: type, field_name: str, number: int) -> None:
+        super().__init__()
+        self.model_type = model_type
+        self.field_name = field_name
+        self.number = number
+
+
+class DuplicateProtoFieldNumberError(AbstractSpakkyGrpcError):
+    """Raised when two explicit ProtoField numbers collide in one message.
+
+    Each protobuf field number must be unique within its message. Two fields
+    carrying the same explicit ``ProtoField(number=N)`` would later be rejected
+    by the descriptor pool with an opaque message. This error surfaces the
+    duplicate at schema-build time, naming both colliding fields and the shared
+    number so the author repins one of them.
+    """
+
+    message = "Duplicate explicit ProtoField number within a single message"
+
+    def __init__(
+        self,
+        model_type: type,
+        first_field_name: str,
+        second_field_name: str,
+        number: int,
+    ) -> None:
+        super().__init__()
+        self.model_type = model_type
+        self.first_field_name = first_field_name
+        self.second_field_name = second_field_name
+        self.number = number

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/schema/field_number.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/schema/field_number.py
@@ -11,6 +11,12 @@ Protobuf field-number constraints honored here:
 - The range ``19_000`` .. ``19_999`` is reserved by protobuf and is never
   assigned.
 
+The auto path satisfies these constraints by construction. An explicit
+``ProtoField`` override bypasses that construction, so the same invariants
+are enforced on it up front — an out-of-range or reserved number, or two
+explicit fields sharing a number, fails at schema-build time with a custom
+error instead of an opaque descriptor-pool rejection later.
+
 Collisions within a single message (two field names hashing to the same
 number, or a derived number landing on an explicit override) are resolved
 by deterministic re-hashing of the colliding name with an incrementing
@@ -41,7 +47,11 @@ from hashlib import sha256
 
 from pydantic import BaseModel
 from spakky.plugins.grpc.annotations.field import ProtoField
-from spakky.plugins.grpc.error import ProtoFieldNumberConflictError
+from spakky.plugins.grpc.error import (
+    DuplicateProtoFieldNumberError,
+    InvalidProtoFieldNumberError,
+    ProtoFieldNumberConflictError,
+)
 
 MIN_FIELD_NUMBER = 1
 """Smallest valid protobuf field number."""
@@ -86,13 +96,42 @@ def _hash_to_number(field_name: str, salt: int) -> int:
     return number
 
 
+def _validate_explicit_number(
+    model_type: type[BaseModel], field_name: str, number: int
+) -> None:
+    """Enforce protobuf number invariants on an explicit ProtoField override.
+
+    The auto-numbering path produces only valid, non-reserved numbers by
+    construction (:func:`_hash_to_number`). An explicit override skips that
+    construction, so the same invariants are checked here: the number must lie
+    in ``MIN_FIELD_NUMBER`` .. ``MAX_FIELD_NUMBER`` and must not fall in the
+    reserved ``RESERVED_RANGE_START`` .. ``RESERVED_RANGE_END`` band.
+
+    Args:
+        model_type: The ``BaseModel`` subclass being numbered (error context).
+        field_name: The field carrying the explicit override (error context).
+        number: The explicit protobuf field number to validate.
+
+    Raises:
+        InvalidProtoFieldNumberError: If the number is out of the valid range
+            or lands in the reserved band.
+    """
+    if not MIN_FIELD_NUMBER <= number <= MAX_FIELD_NUMBER:
+        raise InvalidProtoFieldNumberError(model_type, field_name, number)
+    if RESERVED_RANGE_START <= number <= RESERVED_RANGE_END:
+        raise InvalidProtoFieldNumberError(model_type, field_name, number)
+
+
 def assign_field_numbers(model_type: type[BaseModel]) -> dict[str, int]:
     """Assign a protobuf field number to every field of a ``BaseModel``.
 
     Fields carrying an explicit :class:`ProtoField` annotation are assigned
-    that exact number. All remaining fields receive a number derived from a
-    stable hash of their name, processed in lexicographic order. Collisions
-    between two derived numbers are resolved by deterministic re-hashing.
+    that exact number after the same protobuf invariants the auto path honors
+    are enforced on it: the number must be in the valid range and outside the
+    reserved band, and no two explicit fields may share a number. All remaining
+    fields receive a number derived from a stable hash of their name, processed
+    in lexicographic order. Collisions between two derived numbers are resolved
+    by deterministic re-hashing.
 
     A derived field's primary (salt-0) number colliding with an explicit
     override is *not* silently re-hashed — that would change the auto field's
@@ -107,6 +146,10 @@ def assign_field_numbers(model_type: type[BaseModel]) -> dict[str, int]:
         A mapping of field name to assigned protobuf field number.
 
     Raises:
+        InvalidProtoFieldNumberError: If an explicit ``ProtoField`` number is
+            outside the valid range or lands in the reserved band.
+        DuplicateProtoFieldNumberError: If two explicit ``ProtoField`` numbers
+            are equal within the same message.
         ProtoFieldNumberConflictError: If an auto-derived field's primary
             number equals an explicit ``ProtoField`` number in the same
             message.
@@ -122,6 +165,14 @@ def assign_field_numbers(model_type: type[BaseModel]) -> dict[str, int]:
             None,
         )
         if override is not None:
+            _validate_explicit_number(model_type, field_name, override.number)
+            if override.number in explicit_owner:
+                raise DuplicateProtoFieldNumberError(
+                    model_type,
+                    explicit_owner[override.number],
+                    field_name,
+                    override.number,
+                )
             assigned[field_name] = override.number
             used.add(override.number)
             explicit_owner[override.number] = field_name

--- a/plugins/spakky-grpc/tests/unit/test_error.py
+++ b/plugins/spakky-grpc/tests/unit/test_error.py
@@ -6,6 +6,8 @@ from spakky.core.common.error import AbstractSpakkyFrameworkError
 from spakky.plugins.grpc.error import (
     AbstractSpakkyGrpcError,
     DescriptorAlreadyRegisteredError,
+    DuplicateProtoFieldNumberError,
+    InvalidProtoFieldNumberError,
     ProtoFieldNumberConflictError,
     UnsupportedFieldTypeError,
 )
@@ -59,3 +61,38 @@ def test_proto_field_number_conflict_error_stores_context() -> None:
     assert error.explicit_field_name == "pinned"
     assert error.derived_field_name == "name"
     assert error.number == 95775423
+
+
+def test_invalid_proto_field_number_error_is_grpc_error() -> None:
+    """InvalidProtoFieldNumberError가 AbstractSpakkyGrpcError의 서브클래스인지 검증한다."""
+    assert issubclass(InvalidProtoFieldNumberError, AbstractSpakkyGrpcError)
+
+
+def test_invalid_proto_field_number_error_stores_context() -> None:
+    """InvalidProtoFieldNumberError가 위반 필드·번호 컨텍스트를 저장하는지 검증한다."""
+
+    class Dummy:
+        pass
+
+    error = InvalidProtoFieldNumberError(Dummy, "name", 19000)
+    assert error.model_type is Dummy
+    assert error.field_name == "name"
+    assert error.number == 19000
+
+
+def test_duplicate_proto_field_number_error_is_grpc_error() -> None:
+    """DuplicateProtoFieldNumberError가 AbstractSpakkyGrpcError의 서브클래스인지 검증한다."""
+    assert issubclass(DuplicateProtoFieldNumberError, AbstractSpakkyGrpcError)
+
+
+def test_duplicate_proto_field_number_error_stores_context() -> None:
+    """DuplicateProtoFieldNumberError가 두 충돌 필드와 공유 번호를 저장하는지 검증한다."""
+
+    class Dummy:
+        pass
+
+    error = DuplicateProtoFieldNumberError(Dummy, "first", "second", 5)
+    assert error.model_type is Dummy
+    assert error.first_field_name == "first"
+    assert error.second_field_name == "second"
+    assert error.number == 5

--- a/plugins/spakky-grpc/tests/unit/test_field_number.py
+++ b/plugins/spakky-grpc/tests/unit/test_field_number.py
@@ -12,7 +12,11 @@ from typing import Annotated, Optional
 import pytest
 from pydantic import BaseModel
 from spakky.plugins.grpc.annotations.field import ProtoField
-from spakky.plugins.grpc.error import ProtoFieldNumberConflictError
+from spakky.plugins.grpc.error import (
+    DuplicateProtoFieldNumberError,
+    InvalidProtoFieldNumberError,
+    ProtoFieldNumberConflictError,
+)
 from spakky.plugins.grpc.schema.field_number import (
     MAX_FIELD_NUMBER,
     MIN_FIELD_NUMBER,
@@ -259,3 +263,105 @@ def test_optional_and_repeated_fields_get_numbers() -> None:
     numbers = assign_field_numbers(Composite)
 
     assert set(numbers) == {"tags", "nickname"}
+
+
+def test_explicit_number_in_reserved_range_raises_invalid() -> None:
+    """예약 범위(19000~19999)를 명시한 ProtoField가 빌드 오류로 차단되는지 검증한다.
+
+    자동 경로는 예약 범위를 회피하지만 명시 override는 그 회피를 우회한다.
+    예약 범위 번호를 명시하면 descriptor pool 빌드 시점이 아니라 번호 부여
+    시점에 InvalidProtoFieldNumberError로 조기 차단되어야 한다 (US: 사용자가
+    실수로 19000번대를 지정한 경우).
+    """
+
+    class Reserved(BaseModel):
+        name: Annotated[str, ProtoField(number=RESERVED_RANGE_START)]
+
+    with pytest.raises(InvalidProtoFieldNumberError) as exc_info:
+        assign_field_numbers(Reserved)
+
+    assert exc_info.value.field_name == "name"
+    assert exc_info.value.number == RESERVED_RANGE_START
+    assert exc_info.value.model_type is Reserved
+
+
+def test_explicit_number_at_reserved_range_end_raises_invalid() -> None:
+    """예약 범위 끝(19999)을 명시한 ProtoField도 차단되는지 경계값을 고정한다."""
+
+    class ReservedEnd(BaseModel):
+        name: Annotated[str, ProtoField(number=RESERVED_RANGE_END)]
+
+    with pytest.raises(InvalidProtoFieldNumberError) as exc_info:
+        assign_field_numbers(ReservedEnd)
+
+    assert exc_info.value.number == RESERVED_RANGE_END
+
+
+def test_explicit_number_above_max_raises_invalid() -> None:
+    """유효 범위 상한(536870911)을 초과한 명시 번호가 차단되는지 검증한다.
+
+    사용자가 2**29 이상 번호를 명시하면 protobuf가 거부하기 전에
+    InvalidProtoFieldNumberError로 조기 실패해야 한다.
+    """
+
+    class TooBig(BaseModel):
+        name: Annotated[str, ProtoField(number=MAX_FIELD_NUMBER + 1)]
+
+    with pytest.raises(InvalidProtoFieldNumberError) as exc_info:
+        assign_field_numbers(TooBig)
+
+    assert exc_info.value.field_name == "name"
+    assert exc_info.value.number == MAX_FIELD_NUMBER + 1
+
+
+def test_explicit_number_below_min_raises_invalid() -> None:
+    """유효 범위 하한(1) 미만(0)을 명시한 번호가 차단되는지 검증한다.
+
+    0이나 음수는 유효한 protobuf 필드 번호가 아니다 — 번호 부여 시점에
+    InvalidProtoFieldNumberError로 막아야 한다.
+    """
+
+    class TooSmall(BaseModel):
+        name: Annotated[str, ProtoField(number=MIN_FIELD_NUMBER - 1)]
+
+    with pytest.raises(InvalidProtoFieldNumberError) as exc_info:
+        assign_field_numbers(TooSmall)
+
+    assert exc_info.value.number == MIN_FIELD_NUMBER - 1
+
+
+def test_duplicate_explicit_numbers_raises_duplicate() -> None:
+    """같은 메시지 내 두 명시 ProtoField 번호가 중복이면 차단되는지 검증한다.
+
+    한 메시지에서 두 필드가 동일한 ProtoField(number=N)를 가지면 descriptor
+    pool이 거부하기 전에 DuplicateProtoFieldNumberError로 조기 실패하여 두
+    충돌 필드와 공유 번호를 알려야 한다 (US: 복붙 실수로 같은 번호 명시).
+    """
+
+    class Duplicated(BaseModel):
+        first: Annotated[str, ProtoField(number=5)]
+        second: Annotated[str, ProtoField(number=5)]
+
+    with pytest.raises(DuplicateProtoFieldNumberError) as exc_info:
+        assign_field_numbers(Duplicated)
+
+    assert exc_info.value.first_field_name == "first"
+    assert exc_info.value.second_field_name == "second"
+    assert exc_info.value.number == 5
+    assert exc_info.value.model_type is Duplicated
+
+
+def test_distinct_explicit_numbers_are_accepted() -> None:
+    """서로 다른 명시 번호를 가진 두 필드는 정상적으로 공존하는지 검증한다.
+
+    유효·고유한 명시 번호는 검증을 통과해 그대로 부여되는 정상 경로다 —
+    중복 검증이 정상 케이스를 막지 않음을 보장한다.
+    """
+
+    class DistinctExplicit(BaseModel):
+        first: Annotated[str, ProtoField(number=5)]
+        second: Annotated[str, ProtoField(number=6)]
+
+    numbers = assign_field_numbers(DistinctExplicit)
+
+    assert numbers == {"first": 5, "second": 6}


### PR DESCRIPTION
## 목적

`ProtoField(number=N)`로 명시한 protobuf 필드 번호가 유효하지 않을 때(예약 범위 19000–19999, 유효 범위 1~536,870,911 초과/미만, 한 메시지 내 중복) `assign_field_numbers`가 검증 없이 통과시키던 비대칭을 해소한다. 자동 번호 경로는 이 제약을 결정론적으로 회피하지만 명시 override는 우회하여 descriptor pool 빌드 시점에 opaque protobuf 에러로만 실패했다.

Closes #426 (선행 #402 머지 완료)

## 변경

- `plugins/spakky-grpc/src/spakky/plugins/grpc/error.py`
  - `InvalidProtoFieldNumberError`: 명시 번호가 유효 범위 밖이거나 예약 범위에 있을 때. `model_type`·`field_name`·`number` 컨텍스트 보존.
  - `DuplicateProtoFieldNumberError`: 한 메시지 내 두 명시 번호가 중복일 때. 두 충돌 필드명과 공유 번호 보존.
  - 두 에러 모두 `AbstractSpakkyGrpcError` 가족 상속, class-attr `message`, `super().__init__()` 호출, `__str__`/f-string 미사용 (python-code.md 에러 규칙).
- `plugins/spakky-grpc/src/spakky/plugins/grpc/schema/field_number.py`
  - `_validate_explicit_number`: 범위·예약범위 불변식 검증.
  - `assign_field_numbers`의 explicit override 분기에서 검증 호출 + `explicit_owner` dict로 O(1) 중복 검사 후 조기 차단.
  - 모듈/함수 docstring에 빌드 시점 차단 근거 명시.

## 설계 근거

- 자동 경로(`_hash_to_number`)는 구성상 유효·비예약 번호만 생성한다. 명시 override는 그 구성을 건너뛰므로 동일 불변식을 진입 시점에 강제한다 — 이미 존재하는 `ProtoFieldNumberConflictError`(명시↔자동 충돌)와 일관되게 명시 번호 자체의 유효성도 빌드 시점에 검증.
- 범위/예약범위 위반과 중복은 서로 다른 결함이므로 별도 에러로 분리 (`ProtoFieldNumberConflictError`가 독립 에러인 선례와 일치).

## 검증

- `plugins/spakky-grpc`에서 `uv run pytest`: 228 tests, **100.00% 커버리지**.
- ruff check + format, pyrefly(0 diagnostics) green.
- 단위 테스트: 예약범위 시작/끝, 범위 초과, 범위 미만, 중복 명시 각각 에러 차단 + 정상(서로 다른 명시 번호 공존) 케이스.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
