### PR TITLE
feat(agent): add declarative signal hooks

### DIFF
--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -45,6 +45,7 @@ pip install spakky-agent spakky-vllm "spakky-sqlalchemy[agent]"
 - `AgentState`: long-running agent execution의 materialized lifecycle state
 - `AgentSignal`: 실행 중 들어오는 user message, approval, cancel 같은 inbound stimulus
 - `AgentSignalPollPoint`, `consume_pending_agent_signals`: safe boundary나 configured poll point에서 durable signal queue를 대기 없이 소비하는 helper
+- `on_signal`, `discover_agent_signal_hooks`, `AgentSignalHookCatalog`: 선언형 시그널 훅(ADR-0013 §1). `@on_signal(kind)`는 `@agent_tool`과 같은 선언형 seam으로, `async def m(self, signal: AgentSignal) -> AsyncGenerator[AgentYield[object], None]` 메서드를 표시한다. `Agent` discovery가 `@agent_tool`과 동일한 MRO 워크로 훅을 수집해 `signal_hook_catalog`에 담고, runner가 해당 종류 시그널을 소비하는 poll 지점에서 자동 호출하여 yield된 item을 public stream으로 흘려보낸다. `CANCEL`·`APPROVAL_DECISION`은 runner 전용 단계가 처리하므로 훅 대상에서 제외되고, 훅이 없는 `USER_MESSAGE`는 기본 progress로 폴백한다. 계약 위반(비 async generator, `signal: AgentSignal` 외 인자, `AgentYield` 외 yield 타입)은 정의 시점에 `AgentDefinitionError`로 거부된다.
 - `AgentApprovalRequest`, `plan_agent_tool_approval`, `parse_agent_approval_decision_signal`: 위험 boundary에서만 HITL approval을 요구하고 decision signal을 typed state target으로 해석하는 helper
 - `begin_agent_cancellation`, `run_agent_cancellation_cleanup`, `complete_agent_cancellation`: cancel signal을 `CANCELLING`으로 materialize하고 model stream/tool/delegate cleanup hook 결과를 evidence와 terminal state에 반영하는 helper
 - `AgentEvidence`: tool/model/context 판단 근거를 위한 append-only artifact
@@ -114,6 +115,36 @@ from spakky.agent import RunAgentInput
 run_input = RunAgentInput(state_id="run-001", instruction="Read README.md and summarize.")
 async for item in agent_instance.execute(run_input):
     print(item)
+```
+
+실행 중 들어오는 시그널에 커스텀 반응이 필요하면 `@on_signal`을 선언합니다 — 루프 본문을 작성하지 않고 시그널 종류별 핸들러만 선언하면 runner가 자동 호출합니다.
+
+```python
+from collections.abc import AsyncGenerator
+
+from spakky.agent import (
+    AgentSignal,
+    AgentSignalKind,
+    AgentYield,
+    AgentYieldKind,
+    Progress,
+    on_signal,
+)
+
+
+class FileAgent:
+    @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+    async def on_steering(
+        self,
+        signal: AgentSignal,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        yield AgentYield(
+            kind=AgentYieldKind.PROGRESS,
+            payload=Progress(
+                f"steering: {signal.payload.get('instruction')}",
+                current_step="steering",
+            ),
+        )
 ```
 
 ### 커스텀 execute() 탈출 경로

--- a/core/spakky-agent/examples/code_assistant_demo.py
+++ b/core/spakky-agent/examples/code_assistant_demo.py
@@ -1,7 +1,13 @@
-"""Claude Code-like CodeAssistant demo built from spakky-agent contracts."""
+"""Claude Code-like CodeAssistant demo built from spakky-agent contracts.
+
+ADR-0013 §1 hands the execution loop to the framework runner, so this demo
+declares only an ``@Agent`` spec plus ``@agent_tool`` capabilities and one
+``@on_signal`` hook — it carries no hand-written loop body. The runner-backed
+``execute()`` is synthesized onto the class because no ``execute()`` is declared.
+"""
 
 from collections.abc import AsyncGenerator, AsyncIterator, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from pathlib import Path
 from subprocess import run
 from typing import override
@@ -12,78 +18,26 @@ from spakky.agent import (
     IAgentSignalRepository,
     IAgentStateRepository,
     Agent,
-    ModelCapability,
-    AgentActionBoundaryCheckpoint,
-    AgentEvidence,
-    AgentEvidenceCandidate,
-    AgentEvidenceKind,
     AgentExecutionLimits,
     AgentExecutionSpec,
-    AgentApprovalRequest,
     AgentSignal,
     AgentSignalKind,
-    AgentState,
-    AgentStateReason,
-    AgentStateTransition,
-    AgentStatus,
-    AgentToolDispatcher,
     AgentYield,
     AgentYieldKind,
-    ApprovalDecision,
-    Cancel,
-    Evidence,
     EvidenceCapture,
-    Error,
-    Final,
     Idempotency,
-    JsonSchemaConstraint,
-    JsonValue,
-    ModelMessage,
-    ModelMessageRole,
+    ModelCapability,
     ModelRequest,
     ModelResponse,
     ModelStreamEvent,
-    ModelStreamEventKind,
-    ModelToolCall,
-    ModelToolChoice,
-    ModelToolSpec,
     Progress,
     RecoveryStrategy,
-    SamplingOptions,
-    Tool,
+    RunAgentInput,
     ToolApprovalRequirement,
-    ToolCallingSpec,
     ToolEffects,
-    Token,
     agent_tool,
-    begin_agent_cancellation,
-    complete_agent_cancellation,
-    materialize_agent_approval_decision_state,
-    parse_agent_approval_decision_signal,
-    plan_agent_resume,
-    plan_agent_tool_approval,
-    run_agent_cancellation_cleanup,
+    on_signal,
 )
-from spakky.agent.tooling import AgentToolDescriptor
-
-
-@dataclass(frozen=True, slots=True)
-class CodeAssistantCommand:
-    """Command DTO consumed by the CodeAssistant demo agent."""
-
-    state_id: str
-    instruction: str
-    resume: bool = False
-
-
-@dataclass(frozen=True, slots=True)
-class CodeAssistantResult:
-    """Final summary returned by the demo scenario."""
-
-    state_id: str
-    status: str
-    tool_calls: tuple[str, ...]
-    evidence_count: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -282,6 +236,7 @@ class GitCliAdapter(IGitPort):
             AgentSignalKind.APPROVAL_DECISION,
             AgentSignalKind.CANCEL,
             AgentSignalKind.RESUME,
+            AgentSignalKind.STEERING_INSTRUCTION,
         ),
         recovery=RecoveryStrategy.ACTION_BOUNDARY,
         limits=AgentExecutionLimits(timeout_seconds=600),
@@ -310,109 +265,21 @@ class CodeAssistant:
         self._signals = signals
         self._evidence = evidence
 
-    async def execute(
+    @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+    async def on_steering(
         self,
-        command: CodeAssistantCommand,
+        signal: AgentSignal,
     ) -> AsyncGenerator[AgentYield[object], None]:
-        """Run one model-mediated coding-assistant scenario."""
-        state = self._ensure_active_state(command)
-        if command.resume:
-            async for item in self._emit_resume_plan(state):
-                yield item
-            state = self._states.get(command.state_id)
-
-        cancel = await self._consume_cancel(state)
-        if cancel is not None:
-            yield cancel
-            return
-
-        tool_calls: list[str] = []
+        """Echo a mid-run steering instruction back into the public stream."""
+        instruction = signal.payload.get("instruction")
+        text = instruction if isinstance(instruction, str) else ""
         yield AgentYield(
             kind=AgentYieldKind.PROGRESS,
-            payload=Progress("preparing model request", current_step="model"),
-        )
-        self._append_boundary(
-            state.id,
-            AgentActionBoundaryCheckpoint.before_model_call(
-                "model:code_assistant_decision",
-                idempotency=Idempotency.IDEMPOTENT,
+            payload=Progress(
+                f"steering instruction: {text}",
+                current_step="steering",
+                metadata={"signal_id": signal.id},
             ),
-        )
-        request = self._model_request(command)
-        async for event in self._model.stream(request):
-            cancel = await self._consume_cancel(state)
-            if cancel is not None:
-                yield cancel
-                return
-
-            async for signal_item in self._consume_user_messages(state):
-                yield signal_item
-
-            if event.kind is ModelStreamEventKind.TOKEN_DELTA:
-                yield AgentYield(
-                    kind=AgentYieldKind.TOKEN,
-                    payload=Token(event.token_delta or ""),
-                )
-            elif (
-                event.kind is ModelStreamEventKind.TOOL_CALL_CANDIDATE
-                and event.tool_call is not None
-            ):
-                async for tool_item in self._execute_tool_call(state, event.tool_call):
-                    yield tool_item
-                if self._states.get(state.id).status is not AgentStatus.ACTIVE:
-                    return
-                tool_calls.append(event.tool_call.name)
-            elif event.kind is ModelStreamEventKind.DONE:
-                self._append_boundary(
-                    state.id,
-                    AgentActionBoundaryCheckpoint.after_model_call(
-                        "model:code_assistant_decision",
-                        idempotency=Idempotency.IDEMPOTENT,
-                    ),
-                )
-            elif event.kind is ModelStreamEventKind.ERROR and event.error is not None:
-                current_state = self._states.get(state.id)
-                self._states.save(
-                    replace(
-                        current_state,
-                        status=AgentStatus.FAILED,
-                        transition=AgentStateTransition.FAILED,
-                        reason=AgentStateReason.EXECUTION_FAILED,
-                        current_activity="model stream failed",
-                        metadata={
-                            **current_state.metadata,
-                            "model_error_code": event.error.code,
-                        },
-                    )
-                )
-                yield AgentYield(
-                    kind=AgentYieldKind.ERROR,
-                    payload=Error(
-                        code=event.error.code,
-                        message=event.error.message,
-                        retryable=event.error.retryable,
-                        metadata=event.error.metadata,
-                    ),
-                )
-                return
-
-        final_state = self._states.save(
-            replace(
-                self._states.get(state.id),
-                status=AgentStatus.COMPLETED,
-                transition=AgentStateTransition.COMPLETED,
-                current_activity="demo completed",
-            )
-        )
-        result = CodeAssistantResult(
-            state_id=final_state.id,
-            status=final_state.status.value,
-            tool_calls=tuple(tool_calls),
-            evidence_count=len(self._evidence.list_by_state(final_state.id)),
-        )
-        yield AgentYield(
-            kind=AgentYieldKind.FINAL,
-            payload=Final(output=result, metadata={"demo": "code_assistant"}),
         )
 
     @agent_tool(
@@ -500,285 +367,6 @@ class CodeAssistant:
         """Apply a patch after approval."""
         return self._git.apply_patch(patch)
 
-    def _ensure_active_state(self, command: CodeAssistantCommand) -> AgentState:
-        existing = self._states.get_or_none(command.state_id)
-        if existing is not None:
-            return self._states.save(
-                replace(
-                    existing,
-                    status=AgentStatus.ACTIVE,
-                    transition=AgentStateTransition.RUNNING,
-                    current_activity=command.instruction,
-                )
-            )
-        return self._states.save(
-            AgentState(
-                id=command.state_id,
-                agent_type="CodeAssistant",
-                status=AgentStatus.ACTIVE,
-                transition=AgentStateTransition.RUNNING,
-                current_activity=command.instruction,
-                input_ref=command.instruction,
-            )
-        )
-
-    async def _emit_resume_plan(
-        self,
-        state: AgentState,
-    ) -> AsyncGenerator[AgentYield[object], None]:
-        plan = plan_agent_resume(
-            state,
-            self._evidence.list_by_state(state.id),
-            self._signals.list_pending(state.id),
-        )
-        self._states.save(plan.state)
-        yield AgentYield(
-            kind=AgentYieldKind.PROGRESS,
-            payload=Progress(
-                f"resume action: {plan.action.value}",
-                current_step="resume",
-                metadata={
-                    "requires_human_input": plan.requires_human_input,
-                    "can_resume_automatically": plan.can_resume_automatically,
-                },
-            ),
-        )
-
-    def _model_request(self, command: CodeAssistantCommand) -> ModelRequest:
-        tools = tuple(
-            ModelToolSpec(
-                name=descriptor.schema.name,
-                description=descriptor.description,
-                parameters=JsonSchemaConstraint(schema=descriptor.schema.input_schema),
-                metadata={"tool_identity": descriptor.identity.key},
-            )
-            for descriptor in Agent.get(CodeAssistant).tool_catalog.descriptors
-        )
-        return ModelRequest(
-            messages=(
-                ModelMessage(
-                    ModelMessageRole.SYSTEM,
-                    "Use CodeAssistant tools for workspace, shell, and git actions.",
-                ),
-                ModelMessage(ModelMessageRole.USER, command.instruction),
-            ),
-            tool_calling=ToolCallingSpec(tools=tools, choice=ModelToolChoice.AUTO),
-            sampling=SamplingOptions(temperature=0.0, max_tokens=512),
-            metadata={"state_id": command.state_id, "demo": "code_assistant"},
-        )
-
-    async def _execute_tool_call(
-        self,
-        state: AgentState,
-        call: ModelToolCall,
-    ) -> AsyncGenerator[AgentYield[object], None]:
-        descriptor = Agent.get(CodeAssistant).tool_catalog.by_schema_name(call.name)
-        approval = plan_agent_tool_approval(
-            descriptor=descriptor,
-            approval_id=f"approval:{state.id}:{call.name}",
-            agent_state_id=state.id,
-            agent_type="CodeAssistant",
-            call_id=call.call_id,
-        )
-        if approval.requires_approval and approval.yield_item is not None:
-            self._append_boundary(
-                state.id,
-                AgentActionBoundaryCheckpoint.before_approval_wait(
-                    f"approval:{call.name}",
-                    metadata={"call_id": call.call_id or ""},
-                ),
-            )
-            if approval.state is not None:
-                self._states.save(approval.state)
-            yield AgentYield[object](
-                kind=approval.yield_item.kind,
-                payload=approval.yield_item.payload,
-            )
-            if not self._consume_approval(state.id, approval.request):
-                return
-            self._append_boundary(
-                state.id,
-                AgentActionBoundaryCheckpoint.after_approval_wait(
-                    f"approval:{call.name}",
-                    metadata={"call_id": call.call_id or ""},
-                ),
-            )
-
-        self._append_boundary(
-            state.id,
-            AgentActionBoundaryCheckpoint.before_tool_call(
-                f"tool:{call.name}",
-                idempotency=descriptor.metadata.idempotency,
-                metadata={"call_id": call.call_id or ""},
-            ),
-        )
-        result = await self._invoke_tool(call)
-        self._append_boundary(
-            state.id,
-            AgentActionBoundaryCheckpoint.after_tool_call(
-                f"tool:{call.name}",
-                idempotency=descriptor.metadata.idempotency,
-                metadata={"call_id": call.call_id or ""},
-            ),
-        )
-        evidence = self._append_tool_evidence(state.id, descriptor, result)
-        yield AgentYield(
-            kind=AgentYieldKind.TOOL,
-            payload=Tool(
-                name=call.name,
-                call_id=call.call_id,
-                arguments=call.arguments,
-                result=result,
-                metadata={"tool_identity": descriptor.identity.key},
-            ),
-        )
-        yield AgentYield(
-            kind=AgentYieldKind.EVIDENCE,
-            payload=Evidence(evidence=evidence),
-        )
-
-    async def _invoke_tool(self, call: ModelToolCall) -> JsonValue:
-        result = await AgentToolDispatcher(
-            target=self,
-            catalog=Agent.get(CodeAssistant).tool_catalog,
-        ).dispatch(call)
-        return _tool_result_json(result)
-
-    def _append_tool_evidence(
-        self,
-        state_id: str,
-        descriptor: AgentToolDescriptor,
-        result: JsonValue,
-    ) -> AgentEvidence:
-        payload = result if isinstance(result, dict) else {"result": result}
-        candidate = AgentEvidenceCandidate.tool_result(
-            tool_identity=descriptor.identity.key,
-            tool_schema_name=descriptor.schema.name,
-            result=payload,
-            capture=descriptor.metadata.evidence,
-            summary=f"{descriptor.schema.name} completed",
-        )
-        return self._append_candidate(state_id, candidate)
-
-    def _append_boundary(
-        self,
-        state_id: str,
-        checkpoint: AgentActionBoundaryCheckpoint,
-    ) -> AgentEvidence:
-        return self._append_candidate(
-            state_id,
-            checkpoint.to_evidence_candidate(summary=checkpoint.action_id),
-        )
-
-    def _append_candidate(
-        self,
-        state_id: str,
-        candidate: AgentEvidenceCandidate,
-    ) -> AgentEvidence:
-        index = len(self._evidence.list_by_state(state_id)) + 1
-        return self._evidence.append(
-            candidate.to_evidence(
-                evidence_id=f"{state_id}:evidence:{index}",
-                agent_state_id=state_id,
-            )
-        )
-
-    async def _consume_user_messages(
-        self,
-        state: AgentState,
-    ) -> AsyncGenerator[AgentYield[object], None]:
-        for signal in self._signals.list_pending(state.id):
-            if signal.kind is not AgentSignalKind.USER_MESSAGE:
-                continue
-            self._signals.mark_consumed(signal.id)
-            self._append_candidate(
-                state.id,
-                AgentEvidenceCandidate(
-                    kind=AgentEvidenceKind.EVALUATION,
-                    payload={"signal_id": signal.id, "payload": signal.payload},
-                    summary="user signal consumed",
-                ),
-            )
-            yield AgentYield[object](
-                kind=AgentYieldKind.PROGRESS,
-                payload=Progress(
-                    "user message consumed",
-                    current_step="signal",
-                    metadata={"signal_id": signal.id},
-                ),
-            )
-
-    async def _consume_cancel(
-        self,
-        state: AgentState,
-    ) -> AgentYield[object] | None:
-        for signal in self._signals.list_pending(state.id):
-            if signal.kind is not AgentSignalKind.CANCEL:
-                continue
-            self._signals.mark_consumed(signal.id)
-            cancelling = self._states.save(begin_agent_cancellation(state, signal))
-            report = await run_agent_cancellation_cleanup(
-                state=cancelling,
-                signal=signal,
-                tasks=(),
-            )
-            self._append_candidate(
-                state.id,
-                report.to_evidence_candidate(summary="cancel cleanup completed"),
-            )
-            completed = self._states.save(
-                complete_agent_cancellation(cancelling, report)
-            )
-            return AgentYield[object](
-                kind=AgentYieldKind.CANCEL,
-                payload=Cancel(
-                    reason=completed.reason.value if completed.reason else None,
-                    requested_by=_optional_signal_text(signal, "requested_by"),
-                    metadata={"state": completed.status.value},
-                ),
-            )
-        return None
-
-    def _consume_approval(
-        self,
-        state_id: str,
-        request: AgentApprovalRequest | None,
-    ) -> bool:
-        for signal in self._signals.list_pending(state_id):
-            if signal.kind is not AgentSignalKind.APPROVAL_DECISION:
-                continue
-            if (
-                request is not None
-                and _optional_signal_text(
-                    signal,
-                    "request_id",
-                )
-                != request.id
-            ):
-                continue
-            outcome = parse_agent_approval_decision_signal(signal, request=request)
-            self._signals.mark_consumed(signal.id)
-            current = self._states.get(state_id)
-            next_state = materialize_agent_approval_decision_state(current, outcome)
-            self._states.save(next_state)
-            self._append_candidate(
-                state_id,
-                AgentEvidenceCandidate(
-                    kind=AgentEvidenceKind.APPROVAL,
-                    payload={
-                        "signal_id": signal.id,
-                        "request_id": outcome.request_id,
-                        "decision": outcome.decision.value,
-                    },
-                    summary="approval decision consumed",
-                ),
-            )
-            return outcome.decision in (
-                ApprovalDecision.APPROVE,
-                ApprovalDecision.MODIFY,
-            )
-        return False
-
 
 def _git_result(operation: str, result: ShellCommandResult) -> GitCommandResult:
     return GitCommandResult(
@@ -789,51 +377,6 @@ def _git_result(operation: str, result: ShellCommandResult) -> GitCommandResult:
     )
 
 
-def _tool_result_json(result: object) -> JsonValue:
-    match result:
-        case WorkspaceReadResult():
-            return {"path": result.path, "content": result.content}
-        case WorkspaceSearchResult():
-            return {
-                "query": result.query,
-                "hits": tuple(
-                    {
-                        "path": hit.path,
-                        "line_number": hit.line_number,
-                        "line": hit.line,
-                    }
-                    for hit in result.hits
-                ),
-            }
-        case WorkspaceWriteResult():
-            return {"path": result.path, "bytes_written": result.bytes_written}
-        case ShellCommandResult():
-            return {
-                "command": result.command,
-                "exit_code": result.exit_code,
-                "stdout": result.stdout,
-                "stderr": result.stderr,
-            }
-        case GitCommandResult():
-            return {
-                "operation": result.operation,
-                "exit_code": result.exit_code,
-                "stdout": result.stdout,
-                "stderr": result.stderr,
-            }
-        case _:
-            raise CodeAssistantDemoError(
-                "CodeAssistant tool returned an unknown result"
-            )
-
-
-def _optional_signal_text(signal: AgentSignal, name: str) -> str | None:
-    value = signal.payload.get(name)
-    if isinstance(value, str) and value.strip():
-        return value
-    return None
-
-
 async def collect_stream(
     model: IAgentModel,
     workspace: IWorkspacePort,
@@ -842,12 +385,13 @@ async def collect_stream(
     states: IAgentStateRepository,
     signals: IAgentSignalRepository,
     evidence: IAgentEvidenceRepository,
-    command: CodeAssistantCommand,
+    run_input: RunAgentInput,
 ) -> tuple[AgentYield[object], ...]:
     """Small inbound-adapter-shaped collector for docs and tests."""
     agent = CodeAssistant(model, workspace, shell, git, states, signals, evidence)
+    execute = vars(CodeAssistant)["execute"]
     items: list[AgentYield[object]] = []
-    async for item in agent.execute(command):
+    async for item in execute(agent, run_input):
         items.append(item)
     return tuple(items)
 

--- a/core/spakky-agent/examples/inbound_adapter_examples.py
+++ b/core/spakky-agent/examples/inbound_adapter_examples.py
@@ -6,7 +6,7 @@ the `@Agent` business object that is already registered in the container.
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import AsyncGenerator, Mapping, Sequence
 from dataclasses import fields, is_dataclass
 from enum import Enum
 import json
@@ -14,7 +14,7 @@ from sys import stdin as process_stdin, stdout as process_stdout
 from typing import TextIO, override
 from uuid import uuid4
 
-from examples.code_assistant_demo import CodeAssistant, CodeAssistantCommand
+from examples.code_assistant_demo import CodeAssistant
 from fastapi import WebSocket
 from spakky.agent import (
     IAgentSignalRepository,
@@ -22,12 +22,11 @@ from spakky.agent import (
     AgentSignalKind,
     AgentYield,
     AgentYieldKind,
-    Approval,
     ApprovalDecision,
     JsonObject,
     JsonValue,
+    RunAgentInput,
 )
-from spakky.agent.error import AgentDefinitionError
 from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
 from spakky.core.pod.interfaces.container import IContainer
 from spakky.plugins.fastapi.routes import websocket
@@ -62,11 +61,13 @@ class CodeAssistantWebSocketController(IContainerAware):
     @websocket("/code/ws")
     async def code_assistant(self, socket: WebSocket) -> None:
         await socket.accept()
-        command = code_assistant_command_from_json(await socket.receive_json())
+        payload = await socket.receive_json()
+        run_input = code_assistant_command_from_json(payload)
         await stream_code_assistant_to_websocket(
             _require_container(self._container),
             socket,
-            command,
+            run_input,
+            inbound_signals=code_assistant_signals_from_json(payload),
         )
         await socket.close()
 
@@ -91,7 +92,7 @@ class CodeAssistantCliController(IContainerAware):
     ) -> None:
         await stream_code_assistant_to_stdout(
             _require_container(self._container),
-            CodeAssistantCommand(
+            RunAgentInput(
                 state_id=state_id,
                 instruction=instruction,
                 resume=resume,
@@ -105,38 +106,47 @@ class CodeAssistantCliController(IContainerAware):
 async def stream_code_assistant_to_websocket(
     container: IContainer,
     socket: AgentJsonWebSocket | WebSocket,
-    command: CodeAssistantCommand,
+    run_input: RunAgentInput,
+    *,
+    inbound_signals: Sequence[object] = (),
 ) -> None:
-    """Resolve CodeAssistant from the container and stream yields as JSON."""
+    """Resolve CodeAssistant from the container and stream yields as JSON.
+
+    The framework runner polls the durable signal queue non-blockingly and
+    consumes an approval decision at the tool boundary it reaches (ADR-0013 §5),
+    so the adapter queues any inbound steering/approval messages from the
+    initial command payload before the run rather than blocking the stream for a
+    reply.
+    """
     agent = container.get(CodeAssistant)
     signals = container.get(IAgentSignalRepository)
-    async for item in agent.execute(command):
+    for payload in inbound_signals:
+        signals.append(agent_signal_from_json(run_input.state_id, payload))
+    async for item in _execute_code_assistant(agent, run_input):
         await socket.send_json(agent_yield_to_event(item))
-        if item.kind is AgentYieldKind.APPROVAL:
-            signals.append(
-                agent_signal_from_json(
-                    command.state_id,
-                    await socket.receive_json(),
-                    approval=_approval_payload(item),
-                )
-            )
 
 
 async def stream_code_assistant_to_stdout(
     container: IContainer,
-    command: CodeAssistantCommand,
+    run_input: RunAgentInput,
     *,
     stdout: TextIO,
     stdin: TextIO,
     read_stdin_signal: bool = False,
 ) -> None:
-    """Resolve CodeAssistant and expose its AgentYield stream on stdout."""
+    """Resolve CodeAssistant and expose its AgentYield stream on stdout.
+
+    Inbound stdin signals are queued before the run so the framework runner's
+    non-blocking approval poll observes the decision at the tool boundary it
+    reaches (ADR-0013 §5).
+    """
     signals = container.get(IAgentSignalRepository)
     if read_stdin_signal:
-        _append_signal_line(signals, command.state_id, stdin.readline())
+        for line in stdin:
+            _append_signal_line(signals, run_input.state_id, line)
 
     agent = container.get(CodeAssistant)
-    async for item in agent.execute(command):
+    async for item in _execute_code_assistant(agent, run_input):
         event = agent_yield_to_event(item)
         if item.kind is AgentYieldKind.TOKEN:
             stdout.write(_event_text(event))
@@ -144,26 +154,44 @@ async def stream_code_assistant_to_stdout(
         else:
             stdout.write(f"{event}\n")
             stdout.flush()
-        if item.kind is AgentYieldKind.APPROVAL:
-            _append_signal_line(
-                signals,
-                command.state_id,
-                stdin.readline(),
-                approval=_approval_payload(item),
-            )
 
 
-def code_assistant_command_from_json(payload: object) -> CodeAssistantCommand:
-    """Build the command DTO from an inbound JSON payload."""
-    data = _mapping(payload, "CodeAssistant command")
+def _execute_code_assistant(
+    agent: CodeAssistant,
+    run_input: RunAgentInput,
+) -> AsyncGenerator[AgentYield[object], None]:
+    """Run the CodeAssistant's framework-provided execute() on a resolved instance.
+
+    ``execute()`` is synthesized onto the class at decoration time (ADR-0013 §1),
+    so it is read from the class namespace (``vars``) rather than a statically
+    known attribute and called with the resolved instance as the bound ``self``.
+    """
+    execute = vars(CodeAssistant)["execute"]
+    return execute(agent, run_input)
+
+
+def code_assistant_command_from_json(payload: object) -> RunAgentInput:
+    """Build the run input from an inbound JSON payload."""
+    data = _mapping(payload, "CodeAssistant run input")
     state_id = _text(data, "state_id")
     instruction = _text(data, "instruction")
     resume = data.get("resume") is True
-    return CodeAssistantCommand(
+    return RunAgentInput(
         state_id=state_id,
         instruction=instruction,
         resume=resume,
     )
+
+
+def code_assistant_signals_from_json(payload: object) -> tuple[object, ...]:
+    """Read optional prequeued signals from a CodeAssistant command payload."""
+    data = _mapping(payload, "CodeAssistant run input")
+    signals = data.get("signals")
+    if signals is None:
+        return ()
+    if isinstance(signals, tuple | list):
+        return tuple(signals)
+    raise InboundAdapterExampleError("signals must be a JSON array")
 
 
 def agent_yield_to_event(item: AgentYield[object]) -> dict[str, JsonValue]:
@@ -177,15 +205,13 @@ def agent_yield_to_event(item: AgentYield[object]) -> dict[str, JsonValue]:
 def agent_signal_from_json(
     state_id: str,
     payload: object,
-    *,
-    approval: Approval | None = None,
 ) -> AgentSignal:
     """Materialize an AgentSignal from WebSocket or stdin JSON payload."""
     data = _mapping(payload, "Agent signal")
     kind = _signal_kind(data)
-    signal_payload = _signal_payload(kind, data, approval)
+    signal_payload = _signal_payload(kind, data)
     return AgentSignal(
-        id=_signal_id(state_id, kind, data, approval),
+        id=_signal_id(state_id, kind, data),
         agent_state_id=state_id,
         kind=kind,
         payload=signal_payload,
@@ -196,15 +222,11 @@ def _append_signal_line(
     signals: IAgentSignalRepository,
     state_id: str,
     line: str,
-    *,
-    approval: Approval | None = None,
 ) -> None:
     text = line.strip()
     if not text:
         return
-    signals.append(
-        agent_signal_from_json(state_id, json.loads(text), approval=approval)
-    )
+    signals.append(agent_signal_from_json(state_id, json.loads(text)))
 
 
 def _event_text(event: Mapping[str, JsonValue]) -> str:
@@ -231,13 +253,10 @@ def _signal_kind(data: Mapping[str, object]) -> AgentSignalKind:
 def _signal_payload(
     kind: AgentSignalKind,
     data: Mapping[str, object],
-    approval: Approval | None,
 ) -> JsonObject:
     if kind is AgentSignalKind.APPROVAL_DECISION:
         decision = _approval_decision(data)
         request_id = _optional_text(data, "request_id")
-        if request_id is None and approval is not None:
-            request_id = approval.id
         if request_id is None:
             raise InboundAdapterExampleError("Approval signal requires request_id")
         return {"request_id": request_id, "decision": decision.value}
@@ -258,20 +277,15 @@ def _signal_id(
     state_id: str,
     kind: AgentSignalKind,
     data: Mapping[str, object],
-    approval: Approval | None,
 ) -> str:
     signal_id = _optional_text(data, "id")
     if signal_id is not None:
         return signal_id
-    if kind is AgentSignalKind.APPROVAL_DECISION and approval is not None:
-        return approval.id
+    if kind is AgentSignalKind.APPROVAL_DECISION:
+        request_id = _optional_text(data, "request_id")
+        if request_id is not None:
+            return request_id
     return f"signal:{state_id}:{kind.value}:{uuid4().hex}"
-
-
-def _approval_payload(item: AgentYield[object]) -> Approval:
-    if isinstance(item.payload, Approval):
-        return item.payload
-    raise AgentDefinitionError("Approval yield must carry an Approval payload")
 
 
 def _json_value(value: object) -> JsonValue:

--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -106,10 +106,16 @@ from spakky.agent.execution import (
     AgentCompactionPolicy,
     AgentExecutionLimits,
     AgentExecutionSpec,
-    AgentSignalKind,
     AgentTeammate,
     RecoveryStrategy,
     StreamingExposureMode,
+)
+from spakky.agent.hooks import (
+    AgentSignalHookCatalog,
+    AgentSignalHookDescriptor,
+    AgentSignalHookIdentity,
+    discover_agent_signal_hooks,
+    on_signal,
 )
 from spakky.agent.inbound import RunAgentInput
 from spakky.agent.runner import AgentRunner, AgentRunResult
@@ -139,7 +145,7 @@ from spakky.agent.interfaces.model import (
     StructuredOutputSpec,
     ToolCallingSpec,
 )
-from spakky.agent.signal import AgentSignal, ApprovalDecision
+from spakky.agent.signal import AgentSignal, AgentSignalKind, ApprovalDecision
 from spakky.agent.signal_consumption import (
     AgentSignalConsumptionBatch,
     AgentSignalPollPoint,
@@ -278,6 +284,9 @@ __all__ = [
     "AgentRunner",
     "AgentSignal",
     "AgentSignalConsumptionBatch",
+    "AgentSignalHookCatalog",
+    "AgentSignalHookDescriptor",
+    "AgentSignalHookIdentity",
     "AgentSignalKind",
     "AgentSignalPollPoint",
     "AgentTeammate",
@@ -395,7 +404,9 @@ __all__ = [
     "complete_agent_cancellation",
     "consume_pending_agent_signals",
     "agent_tool",
+    "discover_agent_signal_hooks",
     "discover_agent_tools",
+    "on_signal",
     "materialize_agent_approval_decision_state",
     "parse_agent_approval_decision_signal",
     "plan_agent_resume",

--- a/core/spakky-agent/src/spakky/agent/approval.py
+++ b/core/spakky-agent/src/spakky/agent/approval.py
@@ -5,8 +5,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 
 from spakky.agent.error import AgentDefinitionError
-from spakky.agent.execution import AgentSignalKind
-from spakky.agent.signal import AgentSignal, ApprovalDecision
+from spakky.agent.signal import AgentSignal, AgentSignalKind, ApprovalDecision
 from spakky.agent.state import (
     AgentState,
     AgentStateReason,

--- a/core/spakky-agent/src/spakky/agent/cancellation.py
+++ b/core/spakky-agent/src/spakky/agent/cancellation.py
@@ -6,8 +6,7 @@ from enum import StrEnum
 
 from spakky.agent.error import AgentDefinitionError
 from spakky.agent.evidence import AgentEvidenceCandidate, AgentEvidenceKind
-from spakky.agent.execution import AgentSignalKind
-from spakky.agent.signal import AgentSignal
+from spakky.agent.signal import AgentSignal, AgentSignalKind
 from spakky.agent.state import (
     AgentState,
     AgentStateReason,

--- a/core/spakky-agent/src/spakky/agent/execution.py
+++ b/core/spakky-agent/src/spakky/agent/execution.py
@@ -10,6 +10,8 @@ from urllib.parse import urlsplit
 
 from spakky.agent.compaction import ICompactionStrategy
 from spakky.agent.error import AgentDefinitionError
+from spakky.agent.hooks import AgentSignalHookCatalog, discover_agent_signal_hooks
+from spakky.agent.signal import AgentSignalKind
 from spakky.agent.tooling import AgentToolCatalog, discover_agent_tools
 from spakky.core.pod.annotations.pod import Pod, PodType
 from spakky.core.pod.error import AbstractSpakkyPodError
@@ -32,19 +34,6 @@ class StreamingExposureMode(StrEnum):
     BALANCED = "balanced"
     STRICT = "strict"
     NO_STREAM_UNTIL_FINAL_GUARDED = "no_stream_until_final_guarded"
-
-
-class AgentSignalKind(StrEnum):
-    """Inbound stimulus kinds that an agent may accept while running."""
-
-    USER_MESSAGE = "user_message"
-    APPROVAL_DECISION = "approval_decision"
-    CANCEL = "cancel"
-    PAUSE = "pause"
-    RESUME = "resume"
-    STEERING_INSTRUCTION = "steering_instruction"
-    EXTERNAL_EVENT = "external_event"
-    SCHEDULER_WAKE_UP = "scheduler_wake_up"
 
 
 @dataclass(frozen=True, slots=True)
@@ -166,6 +155,10 @@ class Agent(Pod):
         init=False,
         default_factory=AgentToolCatalog,
     )
+    signal_hook_catalog: AgentSignalHookCatalog = field(
+        init=False,
+        default_factory=AgentSignalHookCatalog,
+    )
 
     def _initialize(self, obj: PodType) -> None:
         """Initialize Pod metadata and validate the Agent execute contract."""
@@ -177,6 +170,7 @@ class Agent(Pod):
         self._ensure_execute_provided(agent_class)
         self._validate_execute_contract(agent_class)
         self.tool_catalog = discover_agent_tools(agent_class)
+        self.signal_hook_catalog = discover_agent_signal_hooks(agent_class)
 
     def validate_bootstrap(self) -> None:
         """Re-run definition validation during application bootstrap."""

--- a/core/spakky-agent/src/spakky/agent/hooks.py
+++ b/core/spakky-agent/src/spakky/agent/hooks.py
@@ -1,0 +1,226 @@
+"""Declarative signal-hook discovery contracts (ADR-0013 §1).
+
+The framework runner owns the execution loop, but a developer still needs a
+declarative seam to react to inbound signals (a steering instruction, an
+external event, a user message) and emit their own stream items without writing
+a loop body. ``@on_signal(kind)`` is that seam: it marks a coroutine generator
+method the same way ``@agent_tool`` marks a tool method, and the runner invokes
+every matching hook when it consumes a signal of that kind at a poll point.
+
+Discovery mirrors ``discover_agent_tools`` exactly — an MRO walk reading
+``vars()`` (not the banned ``getattr``) so the raw function objects are found
+before descriptor binding — so the two declarative seams stay structurally
+identical for a reader.
+"""
+
+from collections.abc import AsyncGenerator, Callable
+from dataclasses import dataclass
+from inspect import Parameter, Signature, isasyncgenfunction, signature
+from types import FunctionType
+from typing import get_args, get_origin, get_type_hints
+
+from spakky.agent.error import AgentDefinitionError
+from spakky.agent.signal import AgentSignal, AgentSignalKind
+from spakky.agent.yield_ import AgentYield
+
+AGENT_SIGNAL_HOOK_DEFINITION_KEY = "__spakky_agent_signal_hook_definition__"
+
+AgentSignalHookCallable = Callable[..., AsyncGenerator[AgentYield[object], None]]
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSignalHookDefinition:
+    """Method-level metadata attached by ``@on_signal`` before owner discovery."""
+
+    kind: AgentSignalKind
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSignalHookIdentity:
+    """Hook identity independent from the developer-chosen method name."""
+
+    owner_module: str
+    owner_qualname: str
+    member_name: str
+
+    @property
+    def key(self) -> str:
+        """Return a stable key for deterministic ordering and logs."""
+        return f"{self.owner_module}.{self.owner_qualname}:{self.member_name}"
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSignalHookDescriptor:
+    """Discovered signal hook bound to an owner class and callable."""
+
+    identity: AgentSignalHookIdentity
+    owner: type[object]
+    callable: AgentSignalHookCallable
+    kind: AgentSignalKind
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSignalHookCatalog:
+    """Deterministic catalog of signal hooks discovered from an Agent class."""
+
+    descriptors: tuple[AgentSignalHookDescriptor, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Reject duplicate hook identities so dispatch order stays stable."""
+        identity_keys: set[str] = set()
+        for descriptor in self.descriptors:
+            if descriptor.identity.key in identity_keys:
+                raise AgentDefinitionError("Agent signal hook identity must be unique")
+            identity_keys.add(descriptor.identity.key)
+
+    def hooks_for(
+        self,
+        kind: AgentSignalKind,
+    ) -> tuple[AgentSignalHookDescriptor, ...]:
+        """Return every hook that handles the requested signal kind, in order."""
+        return tuple(
+            descriptor for descriptor in self.descriptors if descriptor.kind is kind
+        )
+
+
+def on_signal(kind: AgentSignalKind) -> Callable[[FunctionType], FunctionType]:
+    """Declare a method that reacts to one inbound signal kind.
+
+    The decorated method must be an async generator yielding ``AgentYield``
+    items and accepting exactly one ``signal: AgentSignal`` argument besides
+    ``self``. The runner invokes it when it consumes a signal of ``kind`` at a
+    poll point, and forwards every yielded item into the public stream.
+    """
+
+    def decorate(function: FunctionType) -> FunctionType:
+        function.__dict__[AGENT_SIGNAL_HOOK_DEFINITION_KEY] = AgentSignalHookDefinition(
+            kind=kind,
+        )
+        return function
+
+    return decorate
+
+
+def discover_agent_signal_hooks(owner: type[object]) -> AgentSignalHookCatalog:
+    """Discover ``@on_signal`` methods in deterministic class-definition order."""
+    descriptors: list[AgentSignalHookDescriptor] = []
+    resolved_member_names: set[str] = set()
+    for declaring_owner in owner.__mro__:
+        if declaring_owner is object:
+            continue
+        for member_name, member in vars(declaring_owner).items():
+            if member_name in resolved_member_names:
+                continue
+            resolved_member_names.add(member_name)
+            if not isinstance(member, FunctionType):
+                continue
+            definition = _get_signal_hook_definition(member)
+            if definition is None:
+                continue
+            _validate_hook_contract(member)
+            descriptors.append(
+                AgentSignalHookDescriptor(
+                    identity=AgentSignalHookIdentity(
+                        owner_module=declaring_owner.__module__,
+                        owner_qualname=declaring_owner.__qualname__,
+                        member_name=member_name,
+                    ),
+                    owner=declaring_owner,
+                    callable=member,
+                    kind=definition.kind,
+                ),
+            )
+    ordered = tuple(
+        sorted(descriptors, key=lambda descriptor: descriptor.identity.key),
+    )
+    return AgentSignalHookCatalog(descriptors=ordered)
+
+
+def _get_signal_hook_definition(
+    function: FunctionType,
+) -> AgentSignalHookDefinition | None:
+    candidate = vars(function).get(AGENT_SIGNAL_HOOK_DEFINITION_KEY)
+    if candidate is None:
+        return None
+    if not isinstance(candidate, AgentSignalHookDefinition):
+        raise AgentDefinitionError("Agent signal hook metadata is invalid")
+    return candidate
+
+
+def _validate_hook_contract(function: FunctionType) -> None:
+    if not isasyncgenfunction(function):
+        raise AgentDefinitionError(
+            "@on_signal method must be an async generator yielding AgentYield items"
+        )
+    hook_signature = signature(function)
+    _validate_hook_parameters(function, hook_signature)
+    _validate_hook_yield_type(function, hook_signature)
+
+
+def _validate_hook_parameters(
+    function: FunctionType,
+    hook_signature: Signature,
+) -> None:
+    parameters = list(hook_signature.parameters.values())
+    if not parameters or parameters[0].name != "self":
+        raise AgentDefinitionError("@on_signal method must be an instance method")
+    payload_parameters = parameters[1:]
+    if len(payload_parameters) != 1:
+        raise AgentDefinitionError(
+            "@on_signal method must accept exactly one signal: AgentSignal argument"
+        )
+    parameter = payload_parameters[0]
+    if parameter.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD):
+        raise AgentDefinitionError("@on_signal method cannot use variable arguments")
+    annotation = _resolve_signal_annotation(function, parameter)
+    if annotation is not AgentSignal:
+        raise AgentDefinitionError(
+            "@on_signal method argument must be annotated AgentSignal"
+        )
+
+
+def _resolve_signal_annotation(
+    function: FunctionType,
+    parameter: Parameter,
+) -> object:
+    if parameter.annotation == Parameter.empty:
+        raise AgentDefinitionError(
+            "@on_signal method argument must be annotated AgentSignal"
+        )
+    return _resolve_type_hints(function).get(parameter.name, parameter.annotation)
+
+
+def _validate_hook_yield_type(
+    function: FunctionType,
+    hook_signature: Signature,
+) -> None:
+    return_annotation = hook_signature.return_annotation
+    if return_annotation == Signature.empty:
+        raise AgentDefinitionError("@on_signal method return type is required")
+    resolved = _resolve_type_hints(function).get("return", return_annotation)
+    return_origin = get_origin(resolved)
+    if return_origin is None and resolved is AsyncGenerator:
+        raise AgentDefinitionError("@on_signal method yield type is required")
+    if return_origin is not AsyncGenerator:
+        raise AgentDefinitionError("@on_signal method must yield AgentYield items")
+    return_args = get_args(resolved)
+    if not return_args:
+        raise AgentDefinitionError("@on_signal method yield type is required")
+    yield_type = return_args[0]
+    yield_origin = get_origin(yield_type)
+    yield_candidate = yield_type if yield_origin is None else yield_origin
+    if (
+        not isinstance(yield_candidate, type)
+        or yield_candidate.__module__ != "spakky.agent.yield_"
+        or yield_candidate.__name__ != "AgentYield"
+    ):
+        raise AgentDefinitionError("@on_signal method must yield AgentYield items")
+
+
+def _resolve_type_hints(function: FunctionType) -> dict[str, object]:
+    try:
+        return dict(get_type_hints(function, include_extras=True))
+    except (NameError, TypeError) as e:
+        raise AgentDefinitionError(
+            "@on_signal method annotations cannot be resolved"
+        ) from e

--- a/core/spakky-agent/src/spakky/agent/runner.py
+++ b/core/spakky-agent/src/spakky/agent/runner.py
@@ -63,7 +63,8 @@ from spakky.agent.evidence import (
     AgentEvidenceCandidate,
     AgentEvidenceKind,
 )
-from spakky.agent.execution import Agent, AgentSignalKind, RecoveryStrategy
+from spakky.agent.execution import Agent, RecoveryStrategy
+from spakky.agent.hooks import AgentSignalHookDescriptor
 from spakky.agent.inbound import RunAgentInput
 from spakky.agent.interfaces.model import (
     IAgentModel,
@@ -91,7 +92,7 @@ from spakky.agent.recovery import (
     AgentActionBoundaryCheckpoint,
     plan_agent_resume,
 )
-from spakky.agent.signal import AgentSignal, ApprovalDecision
+from spakky.agent.signal import AgentSignal, AgentSignalKind, ApprovalDecision
 from spakky.agent.state import (
     AgentState,
     AgentStateReason,
@@ -414,7 +415,7 @@ class AgentRunner:
             if cancel is not None:
                 yield cancel
                 return
-            for signal_item in self._consume_user_messages(state):
+            async for signal_item in self._consume_inbound_signals(state):
                 yield signal_item
             terminated = False
             async for item in self._consume_stream_event(
@@ -787,34 +788,75 @@ class AgentRunner:
             )
         return None
 
-    def _consume_user_messages(
+    async def _consume_inbound_signals(
         self,
         state: AgentState,
-    ) -> list[AgentYield[object]]:
-        items: list[AgentYield[object]] = []
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        """Dispatch pending non-terminal signals at the model-stream poll point.
+
+        Cancel and approval decisions own dedicated phases, so this poll handles
+        the remaining inbound kinds. A declarative ``@on_signal`` hook, when one
+        is declared for the kind, owns the reaction and its yielded items flow
+        into the public stream. A ``USER_MESSAGE`` with no declared hook falls
+        back to the built-in progress item so the default loop still observes the
+        message. Other kinds with no hook stay pending for a later poll rather
+        than being silently consumed without a handler.
+        """
         for signal in self._signals_required().list_pending(state.id):
-            if signal.kind is not AgentSignalKind.USER_MESSAGE:
+            if signal.kind in (
+                AgentSignalKind.CANCEL,
+                AgentSignalKind.APPROVAL_DECISION,
+            ):
                 continue
-            self._signals_required().mark_consumed(signal.id)
-            self._append_candidate(
-                state.id,
-                AgentEvidenceCandidate(
-                    kind=AgentEvidenceKind.EVALUATION,
-                    payload={"signal_id": signal.id, "payload": signal.payload},
-                    summary="user signal consumed",
-                ),
-            )
-            items.append(
-                AgentYield(
-                    kind=AgentYieldKind.PROGRESS,
-                    payload=Progress(
-                        "user message consumed",
-                        current_step="signal",
-                        metadata={"signal_id": signal.id},
-                    ),
-                )
-            )
-        return items
+            hooks = self.agent.signal_hook_catalog.hooks_for(signal.kind)
+            if hooks:
+                async for item in self._dispatch_signal_hooks(state, signal, hooks):
+                    yield item
+                continue
+            if signal.kind is AgentSignalKind.USER_MESSAGE:
+                yield self._consume_default_user_message(state, signal)
+
+    async def _dispatch_signal_hooks(
+        self,
+        state: AgentState,
+        signal: AgentSignal,
+        hooks: Sequence[AgentSignalHookDescriptor],
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        self._signals_required().mark_consumed(signal.id)
+        self._append_candidate(
+            state.id,
+            AgentEvidenceCandidate(
+                kind=AgentEvidenceKind.EVALUATION,
+                payload={"signal_id": signal.id, "payload": signal.payload},
+                summary=f"{signal.kind.value} signal hook handled",
+            ),
+        )
+        for hook in hooks:
+            async for item in hook.callable(self.target, signal):
+                yield item
+
+    def _consume_default_user_message(
+        self,
+        state: AgentState,
+        signal: AgentSignal,
+    ) -> AgentYield[object]:
+        self._signals_required().mark_consumed(signal.id)
+        self._append_candidate(
+            state.id,
+            AgentEvidenceCandidate(
+                kind=AgentEvidenceKind.EVALUATION,
+                payload={"signal_id": signal.id, "payload": signal.payload},
+                summary="user signal consumed",
+            ),
+        )
+        return AgentYield(
+            kind=AgentYieldKind.PROGRESS,
+            payload=Progress(
+                "user message consumed",
+                current_step="signal",
+                metadata={"signal_id": signal.id},
+            ),
+        )
 
     def _consume_approval(
         self,

--- a/core/spakky-agent/src/spakky/agent/signal.py
+++ b/core/spakky-agent/src/spakky/agent/signal.py
@@ -4,8 +4,20 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 
-from spakky.agent.execution import AgentSignalKind
 from spakky.agent.types import JsonObject
+
+
+class AgentSignalKind(StrEnum):
+    """Inbound stimulus kinds that an agent may accept while running."""
+
+    USER_MESSAGE = "user_message"
+    APPROVAL_DECISION = "approval_decision"
+    CANCEL = "cancel"
+    PAUSE = "pause"
+    RESUME = "resume"
+    STEERING_INSTRUCTION = "steering_instruction"
+    EXTERNAL_EVENT = "external_event"
+    SCHEDULER_WAKE_UP = "scheduler_wake_up"
 
 
 class ApprovalDecision(StrEnum):

--- a/core/spakky-agent/src/spakky/agent/signal_consumption.py
+++ b/core/spakky-agent/src/spakky/agent/signal_consumption.py
@@ -5,9 +5,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from spakky.agent.error import AgentDefinitionError
-from spakky.agent.execution import AgentSignalKind
 from spakky.agent.interfaces.repository import IAgentSignalRepository
-from spakky.agent.signal import AgentSignal
+from spakky.agent.signal import AgentSignal, AgentSignalKind
 
 
 class AgentSignalPollPoint(StrEnum):

--- a/core/spakky-agent/tests/acceptance/test_code_assistant_demo_acceptance.py
+++ b/core/spakky-agent/tests/acceptance/test_code_assistant_demo_acceptance.py
@@ -1,13 +1,12 @@
 """Acceptance tests for the ADR-0009 CodeAssistant demo."""
 
 from examples.code_assistant_demo import (
-    CodeAssistantCommand,
-    CodeAssistantResult,
     StaticModel,
     collect_stream,
 )
 from spakky.agent import (
     AgentEvidenceKind,
+    AgentRunResult,
     AgentStatus,
     AgentYield,
     AgentYieldKind,
@@ -18,6 +17,7 @@ from spakky.agent import (
     ModelStreamEvent,
     ModelStreamEventKind,
     Progress,
+    RunAgentInput,
     Token,
     Tool,
 )
@@ -78,7 +78,7 @@ async def test_code_assistant_acceptance_expect_streaming_approval_signal_eviden
         states,
         signals,
         evidence,
-        CodeAssistantCommand(state_id="run-1", instruction="make a safe edit"),
+        RunAgentInput(state_id="run-1", instruction="make a safe edit"),
     )
 
     assert _payload_count(items, Token) == 1
@@ -94,7 +94,7 @@ async def test_code_assistant_acceptance_expect_streaming_approval_signal_eviden
         AgentEvidenceKind.EVALUATION,
         AgentEvidenceKind.TOOL,
     }
-    assert _final_payload(items).output == CodeAssistantResult(
+    assert _final_payload(items).output == AgentRunResult(
         state_id="run-1",
         status="completed",
         tool_calls=("workspace.read", "workspace.write", "shell.command"),
@@ -109,7 +109,7 @@ async def test_code_assistant_acceptance_expect_streaming_approval_signal_eviden
         states,
         signals,
         evidence,
-        CodeAssistantCommand(
+        RunAgentInput(
             state_id="run-1",
             instruction="resume",
             resume=True,
@@ -141,7 +141,7 @@ async def test_code_assistant_acceptance_expect_cancellation_terminal_state() ->
         states,
         FakeSignalRepository((_cancel_signal("cancel-run"),)),
         evidence,
-        CodeAssistantCommand(state_id="cancel-run", instruction="stop"),
+        RunAgentInput(state_id="cancel-run", instruction="stop"),
     )
 
     assert len(items) == 1
@@ -159,7 +159,7 @@ def _payload_count(
     return sum(1 for item in items if isinstance(item.payload, payload_type))
 
 
-def _final_payload(items: tuple[AgentYield[object], ...]) -> Final[CodeAssistantResult]:
+def _final_payload(items: tuple[AgentYield[object], ...]) -> Final[AgentRunResult]:
     for item in reversed(items):
         if isinstance(item.payload, Final):
             return item.payload

--- a/core/spakky-agent/tests/acceptance/test_declarative_hooks_acceptance.py
+++ b/core/spakky-agent/tests/acceptance/test_declarative_hooks_acceptance.py
@@ -1,0 +1,343 @@
+"""Acceptance test: declarative @on_signal hook through the application container.
+
+This is the issue #413 acceptance scenario: an @Agent that declares only a spec,
+@agent_tool capabilities, and one @on_signal(STEERING_INSTRUCTION) hook — with no
+execute() body — runs the full framework-owned loop when resolved through the
+Spakky application container. The run exercises tool dispatch, the unified HITL
+pause -> approval-decision -> resume flow (ADR-0013 §5), the declarative steering
+hook surfacing its own stream item at the model-stream poll point, and a typed
+COMPLETED termination.
+"""
+
+from collections.abc import AsyncGenerator, AsyncIterator, Sequence
+from dataclasses import dataclass
+from typing import override
+
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+from spakky.core.pod.annotations.pod import Pod
+
+from spakky.agent import (
+    IAgentEvidenceRepository,
+    IAgentModel,
+    IAgentSignalRepository,
+    IAgentStateRepository,
+    Agent,
+    AgentEvidence,
+    AgentEvidenceKind,
+    AgentExecutionLimits,
+    AgentExecutionSpec,
+    AgentSignal,
+    AgentSignalKind,
+    AgentState,
+    AgentStatus,
+    AgentYield,
+    AgentYieldKind,
+    Approval,
+    ApprovalDecision,
+    EvidenceCapture,
+    Final,
+    Idempotency,
+    ModelCapability,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    Progress,
+    RecoveryStrategy,
+    RunAgentInput,
+    Tool,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+    on_signal,
+)
+from spakky.agent.error import AgentDefinitionError
+from spakky.agent.main import initialize
+
+
+@dataclass(frozen=True, slots=True)
+class NoteResult:
+    """Structured tool result for the declarative hook acceptance agent."""
+
+    note: str
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="steering_assistant",
+        objective="run the framework loop reacting to a declarative steering hook",
+        accepted_signals=(
+            AgentSignalKind.USER_MESSAGE,
+            AgentSignalKind.APPROVAL_DECISION,
+            AgentSignalKind.CANCEL,
+            AgentSignalKind.STEERING_INSTRUCTION,
+        ),
+        recovery=RecoveryStrategy.ACTION_BOUNDARY,
+        limits=AgentExecutionLimits(timeout_seconds=600),
+    )
+)
+class SteeringAssistant:
+    """Declarative agent: spec + tools + one @on_signal hook, no execute() body."""
+
+    def __init__(
+        self,
+        model: IAgentModel,
+        states: IAgentStateRepository,
+        signals: IAgentSignalRepository,
+        evidence: IAgentEvidenceRepository,
+    ) -> None:
+        self._model = model
+        self._states = states
+        self._signals = signals
+        self._evidence = evidence
+
+    @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+    async def on_steering(
+        self,
+        signal: AgentSignal,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        """Surface a mid-run steering instruction back into the public stream."""
+        instruction = signal.payload.get("instruction")
+        text = instruction if isinstance(instruction, str) else ""
+        yield AgentYield(
+            kind=AgentYieldKind.PROGRESS,
+            payload=Progress(
+                f"steering instruction: {text}",
+                current_step="steering",
+                metadata={"signal_id": signal.id},
+            ),
+        )
+
+    @agent_tool(
+        schema_name="note.read",
+        description="Read a note without approval.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def note_read(self, topic: str) -> NoteResult:
+        """Read a note for a topic."""
+        return NoteResult(note=f"read:{topic}")
+
+    @agent_tool(
+        schema_name="note.write",
+        description="Write a note after human approval.",
+        effects=ToolEffects.write_state(),
+        idempotency=Idempotency.CONDITIONALLY_IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.REQUIRED,
+    )
+    def note_write(self, topic: str) -> NoteResult:
+        """Write a note for a topic after approval."""
+        return NoteResult(note=f"write:{topic}")
+
+
+async def test_declarative_steering_hook_runs_tools_hitl_and_termination() -> None:
+    """spec+tools+@on_signal만 선언한 Agent가 컨테이너 경유로 도구·HITL·훅·종료를 자동 실행한다."""
+    app = SpakkyApplication(ApplicationContext())
+    initialize(app)
+    app.add(ScriptedModel)
+    app.add(MemoryStateRepository)
+    app.add(MemorySignalRepository)
+    app.add(MemoryEvidenceRepository)
+    app.add(SteeringAssistant)
+    app.start()
+
+    signals = app.container.get(IAgentSignalRepository)
+    states = app.container.get(IAgentStateRepository)
+    evidence = app.container.get(IAgentEvidenceRepository)
+    signals.append(
+        AgentSignal(
+            id="approval:run-1:note.write",
+            agent_state_id="run-1",
+            kind=AgentSignalKind.APPROVAL_DECISION,
+            payload={
+                "request_id": "approval:run-1:note.write",
+                "decision": ApprovalDecision.APPROVE.value,
+            },
+        )
+    )
+    signals.append(
+        AgentSignal(
+            id="steer:run-1",
+            agent_state_id="run-1",
+            kind=AgentSignalKind.STEERING_INSTRUCTION,
+            payload={"instruction": "keep the note short"},
+        )
+    )
+
+    assistant = app.container.get(SteeringAssistant)
+    execute = vars(SteeringAssistant)["execute"]
+    items: list[AgentYield[object]] = []
+    async for item in execute(
+        assistant,
+        RunAgentInput(state_id="run-1", instruction="take a small note"),
+    ):
+        items.append(item)
+
+    kinds = {item.kind for item in items}
+    assert {
+        AgentYieldKind.TOKEN,
+        AgentYieldKind.APPROVAL,
+        AgentYieldKind.TOOL,
+        AgentYieldKind.EVIDENCE,
+        AgentYieldKind.FINAL,
+    } <= kinds
+    assert sum(1 for item in items if isinstance(item.payload, Approval)) == 1
+    assert [item.payload.name for item in items if isinstance(item.payload, Tool)] == [
+        "note.read",
+        "note.write",
+    ]
+    assert any(
+        item.kind is AgentYieldKind.PROGRESS
+        and isinstance(item.payload, Progress)
+        and item.payload.current_step == "steering"
+        and "keep the note short" in item.payload.message
+        for item in items
+    )
+    assert signals.list_pending("run-1") == ()
+    assert states.get("run-1").status is AgentStatus.COMPLETED
+    assert {artifact.kind for artifact in evidence.list_by_state("run-1")} >= {
+        AgentEvidenceKind.ACTION_BOUNDARY,
+        AgentEvidenceKind.APPROVAL,
+        AgentEvidenceKind.EVALUATION,
+        AgentEvidenceKind.TOOL,
+    }
+    final = items[-1].payload
+    assert isinstance(final, Final)
+    app.stop()
+
+
+@Pod()
+class ScriptedModel(IAgentModel):
+    """Scripted model streaming a token, two tool calls, then done."""
+
+    @property
+    @override
+    def capability(self) -> ModelCapability:
+        return ModelCapability()
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        return ModelResponse(content="scripted")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOKEN_DELTA,
+            token_delta="planning",
+        )
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+            tool_call=ModelToolCall(
+                name="note.read",
+                arguments={"topic": "agents"},
+                call_id="read-1",
+            ),
+        )
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+            tool_call=ModelToolCall(
+                name="note.write",
+                arguments={"topic": "agents"},
+                call_id="write-1",
+            ),
+        )
+        yield ModelStreamEvent(kind=ModelStreamEventKind.DONE)
+
+
+@Pod()
+class MemoryStateRepository(IAgentStateRepository):
+    """In-memory state repository for the acceptance scenario."""
+
+    def __init__(self) -> None:
+        self._states: dict[str, AgentState] = {}
+
+    @override
+    def get(self, state_id: str) -> AgentState:
+        state = self._states.get(state_id)
+        if state is None:
+            raise AgentDefinitionError("Missing acceptance state")
+        return state
+
+    @override
+    def get_or_none(self, state_id: str) -> AgentState | None:
+        return self._states.get(state_id)
+
+    @override
+    def save(self, state: AgentState) -> AgentState:
+        self._states[state.id] = state
+        return state
+
+    @override
+    def list_by_status(self, status: AgentStatus) -> Sequence[AgentState]:
+        return tuple(state for state in self._states.values() if state.status is status)
+
+    @override
+    def list_resume_candidates(self) -> Sequence[AgentState]:
+        return ()
+
+
+@Pod()
+class MemorySignalRepository(IAgentSignalRepository):
+    """In-memory signal repository for the acceptance scenario."""
+
+    def __init__(self) -> None:
+        self._signals: tuple[AgentSignal, ...] = ()
+        self._consumed: set[str] = set()
+
+    @override
+    def append(self, signal: AgentSignal) -> AgentSignal:
+        self._signals = (*self._signals, signal)
+        return signal
+
+    @override
+    def list_pending(self, state_id: str) -> Sequence[AgentSignal]:
+        return tuple(
+            signal
+            for signal in self._signals
+            if signal.agent_state_id == state_id and signal.id not in self._consumed
+        )
+
+    @override
+    def mark_consumed(self, signal_id: str) -> AgentSignal:
+        for signal in self._signals:
+            if signal.id == signal_id:
+                self._consumed.add(signal_id)
+                return signal
+        raise AgentDefinitionError("Missing acceptance signal")
+
+
+@Pod()
+class MemoryEvidenceRepository(IAgentEvidenceRepository):
+    """In-memory evidence repository for the acceptance scenario."""
+
+    def __init__(self) -> None:
+        self._evidence: dict[str, AgentEvidence] = {}
+
+    @override
+    def append(self, evidence: AgentEvidence) -> AgentEvidence:
+        self._evidence[evidence.id] = evidence
+        return evidence
+
+    @override
+    def get(self, evidence_id: str) -> AgentEvidence:
+        evidence = self._evidence.get(evidence_id)
+        if evidence is None:
+            raise AgentDefinitionError("Missing acceptance evidence")
+        return evidence
+
+    @override
+    def list_by_state(self, state_id: str) -> Sequence[AgentEvidence]:
+        return tuple(
+            artifact
+            for artifact in self._evidence.values()
+            if artifact.agent_state_id == state_id
+        )
+
+    @override
+    def list_by_manifest_ref(self, manifest_ref: str) -> Sequence[AgentEvidence]:
+        return ()

--- a/core/spakky-agent/tests/unit/test_code_assistant_demo.py
+++ b/core/spakky-agent/tests/unit/test_code_assistant_demo.py
@@ -8,8 +8,6 @@ from examples.code_assistant_demo import (
     IShellPort,
     IWorkspacePort,
     CodeAssistant,
-    CodeAssistantCommand,
-    CodeAssistantResult,
     GitCommandResult,
     ShellCommandResult,
     StaticModel,
@@ -26,6 +24,7 @@ from spakky.agent import (
     Agent,
     AgentEvidence,
     AgentEvidenceKind,
+    AgentRunResult,
     AgentSignal,
     AgentSignalKind,
     AgentState,
@@ -48,6 +47,7 @@ from spakky.agent import (
     ModelStreamEventKind,
     ModelToolCall,
     Progress,
+    RunAgentInput,
     Token,
     Tool,
 )
@@ -136,7 +136,7 @@ async def test_code_assistant_demo_expect_runs_end_to_end_building_block_scenari
         states,
         signals,
         evidence,
-        CodeAssistantCommand(state_id="run-1", instruction="make a small edit"),
+        RunAgentInput(state_id="run-1", instruction="make a small edit"),
     )
 
     assert _kinds(items) == {
@@ -174,7 +174,7 @@ async def test_code_assistant_demo_expect_runs_end_to_end_building_block_scenari
     ]
     final_payload = _final_payload(items)
 
-    assert final_payload.output == CodeAssistantResult(
+    assert final_payload.output == AgentRunResult(
         state_id="run-1",
         status="completed",
         tool_calls=(
@@ -210,7 +210,7 @@ async def test_code_assistant_demo_expect_cancellation_reaches_terminal_state() 
         states,
         FakeSignalRepository((_cancel_signal("cancel-run"),)),
         evidence,
-        CodeAssistantCommand(state_id="cancel-run", instruction="stop now"),
+        RunAgentInput(state_id="cancel-run", instruction="stop now"),
     )
 
     assert len(items) == 1
@@ -245,7 +245,7 @@ async def test_code_assistant_demo_expect_model_stream_error_fails_state() -> No
         states,
         FakeSignalRepository(()),
         FakeEvidenceRepository(),
-        CodeAssistantCommand(state_id="error-run", instruction="trigger model error"),
+        RunAgentInput(state_id="error-run", instruction="trigger model error"),
     )
 
     assert [item.kind for item in items] == [
@@ -285,7 +285,7 @@ async def test_code_assistant_demo_expect_restart_resume_uses_persisted_boundari
         states,
         signals,
         evidence,
-        CodeAssistantCommand(state_id="resume-run", instruction="status"),
+        RunAgentInput(state_id="resume-run", instruction="status"),
     )
     items = await collect_stream(
         StaticModel((ModelStreamEvent(kind=ModelStreamEventKind.DONE),)),
@@ -295,7 +295,7 @@ async def test_code_assistant_demo_expect_restart_resume_uses_persisted_boundari
         states,
         signals,
         evidence,
-        CodeAssistantCommand(
+        RunAgentInput(
             state_id="resume-run",
             instruction="resume",
             resume=True,
@@ -308,6 +308,50 @@ async def test_code_assistant_demo_expect_restart_resume_uses_persisted_boundari
         and "skip_completed" in item.payload.message
         for item in items
     )
+
+
+async def test_code_assistant_demo_expect_steering_hook_echoes_instruction() -> None:
+    """STEERING_INSTRUCTION signal은 @on_signal 훅의 Progress yield로 stream에 노출된다."""
+    states = FakeStateRepository()
+    evidence = FakeEvidenceRepository()
+    signals = FakeSignalRepository(
+        (
+            AgentSignal(
+                id="steer:run-1",
+                agent_state_id="run-1",
+                kind=AgentSignalKind.STEERING_INSTRUCTION,
+                payload={"instruction": "narrow the diff to one file"},
+            ),
+        )
+    )
+
+    items = await collect_stream(
+        StaticModel(
+            (
+                ModelStreamEvent(
+                    kind=ModelStreamEventKind.TOKEN_DELTA, token_delta="ok"
+                ),
+                ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+            )
+        ),
+        FakeWorkspace({}),
+        FakeShell(),
+        FakeGit(),
+        states,
+        signals,
+        evidence,
+        RunAgentInput(state_id="run-1", instruction="edit a file"),
+    )
+
+    assert any(
+        item.kind is AgentYieldKind.PROGRESS
+        and isinstance(item.payload, Progress)
+        and item.payload.current_step == "steering"
+        and "narrow the diff to one file" in item.payload.message
+        for item in items
+    )
+    assert signals.list_pending("run-1") == ()
+    assert states.get("run-1").status is AgentStatus.COMPLETED
 
 
 class RecordingModel(IAgentModel):
@@ -543,7 +587,7 @@ def _kinds(items: Sequence[AgentYield[object]]) -> set[AgentYieldKind]:
     return {item.kind for item in items}
 
 
-def _final_payload(items: Sequence[AgentYield[object]]) -> Final[CodeAssistantResult]:
+def _final_payload(items: Sequence[AgentYield[object]]) -> Final[AgentRunResult]:
     for item in reversed(items):
         if isinstance(item.payload, Final):
             return item.payload

--- a/core/spakky-agent/tests/unit/test_hooks.py
+++ b/core/spakky-agent/tests/unit/test_hooks.py
@@ -1,0 +1,337 @@
+"""Tests for declarative @on_signal signal-hook discovery (ADR-0013 §1)."""
+
+from collections.abc import AsyncGenerator
+import typing
+from typing import override
+
+import pytest
+
+from spakky.agent import (
+    AgentSignal,
+    AgentSignalKind,
+    AgentYield,
+    AgentYieldKind,
+    Progress,
+    on_signal,
+)
+from spakky.agent.error import AgentDefinitionError
+from spakky.agent.hooks import (
+    AGENT_SIGNAL_HOOK_DEFINITION_KEY,
+    AgentSignalHookCatalog,
+    AgentSignalHookDescriptor,
+    AgentSignalHookIdentity,
+    discover_agent_signal_hooks,
+)
+
+
+def _progress_yield(text: str) -> AgentYield[object]:
+    return AgentYield(
+        kind=AgentYieldKind.PROGRESS,
+        payload=Progress(text, current_step="steering"),
+    )
+
+
+def test_discover_agent_signal_hooks_expect_valid_hook_bound_to_kind() -> None:
+    """async-generator @on_signal 메서드는 kind와 함께 descriptor로 발견된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        async def react(
+            self,
+            signal: AgentSignal,
+        ) -> AsyncGenerator[AgentYield[object], None]:
+            yield _progress_yield(signal.id)
+
+    catalog = discover_agent_signal_hooks(Owner)
+
+    assert len(catalog.descriptors) == 1
+    descriptor = catalog.descriptors[0]
+    assert descriptor.kind is AgentSignalKind.STEERING_INSTRUCTION
+    assert descriptor.identity.member_name == "react"
+    assert descriptor.owner is Owner
+
+
+def test_discover_agent_signal_hooks_expect_non_async_generator_rejected() -> None:
+    """@on_signal가 async generator가 아니면 정의 에러로 거부된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        def react(self, signal: AgentSignal) -> None:
+            return None
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)
+
+
+def test_discover_agent_signal_hooks_expect_missing_self_rejected() -> None:
+    """@on_signal 메서드의 첫 인자가 self가 아니면 인스턴스 메서드 아님으로 거부된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        # pyrefly: ignore - 첫 인자 self 누락 거부 검증 (의도적 위반)
+        async def react(
+            signal: AgentSignal,
+        ) -> AsyncGenerator[AgentYield[object], None]:
+            yield _progress_yield(signal.id)
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)
+
+
+def test_discover_agent_signal_hooks_expect_extra_argument_rejected() -> None:
+    """signal 외 인자를 받는 @on_signal 메서드는 거부된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        async def react(
+            self,
+            signal: AgentSignal,
+            extra: str,
+        ) -> AsyncGenerator[AgentYield[object], None]:
+            yield _progress_yield(signal.id + extra)
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)
+
+
+def test_discover_agent_signal_hooks_expect_variadic_argument_rejected() -> None:
+    """가변 인자를 쓰는 @on_signal 메서드는 거부된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        async def react(
+            self,
+            *signal: AgentSignal,
+        ) -> AsyncGenerator[AgentYield[object], None]:
+            yield _progress_yield(signal[0].id)
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)
+
+
+def test_discover_agent_signal_hooks_expect_missing_annotation_rejected() -> None:
+    """signal 인자에 타입 주석이 없으면 거부된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        async def react(self, signal) -> AsyncGenerator[AgentYield[object], None]:  # type: ignore[no-untyped-def] - 의도적 미주석 거부 검증
+            yield _progress_yield(signal.id)
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)
+
+
+def test_discover_agent_signal_hooks_expect_wrong_annotation_rejected() -> None:
+    """signal 인자가 AgentSignal이 아니면 거부된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        async def react(
+            self,
+            signal: str,
+        ) -> AsyncGenerator[AgentYield[object], None]:
+            yield _progress_yield(signal)
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)
+
+
+def test_discover_agent_signal_hooks_expect_missing_return_annotation_rejected() -> (
+    None
+):
+    """반환 타입 주석이 없으면 거부된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        async def react(self, signal: AgentSignal):  # type: ignore[no-untyped-def] - 의도적 미주석 거부 검증
+            yield _progress_yield(signal.id)
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)
+
+
+def test_discover_agent_signal_hooks_expect_non_async_generator_return_rejected() -> (
+    None
+):
+    """반환 타입이 AsyncGenerator가 아니면 거부된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        # pyrefly: ignore - AsyncGenerator 아닌 반환 타입 거부 검증 (의도적 위반)
+        async def react(self, signal: AgentSignal) -> "list[AgentYield[object]]":
+            yield _progress_yield(signal.id)
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)
+
+
+def test_discover_agent_signal_hooks_expect_non_agent_yield_type_rejected() -> None:
+    """AsyncGenerator의 yield 타입이 AgentYield가 아니면 거부된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        async def react(
+            self,
+            signal: AgentSignal,
+        ) -> AsyncGenerator[str, None]:
+            yield signal.id
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)
+
+
+def test_discover_agent_signal_hooks_expect_unresolvable_annotation_rejected() -> None:
+    """해석할 수 없는 주석은 거부된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        async def react(
+            self,
+            # pyrefly: ignore - 미해석 주석 거부 검증 (의도적 위반)
+            signal: "MissingType",  # noqa: F821 - 미해석 주석 거부 검증
+        ) -> AsyncGenerator[AgentYield[object], None]:
+            yield _progress_yield(signal.id)
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)
+
+
+def test_agent_signal_hook_catalog_expect_duplicate_identity_rejected() -> None:
+    """중복 identity를 가진 descriptor는 catalog 생성 시 거부된다."""
+
+    async def react(
+        target: object,
+        signal: AgentSignal,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        yield _progress_yield(signal.id)
+
+    identity = AgentSignalHookIdentity(
+        owner_module="m",
+        owner_qualname="Owner",
+        member_name="react",
+    )
+    descriptor = AgentSignalHookDescriptor(
+        identity=identity,
+        owner=object,
+        callable=react,
+        kind=AgentSignalKind.STEERING_INSTRUCTION,
+    )
+
+    with pytest.raises(AgentDefinitionError):
+        AgentSignalHookCatalog(descriptors=(descriptor, descriptor))
+
+
+def test_agent_signal_hook_catalog_expect_hooks_for_filters_by_kind() -> None:
+    """hooks_for는 요청 kind에 해당하는 hook만 반환한다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        async def steer(
+            self,
+            signal: AgentSignal,
+        ) -> AsyncGenerator[AgentYield[object], None]:
+            yield _progress_yield(signal.id)
+
+        @on_signal(AgentSignalKind.EXTERNAL_EVENT)
+        async def external(
+            self,
+            signal: AgentSignal,
+        ) -> AsyncGenerator[AgentYield[object], None]:
+            yield _progress_yield(signal.id)
+
+    catalog = discover_agent_signal_hooks(Owner)
+
+    steering = catalog.hooks_for(AgentSignalKind.STEERING_INSTRUCTION)
+    assert [descriptor.identity.member_name for descriptor in steering] == ["steer"]
+    assert catalog.hooks_for(AgentSignalKind.USER_MESSAGE) == ()
+
+
+def test_discover_agent_signal_hooks_expect_subclass_override_wins_over_parent() -> (
+    None
+):
+    """MRO 상에서 동일 멤버명은 가장 파생된 정의가 채택된다."""
+
+    class Parent:
+        @on_signal(AgentSignalKind.EXTERNAL_EVENT)
+        async def react(
+            self,
+            signal: AgentSignal,
+        ) -> AsyncGenerator[AgentYield[object], None]:
+            yield _progress_yield("parent")
+
+    class Child(Parent):
+        @override
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        async def react(
+            self,
+            signal: AgentSignal,
+        ) -> AsyncGenerator[AgentYield[object], None]:
+            yield _progress_yield("child")
+
+    catalog = discover_agent_signal_hooks(Child)
+
+    assert len(catalog.descriptors) == 1
+    assert catalog.descriptors[0].kind is AgentSignalKind.STEERING_INSTRUCTION
+    assert catalog.descriptors[0].owner is Child
+
+
+def test_discover_agent_signal_hooks_expect_inherited_hook_discovered() -> None:
+    """부모에 정의된 hook은 자식 클래스 discovery에서도 발견된다."""
+
+    class Parent:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        async def react(
+            self,
+            signal: AgentSignal,
+        ) -> AsyncGenerator[AgentYield[object], None]:
+            yield _progress_yield(signal.id)
+
+    class Child(Parent):
+        """Child adds no hook of its own."""
+
+    catalog = discover_agent_signal_hooks(Child)
+
+    assert len(catalog.descriptors) == 1
+    assert catalog.descriptors[0].owner is Parent
+
+
+def test_discover_agent_signal_hooks_expect_invalid_metadata_rejected() -> None:
+    """@on_signal 메타데이터 슬롯에 잘못된 값이 박히면 거부된다."""
+
+    class Owner:
+        async def react(
+            self,
+            signal: AgentSignal,
+        ) -> AsyncGenerator[AgentYield[object], None]:
+            yield _progress_yield(signal.id)
+
+    Owner.react.__dict__[AGENT_SIGNAL_HOOK_DEFINITION_KEY] = "not-a-definition"
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)
+
+
+def test_discover_agent_signal_hooks_expect_bare_async_generator_rejected() -> None:
+    """타입 파라미터 없는 AsyncGenerator 반환 주석은 yield 타입 누락으로 거부된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        # pyrefly: ignore - yield 타입 누락 거부 검증 (의도적 위반)
+        async def react(self, signal: AgentSignal) -> AsyncGenerator:
+            yield _progress_yield(signal.id)
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)
+
+
+def test_discover_agent_signal_hooks_expect_unparametrized_generic_rejected() -> None:
+    """origin은 AsyncGenerator지만 인자가 비면 yield 타입 누락으로 거부된다."""
+
+    class Owner:
+        @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+        # pyrefly: ignore - yield 타입 누락 거부 검증 (의도적 위반)
+        async def react(self, signal: AgentSignal) -> typing.AsyncGenerator:
+            yield _progress_yield(signal.id)
+
+    with pytest.raises(AgentDefinitionError):
+        discover_agent_signal_hooks(Owner)

--- a/core/spakky-agent/tests/unit/test_inbound_adapter_examples.py
+++ b/core/spakky-agent/tests/unit/test_inbound_adapter_examples.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Sequence
 from io import StringIO
 from typing import cast, overload
 
-from examples.code_assistant_demo import CodeAssistant, CodeAssistantCommand
+from examples.code_assistant_demo import CodeAssistant
 from examples.inbound_adapter_examples import (
     AgentJsonWebSocket,
     agent_signal_from_json,
@@ -18,6 +18,7 @@ from spakky.agent import (
     JsonValue,
     ModelStreamEvent,
     ModelStreamEventKind,
+    RunAgentInput,
 )
 from spakky.core.pod.annotations.pod import Pod, PodType
 from spakky.core.pod.interfaces.container import IContainer, NoSuchPodError
@@ -39,19 +40,19 @@ async def test_fastapi_websocket_example_expect_streams_agent_yields_and_appends
     """WebSocket adapter resolves @Agent and forwards token/progress/approval/final."""
     signals = FakeSignalRepository(())
     container = RecordingContainer(_code_assistant(signals), signals)
-    socket = RecordingWebSocket(
-        (
-            {
-                "kind": "approval_decision",
-                "decision": "approve",
-            },
-        )
-    )
+    socket = RecordingWebSocket(())
 
     await stream_code_assistant_to_websocket(
         container,
         socket,
-        CodeAssistantCommand(state_id="ws-run", instruction="write approved note"),
+        RunAgentInput(state_id="ws-run", instruction="write approved note"),
+        inbound_signals=(
+            {
+                "kind": "approval_decision",
+                "request_id": "approval:ws-run:workspace.write",
+                "decision": "approve",
+            },
+        ),
     )
 
     assert container.resolved_types == (CodeAssistant, IAgentSignalRepository)
@@ -75,14 +76,16 @@ async def test_typer_cli_example_expect_stdout_streaming_and_stdin_user_signal_a
         "".join(
             (
                 '{"kind":"user_message","message":"keep it small"}\n',
-                '{"kind":"approval_decision","decision":"approve"}\n',
+                '{"kind":"approval_decision",'
+                '"request_id":"approval:cli-run:workspace.write",'
+                '"decision":"approve"}\n',
             )
         )
     )
 
     await stream_code_assistant_to_stdout(
         container,
-        CodeAssistantCommand(state_id="cli-run", instruction="write approved note"),
+        RunAgentInput(state_id="cli-run", instruction="write approved note"),
         stdout=stdout,
         stdin=stdin,
         read_stdin_signal=True,

--- a/docs/api/core/spakky-agent.md
+++ b/docs/api/core/spakky-agent.md
@@ -93,6 +93,12 @@ SQLAlchemy, FastAPI, Typer를 import하지 않습니다. 운영에서 durable ex
     options:
       show_root_heading: false
 
+## Signal Hooks
+
+::: spakky.agent.hooks
+    options:
+      show_root_heading: false
+
 ## Yield
 
 ::: spakky.agent.yield_

--- a/docs/guides/agent-code-assistant.md
+++ b/docs/guides/agent-code-assistant.md
@@ -2,7 +2,7 @@
 
 > `spakky-agent`의 tool, approval, evidence, state/signal repository를 하나의 실행 흐름으로 연결하는 심화 예제입니다.
 
-이 문서는 [AI Agent 개발](agents.md)과 [AI Agent 심화](agents-advanced.md)를 읽은 뒤 보는 실행 가능한 예제입니다. `core/spakky-agent/examples/code_assistant_demo.py`는 `CodeAssistant`가 생성자 주입으로 model, workspace, shell, git, state/signal/evidence repository를 받고, 외부 세계 동작을 `@agent_tool` 메서드로 노출하는 흐름을 보여줍니다.
+이 문서는 [AI Agent 개발](agents.md)과 [AI Agent 심화](agents-advanced.md)를 읽은 뒤 보는 실행 가능한 예제입니다. `core/spakky-agent/examples/code_assistant_demo.py`는 `CodeAssistant`가 생성자 주입으로 model, workspace, shell, git, state/signal/evidence repository를 받고, 외부 세계 동작을 `@agent_tool` 메서드로 노출하는 **선언형** 흐름을 보여줍니다. `CodeAssistant`에는 `execute()` 본문이 없습니다 — model 호출 → tool 호출 → 승인 → evidence → 종료 루프는 프레임워크 runner가 spec과 `@agent_tool` 카탈로그로부터 자동 제공합니다 (ADR-0013 §1). 시그널 반응이 필요한 지점은 `@on_signal` 훅으로 선언합니다.
 
 ## 무엇을 검증하나
 
@@ -35,37 +35,40 @@ uv run pytest tests/acceptance/test_code_assistant_demo_acceptance.py -q --no-co
 `spakky-sqlalchemy[agent]`가 제공하는 `spakky.contributions.spakky.agent`
 contribution을 사용해야 합니다.
 
-가장 작은 실행 가능한 `@Agent` 형태는 다음 예시와 같습니다. 파일로 저장해 애플리케이션 scan 대상에 포함하면 `CodeAssistant`는 일반 UseCase처럼 container에서 resolve됩니다.
+가장 작은 선언형 `@Agent` 형태는 다음 예시와 같습니다. 도구만 선언하고 `execute()`를 생략하면, 파일로 저장해 애플리케이션 scan 대상에 포함했을 때 `CodeAssistant`는 일반 UseCase처럼 container에서 resolve되고, runner가 표준 실행 루프를 `execute()`로 제공합니다.
 
 ```python
-from collections.abc import AsyncGenerator
+from spakky.agent import (
+    Agent,
+    AgentExecutionSpec,
+    EvidenceCapture,
+    IAgentModel,
+    Idempotency,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
 
-from spakky.agent import Agent, AgentExecutionSpec, AgentYield, AgentYieldKind, Final
-from spakky.core.pod.annotations.pod import Pod
 
-
-@Pod()
-class AnswerTools:
-    def answer(self, command: str) -> str:
-        return f"handled:{command}"
-
-
-@Agent(spec=AgentExecutionSpec(name="code_assistant", objective="handle commands"))
+@Agent(spec=AgentExecutionSpec(name="code_assistant", objective="inspect a workspace"))
 class CodeAssistant:
-    def __init__(self, tools: AnswerTools) -> None:
-        self._tools = tools
+    def __init__(self, model: IAgentModel, workspace: IWorkspacePort) -> None:
+        self._model = model
+        self._workspace = workspace
 
-    async def execute(
-        self,
-        command: str,
-    ) -> AsyncGenerator[AgentYield[Final[str]], None]:
-        yield AgentYield(
-            kind=AgentYieldKind.FINAL,
-            payload=Final(output=self._tools.answer(command), metadata={}),
-        )
+    @agent_tool(
+        schema_name="workspace.read",
+        description="Read a text file from the bounded workspace.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def workspace_read(self, path: str) -> WorkspaceReadResult:
+        return self._workspace.read_text(path)
 ```
 
-CodeAssistant 예제는 이 최소 형태에 model stream, workspace/shell/git port, approval signal, evidence repository, action boundary resume를 더한 구성입니다. 각 개념의 배경은 [AI Agent 심화](agents-advanced.md)에서 먼저 확인할 수 있습니다.
+`code_assistant_demo.py`의 CodeAssistant는 이 최소 형태에 workspace/shell/git port 도구 7종, write/shell/apply 도구의 approval, evidence repository, action boundary resume, 그리고 `@on_signal(AgentSignalKind.STEERING_INSTRUCTION)` 훅을 더한 구성입니다. 각 개념의 배경은 [AI Agent 심화](agents-advanced.md)에서 먼저 확인할 수 있습니다.
 
 ## 구조
 
@@ -83,10 +86,11 @@ print([descriptor.schema.name for descriptor in agent.tool_catalog.descriptors])
 
 ## 실행 collector
 
-예제 파일의 `collect_stream()`은 FastAPI, WebSocket, Typer 같은 inbound adapter가 할 일을 작은 함수로 축약한 것입니다.
+예제 파일의 `collect_stream()`은 FastAPI, WebSocket, Typer 같은 inbound adapter가 할 일을 작은 함수로 축약한 것입니다. 호출 입력은 `RunAgentInput`이며, runner-backed `execute()`를 순회해 `AgentYield` stream을 모읍니다.
 
 ```python
-from examples.code_assistant_demo import CodeAssistantCommand, collect_stream
+from examples.code_assistant_demo import collect_stream
+from spakky.agent import RunAgentInput
 
 items = await collect_stream(
     model,
@@ -96,14 +100,14 @@ items = await collect_stream(
     states,
     signals,
     evidence,
-    CodeAssistantCommand(
+    RunAgentInput(
         state_id="run-1",
         instruction="inspect the workspace and make a small approved edit",
     ),
 )
 ```
 
-반환되는 item은 `AgentYield` stream입니다. inbound adapter는 `token`, `tool`, `evidence`, `approval`, `cancel`, `final`을 transport별 이벤트로 바꾸면 됩니다. 별도 Agent 전용 inbound adapter package는 필요하지 않습니다.
+반환되는 item은 `AgentYield` stream입니다. inbound adapter는 `token`, `tool`, `evidence`, `approval`, `cancel`, `final`을 transport별 이벤트로 바꾸면 됩니다. 최종 `FINAL` payload는 runner가 만드는 `AgentRunResult`(state_id, status, tool_calls, evidence_count)입니다. 별도 Agent 전용 inbound adapter package는 필요하지 않습니다.
 
 ## FastAPI WebSocket / Typer adapter 예제
 
@@ -118,7 +122,7 @@ from examples.inbound_adapter_examples import CodeAssistantWebSocketController
 # WebSocket path: /agents/code/ws
 ```
 
-각 `AgentYield`는 `{"kind": ..., "payload": ...}` JSON event로 전송됩니다. `approval` event를 보낸 뒤 client가 `{"kind": "approval_decision", "decision": "approve"}` 같은 payload를 보내면 adapter가 `IAgentSignalRepository.append()`로 decision signal을 추가하고 generator를 계속 소비합니다.
+각 `AgentYield`는 `{"kind": ..., "payload": ...}` JSON event로 전송됩니다. runner는 approval decision을 durable signal queue에서 non-blocking으로 확인하므로, WebSocket 예제는 첫 command payload의 `signals` 배열에 사전 수신된 user message / approval decision을 넣어 큐에 append한 뒤 stream을 시작합니다.
 
 Typer 쪽은 `@CliController("agents")`와 `@command("code")`를 사용합니다. command handler 역시 container에서 `CodeAssistant`를 resolve하고 `execute()`를 호출합니다.
 
@@ -126,7 +130,7 @@ Typer 쪽은 `@CliController("agents")`와 `@command("code")`를 사용합니다
 python main.py agents code --state-id run-1 --instruction "inspect and edit" --read-stdin-signal
 ```
 
-`token` yield는 stdout에 즉시 이어 쓰고, `progress`, `approval`, `final` 같은 구조화 event는 줄 단위로 출력합니다. `--read-stdin-signal`을 켜면 첫 stdin JSON line을 user message signal로 append하고, approval 대기 시 다음 stdin JSON line을 approval decision signal로 append합니다.
+`token` yield는 stdout에 즉시 이어 쓰고, `progress`, `approval`, `final` 같은 구조화 event는 줄 단위로 출력합니다. `--read-stdin-signal`을 켜면 stdin JSON line들을 실행 전에 signal queue로 append합니다. 따라서 approval을 같은 run에서 통과시키려면 해당 approval decision JSON line을 미리 제공하고, 이미 `approval` event를 받은 뒤 decision을 보낸 경우에는 같은 state_id로 resume run을 시작합니다.
 
 ## Approval과 resume
 

--- a/docs/guides/agents-advanced.md
+++ b/docs/guides/agents-advanced.md
@@ -1,6 +1,6 @@
 # AI Agent 심화
 
-> `spakky-agent`의 tool catalog, approval, durable execution, transport adapter, AG-UI/CopilotKit 연동을 다룹니다.
+> `spakky-agent`의 tool catalog, approval, `@on_signal` 선언형 훅, context compaction, teammate, durable execution, transport adapter, AG-UI/CopilotKit 연동을 다룹니다.
 
 이 문서는 [AI Agent 개발](agents.md)을 읽은 뒤 보는 심화 가이드입니다. 여기서는 작은 Agent를 운영형 Agent로 확장할 때 필요한 선택지를 정리합니다.
 
@@ -128,21 +128,23 @@ request = ModelRequest(
 )
 ```
 
-Model adapter가 `ModelStreamEventKind.TOOL_CALL_CANDIDATE`를 내보내면 Agent는 보통 다음 순서로 처리합니다.
+Model adapter가 `ModelStreamEventKind.TOOL_CALL_CANDIDATE`를 내보내면, **runner가** 다음 순서를 자동으로 수행합니다 (개발자가 루프 본문에 작성하지 않습니다, ADR-0013 §1).
 
 1. `call.name`으로 `AgentToolCatalog`에서 descriptor를 찾습니다.
 2. `plan_agent_tool_approval()`로 approval이 필요한지 판단합니다.
-3. 필요하면 `AgentYieldKind.APPROVAL`을 yield하고 decision signal을 기다립니다.
+3. 필요하면 `AgentYieldKind.APPROVAL`을 yield하고 decision signal을 기다립니다 (HITL pause → resume).
 4. 승인되었거나 approval이 필요 없으면 `descriptor.bind_invocation(call.arguments)`로 argument를 검증합니다.
 5. Python method를 호출합니다.
-6. result를 `AgentYieldKind.TOOL`이나 evidence로 남깁니다.
+6. result를 `AgentYieldKind.TOOL`과 append-only evidence로 남깁니다.
+
+`bind_invocation()`은 model payload가 Python signature와 맞는지 검사합니다. 필수 인자 누락, 알 수 없는 인자, 중복 인자는 tool method가 실행되기 전에 `AgentToolBindingError`로 실패합니다. 이 전체 dispatch는 `AgentToolDispatcher`가 담당하며, 외부 MCP 도구도 같은 `AgentToolCatalog`로 정규화되어 동일 경로로 호출됩니다.
+
+루프 본문을 직접 들여다보고 싶다면 동일 단계를 명시적으로 작성한 코드는 다음과 같습니다 — 커스텀 제어가 필요할 때만 `execute()` 본문으로 옮깁니다.
 
 ```python
 from spakky.agent import Agent, AgentYield, plan_agent_tool_approval
 
-metadata = Agent.get(CodeAssistant)
-descriptor = metadata.tool_catalog.by_schema_name(call.name)
-
+descriptor = Agent.get(CodeAssistant).tool_catalog.by_schema_name(call.name)
 approval = plan_agent_tool_approval(
     descriptor=descriptor,
     approval_id=f"approval:{state.id}:{call.name}",
@@ -150,16 +152,12 @@ approval = plan_agent_tool_approval(
     agent_type="CodeAssistant",
     call_id=call.call_id,
 )
-
 if approval.requires_approval and approval.yield_item is not None:
     yield AgentYield(kind=approval.yield_item.kind, payload=approval.yield_item.payload)
     return
-
 bound = descriptor.bind_invocation(call.arguments)
 result = descriptor.callable(self, *bound.args, **bound.kwargs)
 ```
-
-`bind_invocation()`은 model payload가 Python signature와 맞는지 검사합니다. 필수 인자 누락, 알 수 없는 인자, 중복 인자는 tool method가 실행되기 전에 `AgentToolBindingError`로 실패합니다.
 
 ## Approval, signal, cancel
 
@@ -196,6 +194,61 @@ Signal은 실행 중 Agent에게 들어오는 외부 입력입니다.
 Durable repository를 쓰는 경우 orchestration은 safe boundary에서 `consume_pending_agent_signals()`를 호출합니다. 이 helper는 pending queue를 append order로 읽고, 현재 Agent가 받아들일 수 있는 prefix만 consumed 처리합니다.
 
 Cancel은 바로 terminal state로 덮어쓰는 flag가 아닙니다. 일반적인 흐름은 `begin_agent_cancellation()`으로 state를 `CANCELLING`으로 만들고, model stream/tool/delegate cleanup hook을 실행한 뒤 `complete_agent_cancellation()`으로 끝냅니다.
+
+## 선언형 시그널 훅: `@on_signal`
+
+`CANCEL`과 `APPROVAL_DECISION`은 runner가 전용 단계에서 처리하지만, 그 외 시그널(`USER_MESSAGE`·`STEERING_INSTRUCTION`·`EXTERNAL_EVENT`·`SCHEDULER_WAKE_UP` 등)에 **커스텀 반응**을 붙이고 싶을 때 `@on_signal`을 씁니다. 이것은 `@agent_tool`과 같은 선언형 seam입니다 — `execute()` 루프를 작성하지 않고, 시그널 종류별 핸들러만 선언하면 runner가 해당 시그널을 소비하는 poll 지점에서 자동 호출합니다.
+
+```python
+from collections.abc import AsyncGenerator
+
+from spakky.agent import (
+    Agent,
+    AgentExecutionSpec,
+    AgentSignal,
+    AgentSignalKind,
+    AgentYield,
+    AgentYieldKind,
+    Progress,
+    on_signal,
+)
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="steerable_agent",
+        objective="react to steering instructions mid-run",
+        accepted_signals=(AgentSignalKind.STEERING_INSTRUCTION,),
+        recovery=RecoveryStrategy.ACTION_BOUNDARY,
+    )
+)
+class SteerableAgent:
+    def __init__(self, model: IAgentModel, states, signals, evidence) -> None:
+        ...
+
+    @on_signal(AgentSignalKind.STEERING_INSTRUCTION)
+    async def on_steering(
+        self,
+        signal: AgentSignal,
+    ) -> AsyncGenerator[AgentYield[object], None]:
+        yield AgentYield(
+            kind=AgentYieldKind.PROGRESS,
+            payload=Progress(
+                f"steering applied: {signal.payload.get('instruction')}",
+                current_step="steering",
+            ),
+        )
+```
+
+`@on_signal` 계약은 정의 시점에 검증됩니다.
+
+- 메서드는 `async def`이며 `AgentYield` item을 yield하는 async generator여야 합니다.
+- `self` 외에 정확히 하나의 `signal: AgentSignal` 인자를 받아야 합니다.
+- 반환 annotation은 `AsyncGenerator[AgentYield[...], None]`이어야 합니다.
+
+위반하면 bootstrap 전에 `AgentDefinitionError`로 실패합니다. 훅이 선언된 시그널 종류는 훅이 소비를 책임지고 yield한 item이 public stream으로 흘러갑니다. 훅이 없는 `USER_MESSAGE`는 runner의 기본 "user message consumed" progress로 폴백합니다.
+
+pydantic-ai의 `@agent.instructions`/event handler 데코레이터처럼, `@on_signal`은 비즈니스 반응만 선언하고 폴링·소비·evidence 기록은 runner가 담당합니다.
 
 ## Durable 실행과 repository
 
@@ -247,6 +300,64 @@ Restart 후에는 `plan_agent_resume(state, evidence, pending_signals)`가 다�
 
 Evidence는 append-only입니다. Tool result를 수정하거나 삭제해서 history를 고치지 않고, redaction, correction, context digest 갱신도 새 evidence를 append하는 방식으로 표현합니다.
 
+## Context compaction
+
+긴 멀티턴 대화는 결국 model backend의 context window를 넘습니다. 압축할지 여부(언제)는 runner가 소유하고, 압축하는 방법(어떻게)은 교체 가능한 `ICompactionStrategy` 포트가 담당합니다 (ADR-0013 §7). `@Agent` spec에 `AgentCompactionPolicy`를 선언하면 runner가 각 model 요청 직전, 누적 토큰 추정치가 임계값을 넘었을 때 선언된 전략 chain을 history에 적용합니다 — 개발자가 루프 본문에서 직접 호출하지 않습니다.
+
+```python
+from spakky.agent import (
+    AgentCompactionPolicy,
+    AgentExecutionSpec,
+    KeepRecentMessagesCompactionStrategy,
+    TrimToolResultsCompactionStrategy,
+)
+
+spec = AgentExecutionSpec(
+    name="long_session_agent",
+    objective="hold a long multi-turn session",
+    compaction=AgentCompactionPolicy(
+        strategies=(
+            TrimToolResultsCompactionStrategy(max_characters=2000),
+            KeepRecentMessagesCompactionStrategy(max_messages=20),
+        ),
+        trigger_token_threshold=8000,
+    ),
+)
+```
+
+`strategies`는 순서대로 적용되는 chain입니다 — 각 전략의 출력이 다음 전략의 입력이 됩니다. 내장 전략은 다음과 같습니다.
+
+| 전략 | 압축 방식 |
+|------|-----------|
+| `KeepRecentMessagesCompactionStrategy` | 가장 오래된 메시지를 버리고 최근 N개만 유지 (가장 저렴) |
+| `TrimToolResultsCompactionStrategy` | 오래된 tool result 본문을 잘라 토큰을 줄임 |
+| `SummarizeOldTurnsCompactionStrategy` | 보조 model 호출로 오래된 turn을 요약 (가장 풍부) |
+| `ProviderManagedCompactionStrategy` | history를 그대로 두고 provider가 압축을 소유 (no-op 명시) |
+
+`ICompactionStrategy`를 직접 구현해 커스텀 전략을 주입할 수도 있습니다. 압축은 ADR-0009 `ContextDigest` 모델과 정렬되어 raw evidence를 대체하지 않고 derived 결과로 표현됩니다.
+
+pydantic-ai의 message history processor / `compact_messages` capability와 같은 자리를 `ICompactionStrategy` 포트가 채웁니다.
+
+## Teammate (팀 모드)와 delegation
+
+multi-agent 팀 모드는 `@Agent` spec의 `teammates`로 선언합니다. 로컬 teammate는 로컬 `@Agent` Pod 타입으로, 원격 teammate는 A2A `AgentCard` 엔드포인트 URL로 해석됩니다 (ADR-0013 §8).
+
+```python
+from spakky.agent import AgentExecutionSpec, AgentTeammate
+
+spec = AgentExecutionSpec(
+    name="orchestrator",
+    objective="delegate sub-tasks to teammates",
+    delegation_allowed=True,
+    teammates=(
+        AgentTeammate(name="researcher", pod=ResearchAgent),
+        AgentTeammate(name="remote_reviewer", card_url="https://reviewer.example/agent"),
+    ),
+)
+```
+
+`AgentTeammate`는 정확히 하나의 바인딩(로컬 `pod` 또는 원격 `card_url`)만 선언해야 하며, 위반 시 정의 시점에 `AgentDefinitionError`로 실패합니다. 위임은 ADR-0009 delegation building block(`DelegationPacket`/`DelegationResult`) 위에서 동작하고, 원격 위임은 A2A 어댑터를 통해 확장됩니다.
+
 ## FastAPI, WebSocket, SSE, CLI
 
 Agent 전용 inbound package는 필요하지 않습니다. 기존 `spakky-fastapi`나 `spakky-typer` controller에서 Agent를 resolve하고 stream을 변환합니다.
@@ -256,9 +367,13 @@ WebSocket adapter의 핵심은 다음과 같습니다.
 ```python
 @websocket("/agents/code/ws")
 async def code_socket(self, websocket: WebSocket) -> None:
-    command = await websocket.receive_json()
+    payload = await websocket.receive_json()
+    run_input = code_assistant_command_from_json(payload)
     agent = self._container.get(CodeAssistant)
-    async for item in agent.execute(command):
+    signals = self._container.get(IAgentSignalRepository)
+    for signal_payload in code_assistant_signals_from_json(payload):
+        signals.append(agent_signal_from_json(run_input.state_id, signal_payload))
+    async for item in agent.execute(run_input):
         await websocket.send_json(agent_yield_to_event(item))
 ```
 
@@ -316,11 +431,13 @@ uv run pytest tests/acceptance/test_code_assistant_demo_acceptance.py -q --no-co
 
 ## 운영 체크리스트
 
-- `@Agent.execute()` input과 return/yield type이 모두 annotate되어 있습니다.
+- 가능한 한 `execute()` 본문을 생략하고 runner-backed 루프를 사용합니다. 커스텀 `execute()`를 직접 쓸 때만 input과 return/yield type을 모두 annotate합니다.
 - Agent가 provider SDK, DB client, HTTP framework를 직접 import하지 않고 port/interface에 의존합니다.
 - Model backend는 `IAgentModel` adapter 뒤에 있습니다.
 - 모든 model-callable capability는 `@agent_tool`로 선언되어 schema, risk, idempotency, evidence metadata가 있습니다.
+- 실행 중 시그널 반응은 `@on_signal` 훅으로 선언하고 루프 본문에 폴링 코드를 작성하지 않습니다.
 - Write/network/destructive tool은 approval path가 있습니다.
+- 긴 멀티턴 Agent는 `AgentCompactionPolicy`를 spec에 선언합니다.
 - Durable path를 쓰면 state/signal/evidence repository contribution이 등록되어 있습니다.
 - Inbound adapter는 `AgentYieldKind.APPROVAL`을 사용자 decision signal로 연결합니다.
 - CopilotKit 연동 endpoint는 Spakky-native `AgentYield` JSON이 아니라 AG-UI `type` event stream을 반환합니다.

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -2,17 +2,21 @@
 
 > `spakky-agent`로 LLM 실행과 도구 호출을 Spakky 애플리케이션 안에 자연스럽게 넣는 입문 가이드입니다.
 
-Spakky에서 Agent는 특별한 외부 런타임이 아니라 하나의 애플리케이션 컴포넌트입니다. 일반 `@UseCase`처럼 생성자 주입을 받고, 실행 결과는 `AgentYield` stream으로 내보냅니다. 모델 호출, 도구 호출, 승인, 재개 같은 복잡한 기능은 필요할 때 단계적으로 붙입니다.
+Spakky에서 Agent는 특별한 외부 런타임이 아니라 하나의 애플리케이션 컴포넌트입니다. 일반 `@UseCase`처럼 생성자 주입을 받고, 실행 결과는 `AgentYield` stream으로 내보냅니다.
+
+핵심은 **누가 실행 루프를 소유하는가**입니다. [ADR-0013](../adr/0013-declarative-agent-loop-ownership.md)에 따라 model 호출 → tool 호출 추출 → tool 실행 → 결과 주입 → 종료 판정으로 이어지는 반복 루프는 **프레임워크 runner가 소유**합니다. 개발자는 루프 본문을 작성하지 않고 `@Agent` spec으로 **무엇을** 실행할지(어떤 model, 어떤 tool, 어떤 정책)만 선언합니다. 이 개발 경험(DX)은 pydantic-ai를 참조합니다 — pydantic-ai에서 `agent.run()`이 루프를 소유하고 개발자는 `@agent.tool`로 도구만 선언하듯이, Spakky에서는 runner가 루프를 소유하고 개발자는 `@agent_tool`(도구)과 `@on_signal`(시그널 반응)만 선언합니다.
 
 처음에는 세 가지만 기억하면 충분합니다.
 
 | 개념 | 역할 |
 |------|------|
-| `@Agent` | Agent class를 Spakky Pod로 등록합니다. |
-| `execute()` | Agent가 실제 일을 하는 public entrypoint입니다. |
+| `@Agent` | Agent class를 Spakky Pod로 등록하고 실행 spec을 선언합니다. |
+| `@agent_tool` | model이 호출할 수 있는 Python 도구를 선언합니다. |
 | `AgentYield` | HTTP, WebSocket, CLI 같은 adapter가 받을 실행 이벤트입니다. |
 
-Tool, approval, durable repository, AG-UI/CopilotKit 연동은 [AI Agent 심화](agents-advanced.md)에서 다룹니다. 실제 CodeAssistant 흐름을 보고 싶다면 [CodeAssistant 에이전트 예제](agent-code-assistant.md)를 이어서 보세요.
+`@Agent`가 도구만 선언하고 `execute()` 본문을 작성하지 않으면, 프레임워크가 표준 실행 루프를 `execute()`로 자동 제공합니다. model-mediated orchestration의 기본 흐름을 벗어나는 커스텀 제어가 필요할 때만 `execute()` 본문을 직접 작성합니다.
+
+선언형 시그널 훅(`@on_signal`), approval, durable repository, context compaction, teammate, AG-UI/A2A/MCP 어댑터는 [AI Agent 심화](agents-advanced.md)에서 다룹니다. 실제 CodeAssistant 흐름을 보고 싶다면 [CodeAssistant 에이전트 예제](agent-code-assistant.md)를 이어서 보세요.
 
 ## 언제 Agent를 쓰나요?
 
@@ -217,15 +221,73 @@ model = app.container.get(type_=IAgentModel)
 `spakky-vllm` 플러그인은 `VllmConfig`, `HttpxVllmChatClient`, `VllmAgentModel`을 등록하고 `IAgentModel -> VllmAgentModel` binding을 설정합니다.
 테스트에서는 network가 없는 scripted `IAgentModel` fake를 만들어 token이나 tool event를 원하는 순서로 내보내면 됩니다.
 
+## 선언형 Agent: 루프를 프레임워크에 맡기기
+
+앞의 예제는 `execute()` 본문을 직접 작성했습니다. 도구를 호출하는 Agent라면 보통 그럴 필요가 없습니다. `@Agent`가 도구만 선언하고 `execute()`를 생략하면, 프레임워크 runner가 model 호출 → tool 호출 → 결과 주입 → 종료 판정 루프를 `execute()`로 자동 제공합니다.
+
+```python
+from spakky.agent import (
+    Agent,
+    AgentExecutionSpec,
+    EvidenceCapture,
+    IAgentModel,
+    Idempotency,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="note_agent",
+        objective="read and write notes for a topic",
+        instructions="Use the declared tools to manage the user's notes.",
+    )
+)
+class NoteAgent:
+    def __init__(self, model: IAgentModel, notes: NoteStore) -> None:
+        self._model = model
+        self._notes = notes
+
+    @agent_tool(
+        schema_name="note.read",
+        description="Read a note for a topic.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def read_note(self, topic: str) -> str:
+        return self._notes.read(topic)
+```
+
+`NoteAgent`에는 `execute()`가 없습니다. runner가 spec(`instructions`)과 생성자에 주입된 `IAgentModel`, 그리고 `@agent_tool` 카탈로그로부터 표준 루프를 합성합니다. 호출 입력은 `RunAgentInput`입니다.
+
+```python
+from spakky.agent import AgentYieldKind, RunAgentInput
+
+agent = container.get(NoteAgent)
+async for item in agent.execute(
+    RunAgentInput(state_id="run-1", instruction="summarize my agent notes")
+):
+    if item.kind is AgentYieldKind.TOOL:
+        ...  # tool 호출 결과
+    elif item.kind is AgentYieldKind.FINAL:
+        return item.payload.output  # 타입은 AgentRunResult
+```
+
+pydantic-ai의 `Agent(..., output_type=...)` + `@agent.tool` + `agent.run()` 조합과 같은 자리를 Spakky에서는 `@Agent(spec=...)` + `@agent_tool` + runner-backed `execute(RunAgentInput)`가 채웁니다. 차이는 도구·model·repository가 모두 **생성자 DI**로 주입된다는 점입니다 — spec은 의존성을 다시 선언하지 않습니다.
+
 ## 다음 단계
 
 처음부터 CodeAssistant 전체를 만들려고 하면 어렵습니다. 이 순서로 쌓아 올리세요.
 
-1. `@Agent` class와 `execute()`만 만든다.
-2. `AgentYieldKind.FINAL`만 yield해서 container resolve와 invocation을 확인한다.
-3. `IAgentModel`을 생성자로 받고 token stream을 `AgentYieldKind.TOKEN`으로 변환한다.
-4. read-only `@agent_tool` 하나를 추가한다.
-5. write/network/destructive tool을 추가하고 approval event를 처리한다.
+1. `@Agent` class에 `@agent_tool` 하나를 선언하고 `execute()`는 생략한다 (runner가 자동 제공).
+2. container에서 resolve해 `RunAgentInput`으로 호출하고 `AgentYieldKind.FINAL`을 확인한다.
+3. `IAgentModel`을 생성자로 받아 model-mediated tool 호출 루프를 돌린다.
+4. write/network/destructive tool을 추가하고 approval event를 처리한다.
+5. 실행 중 시그널 반응이 필요하면 `@on_signal` 훅을 선언한다.
 6. durable 실행이 필요해지면 state/signal/evidence repository를 붙인다.
 7. FastAPI, WebSocket, SSE, CLI adapter에서 `AgentYield`를 transport event로 변환한다.
 


### PR DESCRIPTION
## Summary
- Add declarative @on_signal hook discovery and runner dispatch for non-terminal inbound signals.
- Rewrite the CodeAssistant example around runner-owned execute(), @agent_tool methods, and a steering hook.
- Add unit/acceptance coverage plus Agent guide/API docs for declarative hooks, compaction, teammates, and inbound adapter behavior.

## Acceptance Criteria (self grep)
- Issue #413 has no grep/find/rg acceptance lines in the body, so acceptance_check is missing.

## Verification
- cd core/spakky-agent && uv run ruff format .
- cd core/spakky-agent && uv run ruff check .
- cd core/spakky-agent && uv run pyrefly check src tests examples --config pyproject.toml --min-severity warn --progress-bar no --output-format min-text
- cd core/spakky-agent && uv run pytest -q
- uv run mkdocs build --strict

Closes #413