### PR TITLE
feat(agent): AgentRunner 실행 루프 완전 소유 + execute() 자동 제공 + HITL

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -517,9 +517,9 @@ spakky-data = "spakky.data.main:initialize"
 
 ### Agentic workflow layer
 
-`spakky-agent`는 LLM SDK wrapper가 아니라 application layer building block입니다. `@Agent`는 `@UseCase`와 동격인 `@Pod` 계열 stereotype이고, inbound adapter는 `execute()`가 내보내는 `AgentYield` stream을 HTTP/WebSocket/CLI 이벤트로 변환합니다. Agent 내부의 비결정적 orchestration은 business workflow로 남고, 외부 세계 접근은 constructor DI로 받은 outbound port와 `@agent_tool` descriptor를 통해서만 표현합니다.
+`spakky-agent`는 LLM SDK wrapper가 아니라 application layer building block입니다. `@Agent`는 `@UseCase`와 동격인 `@Pod` 계열 stereotype이고, inbound adapter는 `execute()`가 내보내는 `AgentYield` stream을 HTTP/WebSocket/CLI 이벤트로 변환합니다. Agent 내부의 비결정적 orchestration은 business workflow로 남고, 외부 세계 접근은 constructor DI로 받은 outbound port와 `@agent_tool` descriptor를 통해서만 표현합니다. spec과 `@agent_tool` 메서드만 선언하고 `execute()`를 작성하지 않으면 `@Agent`가 `AgentRunner` 기반 표준 실행 루프를 `execute()`로 자동 바인딩한다(ADR-0013 §1).
 
-Core public API의 중심은 `AgentExecutionSpec`, `AgentYield`, `AgentState`, `AgentSignal`, `AgentEvidence`, `IAgentModel`, `@agent_tool`, `DelegationPacket`/`IAgentDelegate`, context/safety/recovery contract입니다. Durable 실행은 `RecoveryStrategy.ACTION_BOUNDARY` 또는 `accepted_signals` 선언에서 파생되며, bootstrap 단계에서 `IAgentStateRepository`, `IAgentSignalRepository`, `IAgentEvidenceRepository`가 모두 등록되어 있는지 검증합니다. Core는 production in-memory repository fallback을 제공하지 않습니다.
+Core public API의 중심은 `AgentExecutionSpec`, `AgentYield`, `AgentState`, `AgentSignal`, `AgentEvidence`, `IAgentModel`, `@agent_tool`, `AgentRunner`/`AgentRunResult`, `RunAgentInput`, `DelegationPacket`/`IAgentDelegate`, context/safety/recovery contract입니다. Durable 실행은 `RecoveryStrategy.ACTION_BOUNDARY` 또는 `accepted_signals` 선언에서 파생되며, bootstrap 단계에서 `IAgentStateRepository`, `IAgentSignalRepository`, `IAgentEvidenceRepository`가 모두 등록되어 있는지 검증합니다. Core는 production in-memory repository fallback을 제공하지 않습니다.
 
 `spakky-vllm`은 첫 공식 model provider plugin입니다. `VllmConfig`, `HttpxVllmChatClient`, `VllmAgentModel`을 등록하고 `IAgentModel -> VllmAgentModel` binding을 추가합니다. 이 패키지는 OpenAI-compatible vLLM `/v1/chat/completions` 요청, SSE stream, structured output, tool-call JSON validation을 provider-neutral `ModelResponse`/`ModelStreamEvent`로 변환하며, `spakky-agent` core와 inbound adapter package를 역참조하지 않습니다.
 

--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -6,6 +6,7 @@
 ## 언제 필요한가
 
 - agentic workflow를 Spakky DI/hexagonal architecture 안에서 표현하려는 경우
+- spec과 `@agent_tool` 메서드만 선언하고 프레임워크가 표준 실행 루프(`execute()`)를 자동 제공하게 하려는 경우
 - `AgentYield` stream을 FastAPI, WebSocket, CLI 같은 inbound adapter가 직접 소비하게 하려는 경우
 - model adapter를 `IAgentModel` outbound port로 구현하려는 경우
 - long-running execution의 state, signal, evidence 계약을 plugin contribution으로 구현하려는 경우
@@ -28,7 +29,9 @@ pip install spakky-agent spakky-vllm "spakky-sqlalchemy[agent]"
 
 ## 제공하는 public surface
 
-- `Agent`, `AgentExecutionSpec`, `AgentExecutionLimits`: `@UseCase`와 동격인 Pod stereotype과 보조 실행 의미. `AgentExecutionSpec`은 이번 변경에서 네 가지 선언 필드를 추가로 제공한다 — `instructions: str | None` (system-level 안내 문자열, 빈 문자열 거부), `output_type: type[object] | None` (구조화 출력 타입 선언; 클래스여야 하며 provider에 중립, pydantic-ai `output_type`과 같은 의미), `teammates: tuple[AgentTeammate, ...]` (협력 agent 선언, 이름 중복 거부), `compaction: AgentCompactionPolicy | None` (컨텍스트 압축 전략 체인 + token threshold 선언). 잘못된 값은 모두 `AgentDefinitionError`로 거부된다.
+- `Agent`, `AgentExecutionSpec`, `AgentExecutionLimits`: `@UseCase`와 동격인 Pod stereotype과 보조 실행 의미. `AgentExecutionSpec`은 이번 변경에서 네 가지 선언 필드를 추가로 제공한다 — `instructions: str | None` (system-level 안내 문자열, 빈 문자열 거부), `output_type: type[object] | None` (구조화 출력 타입 선언; 클래스여야 하며 provider에 중립, pydantic-ai `output_type`과 같은 의미), `teammates: tuple[AgentTeammate, ...]` (협력 agent 선언, 이름 중복 거부), `compaction: AgentCompactionPolicy | None` (컨텍스트 압축 전략 체인 + token threshold 선언). 잘못된 값은 모두 `AgentDefinitionError`로 거부된다. `execute()` 없이 spec + `@agent_tool` 메서드만 선언하면 프레임워크가 `AgentRunner` 기반 표준 루프를 `execute()`로 자동 바인딩한다(ADR-0013 §1). 개발자가 직접 `execute()`를 작성한 경우에는 건드리지 않는다.
+- `AgentRunner`, `AgentRunResult`: 프레임워크가 소유하는 표준 실행 루프. `AgentRunner.for_agent_instance(instance)`는 인스턴스에 주입된 속성을 타입 기반으로 탐색해 `IAgentModel`·`IAgentStateRepository`·`IAgentSignalRepository`·`IAgentEvidenceRepository`를 resolve한다. `run(run_input)` 메서드는 `AsyncGenerator[AgentYield[object], None]`을 yield한다. `accepted_signals`/`RecoveryStrategy.ACTION_BOUNDARY` 선언이 없는 stateless agent는 model → tool → final의 단순 경로를 실행하고, durable agent는 state 전이·signal 소비·HITL pause→approval→resume 흐름·action boundary checkpoint까지 모두 처리한다. `AgentRunResult`는 spec이 `output_type`을 선언하지 않을 때 기본으로 반환되는 중립 종료 요약 dataclass(`state_id`, `status`, `tool_calls`, `evidence_count`)다.
+- `RunAgentInput`: inbound run 계약. `state_id`(실행 상관 ID), `instruction`(모델 요청의 사용자 프롬프트), `conversation_id`(멀티턴 스레드 ID, 생략 시 `state_id`로 대체), `resume`(일시 중단된 실행 재개 여부), `metadata`(runner 레벨 부가 정보)를 담는다. `effective_conversation_id` property는 `conversation_id or state_id`를 반환한다. approval decision은 이 계약이 아닌 signal repository를 통해 전달된다.
 - `AgentTeammate`: 이름과 로컬 Pod 타입(`pod`) 또는 원격 AgentCard http(s) URL(`card_url`) 중 정확히 하나를 선언하는 협력 agent 기술자. 둘 다 지정하거나 둘 다 생략하면 `AgentDefinitionError`. 런타임 위임 배선은 후속 태스크 E4에서 구현된다.
 - `CompactionStrategy`: 컨텍스트 압축 전략 열거형(`StrEnum`). 값은 `DROP_OLDEST_EVIDENCE`, `SUMMARIZE_TRANSCRIPT`, `DEDUPLICATE_EVIDENCE`, `OFFLOAD_TO_EXTERNAL_STORE`.
 - `AgentCompactionPolicy`: 압축 전략 체인(`strategies: tuple[CompactionStrategy, ...]`, 비어 있거나 중복 불가)과 트리거 토큰 임계값(`trigger_token_threshold: int`, 양수 필수)을 선언하는 값 타입. 런타임 압축 핸들러는 후속 태스크 C7에서 구현된다.
@@ -66,6 +69,50 @@ Durable 실행 경로는 `AgentExecutionSpec.recovery == RecoveryStrategy.ACTION
 `AgentEvidenceRepository`의 agent-facing interface는 append/read 계열만 노출합니다. Redaction, correction, context digest 갱신은 기존 evidence를 수정하지 않고 새 evidence를 append하는 방식으로 표현합니다.
 
 ## 사용 예시
+
+### 선언형 — 프레임워크 제공 루프 (권장)
+
+spec과 `@agent_tool` 메서드만 작성하면 `@Agent`가 `AgentRunner` 기반 표준 루프를 `execute()`로 자동 바인딩합니다. `RunAgentInput`을 인자로 받아 `AgentYield` 스트림을 내보내는 표준 루프가 model → tool dispatch → HITL pause/resume → state 전이 → final 까지 처리합니다.
+
+```python
+from spakky.agent import (
+    Agent,
+    AgentExecutionSpec,
+    IAgentModel,
+    agent_tool,
+)
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="file_agent",
+        instructions="Use the declared tools to read and summarize files.",
+    )
+)
+class FileAgent:
+    def __init__(self, model: IAgentModel) -> None:
+        self.model = model
+
+    @agent_tool(schema_name="file.read")
+    async def read_file(self, path: str) -> str:
+        with open(path) as f:
+            return f.read()
+    # execute()를 작성하지 않으면 AgentRunner 기반 표준 루프가 자동으로 제공된다.
+```
+
+호출 측은 `RunAgentInput`을 구성해 `execute()`를 호출합니다.
+
+```python
+from spakky.agent import RunAgentInput
+
+run_input = RunAgentInput(state_id="run-001", instruction="Read README.md and summarize.")
+async for item in agent_instance.execute(run_input):
+    print(item)
+```
+
+### 커스텀 execute() 탈출 경로
+
+자동 제공 루프로 표현할 수 없는 커스텀 제어가 필요한 경우에만 `execute()`를 직접 작성합니다. 이 경우 자동 바인딩은 적용되지 않으며, `execute()` 본문이 전체 실행을 책임집니다.
 
 ```python
 from collections.abc import AsyncGenerator
@@ -123,7 +170,7 @@ class CodeAssistant:
         )
 ```
 
-`@Agent`는 `@Pod` 계열 stereotype이므로 application scan과 constructor DI에 참여합니다. `execute()`는 `Generator[AgentYield[T], None, None]` 또는 `AsyncGenerator[AgentYield[T], None]`로 typed stream item을 yield할 수 있고, non-generator 반환형은 streaming 없는 직접 결과 계약으로 취급됩니다. Inbound adapter가 SSE/WebSocket/CLI처럼 진행 상태를 즉시 내보내야 한다면 `AgentYield` generator 계약을 사용해야 합니다.
+`@Agent`는 `@Pod` 계열 stereotype이므로 application scan과 constructor DI에 참여합니다. spec과 `@agent_tool` 메서드만 선언하고 `execute()`를 작성하지 않으면 프레임워크가 `AgentRunner` 기반 표준 루프를 `execute()`로 자동 바인딩합니다(ADR-0013 §1). 커스텀 제어가 필요한 경우에만 `execute()`를 직접 작성하며, 이 경우 자동 바인딩은 적용되지 않습니다. `execute()`는 `Generator[AgentYield[T], None, None]` 또는 `AsyncGenerator[AgentYield[T], None]`로 typed stream item을 yield할 수 있고, non-generator 반환형은 streaming 없는 직접 결과 계약으로 취급됩니다. Inbound adapter가 SSE/WebSocket/CLI처럼 진행 상태를 즉시 내보내야 한다면 `AgentYield` generator 계약을 사용해야 합니다.
 
 `AgentYieldKind`의 public status vocabulary는 `token`, `progress`, `tool`, `evidence`, `approval`, `final`, `error`, `cancel`입니다. 각 item의 payload는 `Token`, `Progress`, `Tool`, `Evidence`, `Approval`, `Final[T]`, `Error`, `Cancel` value object로 구분되므로 inbound adapter는 별도 stream projector 없이 generator를 직접 순회해 transport별 이벤트로 바꿀 수 있습니다.
 

--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -105,6 +105,8 @@ from spakky.agent.execution import (
     RecoveryStrategy,
     StreamingExposureMode,
 )
+from spakky.agent.inbound import RunAgentInput
+from spakky.agent.runner import AgentRunner, AgentRunResult
 from spakky.agent.interfaces.repository import (
     IAgentEvidenceRepository,
     IAgentSignalRepository,
@@ -263,6 +265,8 @@ __all__ = [
     "AgentResumeAction",
     "AgentResumeBoundary",
     "AgentResumePlan",
+    "AgentRunResult",
+    "AgentRunner",
     "AgentSignal",
     "AgentSignalConsumptionBatch",
     "AgentSignalKind",
@@ -344,6 +348,7 @@ __all__ = [
     "RecoveryStrategy",
     "RedactionPolicy",
     "ResultBudget",
+    "RunAgentInput",
     "SamplingOptions",
     "SecretField",
     "SecretRef",

--- a/core/spakky-agent/src/spakky/agent/execution.py
+++ b/core/spakky-agent/src/spakky/agent/execution.py
@@ -185,6 +185,7 @@ class Agent(Pod):
             super()._initialize(agent_class)
         except AbstractSpakkyPodError as e:
             raise AgentDefinitionError("Agent Pod metadata is invalid") from e
+        self._ensure_execute_provided(agent_class)
         self._validate_execute_contract(agent_class)
         self.tool_catalog = discover_agent_tools(agent_class)
 
@@ -216,10 +217,27 @@ class Agent(Pod):
             raise AgentDefinitionError("@Agent can only annotate classes")
         return obj
 
+    def _ensure_execute_provided(self, obj: type[object]) -> None:
+        """Bind the framework-owned loop as ``execute()`` when none is declared.
+
+        ADR-0013 §1 keeps the ``execute()`` interface but lets the framework
+        runner auto-provide the standard loop. A developer who declares only a
+        spec plus ``@agent_tool`` methods writes no loop body; the synthesized
+        ``execute()`` satisfies the strict contract validated below, so the
+        validator is reused rather than weakened. A developer-written
+        ``execute()`` is left untouched for custom control.
+        """
+        if getattr_static(obj, "execute", None) is not None:
+            return
+        from spakky.agent.runner import runner_backed_execute
+
+        # Framework metaprogramming: bind the runner-backed generator as the
+        # agent's execute() so the strict contract validation accepts it.
+        obj.execute = runner_backed_execute  # type: ignore[attr-defined] - synthesized contract method
+
     def _validate_execute_contract(self, obj: type[object]) -> None:
-        execute = getattr_static(obj, "execute", None)
-        if execute is None:
-            raise AgentDefinitionError("@Agent class must define execute()")
+        # _ensure_execute_provided guarantees execute() exists before validation.
+        execute = getattr_static(obj, "execute")
         execute_signature = signature(execute)
         self._validate_execute_parameters(execute_signature)
         return_annotation = self._resolve_execute_return_annotation(

--- a/core/spakky-agent/src/spakky/agent/inbound.py
+++ b/core/spakky-agent/src/spakky/agent/inbound.py
@@ -1,0 +1,50 @@
+"""Inbound run contract consumed by the framework-owned agent runner.
+
+ADR-0013 §1 hands the execution loop to the framework runner. A caller (an
+inbound adapter today, an AG-UI/A2A protocol adapter later) hands the runner a
+``RunAgentInput`` describing one run: which durable run to correlate against, the
+user instruction that seeds the model request, and whether the run resumes a
+paused/interrupted execution (ADR-0013 §5 HITL resume / restart recovery).
+
+Approval decisions are **not** carried here. The unified pause -> approval
+request -> resume flow (ADR-0013 §5) delivers a decision through the durable
+signal repository, not through this input, so the runner polls the signal queue
+non-blockingly rather than reading a decision off the inbound contract.
+"""
+
+from dataclasses import dataclass, field
+
+from spakky.agent.error import AgentDefinitionError
+from spakky.agent.types import JsonObject
+
+
+@dataclass(frozen=True, slots=True)
+class RunAgentInput:
+    """Inbound contract for one framework-owned agent run."""
+
+    state_id: str
+    instruction: str
+    conversation_id: str | None = None
+    resume: bool = False
+    metadata: JsonObject = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Reject inbound input that cannot correlate a run or seed a request."""
+        if not self.state_id.strip():
+            raise AgentDefinitionError("Run agent input state id cannot be blank")
+        if not self.instruction.strip():
+            raise AgentDefinitionError("Run agent input instruction cannot be blank")
+        if self.conversation_id is not None and not self.conversation_id.strip():
+            raise AgentDefinitionError(
+                "Run agent input conversation id cannot be blank"
+            )
+
+    @property
+    def effective_conversation_id(self) -> str:
+        """Return the multi-turn thread id, defaulting to the run id.
+
+        ADR-0013 §3 attribution requires a conversation id on every event. A
+        single-turn caller may omit it, in which case the run id identifies the
+        (degenerate) one-turn conversation.
+        """
+        return self.conversation_id or self.state_id

--- a/core/spakky-agent/src/spakky/agent/runner.py
+++ b/core/spakky-agent/src/spakky/agent/runner.py
@@ -1,0 +1,805 @@
+"""Framework-owned agent execution loop (ADR-0013 §1).
+
+The runner generalizes the manual model -> tool -> evidence -> terminate loop
+that ADR-0009 left in developer ``execute()`` bodies. A developer declares an
+``@Agent`` spec plus ``@agent_tool`` methods; the framework provides the loop.
+The runner consumes the provider-neutral model stream (C2), dispatches tool
+calls through the discovered catalog (C4), records boundary/evidence (C3 model
+contracts), consumes durable signals, drives the unified HITL pause -> approval
+request -> resume flow (ADR-0013 §5), and terminates with a typed final output
+shaped by ``spec.output_type``.
+
+The loop yields the public ``AgentYield`` vocabulary. ADR-0013 §3 generalizes
+that vocabulary into the neutral ``AgentEvent`` taxonomy and assigns the exact
+projection to the follow-up protocol-adapter groups; the runner therefore stays
+on ``AgentYield`` and does not emit ``AgentEvent`` directly.
+"""
+
+from collections.abc import AsyncGenerator, Mapping, Sequence
+from dataclasses import asdict, dataclass, is_dataclass, replace
+
+from pydantic import BaseModel
+
+from spakky.agent.approval import (
+    AgentApprovalRequest,
+    materialize_agent_approval_decision_state,
+    parse_agent_approval_decision_signal,
+    plan_agent_tool_approval,
+)
+from spakky.agent.cancellation import (
+    begin_agent_cancellation,
+    complete_agent_cancellation,
+    run_agent_cancellation_cleanup,
+)
+from spakky.agent.dispatcher import AgentToolDispatcher
+from spakky.agent.error import (
+    AgentModelConfigurationError,
+    AgentPersistenceConfigurationError,
+    AgentToolDispatchError,
+)
+from spakky.agent.evidence import (
+    AgentEvidence,
+    AgentEvidenceCandidate,
+    AgentEvidenceKind,
+)
+from spakky.agent.execution import Agent, AgentSignalKind, RecoveryStrategy
+from spakky.agent.inbound import RunAgentInput
+from spakky.agent.interfaces.model import (
+    IAgentModel,
+    JsonSchemaConstraint,
+    ModelError,
+    ModelMessage,
+    ModelMessageRole,
+    ModelRequest,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    ModelToolChoice,
+    ModelToolSpec,
+    SamplingOptions,
+    ToolCallingSpec,
+)
+from spakky.agent.interfaces.repository import (
+    IAgentEvidenceRepository,
+    IAgentSignalRepository,
+    IAgentStateRepository,
+)
+from spakky.agent.recovery import (
+    AgentActionBoundaryCheckpoint,
+    plan_agent_resume,
+)
+from spakky.agent.signal import AgentSignal, ApprovalDecision
+from spakky.agent.state import (
+    AgentState,
+    AgentStateReason,
+    AgentStateTransition,
+    AgentStatus,
+)
+from spakky.agent.tooling import AgentToolDescriptor, Idempotency
+from spakky.agent.types import JsonValue
+from spakky.agent.yield_ import (
+    AgentYield,
+    AgentYieldKind,
+    Cancel,
+    Error,
+    Evidence,
+    Final,
+    Progress,
+    Token,
+    Tool,
+)
+
+DEFAULT_SYSTEM_INSTRUCTION = "Use the declared tools to accomplish the objective."
+"""Fallback system message when an agent spec declares no instructions."""
+
+DEFAULT_SAMPLING = SamplingOptions(temperature=0.0, max_tokens=512)
+"""Deterministic default sampling for the framework-owned model request."""
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRunResult:
+    """Neutral terminal summary returned when a spec declares no output type."""
+
+    state_id: str
+    status: str
+    tool_calls: tuple[str, ...]
+    evidence_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRunner:
+    """Framework-owned standard agent loop bound to one agent instance.
+
+    Durable repositories are ``None`` for a stateless agent (one that declares
+    no ``accepted_signals`` and no action-boundary recovery). In that mode the
+    runner skips state/evidence/signal handling and runs model -> tool -> final.
+    """
+
+    agent: Agent
+    # target: the @Agent instance owning the @agent_tool callables — no base type.
+    target: object
+    model: IAgentModel
+    states: IAgentStateRepository | None = None
+    signals: IAgentSignalRepository | None = None
+    evidence: IAgentEvidenceRepository | None = None
+
+    @classmethod
+    def for_agent_instance(cls, instance: object) -> "AgentRunner":
+        """Resolve runner ports from an agent instance's injected attributes.
+
+        ADR-0009 stores constructor-injected ports as instance attributes, so the
+        runner reads ``vars(instance)`` (the typed instance ``__dict__``, not the
+        banned ``getattr``) and resolves each port by runtime type. Attribute
+        names are developer-chosen, so resolution is type-driven, not name-driven.
+        """
+        agent = Agent.get(type(instance))
+        attributes = tuple(vars(instance).values())
+        model = cls._resolve_required(attributes, IAgentModel)
+        if model is None:
+            raise AgentModelConfigurationError(
+                "Agent run requires an IAgentModel port but none was injected"
+            )
+        states = cls._resolve_optional(attributes, IAgentStateRepository)
+        signals = cls._resolve_optional(attributes, IAgentSignalRepository)
+        evidence = cls._resolve_optional(attributes, IAgentEvidenceRepository)
+        runner = cls(
+            agent=agent,
+            target=instance,
+            model=model,
+            states=states,
+            signals=signals,
+            evidence=evidence,
+        )
+        runner._require_durable_ports()
+        return runner
+
+    async def run(
+        self,
+        run_input: RunAgentInput,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        """Run one model-mediated agent loop, yielding the public stream."""
+        if self.states is None:
+            async for item in self._run_stateless(run_input):
+                yield item
+            return
+        async for item in self._run_durable(run_input, self.states):
+            yield item
+
+    async def _run_stateless(
+        self,
+        run_input: RunAgentInput,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        tool_calls: list[str] = []
+        yield _progress("preparing model request", "model")
+        async for event in self.model.stream(self._model_request(run_input)):
+            async for item in self._consume_stream_event(event, None, tool_calls):
+                yield item
+            if event.kind is ModelStreamEventKind.ERROR and event.error is not None:
+                return
+        yield self._final_yield(run_input.state_id, tool_calls, evidence_count=0)
+
+    async def _run_durable(
+        self,
+        run_input: RunAgentInput,
+        states: IAgentStateRepository,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        # Phase 1: ensure an active durable state for the run.
+        state = self._ensure_active_state(run_input, states)
+
+        # Phase 2: replay resume plan from persisted evidence when requested.
+        if run_input.resume:
+            yield self._emit_resume_plan(state)
+            state = states.get(run_input.state_id)
+
+        # Phase 3: honor a cancel signal queued before the model loop.
+        cancel = await self._consume_cancel(state)
+        if cancel is not None:
+            yield cancel
+            return
+
+        # Phase 4: open the model action boundary and request the model.
+        tool_calls: list[str] = []
+        yield _progress("preparing model request", "model")
+        self._append_boundary(state.id, _before_model(self._model_action_id()))
+        request = self._model_request(run_input)
+
+        # Phase 5: consume the provider-neutral model stream.
+        async for event in self.model.stream(request):
+            cancel = await self._consume_cancel(state)
+            if cancel is not None:
+                yield cancel
+                return
+            for signal_item in self._consume_user_messages(state):
+                yield signal_item
+            terminated = False
+            async for item in self._consume_stream_event(event, state, tool_calls):
+                yield item
+            if event.kind is ModelStreamEventKind.ERROR and event.error is not None:
+                return
+            if (
+                event.kind is ModelStreamEventKind.TOOL_CALL_CANDIDATE
+                and event.tool_call is not None
+                and states.get(state.id).status is not AgentStatus.ACTIVE
+            ):
+                terminated = True
+            if terminated:
+                return
+
+        # Phase 6: transition to a terminal completed state and emit the final.
+        final_state = states.save(
+            replace(
+                states.get(state.id),
+                status=AgentStatus.COMPLETED,
+                transition=AgentStateTransition.COMPLETED,
+                current_activity="run completed",
+            )
+        )
+        yield self._final_yield(
+            final_state.id,
+            tool_calls,
+            evidence_count=self._evidence_count(final_state.id),
+        )
+
+    async def _consume_stream_event(
+        self,
+        event: ModelStreamEvent,
+        state: AgentState | None,
+        tool_calls: list[str],
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        """Translate one model stream event into the public yield vocabulary."""
+        match event.kind:
+            case ModelStreamEventKind.TOKEN_DELTA:
+                yield _token(event.token_delta or "")
+            case ModelStreamEventKind.MESSAGE_DELTA:
+                yield _token(event.message_delta or "")
+            case ModelStreamEventKind.REASONING_DELTA:
+                if self.model.capability.supports_reasoning:
+                    yield _token(event.reasoning_delta or "")
+            case ModelStreamEventKind.TOOL_CALL_CANDIDATE if (
+                event.tool_call is not None
+            ):
+                async for item in self._execute_tool_call(state, event.tool_call):
+                    yield item
+                tool_calls.append(event.tool_call.name)
+            case ModelStreamEventKind.DONE:
+                if state is not None:
+                    self._append_boundary(
+                        state.id, _after_model(self._model_action_id())
+                    )
+            case ModelStreamEventKind.ERROR if event.error is not None:
+                yield self._fail_on_model_error(state, event.error)
+            case _:
+                return
+
+    async def _execute_tool_call(
+        self,
+        state: AgentState | None,
+        call: ModelToolCall,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        descriptor = self.agent.tool_catalog.by_schema_name(call.name)
+        if state is not None:
+            approval_item, cleared = self._resolve_approval(state, descriptor, call)
+            if approval_item is not None:
+                yield approval_item
+            if not cleared:
+                return
+            self._append_boundary(state.id, _before_tool(descriptor, call))
+        result = await self._dispatch(call)
+        if state is not None:
+            self._append_boundary(state.id, _after_tool(descriptor, call))
+            yield _evidence_yield(
+                self._append_tool_evidence(state.id, descriptor, result)
+            )
+        yield _tool_yield(descriptor, call, result)
+
+    def _resolve_approval(
+        self,
+        state: AgentState,
+        descriptor: AgentToolDescriptor,
+        call: ModelToolCall,
+    ) -> tuple[AgentYield[object] | None, bool]:
+        """Drive the HITL pause -> approval-request -> resume flow for one call.
+
+        Returns ``(approval_item, cleared)``: the approval request to surface (or
+        ``None`` when no approval is needed) paired with whether the tool may now
+        proceed. ``cleared`` is decided by the durable approval decision polled
+        from the signal queue, the non-blocking resume the ADR-0013 §5 flow uses.
+        """
+        plan = plan_agent_tool_approval(
+            descriptor=descriptor,
+            approval_id=self._approval_id(state.id, call),
+            agent_state_id=state.id,
+            agent_type=self._agent_type(),
+            call_id=call.call_id,
+        )
+        if not (plan.requires_approval and plan.yield_item is not None):
+            return None, True
+        self._append_boundary(state.id, _before_approval(call, descriptor))
+        # plan_agent_tool_approval pairs state with yield_item for WAIT_FOR_APPROVAL.
+        if plan.state is not None:  # pragma: no branch - state paired with yield_item
+            self._states_required().save(plan.state)
+        approval_item = AgentYield[object](
+            kind=plan.yield_item.kind,
+            payload=plan.yield_item.payload,
+        )
+        cleared = self._consume_approval(state.id, plan.request)
+        if cleared:
+            self._append_boundary(state.id, _after_approval(call, descriptor))
+        return approval_item, cleared
+
+    async def _dispatch(self, call: ModelToolCall) -> JsonValue:
+        dispatcher = AgentToolDispatcher(
+            target=self.target,
+            catalog=self.agent.tool_catalog,
+        )
+        return _tool_result_json(await dispatcher.dispatch(call))
+
+    def _fail_on_model_error(
+        self,
+        state: AgentState | None,
+        error: ModelError,
+    ) -> AgentYield[object]:
+        if state is not None:
+            current = self._states_required().get(state.id)
+            self._states_required().save(
+                replace(
+                    current,
+                    status=AgentStatus.FAILED,
+                    transition=AgentStateTransition.FAILED,
+                    reason=AgentStateReason.EXECUTION_FAILED,
+                    current_activity="model stream failed",
+                    metadata={**current.metadata, "model_error_code": error.code},
+                )
+            )
+        return AgentYield(
+            kind=AgentYieldKind.ERROR,
+            payload=Error(
+                code=error.code,
+                message=error.message,
+                retryable=error.retryable,
+                metadata=error.metadata,
+            ),
+        )
+
+    def _ensure_active_state(
+        self,
+        run_input: RunAgentInput,
+        states: IAgentStateRepository,
+    ) -> AgentState:
+        existing = states.get_or_none(run_input.state_id)
+        if existing is not None:
+            return states.save(
+                replace(
+                    existing,
+                    status=AgentStatus.ACTIVE,
+                    transition=AgentStateTransition.RUNNING,
+                    current_activity=run_input.instruction,
+                )
+            )
+        return states.save(
+            AgentState(
+                id=run_input.state_id,
+                agent_type=self._agent_type(),
+                status=AgentStatus.ACTIVE,
+                transition=AgentStateTransition.RUNNING,
+                current_activity=run_input.instruction,
+                input_ref=run_input.instruction,
+            )
+        )
+
+    def _emit_resume_plan(self, state: AgentState) -> AgentYield[object]:
+        plan = plan_agent_resume(
+            state,
+            self._evidence_required().list_by_state(state.id),
+            self._signals_required().list_pending(state.id),
+        )
+        self._states_required().save(plan.state)
+        return AgentYield(
+            kind=AgentYieldKind.PROGRESS,
+            payload=Progress(
+                f"resume action: {plan.action.value}",
+                current_step="resume",
+                metadata={
+                    "requires_human_input": plan.requires_human_input,
+                    "can_resume_automatically": plan.can_resume_automatically,
+                },
+            ),
+        )
+
+    def _model_request(self, run_input: RunAgentInput) -> ModelRequest:
+        tools = tuple(
+            ModelToolSpec(
+                name=descriptor.schema.name,
+                description=descriptor.description,
+                parameters=JsonSchemaConstraint(schema=descriptor.schema.input_schema),
+                metadata={"tool_identity": descriptor.identity.key},
+            )
+            for descriptor in self.agent.tool_catalog.descriptors
+        )
+        tool_calling = (
+            ToolCallingSpec(tools=tools, choice=ModelToolChoice.AUTO) if tools else None
+        )
+        return ModelRequest(
+            messages=(
+                ModelMessage(
+                    ModelMessageRole.SYSTEM,
+                    self.agent.spec.instructions or DEFAULT_SYSTEM_INSTRUCTION,
+                ),
+                ModelMessage(ModelMessageRole.USER, run_input.instruction),
+            ),
+            tool_calling=tool_calling,
+            sampling=DEFAULT_SAMPLING,
+            metadata={"state_id": run_input.state_id, **run_input.metadata},
+        )
+
+    def _final_yield(
+        self,
+        state_id: str,
+        tool_calls: Sequence[str],
+        *,
+        evidence_count: int,
+    ) -> AgentYield[object]:
+        output_type = self.agent.spec.output_type
+        result = AgentRunResult(
+            state_id=state_id,
+            status=AgentStatus.COMPLETED.value,
+            tool_calls=tuple(tool_calls),
+            evidence_count=evidence_count,
+        )
+        return AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(
+                output=result,
+                metadata={
+                    "output_type": output_type.__name__
+                    if output_type is not None
+                    else None,
+                },
+            ),
+        )
+
+    async def _consume_cancel(self, state: AgentState) -> AgentYield[object] | None:
+        for signal in self._signals_required().list_pending(state.id):
+            if signal.kind is not AgentSignalKind.CANCEL:
+                continue
+            self._signals_required().mark_consumed(signal.id)
+            cancelling = self._states_required().save(
+                begin_agent_cancellation(state, signal)
+            )
+            report = await run_agent_cancellation_cleanup(
+                state=cancelling,
+                signal=signal,
+                tasks=(),
+            )
+            self._append_candidate(
+                state.id,
+                report.to_evidence_candidate(summary="cancel cleanup completed"),
+            )
+            completed = self._states_required().save(
+                complete_agent_cancellation(cancelling, report)
+            )
+            return AgentYield(
+                kind=AgentYieldKind.CANCEL,
+                payload=Cancel(
+                    reason=completed.reason.value if completed.reason else None,
+                    requested_by=_optional_signal_text(signal, "requested_by"),
+                    metadata={"state": completed.status.value},
+                ),
+            )
+        return None
+
+    def _consume_user_messages(
+        self,
+        state: AgentState,
+    ) -> list[AgentYield[object]]:
+        items: list[AgentYield[object]] = []
+        for signal in self._signals_required().list_pending(state.id):
+            if signal.kind is not AgentSignalKind.USER_MESSAGE:
+                continue
+            self._signals_required().mark_consumed(signal.id)
+            self._append_candidate(
+                state.id,
+                AgentEvidenceCandidate(
+                    kind=AgentEvidenceKind.EVALUATION,
+                    payload={"signal_id": signal.id, "payload": signal.payload},
+                    summary="user signal consumed",
+                ),
+            )
+            items.append(
+                AgentYield(
+                    kind=AgentYieldKind.PROGRESS,
+                    payload=Progress(
+                        "user message consumed",
+                        current_step="signal",
+                        metadata={"signal_id": signal.id},
+                    ),
+                )
+            )
+        return items
+
+    def _consume_approval(
+        self,
+        state_id: str,
+        request: AgentApprovalRequest | None,
+    ) -> bool:
+        for signal in self._signals_required().list_pending(state_id):
+            if signal.kind is not AgentSignalKind.APPROVAL_DECISION:
+                continue
+            if (
+                request is not None
+                and _optional_signal_text(signal, "request_id") != request.id
+            ):
+                continue
+            outcome = parse_agent_approval_decision_signal(signal, request=request)
+            self._signals_required().mark_consumed(signal.id)
+            current = self._states_required().get(state_id)
+            self._states_required().save(
+                materialize_agent_approval_decision_state(current, outcome)
+            )
+            self._append_candidate(
+                state_id,
+                AgentEvidenceCandidate(
+                    kind=AgentEvidenceKind.APPROVAL,
+                    payload={
+                        "signal_id": signal.id,
+                        "request_id": outcome.request_id,
+                        "decision": outcome.decision.value,
+                    },
+                    summary="approval decision consumed",
+                ),
+            )
+            return outcome.decision in (
+                ApprovalDecision.APPROVE,
+                ApprovalDecision.MODIFY,
+            )
+        return False
+
+    def _append_tool_evidence(
+        self,
+        state_id: str,
+        descriptor: AgentToolDescriptor,
+        result: JsonValue,
+    ) -> AgentEvidence:
+        payload = result if isinstance(result, Mapping) else {"result": result}
+        return self._append_candidate(
+            state_id,
+            AgentEvidenceCandidate.tool_result(
+                tool_identity=descriptor.identity.key,
+                tool_schema_name=descriptor.schema.name,
+                result=payload,
+                capture=descriptor.metadata.evidence,
+                summary=f"{descriptor.schema.name} completed",
+            ),
+        )
+
+    def _append_boundary(
+        self,
+        state_id: str,
+        checkpoint: AgentActionBoundaryCheckpoint,
+    ) -> AgentEvidence:
+        return self._append_candidate(
+            state_id,
+            checkpoint.to_evidence_candidate(summary=checkpoint.action_id),
+        )
+
+    def _append_candidate(
+        self,
+        state_id: str,
+        candidate: AgentEvidenceCandidate,
+    ) -> AgentEvidence:
+        index = self._evidence_count(state_id) + 1
+        return self._evidence_required().append(
+            candidate.to_evidence(
+                evidence_id=f"{state_id}:evidence:{index}",
+                agent_state_id=state_id,
+            )
+        )
+
+    def _evidence_count(self, state_id: str) -> int:
+        return len(self._evidence_required().list_by_state(state_id))
+
+    def _agent_type(self) -> str:
+        return self.agent.spec.name or type(self.target).__name__
+
+    def _model_action_id(self) -> str:
+        return f"model:{self._agent_type()}_decision"
+
+    def _approval_id(self, state_id: str, call: ModelToolCall) -> str:
+        return f"approval:{state_id}:{call.name}"
+
+    def _require_durable_ports(self) -> None:
+        if not self._is_durable():
+            return
+        missing = tuple(
+            name
+            for name, port in (
+                ("IAgentStateRepository", self.states),
+                ("IAgentSignalRepository", self.signals),
+                ("IAgentEvidenceRepository", self.evidence),
+            )
+            if port is None
+        )
+        if missing:
+            raise AgentPersistenceConfigurationError(
+                "Agent run requires durable repositories but these are missing: "
+                + ", ".join(missing)
+            )
+
+    def _is_durable(self) -> bool:
+        spec = self.agent.spec
+        return (
+            spec.recovery is RecoveryStrategy.ACTION_BOUNDARY
+            or len(spec.accepted_signals) > 0
+        )
+
+    def _states_required(self) -> IAgentStateRepository:
+        if self.states is None:  # pragma: no cover - durable guard
+            raise AgentPersistenceConfigurationError(
+                "Agent run reached a durable path without a state repository"
+            )
+        return self.states
+
+    def _signals_required(self) -> IAgentSignalRepository:
+        if self.signals is None:  # pragma: no cover - durable guard
+            raise AgentPersistenceConfigurationError(
+                "Agent run reached a durable path without a signal repository"
+            )
+        return self.signals
+
+    def _evidence_required(self) -> IAgentEvidenceRepository:
+        if self.evidence is None:  # pragma: no cover - durable guard
+            raise AgentPersistenceConfigurationError(
+                "Agent run reached a durable path without an evidence repository"
+            )
+        return self.evidence
+
+    @staticmethod
+    def _resolve_required[PortT](
+        attributes: Sequence[object],
+        port_type: type[PortT],
+    ) -> PortT | None:
+        matches = tuple(
+            attribute for attribute in attributes if isinstance(attribute, port_type)
+        )
+        if len(matches) > 1:
+            raise AgentModelConfigurationError(
+                f"Agent run found multiple {port_type.__name__} ports injected"
+            )
+        return matches[0] if matches else None
+
+    @staticmethod
+    def _resolve_optional[PortT](
+        attributes: Sequence[object],
+        port_type: type[PortT],
+    ) -> PortT | None:
+        return AgentRunner._resolve_required(attributes, port_type)
+
+
+async def runner_backed_execute(
+    self: object,
+    run_input: RunAgentInput,
+) -> AsyncGenerator[AgentYield[object], None]:
+    """Framework-provided ``execute()`` bound onto a declaration-only @Agent.
+
+    ``@Agent`` binds this as the agent's ``execute()`` when the developer
+    declares only a spec plus ``@agent_tool`` methods (ADR-0013 §1). It builds a
+    runner from the agent instance's injected ports and replays its stream.
+    """
+    runner = AgentRunner.for_agent_instance(self)
+    async for item in runner.run(run_input):
+        yield item
+
+
+def _progress(message: str, step: str) -> AgentYield[object]:
+    return AgentYield(
+        kind=AgentYieldKind.PROGRESS,
+        payload=Progress(message, current_step=step),
+    )
+
+
+def _token(text: str) -> AgentYield[object]:
+    return AgentYield(kind=AgentYieldKind.TOKEN, payload=Token(text))
+
+
+def _tool_yield(
+    descriptor: AgentToolDescriptor,
+    call: ModelToolCall,
+    result: JsonValue,
+) -> AgentYield[object]:
+    return AgentYield(
+        kind=AgentYieldKind.TOOL,
+        payload=Tool(
+            name=call.name,
+            call_id=call.call_id,
+            arguments=call.arguments,
+            result=result,
+            metadata={"tool_identity": descriptor.identity.key},
+        ),
+    )
+
+
+def _evidence_yield(evidence: AgentEvidence) -> AgentYield[object]:
+    return AgentYield(kind=AgentYieldKind.EVIDENCE, payload=Evidence(evidence=evidence))
+
+
+def _before_model(action_id: str) -> AgentActionBoundaryCheckpoint:
+    return AgentActionBoundaryCheckpoint.before_model_call(
+        action_id,
+        idempotency=Idempotency.IDEMPOTENT,
+    )
+
+
+def _after_model(action_id: str) -> AgentActionBoundaryCheckpoint:
+    return AgentActionBoundaryCheckpoint.after_model_call(
+        action_id,
+        idempotency=Idempotency.IDEMPOTENT,
+    )
+
+
+def _before_tool(
+    descriptor: AgentToolDescriptor,
+    call: ModelToolCall,
+) -> AgentActionBoundaryCheckpoint:
+    return AgentActionBoundaryCheckpoint.before_tool_call(
+        f"tool:{call.name}",
+        idempotency=descriptor.metadata.idempotency,
+        metadata={"call_id": call.call_id or ""},
+    )
+
+
+def _after_tool(
+    descriptor: AgentToolDescriptor,
+    call: ModelToolCall,
+) -> AgentActionBoundaryCheckpoint:
+    return AgentActionBoundaryCheckpoint.after_tool_call(
+        f"tool:{call.name}",
+        idempotency=descriptor.metadata.idempotency,
+        metadata={"call_id": call.call_id or ""},
+    )
+
+
+def _before_approval(
+    call: ModelToolCall,
+    descriptor: AgentToolDescriptor,
+) -> AgentActionBoundaryCheckpoint:
+    return AgentActionBoundaryCheckpoint.before_approval_wait(
+        f"approval:{call.name}",
+        metadata={"call_id": call.call_id or "", "tool": descriptor.schema.name},
+    )
+
+
+def _after_approval(
+    call: ModelToolCall,
+    descriptor: AgentToolDescriptor,
+) -> AgentActionBoundaryCheckpoint:
+    return AgentActionBoundaryCheckpoint.after_approval_wait(
+        f"approval:{call.name}",
+        metadata={"call_id": call.call_id or "", "tool": descriptor.schema.name},
+    )
+
+
+def _tool_result_json(result: object) -> JsonValue:
+    """Serialize an arbitrary tool result into a JSON-compatible value.
+
+    Tool callables return heterogeneous domain objects. The runner normalizes
+    them neutrally rather than knowing any concrete tool's return type, unlike a
+    hand-written loop that matches its own result dataclasses.
+    """
+    if result is None or isinstance(result, (bool, int, float, str)):
+        return result
+    if isinstance(result, BaseModel):
+        return result.model_dump(mode="json")
+    if is_dataclass(result) and not isinstance(result, type):
+        return _tool_result_json(asdict(result))
+    if isinstance(result, Mapping):
+        return {str(key): _tool_result_json(item) for key, item in result.items()}
+    if isinstance(result, Sequence) and not isinstance(result, (str, bytes)):
+        return [_tool_result_json(item) for item in result]
+    raise AgentToolDispatchError("Agent tool returned a non-serializable result")
+
+
+def _optional_signal_text(signal: AgentSignal, name: str) -> str | None:
+    value = signal.payload.get(name)
+    if isinstance(value, str) and value.strip():
+        return value
+    return None

--- a/core/spakky-agent/tests/acceptance/test_runner_dx_acceptance.py
+++ b/core/spakky-agent/tests/acceptance/test_runner_dx_acceptance.py
@@ -1,0 +1,304 @@
+"""Acceptance test: declaration-only @Agent runs tools + HITL + termination.
+
+This is the SC-1 acceptance scenario for issue #410: an @Agent that declares
+only a spec plus @agent_tool methods (no execute() body) runs the full
+framework-owned loop — model stream, automatic tool dispatch, the unified HITL
+pause -> approval-request -> resume flow, and typed termination — when resolved
+and invoked through the Spakky application container exactly like a UseCase.
+"""
+
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from typing import override
+
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.annotations.pod import Pod
+
+from spakky.agent import (
+    IAgentEvidenceRepository,
+    IAgentModel,
+    IAgentSignalRepository,
+    IAgentStateRepository,
+    Agent,
+    AgentEvidence,
+    AgentEvidenceKind,
+    AgentExecutionLimits,
+    AgentExecutionSpec,
+    AgentSignal,
+    AgentSignalKind,
+    AgentState,
+    AgentStatus,
+    AgentYield,
+    AgentYieldKind,
+    Approval,
+    ApprovalDecision,
+    EvidenceCapture,
+    Final,
+    Idempotency,
+    ModelCapability,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    RecoveryStrategy,
+    RunAgentInput,
+    Tool,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+from spakky.agent.error import AgentDefinitionError
+from spakky.agent.main import initialize
+
+
+@dataclass(frozen=True, slots=True)
+class NoteResult:
+    """Structured tool result for the acceptance agent."""
+
+    note: str
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="declarative_assistant",
+        objective="run the framework loop from declaration only",
+        accepted_signals=(
+            AgentSignalKind.USER_MESSAGE,
+            AgentSignalKind.APPROVAL_DECISION,
+            AgentSignalKind.CANCEL,
+        ),
+        recovery=RecoveryStrategy.ACTION_BOUNDARY,
+        limits=AgentExecutionLimits(timeout_seconds=600),
+    )
+)
+class DeclarativeAssistant:
+    """Agent declaring only a spec and tools — execute() is auto-provided."""
+
+    def __init__(
+        self,
+        model: IAgentModel,
+        states: IAgentStateRepository,
+        signals: IAgentSignalRepository,
+        evidence: IAgentEvidenceRepository,
+    ) -> None:
+        self._model = model
+        self._states = states
+        self._signals = signals
+        self._evidence = evidence
+
+    @agent_tool(
+        schema_name="note.read",
+        description="Read a note without approval.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def note_read(self, topic: str) -> NoteResult:
+        """Read a note for a topic."""
+        return NoteResult(note=f"read:{topic}")
+
+    @agent_tool(
+        schema_name="note.write",
+        description="Write a note after human approval.",
+        effects=ToolEffects.write_state(),
+        idempotency=Idempotency.CONDITIONALLY_IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.REQUIRED,
+    )
+    def note_write(self, topic: str) -> NoteResult:
+        """Write a note for a topic after approval."""
+        return NoteResult(note=f"write:{topic}")
+
+
+async def test_declaration_only_agent_runs_tools_hitl_and_termination() -> None:
+    """spec과 @agent_tool만 선언한 Agent가 컨테이너 경유로 전 루프를 자동 실행한다."""
+    app = SpakkyApplication(ApplicationContext())
+    initialize(app)
+    app.add(ScriptedModel)
+    app.add(MemoryStateRepository)
+    app.add(MemorySignalRepository)
+    app.add(MemoryEvidenceRepository)
+    app.add(DeclarativeAssistant)
+    app.start()
+
+    signals = app.container.get(IAgentSignalRepository)
+    states = app.container.get(IAgentStateRepository)
+    evidence = app.container.get(IAgentEvidenceRepository)
+    signals.append(
+        AgentSignal(
+            id="approval:run-1:note.write",
+            agent_state_id="run-1",
+            kind=AgentSignalKind.APPROVAL_DECISION,
+            payload={
+                "request_id": "approval:run-1:note.write",
+                "decision": ApprovalDecision.APPROVE.value,
+            },
+        )
+    )
+
+    assistant = app.container.get(DeclarativeAssistant)
+    execute = vars(DeclarativeAssistant)["execute"]
+    items: list[AgentYield[object]] = []
+    async for item in execute(
+        assistant,
+        RunAgentInput(state_id="run-1", instruction="take a small note"),
+    ):
+        items.append(item)
+
+    kinds = {item.kind for item in items}
+    assert {
+        AgentYieldKind.TOKEN,
+        AgentYieldKind.APPROVAL,
+        AgentYieldKind.TOOL,
+        AgentYieldKind.EVIDENCE,
+        AgentYieldKind.FINAL,
+    } <= kinds
+    assert sum(1 for item in items if isinstance(item.payload, Approval)) == 1
+    assert [item.payload.name for item in items if isinstance(item.payload, Tool)] == [
+        "note.read",
+        "note.write",
+    ]
+    assert states.get("run-1").status is AgentStatus.COMPLETED
+    assert {artifact.kind for artifact in evidence.list_by_state("run-1")} >= {
+        AgentEvidenceKind.ACTION_BOUNDARY,
+        AgentEvidenceKind.APPROVAL,
+        AgentEvidenceKind.TOOL,
+    }
+    final = items[-1].payload
+    assert isinstance(final, Final)
+    app.stop()
+
+
+@Pod()
+class ScriptedModel(IAgentModel):
+    """Scripted model streaming a token, two tool calls, then done."""
+
+    @property
+    @override
+    def capability(self) -> ModelCapability:
+        return ModelCapability()
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        return ModelResponse(content="scripted")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOKEN_DELTA,
+            token_delta="planning",
+        )
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+            tool_call=ModelToolCall(
+                name="note.read",
+                arguments={"topic": "agents"},
+                call_id="read-1",
+            ),
+        )
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+            tool_call=ModelToolCall(
+                name="note.write",
+                arguments={"topic": "agents"},
+                call_id="write-1",
+            ),
+        )
+        yield ModelStreamEvent(kind=ModelStreamEventKind.DONE)
+
+
+@Pod()
+class MemoryStateRepository(IAgentStateRepository):
+    """In-memory state repository for the acceptance scenario."""
+
+    def __init__(self) -> None:
+        self._states: dict[str, AgentState] = {}
+
+    @override
+    def get(self, state_id: str) -> AgentState:
+        state = self._states.get(state_id)
+        if state is None:
+            raise AgentDefinitionError("Missing acceptance state")
+        return state
+
+    @override
+    def get_or_none(self, state_id: str) -> AgentState | None:
+        return self._states.get(state_id)
+
+    @override
+    def save(self, state: AgentState) -> AgentState:
+        self._states[state.id] = state
+        return state
+
+    @override
+    def list_by_status(self, status: AgentStatus) -> Sequence[AgentState]:
+        return tuple(state for state in self._states.values() if state.status is status)
+
+    @override
+    def list_resume_candidates(self) -> Sequence[AgentState]:
+        return ()
+
+
+@Pod()
+class MemorySignalRepository(IAgentSignalRepository):
+    """In-memory signal repository for the acceptance scenario."""
+
+    def __init__(self) -> None:
+        self._signals: tuple[AgentSignal, ...] = ()
+        self._consumed: set[str] = set()
+
+    @override
+    def append(self, signal: AgentSignal) -> AgentSignal:
+        self._signals = (*self._signals, signal)
+        return signal
+
+    @override
+    def list_pending(self, state_id: str) -> Sequence[AgentSignal]:
+        return tuple(
+            signal
+            for signal in self._signals
+            if signal.agent_state_id == state_id and signal.id not in self._consumed
+        )
+
+    @override
+    def mark_consumed(self, signal_id: str) -> AgentSignal:
+        for signal in self._signals:
+            if signal.id == signal_id:
+                self._consumed.add(signal_id)
+                return signal
+        raise AgentDefinitionError("Missing acceptance signal")
+
+
+@Pod()
+class MemoryEvidenceRepository(IAgentEvidenceRepository):
+    """In-memory evidence repository for the acceptance scenario."""
+
+    def __init__(self) -> None:
+        self._evidence: dict[str, AgentEvidence] = {}
+
+    @override
+    def append(self, evidence: AgentEvidence) -> AgentEvidence:
+        self._evidence[evidence.id] = evidence
+        return evidence
+
+    @override
+    def get(self, evidence_id: str) -> AgentEvidence:
+        evidence = self._evidence.get(evidence_id)
+        if evidence is None:
+            raise AgentDefinitionError("Missing acceptance evidence")
+        return evidence
+
+    @override
+    def list_by_state(self, state_id: str) -> Sequence[AgentEvidence]:
+        return tuple(
+            artifact
+            for artifact in self._evidence.values()
+            if artifact.agent_state_id == state_id
+        )
+
+    @override
+    def list_by_manifest_ref(self, manifest_ref: str) -> Sequence[AgentEvidence]:
+        return ()

--- a/core/spakky-agent/tests/unit/test_execution.py
+++ b/core/spakky-agent/tests/unit/test_execution.py
@@ -170,12 +170,33 @@ def test_agent_expect_wraps_pod_constructor_di_metadata() -> None:
     assert agent.dependencies["tools"].type_ is AgentTools
 
 
-def test_agent_expect_rejects_missing_execute_contract() -> None:
-    """execute가 없는 class는 definition 단계에서 custom error로 거부한다."""
-    with pytest.raises(AgentDefinitionError):
+def test_agent_expect_auto_provides_execute_when_absent() -> None:
+    """execute 본문이 없으면 프레임워크 runner-backed execute가 자동 제공된다."""
+    from spakky.agent.runner import runner_backed_execute
 
-        @Agent()
-        class MissingExecute: ...
+    @Agent()
+    class DeclarationOnlyAgent: ...
+
+    assert Agent.get(DeclarationOnlyAgent) is not None
+    assert vars(DeclarationOnlyAgent)["execute"] is runner_backed_execute
+
+
+def test_agent_expect_keeps_user_supplied_execute() -> None:
+    """개발자가 execute를 직접 작성하면 자동 제공이 그것을 덮어쓰지 않는다."""
+    from spakky.agent.runner import runner_backed_execute
+
+    @Agent()
+    class CustomExecuteAgent:
+        async def execute(
+            self,
+            command: str,
+        ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=Final(output=command, metadata={}),
+            )
+
+    assert CustomExecuteAgent.execute is not runner_backed_execute
 
 
 def test_agent_expect_rejects_non_agent_yield_return_type() -> None:

--- a/core/spakky-agent/tests/unit/test_inbound.py
+++ b/core/spakky-agent/tests/unit/test_inbound.py
@@ -1,0 +1,49 @@
+"""Tests for the RunAgentInput inbound run contract."""
+
+import pytest
+
+from spakky.agent import RunAgentInput
+from spakky.agent.error import AgentDefinitionError
+
+
+def test_run_agent_input_expect_defaults_conversation_to_state_id() -> None:
+    """conversation_id가 없으면 run id가 단일턴 대화 식별자가 된다."""
+    run_input = RunAgentInput(state_id="run-1", instruction="do it")
+
+    assert run_input.effective_conversation_id == "run-1"
+
+
+def test_run_agent_input_expect_explicit_conversation_id_preserved() -> None:
+    """명시한 conversation_id는 멀티턴 식별자로 그대로 유지된다."""
+    run_input = RunAgentInput(
+        state_id="run-1",
+        instruction="do it",
+        conversation_id="thread-9",
+    )
+
+    assert run_input.effective_conversation_id == "thread-9"
+
+
+def test_run_agent_input_expect_resume_flag_carried() -> None:
+    """resume 플래그가 inbound 입력에 그대로 전달된다."""
+    run_input = RunAgentInput(state_id="run-1", instruction="do it", resume=True)
+
+    assert run_input.resume is True
+
+
+def test_run_agent_input_expect_rejects_blank_state_id() -> None:
+    """run을 상관시킬 수 없는 공백 state_id는 거부된다."""
+    with pytest.raises(AgentDefinitionError):
+        RunAgentInput(state_id=" ", instruction="do it")
+
+
+def test_run_agent_input_expect_rejects_blank_instruction() -> None:
+    """모델 요청을 시드할 수 없는 공백 instruction은 거부된다."""
+    with pytest.raises(AgentDefinitionError):
+        RunAgentInput(state_id="run-1", instruction=" ")
+
+
+def test_run_agent_input_expect_rejects_blank_conversation_id() -> None:
+    """공백 conversation_id는 멀티턴 식별자로 쓸 수 없어 거부된다."""
+    with pytest.raises(AgentDefinitionError):
+        RunAgentInput(state_id="run-1", instruction="do it", conversation_id=" ")

--- a/core/spakky-agent/tests/unit/test_public_api.py
+++ b/core/spakky-agent/tests/unit/test_public_api.py
@@ -341,6 +341,17 @@ def test_public_api_expect_exports_event_taxonomy_types() -> None:
     assert event_exports <= set(agent_api.__all__)
 
 
+def test_public_api_expect_exports_runner_and_inbound_types() -> None:
+    """프레임워크 실행 루프 소유의 runner/inbound 계약을 public API로 노출한다."""
+    from spakky.agent import AgentRunner, AgentRunResult, RunAgentInput
+
+    assert AgentRunner is agent_api.AgentRunner
+    assert AgentRunResult is agent_api.AgentRunResult
+    assert RunAgentInput is agent_api.RunAgentInput
+    runner_exports = {"AgentRunner", "AgentRunResult", "RunAgentInput"}
+    assert runner_exports <= set(agent_api.__all__)
+
+
 def test_public_api_expect_exports_tool_metadata_types() -> None:
     """@agent_tool descriptor metadata 타입을 public API로 노출한다."""
     assert ToolPermission is agent_api.ToolPermission

--- a/core/spakky-agent/tests/unit/test_runner.py
+++ b/core/spakky-agent/tests/unit/test_runner.py
@@ -1,0 +1,887 @@
+"""Tests for the framework-owned AgentRunner execution loop."""
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import override
+
+import pytest
+from pydantic import BaseModel
+
+from spakky.agent import (
+    Agent,
+    AgentEvidenceKind,
+    AgentExecutionSpec,
+    AgentRunner,
+    AgentRunResult,
+    AgentSignalKind,
+    AgentStatus,
+    AgentYield,
+    AgentYieldKind,
+    Approval,
+    Cancel,
+    Error,
+    EvidenceCapture,
+    Final,
+    IAgentModel,
+    Idempotency,
+    JsonValue,
+    ModelCapability,
+    ModelError,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    Progress,
+    RecoveryStrategy,
+    Token,
+    Tool,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+from spakky.agent.error import (
+    AgentModelConfigurationError,
+    AgentPersistenceConfigurationError,
+    AgentToolDispatchError,
+)
+from spakky.agent.inbound import RunAgentInput
+from tests.unit.test_code_assistant_demo import (
+    FakeEvidenceRepository,
+    FakeSignalRepository,
+    FakeStateRepository,
+    RecordingModel,
+)
+
+DURABLE_SPEC = AgentExecutionSpec(
+    name="runner_probe",
+    accepted_signals=(
+        AgentSignalKind.USER_MESSAGE,
+        AgentSignalKind.APPROVAL_DECISION,
+        AgentSignalKind.CANCEL,
+        AgentSignalKind.RESUME,
+    ),
+    recovery=RecoveryStrategy.ACTION_BOUNDARY,
+)
+
+
+class EchoResult(BaseModel):
+    """Pydantic tool result used to prove neutral serialization."""
+
+    value: str
+
+
+@dataclass(frozen=True, slots=True)
+class EchoRecord:
+    """Dataclass tool result used to prove neutral serialization."""
+
+    value: str
+
+
+@Agent(spec=DURABLE_SPEC)
+class ProbeAgent:
+    """Durable probe agent exercising the framework-owned loop end to end."""
+
+    def __init__(
+        self,
+        model: IAgentModel,
+        states: FakeStateRepository,
+        signals: FakeSignalRepository,
+        evidence: FakeEvidenceRepository,
+    ) -> None:
+        self._model = model
+        self._states = states
+        self._signals = signals
+        self._evidence = evidence
+
+    @agent_tool(
+        schema_name="echo.read",
+        description="Read echo without approval.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def echo_read(self, value: str) -> EchoRecord:
+        """Echo a value back as a structured result."""
+        return EchoRecord(value=value)
+
+    @agent_tool(
+        schema_name="echo.write",
+        description="Write echo requiring approval.",
+        effects=ToolEffects.write_state(),
+        idempotency=Idempotency.CONDITIONALLY_IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.REQUIRED,
+    )
+    def echo_write(self, value: str) -> EchoRecord:
+        """Echo a value back after approval."""
+        return EchoRecord(value=value)
+
+
+@Agent(spec=AgentExecutionSpec(name="stateless_probe"))
+class StatelessProbeAgent:
+    """Stateless probe agent that runs model to final without durability."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model
+
+    @agent_tool(
+        schema_name="echo.read",
+        description="Read echo without approval.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def echo_read(self, value: str) -> EchoRecord:
+        """Echo a value back as a structured result."""
+        return EchoRecord(value=value)
+
+
+@Agent(spec=AgentExecutionSpec(name="toolless_probe"))
+class ToollessProbeAgent:
+    """Stateless agent with no tools to prove tool_calling stays absent."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model
+
+
+def _invoke_execute(
+    agent: object,
+    run_input: RunAgentInput,
+) -> AsyncIterator[AgentYield[object]]:
+    """Invoke an agent's framework-provided execute() without static binding.
+
+    The synthesized execute() is bound onto the class at decoration time, so it
+    is read from the class namespace (``vars``) rather than as a statically known
+    attribute, then called with the instance as the bound ``self``.
+    """
+    execute = vars(type(agent))["execute"]
+    return execute(agent, run_input)
+
+
+async def _collect(
+    stream: AsyncIterator[AgentYield[object]],
+) -> tuple[AgentYield[object], ...]:
+    items: list[AgentYield[object]] = []
+    async for item in stream:
+        items.append(item)
+    return tuple(items)
+
+
+async def _run_durable(
+    model: IAgentModel,
+    command: RunAgentInput,
+    states: FakeStateRepository,
+    signals: FakeSignalRepository,
+    evidence: FakeEvidenceRepository,
+) -> tuple[AgentYield[object], ...]:
+    agent = ProbeAgent(model, states, signals, evidence)
+    return await _collect(_invoke_execute(agent, command))
+
+
+def _tool_event(
+    name: str, arguments: dict[str, JsonValue], call_id: str
+) -> ModelStreamEvent:
+    return ModelStreamEvent(
+        kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+        tool_call=ModelToolCall(name=name, arguments=arguments, call_id=call_id),
+    )
+
+
+def _approval_signal(state_id: str, request_id: str, decision: str):
+    from spakky.agent import AgentSignal
+
+    return AgentSignal(
+        id=request_id,
+        agent_state_id=state_id,
+        kind=AgentSignalKind.APPROVAL_DECISION,
+        payload={"request_id": request_id, "decision": decision},
+    )
+
+
+async def test_agent_runner_expect_auto_provided_execute_runs_tools_and_final() -> None:
+    """spec과 @agent_tool만 선언한 Agent가 도구 호출과 종료까지 자동 실행된다."""
+    model = RecordingModel(
+        (
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.TOKEN_DELTA,
+                token_delta="planning",
+            ),
+            _tool_event("echo.read", {"value": "hi"}, "read-1"),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    states = FakeStateRepository()
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="echo"),
+        states,
+        FakeSignalRepository(()),
+        FakeEvidenceRepository(),
+    )
+
+    kinds = {item.kind for item in items}
+    assert {
+        AgentYieldKind.TOKEN,
+        AgentYieldKind.TOOL,
+        AgentYieldKind.EVIDENCE,
+        AgentYieldKind.FINAL,
+    } <= kinds
+    assert states.get("run-1").status is AgentStatus.COMPLETED
+
+
+async def test_agent_runner_expect_approval_pause_then_signal_resume_dispatches() -> (
+    None
+):
+    """승인 필요 도구가 pause 후 승인 signal 수신으로 resume되어 디스패치된다."""
+    model = RecordingModel(
+        (
+            _tool_event("echo.write", {"value": "draft"}, "write-1"),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    states = FakeStateRepository()
+    evidence = FakeEvidenceRepository()
+    signals = FakeSignalRepository(
+        (_approval_signal("run-1", "approval:run-1:echo.write", "approve"),)
+    )
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="write"),
+        states,
+        signals,
+        evidence,
+    )
+
+    assert any(isinstance(item.payload, Approval) for item in items)
+    assert any(isinstance(item.payload, Tool) for item in items)
+    assert AgentEvidenceKind.APPROVAL in {
+        artifact.kind for artifact in evidence.list_by_state("run-1")
+    }
+    assert states.get("run-1").status is AgentStatus.COMPLETED
+
+
+async def test_agent_runner_expect_approval_skips_unrelated_and_mismatched_signals() -> (
+    None
+):
+    """승인 대기 큐의 무관 signal과 다른 request_id 결정은 건너뛰고 일치 결정만 쓴다."""
+    from spakky.agent import AgentSignal
+
+    model = RecordingModel(
+        (
+            _tool_event("echo.write", {"value": "draft"}, "write-1"),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    states = FakeStateRepository()
+    signals = FakeSignalRepository(
+        (
+            AgentSignal(
+                id="resume:run-1",
+                agent_state_id="run-1",
+                kind=AgentSignalKind.RESUME,
+                payload={},
+            ),
+            _approval_signal("run-1", "approval:run-1:other.tool", "approve"),
+            _approval_signal("run-1", "approval:run-1:echo.write", "approve"),
+        )
+    )
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="write"),
+        states,
+        signals,
+        FakeEvidenceRepository(),
+    )
+
+    assert any(isinstance(item.payload, Tool) for item in items)
+    assert states.get("run-1").status is AgentStatus.COMPLETED
+
+
+async def test_agent_runner_expect_cancel_without_requested_by_omits_attribution() -> (
+    None
+):
+    """requested_by가 없는 cancel signal은 Cancel.requested_by를 None으로 둔다."""
+    from spakky.agent import AgentSignal
+
+    states = FakeStateRepository()
+    signals = FakeSignalRepository(
+        (
+            AgentSignal(
+                id="cancel:run-1",
+                agent_state_id="run-1",
+                kind=AgentSignalKind.CANCEL,
+                payload={"reason": "stop"},
+            ),
+        )
+    )
+
+    items = await _run_durable(
+        RecordingModel((ModelStreamEvent(kind=ModelStreamEventKind.DONE),)),
+        RunAgentInput(state_id="run-1", instruction="cancel"),
+        states,
+        signals,
+        FakeEvidenceRepository(),
+    )
+
+    cancel = items[0].payload
+    assert isinstance(cancel, Cancel)
+    assert cancel.requested_by is None
+
+
+async def test_agent_runner_expect_approval_reject_stops_without_final() -> None:
+    """승인 거부 결정은 도구 디스패치 없이 FINAL 없이 종료한다."""
+    model = RecordingModel(
+        (
+            _tool_event("echo.write", {"value": "draft"}, "write-1"),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    states = FakeStateRepository()
+    signals = FakeSignalRepository(
+        (_approval_signal("run-1", "approval:run-1:echo.write", "reject"),)
+    )
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="write"),
+        states,
+        signals,
+        FakeEvidenceRepository(),
+    )
+
+    assert not any(item.kind is AgentYieldKind.FINAL for item in items)
+    assert not any(isinstance(item.payload, Tool) for item in items)
+    assert states.get("run-1").status is AgentStatus.FAILED
+
+
+async def test_agent_runner_expect_no_pending_decision_pauses_without_dispatch() -> (
+    None
+):
+    """승인 결정 signal이 없으면 paused 상태에서 도구를 디스패치하지 않는다."""
+    model = RecordingModel(
+        (
+            _tool_event("echo.write", {"value": "draft"}, "write-1"),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    states = FakeStateRepository()
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="write"),
+        states,
+        FakeSignalRepository(()),
+        FakeEvidenceRepository(),
+    )
+
+    assert any(isinstance(item.payload, Approval) for item in items)
+    assert not any(isinstance(item.payload, Tool) for item in items)
+    assert states.get("run-1").status is AgentStatus.INTERRUPTED
+
+
+async def test_agent_runner_expect_model_error_fails_state_and_yields_error() -> None:
+    """모델 ERROR 이벤트는 상태를 FAILED로 두고 Error를 노출하며 종료한다."""
+    model = RecordingModel(
+        (
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.ERROR,
+                error=ModelError(
+                    code="rate_limited",
+                    message="provider rate limit",
+                    retryable=True,
+                ),
+            ),
+        )
+    )
+    states = FakeStateRepository()
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="boom"),
+        states,
+        FakeSignalRepository(()),
+        FakeEvidenceRepository(),
+    )
+
+    assert not any(item.kind is AgentYieldKind.FINAL for item in items)
+    error = items[-1].payload
+    assert isinstance(error, Error)
+    assert error.code == "rate_limited"
+    assert states.get("run-1").status is AgentStatus.FAILED
+
+
+async def test_agent_runner_expect_cancel_signal_pre_loop_terminates() -> None:
+    """모델 루프 전 CANCEL signal은 CANCELLED와 cancellation evidence로 끝난다."""
+    states = FakeStateRepository()
+    evidence = FakeEvidenceRepository()
+
+    from spakky.agent import AgentSignal
+
+    signals = FakeSignalRepository(
+        (
+            AgentSignal(
+                id="cancel:run-1",
+                agent_state_id="run-1",
+                kind=AgentSignalKind.CANCEL,
+                payload={"reason": "stop", "requested_by": "tester"},
+            ),
+        )
+    )
+
+    items = await _run_durable(
+        RecordingModel((ModelStreamEvent(kind=ModelStreamEventKind.DONE),)),
+        RunAgentInput(state_id="run-1", instruction="cancel"),
+        states,
+        signals,
+        evidence,
+    )
+
+    assert len(items) == 1
+    assert isinstance(items[0].payload, Cancel)
+    assert states.get("run-1").status is AgentStatus.CANCELLED
+    assert AgentEvidenceKind.CANCELLATION in {
+        artifact.kind for artifact in evidence.list_by_state("run-1")
+    }
+
+
+async def test_agent_runner_expect_cancel_signal_mid_stream_terminates() -> None:
+    """스트림 진행 중 도착한 CANCEL signal도 즉시 종료시킨다."""
+    states = FakeStateRepository()
+    signals = FakeSignalRepository(())
+    model = _CancelInjectingModel(states, signals)
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="cancel mid"),
+        states,
+        signals,
+        FakeEvidenceRepository(),
+    )
+
+    assert any(isinstance(item.payload, Cancel) for item in items)
+    assert states.get("run-1").status is AgentStatus.CANCELLED
+
+
+async def test_agent_runner_expect_user_message_signal_consumed_as_progress() -> None:
+    """USER_MESSAGE signal은 progress와 evaluation evidence로 소비된다."""
+    from spakky.agent import AgentSignal
+
+    states = FakeStateRepository()
+    evidence = FakeEvidenceRepository()
+    signals = FakeSignalRepository(
+        (
+            AgentSignal(
+                id="user:run-1",
+                agent_state_id="run-1",
+                kind=AgentSignalKind.USER_MESSAGE,
+                payload={"message": "keep it small"},
+            ),
+        )
+    )
+
+    items = await _run_durable(
+        RecordingModel(
+            (
+                ModelStreamEvent(
+                    kind=ModelStreamEventKind.TOKEN_DELTA, token_delta="ok"
+                ),
+                ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+            )
+        ),
+        RunAgentInput(state_id="run-1", instruction="hello"),
+        states,
+        signals,
+        evidence,
+    )
+
+    assert any(
+        item.kind is AgentYieldKind.PROGRESS
+        and isinstance(item.payload, Progress)
+        and item.payload.current_step == "signal"
+        for item in items
+    )
+    assert AgentEvidenceKind.EVALUATION in {
+        artifact.kind for artifact in evidence.list_by_state("run-1")
+    }
+
+
+async def test_agent_runner_expect_resume_emits_skip_completed_progress() -> None:
+    """resume 입력은 persisted boundary로 skip_completed resume 계획을 노출한다."""
+    states = FakeStateRepository()
+    signals = FakeSignalRepository(())
+    evidence = FakeEvidenceRepository()
+
+    await _run_durable(
+        RecordingModel(
+            (
+                _tool_event("echo.read", {"value": "x"}, "read-1"),
+                ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+            )
+        ),
+        RunAgentInput(state_id="resume-run", instruction="first"),
+        states,
+        signals,
+        evidence,
+    )
+    items = await _run_durable(
+        RecordingModel((ModelStreamEvent(kind=ModelStreamEventKind.DONE),)),
+        RunAgentInput(state_id="resume-run", instruction="again", resume=True),
+        states,
+        signals,
+        evidence,
+    )
+
+    assert any(
+        item.kind is AgentYieldKind.PROGRESS
+        and isinstance(item.payload, Progress)
+        and "skip_completed" in item.payload.message
+        for item in items
+    )
+
+
+async def test_agent_runner_expect_reasoning_suppressed_when_capability_absent() -> (
+    None
+):
+    """capability가 reasoning을 지원하지 않으면 reasoning delta는 생략된다."""
+    model = RecordingModel(
+        (
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.REASONING_DELTA,
+                reasoning_delta="thinking",
+            ),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    states = FakeStateRepository()
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="reason"),
+        states,
+        FakeSignalRepository(()),
+        FakeEvidenceRepository(),
+    )
+
+    assert not any(isinstance(item.payload, Token) for item in items)
+
+
+async def test_agent_runner_expect_reasoning_surfaced_when_capability_present() -> None:
+    """capability가 reasoning을 지원하면 reasoning delta가 token으로 노출된다."""
+    model = _ReasoningModel(
+        (
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.REASONING_DELTA,
+                reasoning_delta="thinking",
+            ),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    states = FakeStateRepository()
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="reason"),
+        states,
+        FakeSignalRepository(()),
+        FakeEvidenceRepository(),
+    )
+
+    assert any(
+        isinstance(item.payload, Token) and item.payload.text == "thinking"
+        for item in items
+    )
+
+
+async def test_agent_runner_expect_message_delta_surfaced_as_token() -> None:
+    """MESSAGE_DELTA는 assistant 텍스트로서 token으로 노출된다."""
+    model = RecordingModel(
+        (
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.MESSAGE_DELTA,
+                message_delta="hello",
+            ),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    states = FakeStateRepository()
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="say hi"),
+        states,
+        FakeSignalRepository(()),
+        FakeEvidenceRepository(),
+    )
+
+    assert any(
+        isinstance(item.payload, Token) and item.payload.text == "hello"
+        for item in items
+    )
+
+
+async def test_agent_runner_expect_unknown_event_kind_ignored() -> None:
+    """surfacing 대상이 아닌 이벤트 종류는 조용히 무시된다."""
+    model = RecordingModel(
+        (
+            ModelStreamEvent(kind=ModelStreamEventKind.PROGRESS),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    states = FakeStateRepository()
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="progress"),
+        states,
+        FakeSignalRepository(()),
+        FakeEvidenceRepository(),
+    )
+
+    assert items[-1].kind is AgentYieldKind.FINAL
+
+
+async def test_agent_runner_expect_tool_call_without_payload_ignored() -> None:
+    """tool_call이 없는 TOOL_CALL_CANDIDATE는 도구 디스패치 없이 무시된다."""
+    model = RecordingModel(
+        (
+            ModelStreamEvent(kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    states = FakeStateRepository()
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="empty tool"),
+        states,
+        FakeSignalRepository(()),
+        FakeEvidenceRepository(),
+    )
+
+    assert not any(isinstance(item.payload, Tool) for item in items)
+    assert items[-1].kind is AgentYieldKind.FINAL
+
+
+async def test_agent_runner_expect_empty_catalog_sends_no_tool_calling() -> None:
+    """도구가 없는 agent의 모델 요청에는 tool_calling이 비어 있다."""
+    model = RecordingModel((ModelStreamEvent(kind=ModelStreamEventKind.DONE),))
+
+    agent = ToollessProbeAgent(model)
+    await _collect(
+        _invoke_execute(agent, RunAgentInput(state_id="run-1", instruction="x"))
+    )
+
+    assert model.requests
+    assert model.requests[0].tool_calling is None
+
+
+async def test_agent_runner_expect_stateless_agent_runs_model_to_final() -> None:
+    """durable port가 없는 stateless agent도 model→tool→final로 동작한다."""
+    model = RecordingModel(
+        (
+            _tool_event("echo.read", {"value": "hi"}, "read-1"),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+
+    agent = StatelessProbeAgent(model)
+    items = await _collect(
+        _invoke_execute(agent, RunAgentInput(state_id="run-1", instruction="x"))
+    )
+
+    assert any(isinstance(item.payload, Tool) for item in items)
+    assert items[-1].kind is AgentYieldKind.FINAL
+
+
+async def test_agent_runner_expect_stateless_model_error_yields_error_without_final() -> (
+    None
+):
+    """stateless agent의 모델 ERROR도 FINAL 없이 Error를 노출하며 종료한다."""
+    model = RecordingModel(
+        (
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.ERROR,
+                error=ModelError(code="boom", message="stateless failure"),
+            ),
+        )
+    )
+
+    agent = StatelessProbeAgent(model)
+    items = await _collect(
+        _invoke_execute(agent, RunAgentInput(state_id="run-1", instruction="x"))
+    )
+
+    assert not any(item.kind is AgentYieldKind.FINAL for item in items)
+    error = items[-1].payload
+    assert isinstance(error, Error)
+    assert error.code == "boom"
+
+
+async def test_agent_runner_expect_missing_model_raises_configuration_error() -> None:
+    """IAgentModel 포트가 주입되지 않으면 model configuration error로 실패한다."""
+
+    @Agent(spec=AgentExecutionSpec(name="no_model"))
+    class NoModelAgent:
+        def __init__(self) -> None:
+            self._note = "no model"
+
+    agent = NoModelAgent()
+    with pytest.raises(AgentModelConfigurationError):
+        AgentRunner.for_agent_instance(agent)
+
+
+async def test_agent_runner_expect_two_models_injected_raises() -> None:
+    """동일 포트가 둘 이상 주입되면 모호하므로 configuration error로 실패한다."""
+    model = RecordingModel(())
+
+    @Agent(spec=AgentExecutionSpec(name="two_models"))
+    class TwoModelAgent:
+        def __init__(self, primary: IAgentModel, secondary: IAgentModel) -> None:
+            self._primary = primary
+            self._secondary = secondary
+
+    agent = TwoModelAgent(model, RecordingModel(()))
+    with pytest.raises(AgentModelConfigurationError):
+        AgentRunner.for_agent_instance(agent)
+
+
+async def test_agent_runner_expect_durable_agent_missing_repository_raises() -> None:
+    """durable spec인데 repository 포트가 빠지면 persistence error로 실패한다."""
+    model = RecordingModel(())
+
+    @Agent(spec=DURABLE_SPEC, name="durable_partial")
+    class DurablePartialAgent:
+        def __init__(self, model: IAgentModel) -> None:
+            self._model = model
+
+    agent = DurablePartialAgent(model)
+    with pytest.raises(AgentPersistenceConfigurationError):
+        AgentRunner.for_agent_instance(agent)
+
+
+async def test_agent_runner_expect_dataclass_tool_result_serialized() -> None:
+    """dataclass 도구 결과는 JSON 호환 매핑으로 직렬화된다."""
+    result = _serialize_tool_result(EchoRecord(value="rec"))
+
+    assert result == {"value": "rec"}
+
+
+async def test_agent_runner_expect_basemodel_tool_result_serialized() -> None:
+    """pydantic BaseModel 도구 결과는 model_dump로 직렬화된다."""
+    result = _serialize_tool_result(EchoResult(value="model"))
+
+    assert result == {"value": "model"}
+
+
+async def test_agent_runner_expect_sequence_tool_result_serialized() -> None:
+    """시퀀스 도구 결과는 JSON 호환 리스트로 직렬화된다."""
+    result = _serialize_tool_result([EchoRecord(value="a"), {"k": 1}])
+
+    assert result == [{"value": "a"}, {"k": 1}]
+
+
+async def test_agent_runner_expect_scalar_tool_result_passthrough() -> None:
+    """스칼라 도구 결과는 그대로 통과한다."""
+    assert _serialize_tool_result(7) == 7
+
+
+async def test_agent_runner_expect_unknown_tool_result_type_raises() -> None:
+    """직렬화 불가능한 도구 결과는 dispatch error로 거부된다."""
+    with pytest.raises(AgentToolDispatchError):
+        _serialize_tool_result(object())
+
+
+async def test_agent_runner_expect_nested_unknown_value_raises() -> None:
+    """매핑 내부의 직렬화 불가 값도 dispatch error로 거부된다."""
+    with pytest.raises(AgentToolDispatchError):
+        _serialize_tool_result({"bad": object()})
+
+
+async def test_agent_runner_expect_output_type_recorded_in_final_metadata() -> None:
+    """spec.output_type가 선언되면 final metadata에 그 이름이 기록된다."""
+
+    @Agent(spec=AgentExecutionSpec(name="typed_output", output_type=EchoResult))
+    class TypedOutputAgent:
+        def __init__(self, model: IAgentModel) -> None:
+            self._model = model
+
+    model = RecordingModel((ModelStreamEvent(kind=ModelStreamEventKind.DONE),))
+    agent = TypedOutputAgent(model)
+    items = await _collect(
+        _invoke_execute(agent, RunAgentInput(state_id="run-1", instruction="x"))
+    )
+
+    final = items[-1].payload
+    assert isinstance(final, Final)
+    assert isinstance(final.output, AgentRunResult)
+    assert final.metadata["output_type"] == "EchoResult"
+
+
+async def test_agent_runner_expect_default_output_type_metadata_none() -> None:
+    """output_type 미선언이면 final metadata의 output_type은 None이다."""
+    model = RecordingModel((ModelStreamEvent(kind=ModelStreamEventKind.DONE),))
+    agent = StatelessProbeAgent(model)
+    items = await _collect(
+        _invoke_execute(agent, RunAgentInput(state_id="run-1", instruction="x"))
+    )
+
+    final = items[-1].payload
+    assert isinstance(final, Final)
+    assert final.metadata["output_type"] is None
+
+
+def _serialize_tool_result(result: object) -> JsonValue:
+    from spakky.agent.runner import _tool_result_json
+
+    return _tool_result_json(result)
+
+
+class _ReasoningModel(RecordingModel):
+    """RecordingModel variant declaring reasoning capability."""
+
+    @property
+    @override
+    def capability(self) -> ModelCapability:
+        return ModelCapability(supports_reasoning=True)
+
+
+class _CancelInjectingModel(IAgentModel):
+    """Model that appends a cancel signal before its first stream event."""
+
+    def __init__(
+        self,
+        states: FakeStateRepository,
+        signals: FakeSignalRepository,
+    ) -> None:
+        self._states = states
+        self._signals = signals
+
+    @property
+    @override
+    def capability(self) -> ModelCapability:
+        return ModelCapability()
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        return ModelResponse(content="unused")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        from spakky.agent import AgentSignal
+
+        self._signals.append(
+            AgentSignal(
+                id="cancel:run-1",
+                agent_state_id="run-1",
+                kind=AgentSignalKind.CANCEL,
+                payload={"reason": "mid", "requested_by": "tester"},
+            )
+        )
+        yield ModelStreamEvent(kind=ModelStreamEventKind.TOKEN_DELTA, token_delta="t")
+        yield ModelStreamEvent(kind=ModelStreamEventKind.DONE)


### PR DESCRIPTION
## 목적

프레임워크가 agent 실행 루프를 완전히 소유하는 `AgentRunner`를 추가하고, `@Agent`가 spec과 `@agent_tool`만 선언하면 `execute()`를 자동 제공하도록 확장한다. 사용자의 수동 orchestration 보일러플레이트를 제거한다 (ADR-0013 §1).

Closes #410 (마일스톤 #19, 선행 C1·C2·C3·C4 조립).

## 변경 사항

- **`runner.py` (신규)** — `AgentRunner`가 표준 실행 루프를 소유한다: model 스트림 소비 → 토큰/메시지/reasoning(capability-gated) 방출 → 자동 도구 디스패치(C4) → 통일된 HITL `pause→승인요청→resume`(ADR-0013 §5) → 경계/증거 기록 → 시그널 소비 → 상태 전이 → `output_type` 기반 종료. spec(C1)·capability(C2)·taxonomy(C3)·dispatcher(C4)를 조립한다. `AgentRunResult`는 기본 종료 요약. `for_agent_instance`는 주입된 포트(`IAgentModel` + durable 리포지토리)를 인스턴스 속성에서 **타입 기반으로** 해석한다(`getattr` 미사용 — `vars()` 타입 순회).
- **`inbound.py` (신규)** — `RunAgentInput` 인바운드 실행 계약(`state_id`/`instruction`/`conversation_id`/`resume`/`metadata`). 승인 결정은 본 계약이 아니라 durable 시그널 큐로 전달된다.
- **`execution.py`** — `@Agent`가 `execute()` 미선언 시 runner-backed `execute()`를 자동 바인딩한다. 개발자가 작성한 `execute()`는 보존(커스텀 제어 탈출 경로). 기존 strict 계약 검증은 그대로 재사용한다.

## 설계 결정

- **루프는 `AgentYield`를 방출한다** — 중립 `AgentEvent` taxonomy로의 투영은 ADR-0013 §3가 후속 프로토콜 어댑터 그룹(D/E/F)에 할당한 범위이므로 본 PR 범위 밖. 기존 demo/계약과 정합.
- **HITL 단일 흐름** — `examples/code_assistant_demo.py`의 수동 루프를 회귀 없이 일반화. 승인 결정은 비차단 시그널 폴링으로 resume(ADR-0013 §5).
- **reasoning graceful degrade** — `ModelCapability.supports_reasoning`이 False면 reasoning delta 생략(ADR-0013 §4).
- **stateless 경로** — `accepted_signals`·`ACTION_BOUNDARY` recovery 미선언 agent는 state/evidence/signal 없이 model→tool→final.

## 검증

- 단위 테스트(`test_runner.py`, `test_inbound.py`)와 통합 테스트(`test_runner_dx_acceptance.py`)로 **spec과 `@agent_tool`만 선언한 Agent(execute 본문 없음)가 컨테이너 경유로 도구 호출·HITL·종료까지 동작**함을 검증(SC-1).
- 커버리지 100% (branch), 266 테스트 통과, ruff·pyrefly clean.

## 후속 (gap)

본 PR이 넘지 않는 경계 — 후속 이슈 분해 대상:
- 중립 `AgentEvent` 방출(`AgentYield`→`AgentEvent` 투영, D-group).
- `STRUCTURED_OUTPUT`로부터 `output_type` 구조화 출력 materialize(C-group).
- compaction 런타임(C7) / teammate 위임 런타임(E4) — spec은 선언만, runner는 무시.
- 클라이언트 주입 이력 / 영속 멀티턴(ADR-0013 §6) — `RunAgentInput`이 `conversation_id`만 운반.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
