### PR TITLE
feat(mcp): MCP 서버로 에이전트 도구 노출 (#417)

### DIFF
--- a/docs/contributing/ia-map.md
+++ b/docs/contributing/ia-map.md
@@ -74,4 +74,4 @@
 | `contributing/ia-map.md` | 기여 | 작성 완료 (이 문서) |
 | `guides/agent-ag-ui.md` | Agent > 프로토콜 어댑터 | 빈 페이지(후속 태스크) |
 | `guides/agent-a2a.md` | Agent > 프로토콜 어댑터 | 빈 페이지(후속 태스크) |
-| `guides/agent-mcp.md` | Agent > 프로토콜 어댑터 | 빈 페이지(후속 태스크) |
+| `guides/agent-mcp.md` | Agent > 프로토콜 어댑터 | 작성 완료 |

--- a/docs/guides/agent-mcp.md
+++ b/docs/guides/agent-mcp.md
@@ -1,8 +1,12 @@
-# MCP 클라이언트 어댑터
+# MCP 어댑터 (클라이언트·서버)
 
-> 외부 MCP(Model Context Protocol) 서버의 도구를 발견해 선언형 Agent의 도구 카탈로그에 합류시키는 클라이언트 어댑터 가이드입니다. 외부 도구는 `@agent_tool`로 선언한 도구와 **동일한 디스패치 경로**로 자동 호출됩니다.
+> MCP(Model Context Protocol) 양방향 어댑터 가이드입니다. **클라이언트** 방향은 외부 MCP 서버의 도구를 선언형 Agent의 도구 카탈로그에 합류시키고, **서버** 방향은 Agent의 `@agent_tool` 도구를 MCP 서버로 노출해 외부 MCP 클라이언트가 발견·호출하게 합니다.
 
-`spakky-mcp` 플러그인은 [ADR-0013](../adr/0013-declarative-agent-loop-ownership.md) §2의 결정에 따라 프로토콜 중립 코어(`spakky-agent`) 밖에 위치하는 독립 어댑터입니다. 코어는 MCP 라이브러리에 의존하지 않으며, 외부 도구 정규화·연결 수명주기는 이 플러그인이 전담합니다.
+`spakky-mcp` 플러그인은 [ADR-0013](../adr/0013-declarative-agent-loop-ownership.md) §2의 결정에 따라 프로토콜 중립 코어(`spakky-agent`) 밖에 위치하는 독립 어댑터입니다. 코어는 MCP 라이브러리에 의존하지 않으며, 외부 도구 정규화·연결 수명주기와 도구의 MCP 서버 노출은 이 플러그인이 전담합니다.
+
+> 아래 "클라이언트" 절은 외부 도구를 끌어오는 방향이고, "서버" 절은 자신의 도구를 내보내는 방향입니다.
+
+## 클라이언트: 외부 도구 끌어오기
 
 ## 언제 쓰는가
 
@@ -73,6 +77,53 @@ async def run_with_external_tools(client: McpClient, agent: WeatherAgent) -> Non
 - 외부 도구 결과는 구조화 콘텐츠(`structuredContent`)가 있으면 그대로, 없으면 텍스트 콘텐츠를 모아 JSON 값으로 정규화합니다.
 - 서버가 오류 결과(`isError`)를 반환하거나 연결·디스커버리·호출이 실패하면 `McpTransportError`·`McpToolDiscoveryError`·`McpToolInvocationError` 등 타입화된 오류로 표면화됩니다.
 - 외부 도구 이름이 기존 카탈로그 도구와 충돌하면 `McpCatalogMergeError`로 거부됩니다.
+
+## 서버: 자신의 도구 내보내기
+
+반대 방향으로, Agent가 선언한 `@agent_tool` 도구를 MCP 서버로 노출하면 외부 MCP 클라이언트가 표준 MCP 프로토콜로 그 도구들을 발견·호출할 수 있습니다. 노출된 각 도구는 모델이 보는 것과 같은 디스패치 경로(`AgentToolDispatcher`)로 실행되므로, 원격 클라이언트의 호출은 로컬 모델의 도구 호출과 동일하게 동작합니다.
+
+### 서버 만들기
+
+`build_agent_tool_server(agent_instance, server_name)`는 한 에이전트 인스턴스의 도구 카탈로그를 노출하는 MCP `Server`를 만듭니다. `list_tools` 요청에는 각 카탈로그 디스크립터를 `mcp.types.Tool`(모델용 이름·설명·입력 JSON Schema)로 변환해 응답하고, `call_tool` 요청은 디스패처로 위임합니다.
+
+```python
+from spakky.plugins.mcp import build_agent_tool_server, serve_stdio
+
+
+async def expose_over_stdio(agent: WeatherAgent) -> None:
+    server = build_agent_tool_server(agent, "spakky-agent")
+    await serve_stdio(server)  # stdio 전송으로 클라이언트가 연결을 닫을 때까지 서빙
+```
+
+`McpToolServer` Pod를 쓰면 설정(`McpConfig.tool_server`)에 선언한 서버 이름·전송으로 같은 작업을 수행합니다.
+
+```python
+from spakky.plugins.mcp import McpToolServer
+
+
+async def expose(server: McpToolServer, agent: WeatherAgent) -> None:
+    await server.serve_stdio(agent)
+```
+
+### 전송 선택
+
+| 전송 | 진입점 | 용도 |
+|------|--------|------|
+| `stdio` | `serve_stdio(server)` / `McpToolServer.serve_stdio(agent)` | 클라이언트가 하위 프로세스로 서버를 구동 |
+| `streamable_http` | `streamable_http_session_manager(server)` / `McpToolServer.streamable_http_session_manager(agent)` | 원격 HTTP 노출 — 반환된 세션 매니저를 호스트 애플리케이션의 lifespan에서 구동하고 인바운드 요청을 `handle_request`로 라우팅 |
+
+`streamable_http` 세션 매니저는 자신의 `run()` 컨텍스트 동안 단일 task group을 소유하며 컨텍스트를 벗어나면 재사용할 수 없습니다 — 호스트 애플리케이션 lifespan에서 1회 구동합니다.
+
+### 서버 노출 설정
+
+| 환경변수 | 의미 | 기본값 |
+|----------|------|--------|
+| `SPAKKY_MCP__TOOL_SERVER__NAME` | MCP 핸드셰이크에서 광고할 서버 이름 | `spakky-agent` |
+| `SPAKKY_MCP__TOOL_SERVER__TRANSPORT` | `stdio`(기본) 또는 `streamable_http` | `stdio` |
+
+### 결과 변환
+
+도구 디스패치 결과는 MCP의 `content`(사람이 읽는 텍스트)와 `structuredContent`(기계가 읽는 JSON)로 변환됩니다. 매핑(`dict`) 결과는 그대로 구조화 콘텐츠가 되고, 그 외 값은 `{"result": ...}` 형태로 감싸집니다 — 이는 클라이언트 방향의 결과 정규화(`normalize_call_result`)가 읽어 들이는 형태와 대칭입니다. 디스패치가 실패하면 `McpToolExposureError`로 표면화되어 SDK가 원격 클라이언트에 도구 오류로 보고합니다.
 
 ## 함께 보기
 

--- a/docs/sections/agent.md
+++ b/docs/sections/agent.md
@@ -25,4 +25,4 @@
 | --- | --- |
 | [AG-UI 어댑터](../guides/agent-ag-ui.md) | AG-UI 프로토콜로 Agent 실행을 UI에 스트리밍 |
 | [A2A 어댑터](../guides/agent-a2a.md) | A2A(Agent-to-Agent) 프로토콜 연동 |
-| [MCP 어댑터](../guides/agent-mcp.md) | MCP(Model Context Protocol) 서버로 도구 노출 |
+| [MCP 어댑터](../guides/agent-mcp.md) | MCP(Model Context Protocol) 클라이언트·서버 양방향 어댑터 |

--- a/plugins/spakky-mcp/README.md
+++ b/plugins/spakky-mcp/README.md
@@ -1,12 +1,15 @@
 # spakky-mcp
 
-외부 MCP(Model Context Protocol) 서버의 도구를 발견해 Spakky Agent 도구 카탈로그에 합류시키는 MCP 클라이언트 어댑터 플러그인입니다. 외부 도구는 `@agent_tool`로 선언한 도구와 동일한 디스패치 경로로 자동 호출됩니다.
+MCP(Model Context Protocol) 양방향 어댑터 플러그인입니다. **클라이언트** 방향은 외부 MCP 서버의 도구를 발견해 Spakky Agent 도구 카탈로그에 합류시키고, **서버** 방향은 Agent의 `@agent_tool` 도구를 MCP 서버로 노출해 외부 MCP 클라이언트가 발견·호출하게 합니다. 양쪽 모두 `@agent_tool`로 선언한 도구와 동일한 디스패치 경로(`AgentToolDispatcher`)로 실행됩니다.
 
-[ADR-0013](../../docs/adr/0013-declarative-agent-loop-ownership.md) §2에 따라 코어(`spakky-agent`)는 MCP 라이브러리에 의존하지 않으며, 외부 도구 정규화와 연결 수명주기는 이 어댑터가 전담합니다.
+[ADR-0013](../../docs/adr/0013-declarative-agent-loop-ownership.md) §2에 따라 코어(`spakky-agent`)는 MCP 라이브러리에 의존하지 않으며, 외부 도구 정규화·연결 수명주기와 도구의 MCP 서버 노출은 이 어댑터가 전담합니다.
 
 ## 언제 필요한가
 
-운영 중인 외부 MCP 서버의 도구를 에이전트가 일반 도구처럼 사용하고 싶을 때 사용합니다. 이 플러그인은 **도구 공급원**이며 모델 어댑터가 아닙니다 — 실행에는 별도의 `IAgentModel` 공급자(예: `spakky-vllm`)가 필요합니다.
+- **클라이언트**: 운영 중인 외부 MCP 서버의 도구를 에이전트가 일반 도구처럼 사용하고 싶을 때.
+- **서버**: 에이전트의 도구를 외부 MCP 클라이언트(다른 에이전트·IDE·MCP 호스트)에 표준 프로토콜로 노출하고 싶을 때.
+
+이 플러그인은 **도구 공급원/노출원**이며 모델 어댑터가 아닙니다 — 에이전트 실행에는 별도의 `IAgentModel` 공급자(예: `spakky-vllm`)가 필요합니다.
 
 ## 설치
 
@@ -27,7 +30,11 @@ uv add "spakky[agent]"
 
 서버 항목은 `name`, `transport`(`stdio` 또는 `streamable_http`), `command`/`args`/`env`(stdio), `url`(streamable_http), `call_timeout_seconds`를 가집니다. `name`은 도구 이름 충돌을 막는 접두사로 쓰이며 `__`를 포함할 수 없습니다.
 
+도구를 MCP 서버로 노출할 때의 식별자·전송은 `SPAKKY_MCP__TOOL_SERVER__NAME`(기본 `spakky-agent`)·`SPAKKY_MCP__TOOL_SERVER__TRANSPORT`(기본 `stdio`)로 선언합니다.
+
 ## 사용
+
+### 클라이언트: 외부 도구 끌어오기
 
 ```python
 from spakky.plugins.mcp import McpClient
@@ -42,7 +49,20 @@ async def run_with_external_tools(client: McpClient, agent: object) -> None:
 
 모델이 보는 외부 도구 이름은 `<서버이름>__<도구이름>` 형태로 접두사가 붙어 서버 간 이름 충돌을 막습니다.
 
-자세한 내용은 [MCP 클라이언트 어댑터 가이드](../../docs/guides/agent-mcp.md)를 참고하세요.
+### 서버: 자신의 도구 내보내기
+
+```python
+from spakky.plugins.mcp import McpToolServer
+
+
+async def expose_tools(server: McpToolServer, agent: object) -> None:
+    # 에이전트의 @agent_tool 도구를 stdio MCP 서버로 노출한다.
+    await server.serve_stdio(agent)
+```
+
+원격 노출에는 `McpToolServer.streamable_http_session_manager(agent)`가 돌려주는 세션 매니저를 호스트 애플리케이션 lifespan에서 구동합니다.
+
+자세한 내용은 [MCP 어댑터 가이드](../../docs/guides/agent-mcp.md)를 참고하세요.
 
 ## License
 

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/__init__.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/__init__.py
@@ -1,4 +1,9 @@
-"""MCP client adapter plugin joining external server tools to the agent catalog."""
+"""MCP adapter plugin bridging external server tools and the agent catalog.
+
+Joins external MCP server tools into the agent tool catalog (client side,
+issue #416) and exposes an agent's own tools as an MCP server (server side,
+issue #417).
+"""
 
 from spakky.core.application.plugin import Plugin
 
@@ -10,6 +15,7 @@ from spakky.plugins.mcp.client import (
 from spakky.plugins.mcp.config import (
     McpConfig,
     McpServerConfig,
+    McpToolServerConfig,
     McpTransport,
 )
 from spakky.plugins.mcp.descriptor import (
@@ -28,12 +34,21 @@ from spakky.plugins.mcp.error import (
     McpResponseError,
     McpServerConfigurationError,
     McpToolDiscoveryError,
+    McpToolExposureError,
     McpToolInvocationError,
     McpTransportError,
 )
+from spakky.plugins.mcp.server import (
+    McpToolServer,
+    build_agent_tool_server,
+    build_agent_tools,
+    normalize_dispatch_result,
+    serve_stdio,
+    streamable_http_session_manager,
+)
 
 PLUGIN_NAME = Plugin(name="spakky-mcp")
-"""Plugin identifier for the MCP client adapter package."""
+"""Plugin identifier for the MCP adapter package."""
 
 __all__ = [
     "PLUGIN_NAME",
@@ -47,9 +62,14 @@ __all__ = [
     "McpServerConfig",
     "McpServerConfigurationError",
     "McpToolDiscoveryError",
+    "McpToolExposureError",
     "McpToolInvocationError",
+    "McpToolServer",
+    "McpToolServerConfig",
     "McpTransport",
     "McpTransportError",
+    "build_agent_tool_server",
+    "build_agent_tools",
     "build_external_descriptor",
     "build_external_descriptors",
     "build_mcp_runner",
@@ -57,5 +77,8 @@ __all__ = [
     "make_mcp_tool_callable",
     "merge_external_catalog",
     "normalize_call_result",
+    "normalize_dispatch_result",
     "prefixed_tool_name",
+    "serve_stdio",
+    "streamable_http_session_manager",
 ]

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/config.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/config.py
@@ -1,4 +1,4 @@
-"""Configuration for the spakky-mcp client plugin."""
+"""Configuration for the spakky-mcp adapter (external clients and tool server)."""
 
 from enum import StrEnum
 from typing import ClassVar
@@ -10,6 +10,7 @@ from spakky.core.stereotype.configuration import Configuration
 from spakky.plugins.mcp.constants import (
     DEFAULT_MCP_CALL_TIMEOUT_SECONDS,
     DEFAULT_MCP_CONNECT_TIMEOUT_SECONDS,
+    DEFAULT_MCP_SERVER_NAME,
     MCP_TOOL_NAME_SEPARATOR,
     SPAKKY_MCP_CONFIG_ENV_PREFIX,
 )
@@ -74,6 +75,21 @@ def _is_http_url(url: str | None) -> bool:
     return url is not None and (url.startswith("http://") or url.startswith("https://"))
 
 
+class McpToolServerConfig(BaseModel):
+    """Declaration of how this agent exposes its own tools as an MCP server."""
+
+    name: str = DEFAULT_MCP_SERVER_NAME
+    transport: McpTransport = McpTransport.STDIO
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        """Reject a blank server identity that cannot front the protocol handshake."""
+        if not value.strip():
+            raise McpServerConfigurationError("MCP server name cannot be blank")
+        return value
+
+
 @Configuration()
 class McpConfig(BaseSettings):
     """Settings declaring the external MCP servers an agent consumes."""
@@ -89,6 +105,9 @@ class McpConfig(BaseSettings):
 
     connect_timeout_seconds: float = DEFAULT_MCP_CONNECT_TIMEOUT_SECONDS
     """Timeout budget for establishing an MCP server connection."""
+
+    tool_server: McpToolServerConfig = McpToolServerConfig()
+    """Identity and transport this agent advertises when exposing its own tools."""
 
     def __init__(self) -> None:
         super().__init__()

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/constants.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/constants.py
@@ -1,4 +1,4 @@
-"""Constants for the spakky-mcp client plugin."""
+"""Constants for the spakky-mcp adapter (external clients and tool server)."""
 
 SPAKKY_MCP_CONFIG_ENV_PREFIX: str = "SPAKKY_MCP__"
 DEFAULT_MCP_CONNECT_TIMEOUT_SECONDS: float = 30.0
@@ -11,3 +11,7 @@ MCP_EXTERNAL_TOOL_OWNER_MODULE: str = "spakky.plugins.mcp"
 # Separates a server name from a raw tool name in the model-facing tool name. A
 # double underscore avoids the dotted form some model tool-name validators reject.
 MCP_TOOL_NAME_SEPARATOR: str = "__"
+
+# Default identity advertised when this plugin exposes an agent's tools as an
+# MCP server, used in the protocol initialization handshake.
+DEFAULT_MCP_SERVER_NAME: str = "spakky-agent"

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/error.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/error.py
@@ -1,4 +1,4 @@
-"""Error classes for the spakky-mcp client plugin."""
+"""Error classes for the spakky-mcp adapter (external clients and tool server)."""
 
 from abc import ABC
 
@@ -6,7 +6,7 @@ from spakky.core.common.error import AbstractSpakkyFrameworkError
 
 
 class AbstractMcpError(AbstractSpakkyFrameworkError, ABC):
-    """Base class for MCP client adapter errors."""
+    """Base class for MCP adapter errors (external client and tool server)."""
 
     ...
 
@@ -45,3 +45,9 @@ class McpCatalogMergeError(AbstractMcpError):
     """Raised when an external MCP tool collides with an existing catalog tool."""
 
     message = "MCP tool collides with an existing catalog tool"
+
+
+class McpToolExposureError(AbstractMcpError):
+    """Raised when dispatching an inbound MCP tool call against the agent fails."""
+
+    message = "MCP tool call dispatch failed"

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/main.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/main.py
@@ -1,12 +1,14 @@
-"""Plugin initialization for the MCP client adapter."""
+"""Plugin initialization for the MCP client and server adapters."""
 
 from spakky.core.application.application import SpakkyApplication
 
 from spakky.plugins.mcp.client import McpClient
 from spakky.plugins.mcp.config import McpConfig
+from spakky.plugins.mcp.server import McpToolServer
 
 
 def initialize(app: SpakkyApplication) -> None:
-    """Register MCP client configuration and the external-tool client."""
+    """Register MCP configuration, the external-tool client and the tool server."""
     app.add(McpConfig)
     app.add(McpClient)
+    app.add(McpToolServer)

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/server.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/server.py
@@ -1,0 +1,147 @@
+"""Expose native ``@agent_tool`` tools as an MCP server (issue #417).
+
+This is the server-side counterpart of the MCP client adapter (issue #416).
+ADR-0013 §2 keeps ``core/spakky-agent`` protocol-neutral and pushes the MCP
+library dependency into this adapter plugin, so the conversion of an agent's
+``AgentToolCatalog`` into MCP tool definitions and the dispatch of inbound MCP
+``call_tool`` requests live here rather than in the core.
+
+An external MCP client discovers an agent's tools through the standard
+``list_tools`` request — each catalog descriptor becomes an ``mcp.types.Tool``
+carrying the descriptor's model-facing name, description and JSON Schema. A
+``call_tool`` request runs through the same ``AgentToolDispatcher`` the
+framework runner dispatches native tool calls through, so the tool a remote
+client invokes behaves identically to a local model-issued tool call.
+"""
+
+import json
+from collections.abc import Mapping
+from typing import cast
+
+from mcp.server.lowlevel.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.types import ContentBlock, TextContent, Tool
+from spakky.agent import (
+    Agent,
+    AgentToolCatalog,
+    AgentToolDispatcher,
+    JsonObject,
+    JsonValue,
+)
+from spakky.agent.interfaces.model import ModelToolCall
+from spakky.core.pod.annotations.pod import Pod
+
+from spakky.plugins.mcp.config import McpConfig
+from spakky.plugins.mcp.error import McpToolExposureError
+
+
+def build_agent_tools(catalog: AgentToolCatalog) -> list[Tool]:
+    """Convert every catalog descriptor into an MCP tool definition.
+
+    The model-facing schema name is the MCP tool name so an inbound
+    ``call_tool`` resolves to the same descriptor the dispatcher keys on, and
+    the descriptor's input schema is forwarded verbatim as the tool's
+    ``inputSchema`` so the SDK validates arguments against the agent's contract.
+    """
+    return [
+        Tool(
+            name=descriptor.schema.name,
+            description=descriptor.description,
+            inputSchema=dict(descriptor.schema.input_schema),
+        )
+        for descriptor in catalog.descriptors
+    ]
+
+
+def normalize_dispatch_result(
+    result: JsonValue,
+) -> tuple[list[ContentBlock], JsonObject]:
+    """Map a dispatched tool result into MCP content and structured content.
+
+    MCP carries a tool result as human-readable ``content`` plus optional
+    machine-readable ``structuredContent``. A mapping result is structured as
+    is; any other value is wrapped under a ``result`` key so the structured
+    payload is always a JSON object, mirroring the ``{"result": ...}`` shape the
+    client adapter reads back (``normalize_call_result``).
+    """
+    structured: JsonObject = (
+        dict(result) if isinstance(result, Mapping) else {"result": result}
+    )
+    text = json.dumps(structured)
+    return [TextContent(type="text", text=text)], structured
+
+
+def build_agent_tool_server(agent_instance: object, server_name: str) -> Server:
+    """Build an MCP server exposing one agent instance's tool catalog.
+
+    The catalog is read once from the agent Pod metadata; the dispatcher binds
+    to the live ``agent_instance`` so a ``call_tool`` request executes the bound
+    method. A failed dispatch surfaces as a typed error rather than a silent
+    empty result so the SDK reports it as a tool error to the remote client.
+    """
+    dispatcher = AgentToolDispatcher(
+        target=agent_instance,
+        catalog=Agent.get(type(agent_instance)).tool_catalog,
+    )
+    server: Server[object, object] = Server(server_name)
+
+    @server.list_tools()
+    async def _list_tools() -> list[Tool]:
+        return build_agent_tools(dispatcher.catalog)
+
+    @server.call_tool()
+    async def _call_tool(
+        name: str,
+        arguments: JsonObject,
+    ) -> tuple[list[ContentBlock], JsonObject]:
+        try:
+            result = await dispatcher.dispatch(
+                ModelToolCall(name=name, arguments=arguments)
+            )
+        except Exception as e:
+            raise McpToolExposureError from e
+        # The dispatcher returns ``object``; an agent tool result is JSON-serializable
+        # by contract (the runner serializes it back to the model), so it is a JsonValue.
+        return normalize_dispatch_result(cast(JsonValue, result))
+
+    return server
+
+
+async def serve_stdio(server: Server) -> None:
+    """Serve the MCP server over the stdio transport until the client closes it."""
+    async with stdio_server() as (read, write):
+        await server.run(read, write, server.create_initialization_options())
+
+
+def streamable_http_session_manager(server: Server) -> StreamableHTTPSessionManager:
+    """Build the streamable-HTTP session manager wrapping the MCP server.
+
+    The manager owns one task group for the lifetime of its ``run`` context and
+    cannot be reused once that context exits; the caller drives it from the host
+    application's lifespan and routes inbound requests to ``handle_request``.
+    """
+    return StreamableHTTPSessionManager(app=server)
+
+
+@Pod()
+class McpToolServer:
+    """Application entry point exposing an agent's tools over an MCP transport."""
+
+    def __init__(self, config: McpConfig) -> None:
+        self.config = config
+
+    def build_server(self, agent_instance: object) -> Server:
+        """Build an MCP server advertising the configured identity for one agent."""
+        return build_agent_tool_server(agent_instance, self.config.tool_server.name)
+
+    async def serve_stdio(self, agent_instance: object) -> None:
+        """Serve the agent's tools over stdio until the connected client closes."""
+        await serve_stdio(self.build_server(agent_instance))
+
+    def streamable_http_session_manager(
+        self,
+        agent_instance: object,
+    ) -> StreamableHTTPSessionManager:
+        """Build the streamable-HTTP session manager exposing the agent's tools."""
+        return streamable_http_session_manager(self.build_server(agent_instance))

--- a/plugins/spakky-mcp/tests/acceptance/test_mcp_server_acceptance.py
+++ b/plugins/spakky-mcp/tests/acceptance/test_mcp_server_acceptance.py
@@ -1,0 +1,125 @@
+"""End-to-end acceptance: external MCP clients discover and call agent tools.
+
+Drives the agent tool server over the SDK's in-memory client session: an
+external ``ClientSession`` lists the agent's tools and invokes one, exercising
+the same ``AgentToolDispatcher`` path the framework runner dispatches native
+tool calls through (issue #417 SC-1).
+"""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from mcp.shared.memory import create_connected_server_and_client_session
+from spakky.agent import (
+    Agent,
+    AgentExecutionSpec,
+    AgentYield,
+    AgentYieldKind,
+    Final,
+    Idempotency,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+
+from spakky.plugins.mcp.config import McpConfig, McpToolServerConfig
+from spakky.plugins.mcp.server import McpToolServer, build_agent_tool_server
+
+
+@Agent(spec=AgentExecutionSpec(name="catalog", objective="serve tools"))
+class CatalogAgent:
+    """Agent fixture exposing tools whose results cover both result shapes."""
+
+    @agent_tool(
+        schema_name="forecast",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def forecast(self, city: str) -> str:
+        """Return a canned forecast for a city."""
+        return f"sunny in {city}"
+
+    @agent_tool(
+        schema_name="lookup",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def lookup(self, key: str) -> dict[str, str | bool]:
+        """Return a mapping result keyed by the requested key."""
+        return {"key": key, "found": True}
+
+    async def execute(
+        self,
+        command: str,
+    ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+        """Satisfy the @Agent execute contract."""
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(output=command, metadata={}),
+        )
+
+
+async def test_external_client_discovers_agent_tools_with_schema() -> None:
+    """An external MCP client lists the agent's tools with their input schema."""
+    server = build_agent_tool_server(CatalogAgent(), "spakky-agent")
+    async with create_connected_server_and_client_session(server) as session:
+        await session.initialize()
+        listed = await session.list_tools()
+
+    by_name = {tool.name: tool for tool in listed.tools}
+    assert set(by_name) == {"forecast", "lookup"}
+    assert by_name["forecast"].inputSchema["properties"] == {"city": {"type": "string"}}
+
+
+async def test_external_client_calls_scalar_tool_expect_wrapped_result() -> None:
+    """A scalar tool result is exposed under the ``result`` structured key."""
+    server = build_agent_tool_server(CatalogAgent(), "spakky-agent")
+    async with create_connected_server_and_client_session(server) as session:
+        await session.initialize()
+        result = await session.call_tool("forecast", arguments={"city": "seoul"})
+
+    assert result.isError is False
+    assert result.structuredContent == {"result": "sunny in seoul"}
+
+
+async def test_external_client_calls_mapping_tool_expect_structured_result() -> None:
+    """A mapping tool result is exposed as structured content as is."""
+    server = build_agent_tool_server(CatalogAgent(), "spakky-agent")
+    async with create_connected_server_and_client_session(server) as session:
+        await session.initialize()
+        result = await session.call_tool("lookup", arguments={"key": "alpha"})
+
+    assert result.isError is False
+    assert result.structuredContent == {"key": "alpha", "found": True}
+
+
+async def test_external_client_calls_unknown_tool_expect_error_result() -> None:
+    """Dispatching a tool the catalog does not contain reports a tool error."""
+    server = build_agent_tool_server(CatalogAgent(), "spakky-agent")
+    async with create_connected_server_and_client_session(server) as session:
+        await session.initialize()
+        result = await session.call_tool("absent", arguments={})
+
+    assert result.isError is True
+
+
+@pytest.fixture
+def tool_server() -> McpToolServer:
+    """The MCP tool server Pod wired with default configuration."""
+    config = McpConfig()
+    config.tool_server = McpToolServerConfig(name="spakky-agent")
+    return McpToolServer(config)
+
+
+async def test_tool_server_pod_builds_server_exposing_agent_tools(
+    tool_server: McpToolServer,
+) -> None:
+    """The Pod builds a server an external client discovers tools through."""
+    server = tool_server.build_server(CatalogAgent())
+    async with create_connected_server_and_client_session(server) as session:
+        await session.initialize()
+        result = await session.call_tool("forecast", arguments={"city": "busan"})
+
+    assert result.structuredContent == {"result": "sunny in busan"}

--- a/plugins/spakky-mcp/tests/unit/test_config.py
+++ b/plugins/spakky-mcp/tests/unit/test_config.py
@@ -2,10 +2,16 @@
 
 import pytest
 
-from spakky.plugins.mcp.config import McpConfig, McpServerConfig, McpTransport
+from spakky.plugins.mcp.config import (
+    McpConfig,
+    McpServerConfig,
+    McpToolServerConfig,
+    McpTransport,
+)
 from spakky.plugins.mcp.constants import (
     DEFAULT_MCP_CALL_TIMEOUT_SECONDS,
     DEFAULT_MCP_CONNECT_TIMEOUT_SECONDS,
+    DEFAULT_MCP_SERVER_NAME,
 )
 from spakky.plugins.mcp.error import McpServerConfigurationError
 
@@ -16,6 +22,31 @@ def test_config_defaults_to_no_servers() -> None:
 
     assert config.servers == ()
     assert config.connect_timeout_seconds == DEFAULT_MCP_CONNECT_TIMEOUT_SECONDS
+
+
+def test_config_defaults_tool_server_to_default_identity() -> None:
+    """Default config exposes the default tool-server name over stdio."""
+    config = McpConfig()
+
+    assert config.tool_server.name == DEFAULT_MCP_SERVER_NAME
+    assert config.tool_server.transport is McpTransport.STDIO
+
+
+def test_tool_server_name_cannot_be_blank() -> None:
+    """A blank tool-server name cannot front the protocol handshake."""
+    with pytest.raises(McpServerConfigurationError):
+        McpToolServerConfig(name="   ")
+
+
+def test_tool_server_accepts_named_identity_and_transport() -> None:
+    """An explicit tool-server identity and transport are retained."""
+    tool_server = McpToolServerConfig(
+        name="my-agent",
+        transport=McpTransport.STREAMABLE_HTTP,
+    )
+
+    assert tool_server.name == "my-agent"
+    assert tool_server.transport is McpTransport.STREAMABLE_HTTP
 
 
 def test_stdio_server_uses_default_call_timeout() -> None:

--- a/plugins/spakky-mcp/tests/unit/test_main.py
+++ b/plugins/spakky-mcp/tests/unit/test_main.py
@@ -1,4 +1,4 @@
-"""Tests for MCP client plugin initialization."""
+"""Tests for MCP plugin initialization."""
 
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
@@ -6,15 +6,18 @@ from spakky.core.application.application_context import ApplicationContext
 from spakky.plugins.mcp.client import McpClient
 from spakky.plugins.mcp.config import McpConfig
 from spakky.plugins.mcp.main import initialize
+from spakky.plugins.mcp.server import McpToolServer
 
 
-def test_initialize_registers_mcp_config_and_client() -> None:
-    """initialize() registers the MCP config and the external-tool client."""
+def test_initialize_registers_mcp_config_client_and_tool_server() -> None:
+    """initialize() registers the MCP config, the client and the tool server."""
     app = SpakkyApplication(ApplicationContext())
 
     initialize(app)
 
     assert app.container.contains(McpConfig)
     assert app.container.contains(McpClient)
+    assert app.container.contains(McpToolServer)
     app.start()
     assert isinstance(app.container.get(McpClient), McpClient)
+    assert isinstance(app.container.get(McpToolServer), McpToolServer)

--- a/plugins/spakky-mcp/tests/unit/test_public_api.py
+++ b/plugins/spakky-mcp/tests/unit/test_public_api.py
@@ -13,9 +13,14 @@ from spakky.plugins.mcp import (
     McpServerConfig,
     McpServerConfigurationError,
     McpToolDiscoveryError,
+    McpToolExposureError,
     McpToolInvocationError,
+    McpToolServer,
+    McpToolServerConfig,
     McpTransport,
     McpTransportError,
+    build_agent_tool_server,
+    build_agent_tools,
     build_external_descriptor,
     build_external_descriptors,
     build_mcp_runner,
@@ -23,7 +28,10 @@ from spakky.plugins.mcp import (
     make_mcp_tool_callable,
     merge_external_catalog,
     normalize_call_result,
+    normalize_dispatch_result,
     prefixed_tool_name,
+    serve_stdio,
+    streamable_http_session_manager,
 )
 
 
@@ -32,7 +40,19 @@ def test_public_api_exposes_plugin_identity() -> None:
     assert PLUGIN_NAME.name == "spakky-mcp"
     assert McpConfig is mcp_api.McpConfig
     assert McpServerConfig is mcp_api.McpServerConfig
+    assert McpToolServerConfig is mcp_api.McpToolServerConfig
     assert McpTransport is mcp_api.McpTransport
+
+
+def test_public_api_exposes_tool_server_surface() -> None:
+    """The public API exposes the server-side exposure functions and Pod."""
+    assert McpToolServer is mcp_api.McpToolServer
+    assert build_agent_tool_server is mcp_api.build_agent_tool_server
+    assert build_agent_tools is mcp_api.build_agent_tools
+    assert normalize_dispatch_result is mcp_api.normalize_dispatch_result
+    assert serve_stdio is mcp_api.serve_stdio
+    assert streamable_http_session_manager is mcp_api.streamable_http_session_manager
+    assert McpToolExposureError is mcp_api.McpToolExposureError
 
 
 def test_public_api_exposes_client_and_catalog_surface() -> None:

--- a/plugins/spakky-mcp/tests/unit/test_server.py
+++ b/plugins/spakky-mcp/tests/unit/test_server.py
@@ -1,0 +1,185 @@
+"""Unit coverage for the MCP tool server building blocks."""
+
+import json
+from collections.abc import AsyncGenerator
+
+import pytest
+from mcp.server.lowlevel.server import Server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.types import (
+    CallToolRequest,
+    CallToolRequestParams,
+    CallToolResult,
+    TextContent,
+)
+from spakky.agent import (
+    Agent,
+    AgentExecutionSpec,
+    AgentToolCatalog,
+    AgentYield,
+    AgentYieldKind,
+    Final,
+    Idempotency,
+    JsonValue,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+
+from spakky.plugins.mcp.config import McpConfig, McpToolServerConfig
+from spakky.plugins.mcp.server import (
+    McpToolServer,
+    build_agent_tool_server,
+    build_agent_tools,
+    normalize_dispatch_result,
+    serve_stdio,
+    streamable_http_session_manager,
+)
+
+
+@Agent(spec=AgentExecutionSpec(name="unit", objective="serve tools"))
+class ToolAgent:
+    """Agent fixture with one native tool used across server unit tests."""
+
+    @agent_tool(
+        schema_name="echo",
+        description="Return the value unchanged.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def echo(self, value: str) -> str:
+        """Return the value unchanged."""
+        return value
+
+    async def execute(
+        self,
+        command: str,
+    ) -> AsyncGenerator[AgentYield[Final[str]], None]:
+        """Satisfy the @Agent execute contract."""
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=Final(output=command, metadata={}),
+        )
+
+
+def test_build_agent_tools_maps_descriptor_name_description_and_schema() -> None:
+    """Each catalog descriptor becomes a tool carrying its name and input schema."""
+    tools = build_agent_tools(Agent.get(ToolAgent).tool_catalog)
+
+    tool = next(tool for tool in tools if tool.name == "echo")
+    assert tool.description == "Return the value unchanged."
+    assert tool.inputSchema["properties"] == {"value": {"type": "string"}}
+
+
+def test_build_agent_tools_on_empty_catalog_expect_no_tools() -> None:
+    """An empty catalog yields no tool definitions."""
+    assert build_agent_tools(AgentToolCatalog()) == []
+
+
+def test_normalize_dispatch_result_scalar_expect_wrapped_under_result() -> None:
+    """A scalar result is wrapped under the ``result`` structured key."""
+    content, structured = normalize_dispatch_result("done")
+
+    assert structured == {"result": "done"}
+    assert content == [TextContent(type="text", text=json.dumps({"result": "done"}))]
+
+
+def test_normalize_dispatch_result_mapping_expect_structured_as_is() -> None:
+    """A mapping result is exposed as structured content without wrapping."""
+    payload: dict[str, JsonValue] = {"city": "seoul", "ok": True}
+
+    content, structured = normalize_dispatch_result(payload)
+
+    assert structured == payload
+    assert content == [TextContent(type="text", text=json.dumps(payload))]
+
+
+async def test_build_agent_tool_server_dispatch_failure_surfaces_error_result() -> None:
+    """A handler dispatch failure is reported to the SDK as a tool error."""
+    server = build_agent_tool_server(ToolAgent(), "spakky-agent")
+    request = CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(name="echo", arguments={"missing": "arg"}),
+    )
+
+    result = await server.request_handlers[CallToolRequest](request)
+
+    tool_result = result.root
+    assert isinstance(tool_result, CallToolResult)
+    assert tool_result.isError is True
+
+
+def test_streamable_http_session_manager_wraps_server() -> None:
+    """The streamable-HTTP helper returns a session manager bound to the server."""
+    server = build_agent_tool_server(ToolAgent(), "spakky-agent")
+
+    manager = streamable_http_session_manager(server)
+
+    assert isinstance(manager, StreamableHTTPSessionManager)
+
+
+async def test_serve_stdio_runs_until_streams_close(monkeypatch) -> None:
+    """serve_stdio drives the server over the stdio transport streams."""
+    server = build_agent_tool_server(ToolAgent(), "spakky-agent")
+    run_calls: list[tuple[object, object]] = []
+
+    class _Streams:
+        async def __aenter__(self) -> tuple[object, object]:
+            return ("read", "write")
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
+    async def _run(read: object, write: object, _options: object) -> None:
+        run_calls.append((read, write))
+
+    monkeypatch.setattr("spakky.plugins.mcp.server.stdio_server", lambda: _Streams())
+    monkeypatch.setattr(server, "run", _run)
+
+    await serve_stdio(server)
+
+    assert run_calls == [("read", "write")]
+
+
+@pytest.fixture
+def tool_server() -> McpToolServer:
+    """The MCP tool server Pod wired with a named tool-server identity."""
+    config = McpConfig()
+    config.tool_server = McpToolServerConfig(name="named-agent")
+    return McpToolServer(config)
+
+
+def test_tool_server_build_server_uses_configured_name(
+    tool_server: McpToolServer,
+) -> None:
+    """The Pod builds a server advertising the configured identity."""
+    server = tool_server.build_server(ToolAgent())
+
+    assert isinstance(server, Server)
+    assert server.name == "named-agent"
+
+
+def test_tool_server_streamable_http_session_manager_wraps_built_server(
+    tool_server: McpToolServer,
+) -> None:
+    """The Pod exposes a streamable-HTTP manager for the built server."""
+    manager = tool_server.streamable_http_session_manager(ToolAgent())
+
+    assert isinstance(manager, StreamableHTTPSessionManager)
+
+
+async def test_tool_server_serve_stdio_delegates_to_built_server(monkeypatch) -> None:
+    """The Pod's serve_stdio drives the server it builds over stdio."""
+    served: list[Server] = []
+
+    async def _serve(server: Server) -> None:
+        served.append(server)
+
+    monkeypatch.setattr("spakky.plugins.mcp.server.serve_stdio", _serve)
+    config = McpConfig()
+    config.tool_server = McpToolServerConfig(name="named-agent")
+
+    await McpToolServer(config).serve_stdio(ToolAgent())
+
+    assert served[0].name == "named-agent"


### PR DESCRIPTION
## 목적

선언형 Agent의 `@agent_tool` 도구를 MCP(Model Context Protocol) **서버**로 노출하여, 외부 MCP 클라이언트(다른 에이전트·IDE·MCP 호스트)가 표준 프로토콜로 그 도구들을 발견·호출할 수 있게 한다. 마일스톤 #19 선언형 Agent의 MCP 양방향 중 서버 측이며, 이미 머지된 F1(#416) 클라이언트 어댑터의 대칭 기능이다.

Closes #417

## 무엇을 했나

- **`server.py` (신규)** — 한 에이전트 인스턴스의 `AgentToolCatalog`를 노출하는 저수준 MCP `Server` 빌더(`build_agent_tool_server`). `list_tools`는 각 카탈로그 디스크립터를 `mcp.types.Tool`(모델용 이름·설명·입력 JSON Schema)로 변환하고, `call_tool`은 `AgentToolDispatcher`로 위임한다 — 노출된 도구는 로컬 모델이 호출하는 것과 **동일한 디스패치 경로**로 실행된다.
- **표준 전송 준수** — `serve_stdio(server)`(stdio), `streamable_http_session_manager(server)`(streamable_http). 후자는 SDK의 `StreamableHTTPSessionManager`를 돌려주어 호스트 애플리케이션 lifespan에서 구동한다.
- **`McpToolServer` `@Pod`** — `McpConfig.tool_server`(이름·전송)로 서버를 구성하는 애플리케이션 진입점. 클라이언트 측 `McpClient`와 대칭.
- **결과 변환** — 매핑 결과는 `structuredContent`로 그대로, 그 외 값은 `{"result": ...}`로 감싼다(클라이언트 측 `normalize_call_result`와 대칭). 디스패치 실패는 `McpToolExposureError`로 표면화되어 SDK가 원격 클라이언트에 도구 오류로 보고한다.
- **코어 무접촉** — MCP 라이브러리 의존은 어댑터 플러그인에만 위치(ADR-0013 §2). `core/spakky-agent`의 공개 `AgentToolCatalog`/`AgentToolDescriptor`/`AgentToolDispatcher` 계약만 재사용했고 코어는 수정하지 않았다.

## 결정 근거 (PR 폼팩터로 회수)

- **저수준 `Server` 채택(FastMCP 아님)** — F1이 저수준 클라이언트 프리미티브를 쓴 선례와 일관되고, 동적 카탈로그를 그대로 노출하기에 FastMCP의 인스턴스별 도구 등록보다 적합하며 어댑터를 얇게 유지한다.
- **`cast(JsonValue, result)` 1회 사용(사유 주석 동반)** — 디스패처는 `object`를 반환하지만 `@agent_tool`은 데코레이션 시점에 반환 타입 주석을 요구하고 그로부터 출력 스키마를 합성한다(정적 게이트). "JSON 직렬화 가능"은 단언이 아니라 강제된 계약이다.
- **`McpToolServerConfig`/`McpToolServer` 신규 식별자** — 클라이언트 측 `McpServerConfig`(외부 서버 선언)와 의미가 다른 "자신의 도구 노출 설정"이므로 별도 이름. ADR-0013 §2 어휘 정합.

## 검증

- 단위 + 인수 테스트로 외부 MCP 클라이언트의 도구 발견·호출을 SDK in-process 세션(`create_connected_server_and_client_session`)으로 검증 — 스칼라 결과, 매핑 결과, 미존재 도구 오류 경로 포함 (SC-1).
- `ruff` + `pyrefly`(0 diagnostics) + `pytest` 67 passed, **브랜치 커버리지 100%**.

## 문서

- `docs/guides/agent-mcp.md` — 가이드를 양방향으로 재구성하고 "서버: 자신의 도구 내보내기" 절 추가.
- `plugins/spakky-mcp/README.md` — 양방향 어댑터로 갱신.
- `docs/sections/agent.md`, `docs/contributing/ia-map.md` — #417로 노출된 stale 설명 정정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
