### PR TITLE
feat(agui): add AG-UI SSE adapter

### DIFF
--- a/core/spakky-agent/src/spakky/agent/runner.py
+++ b/core/spakky-agent/src/spakky/agent/runner.py
@@ -246,7 +246,14 @@ class AgentRunner:
                 )
                 return
         yield StepFinishedEvent(attribution, step_name="model-call")
-        if state is not None:
+        # A tool that paused for approval already saved a WAIT_FOR_APPROVAL state
+        # (INTERRUPTED, not ACTIVE); completing it would clobber the durable pause
+        # the adapter surfaces as its deferred-tool request, so only an unpaused
+        # (still ACTIVE) run transitions to COMPLETED — mirroring _run_durable.
+        if (
+            state is not None
+            and self._states_required().get(state.id).status is AgentStatus.ACTIVE
+        ):
             self._complete_state(state.id)
         yield RunFinishedEvent(attribution)
 

--- a/core/spakky-agent/tests/unit/test_runner.py
+++ b/core/spakky-agent/tests/unit/test_runner.py
@@ -14,6 +14,7 @@ from spakky.agent import (
     AgentRunner,
     AgentRunResult,
     AgentSignalKind,
+    AgentStateReason,
     AgentStatus,
     AgentYield,
     AgentYieldKind,
@@ -1402,23 +1403,29 @@ async def test_agent_runner_events_expect_reasoning_suppressed_without_capabilit
 async def test_agent_runner_events_expect_approval_gate_blocks_result_emission() -> (
     None
 ):
-    """승인 미결 도구는 dispatch 없이 tool result AgentEvent를 방출하지 않는다."""
+    """승인 미결 도구는 dispatch 없이 result를 방출하지 않고 paused 상태를 보존한다."""
     model = RecordingModel(
         (
             _tool_event("echo.write", {"value": "draft"}, "write-1"),
             ModelStreamEvent(kind=ModelStreamEventKind.DONE),
         )
     )
+    states = FakeStateRepository()
 
     events = await _run_events_durable(
         model,
         RunAgentInput(state_id="run-1", instruction="write"),
-        FakeStateRepository(),
+        states,
         FakeSignalRepository(()),
         FakeEvidenceRepository(),
     )
 
     assert not any(isinstance(event, ToolCallResultEvent) for event in events)
+    # The guard must NOT complete a run that paused for approval — the durable
+    # WAIT_FOR_APPROVAL state stays INTERRUPTED so the adapter can surface it.
+    paused = states.get("run-1")
+    assert paused.status is AgentStatus.INTERRUPTED
+    assert paused.reason is AgentStateReason.APPROVAL_REQUIRED
 
 
 async def test_agent_runner_events_expect_approved_tool_emits_result() -> None:

--- a/core/spakky/pyproject.toml
+++ b/core/spakky/pyproject.toml
@@ -17,6 +17,7 @@ data = ["spakky-data>=6.9.1"]
 event = ["spakky-event>=6.9.1"]
 task = ["spakky-task>=6.9.1"]
 agent-core = ["spakky-agent>=6.9.1"]
+agui = ["spakky-agui>=6.9.1"]
 actuator = ["spakky-actuator>=6.9.1"]
 cache-core = ["spakky-cache>=6.9.1"]
 tracing = ["spakky-tracing>=6.9.1"]
@@ -99,6 +100,7 @@ agent = [
     "spakky-agent>=6.9.1",
     "spakky[vllm]>=6.5.0",
     "spakky[mcp]>=6.5.0",
+    "spakky[agui]>=6.5.0",
     "spakky[sqlalchemy]>=6.5.0",
 ]
 recommended = [
@@ -118,6 +120,7 @@ full = [
     "spakky-saga>=6.9.1",
     "spakky-task>=6.9.1",
     "spakky-tracing>=6.9.1",
+    "spakky[agui]>=6.5.0",
     "spakky[celery]>=6.5.0",
     "spakky[cryptography]>=6.5.0",
     "spakky[fastapi]>=6.5.0",

--- a/docs/guides/agent-ag-ui.md
+++ b/docs/guides/agent-ag-ui.md
@@ -1,6 +1,146 @@
 # AG-UI 어댑터
 
-> 선언형 Agent를 AG-UI 프로토콜로 노출해, Agent 실행 이벤트를 UI에 스트리밍하는 어댑터 가이드입니다.
+> 선언형 Agent를 AG-UI (Agent User Interaction) 프로토콜로 노출해, Agent 실행 이벤트를
+> UI에 SSE (Server-Sent Events)로 스트리밍하는 어댑터 가이드입니다. 렌더링(프런트엔드)은
+> 범위 밖이며, 본 가이드는 와이어 프로토콜까지를 다룹니다.
 
-!!! note "작성 예정"
-    이 페이지는 정보구조(IA) 재설계에서 마련한 자리입니다. 선언형 Agent 어댑터 기능이 추가되면 후속 문서 태스크가 내용을 채웁니다. 지금은 [AI Agent 개발](agents.md)과 [AI Agent 심화](agents-advanced.md)를 참고하세요.
+`spakky-agui` plugin은 선언형 `@Agent`의 실행 스트림을 AG-UI 이벤트로 투영하여 SSE로
+노출합니다. 승인이 필요한 도구는 deferred-tool 방식의 HITL (Human-in-the-loop) 흐름으로
+표면화됩니다.
+
+## 1. `@Agent` 선언
+
+선언형 Agent는 spec과 `@agent_tool` 메서드만 선언하면 프레임워크가 실행 루프를 제공합니다
+(자세한 내용은 [AI Agent 심화](agents-advanced.md)).
+
+```python
+from spakky.agent import (
+    Agent, AgentExecutionSpec, AgentSignalKind, RecoveryStrategy,
+    EvidenceCapture, Idempotency, ToolApprovalRequirement, ToolEffects, agent_tool,
+)
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="assistant",
+        objective="answer with tools",
+        accepted_signals=(
+            AgentSignalKind.APPROVAL_DECISION,
+        ),
+        recovery=RecoveryStrategy.ACTION_BOUNDARY,
+    )
+)
+class Assistant:
+    def __init__(self, model, states, signals, evidence) -> None:
+        self._model = model
+        self._states = states
+        self._signals = signals
+        self._evidence = evidence
+
+    @agent_tool(
+        schema_name="note.write",
+        description="Write a note after human approval.",
+        effects=ToolEffects.write_state(),
+        idempotency=Idempotency.CONDITIONALLY_IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.REQUIRED,
+    )
+    def note_write(self, topic: str) -> str:
+        """Write a note for a topic after approval."""
+        return f"write:{topic}"
+```
+
+## 2. SSE endpoint 마운트
+
+`add_agui_endpoint`로 FastAPI 앱에 `POST {sse_path}` 라우트를 등록합니다. plugin은
+`fastapi` 서드파티에 직접 의존하며(`StreamingResponse`), `spakky-fastapi` plugin을
+import하지 않습니다.
+
+```python
+from fastapi import FastAPI
+from ag_ui.encoder import EventEncoder
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+
+from spakky.agent import AgentRunner, RunAgentInput
+from spakky.plugins.agui import (
+    AgUiProjector, AgUiRunDriver,
+    AgUiConfig, add_agui_endpoint, ingest_decision,
+)
+
+app = FastAPI()
+config = application.container.get(AgUiConfig)
+
+
+def run_driver_factory(core_input, ag_ui_input, accept):
+    assistant = application.container.get(Assistant)
+    runner = AgentRunner.for_agent_instance(assistant)
+    if core_input.resume:
+        ingest_decision(ag_ui_input, runner.signals, core_input.state_id)
+    return AgUiRunDriver(
+        runner=runner,
+        run_input=core_input,
+        agent_id="assistant",
+        projector=AgUiProjector(config),
+        encoder=EventEncoder(accept=accept),
+    )
+
+
+add_agui_endpoint(app, run_driver_factory=run_driver_factory, config=config)
+```
+
+`initialize`는 `AgUiConfig`만 등록합니다. 투영기는 실행마다 상태를 가지므로 싱글턴 Pod이
+될 수 없고, 어떤 Agent가 응답할지는 애플리케이션마다 다르기 때문에 endpoint 와이어링은
+애플리케이션 작성자의 명시적 호출(public hook)로 남깁니다.
+
+### 설정
+
+| 환경변수 | 기본값 | 목적 |
+|---------|--------|------|
+| `SPAKKY_AGUI_SSE_PATH` | `/agui` | SSE endpoint 경로 |
+| `SPAKKY_AGUI_EMIT_STATE_SNAPSHOT` | `true` | `STATE_SNAPSHOT` 투영 여부 |
+| `SPAKKY_AGUI_MESSAGES_SNAPSHOT_ENABLED` | `false` | `RUN_FINISHED` 직전 `MESSAGES_SNAPSHOT` 방출 여부 |
+
+## 3. 이벤트 매핑 (중립 → AG-UI)
+
+| 중립 `AgentEvent` | AG-UI 이벤트 |
+|------------------|-------------|
+| `MESSAGE_DELTA` | `TEXT_MESSAGE_START` + `TEXT_MESSAGE_CONTENT` (빈 delta 생략) |
+| `REASONING_DELTA` | `REASONING_START` + `REASONING_MESSAGE_START` + `REASONING_MESSAGE_CONTENT` |
+| `TOOL_CALL_START` | `TOOL_CALL_START` |
+| `TOOL_CALL_ARGS_DELTA` | `TOOL_CALL_ARGS` |
+| `TOOL_CALL_END` | `TOOL_CALL_END` |
+| `TOOL_CALL_RESULT` | `TOOL_CALL_RESULT` |
+| `RUN_STARTED` | `RUN_STARTED` |
+| `RUN_FINISHED` | `RUN_FINISHED` 또는 `RUN_ERROR` |
+| `STEP_STARTED`/`STEP_FINISHED` | `STEP_STARTED`/`STEP_FINISHED` |
+| `STATE_SNAPSHOT` | `STATE_SNAPSHOT` (설정 게이트) |
+| `STATE_DELTA` | `STATE_DELTA` |
+| `ARTIFACT` | `CUSTOM` (name=`artifact`) |
+
+## 4. deferred-tool HITL 흐름
+
+AG-UI에는 1급 승인 이벤트가 없습니다. 승인 요청은 `hitl_approval` 도구의 **deferred tool
+call**로 표면화됩니다. `run_events()`는 승인 이벤트를 방출하지 않습니다 — 승인 필요 도구는
+dispatch 없이 결과를 내보내지 않고, 그 멈춤은 durable한 `WAIT_FOR_APPROVAL` 상태(상태
+`INTERRUPTED`, 사유 `APPROVAL_REQUIRED`)로 기록됩니다.
+
+1. 런너가 승인 필요 도구에서 멈추면 `run_events()` 스트림은 결과 없이 끝나고, durable 상태에
+   승인 요청이 남습니다. `AgUiRunDriver`는 종단 `RUN_FINISHED` 직전에 그 상태를 읽어
+   (`project_pending_approval`), `hitl_approval`의 `TOOL_CALL_START`/`ARGS`/`END` 프레임을
+   주입합니다 — **결과 프레임은 없습니다** (결과 지연).
+2. 클라이언트가 사람의 결정을 수집해 다음 `RunAgentInput`에 담아 다시 POST합니다 (deferred
+   call id를 향한 tool-result 메시지, 또는 `forwardedProps.approvalDecision`).
+3. `ingest_decision`이 결정을 디코딩하여 durable signal queue에 `APPROVAL_DECISION`
+   signal로 적재하면 런너가 `run_events()`를 다시 돌며 재개합니다. `APPROVE`/`MODIFY`는
+   도구를 진행시키고, `REJECT`는 종료로 이어집니다.
+
+## 매핑 충실도
+
+도구·메시지·실행 이벤트 매핑은 `run_events()`를 통해 **완전 무손실(lossless)**입니다. 런너가
+메시지/추론 delta, 도구 호출 `start`/`args-delta`/`end`/`result` 생명주기, run/step 경계를
+각각 별개의 중립 `AgentEvent`로 native 방출하므로, 어댑터는 거친 yield를 재구성하지 않고
+1:1로 투영합니다(과거 `AgentYield → AgentEvent` bridge는 제거되었습니다). reasoning을
+지원하지 않는 모델에서는 `REASONING_DELTA`가 생략되고(graceful degrade), 현재 모델 루프가
+생성하지 않는 `STATE_SNAPSHOT`/`STATE_DELTA`/`ARTIFACT`는 live 런에서 방출되지 않지만
+projector는 taxonomy 완전성을 위해 이들 종류도 계속 처리합니다. `parentRunId`는 `run_events`가
+parent run을 세팅하지 않으므로 `RUN_STARTED`에 항상 포함되지 않습니다.

--- a/plugins/spakky-agui/README.md
+++ b/plugins/spakky-agui/README.md
@@ -1,0 +1,148 @@
+# spakky-agui
+
+> `spakky-agui`는 `spakky-agent`를 위한 공식 AG-UI (Agent User Interaction) protocol adapter plugin입니다.
+> 선언형 `@Agent` 실행 스트림을 AG-UI 이벤트로 투영(project)하여 SSE (Server-Sent Events)로 노출하고,
+> deferred-tool 방식의 HITL (Human-in-the-loop) 승인 흐름을 지원합니다.
+
+## 언제 필요한가
+
+애플리케이션이 선언형 `@Agent` workflow를 실행하고, 그 실행 이벤트(토큰, 도구 호출,
+승인 요청, 종료)를 AG-UI 호환 프런트엔드에 실시간 스트리밍하려 할 때 사용합니다.
+렌더링(프런트엔드 UI)은 본 plugin의 범위 밖입니다 — 본 plugin은 와이어 프로토콜(SSE
+프레임)만 책임집니다.
+
+## 설치
+
+```bash
+pip install spakky-agui
+```
+
+durable Agent 실행(state·signal·evidence repository)과 모델 어댑터(`IAgentModel`)는
+별도 provider가 제공합니다. `spakky-agui`는 inbound SSE 어댑터만 제공합니다.
+
+## 설정
+
+설정은 `SPAKKY_AGUI_` 환경변수 접두사를 사용하는 `AgUiConfig`로 읽습니다.
+
+| 설정 | 기본값 | 목적 |
+|------|--------|------|
+| `SPAKKY_AGUI_SSE_PATH` | `/agui` | SSE endpoint가 마운트되는 경로 |
+| `SPAKKY_AGUI_EMIT_STATE_SNAPSHOT` | `true` | 중립 `STATE_SNAPSHOT` 이벤트를 AG-UI로 투영할지 여부 |
+| `SPAKKY_AGUI_MESSAGES_SNAPSHOT_ENABLED` | `false` | `RUN_FINISHED` 직전에 `MESSAGES_SNAPSHOT` 프레임을 1회 방출할지 여부 |
+
+## 동작 구조
+
+```
+AgentRunner.run_events() → 중립 AgentEvent  (런너가 native로 방출)
+중립 AgentEvent  ──(AgUiProjector)──▶  AG-UI BaseEvent
+AG-UI BaseEvent  ──(EventEncoder)──▶  "data: {...}\n\n" SSE 프레임
+```
+
+- **`AgentRunner.run_events()`**: 런너가 중립 `AgentEvent` taxonomy를 native로 방출하는
+  스트림입니다. 메시지/추론 delta, 도구 호출 `start`/`args-delta`/`end`/`result` 생명주기,
+  run/step 경계를 각각 별개 이벤트로 내보내므로, 어댑터는 별도 재구성 없이 1:1로 투영합니다.
+- **`AgUiProjector`**: 중립 이벤트의 delta를 AG-UI의 START/CONTENT/END 프레이밍으로
+  투영하는 상태 기계입니다. 열린 message/reasoning/tool 프레임을 추적하고, 스트림이
+  중간에 끊겨도 `finish()`가 열린 프레임을 닫아 와이어 형식을 보존합니다.
+- **`AgUiRunDriver`**: `run_events()`를 projector·encoder에 연결하는 async generator입니다.
+  `StreamingResponse`에 직접 전달됩니다. `run_events()`는 승인 이벤트를 방출하지 않으므로,
+  종단 `RUN_FINISHED` 직전에 durable한 승인 대기 상태를 읽어 deferred-tool 승인 프레임을
+  주입합니다(아래 HITL 참조).
+
+## 이벤트 매핑 (중립 → AG-UI)
+
+| 중립 `AgentEvent` | AG-UI 이벤트 |
+|------------------|-------------|
+| `MESSAGE_DELTA` | `TEXT_MESSAGE_START` (id 변경 시) + `TEXT_MESSAGE_CONTENT` (빈 delta는 생략) |
+| `REASONING_DELTA` | `REASONING_START` + `REASONING_MESSAGE_START` + `REASONING_MESSAGE_CONTENT` |
+| `TOOL_CALL_START` | `TOOL_CALL_START` (`parentMessageId`는 열린 message로 fallback) |
+| `TOOL_CALL_ARGS_DELTA` | `TOOL_CALL_ARGS` (빈 delta는 생략) |
+| `TOOL_CALL_END` | `TOOL_CALL_END` |
+| `TOOL_CALL_RESULT` | `TOOL_CALL_RESULT` (`content`는 result의 JSON 텍스트) |
+| `RUN_STARTED` | `RUN_STARTED` (`threadId`=conversation, `runId`; `parentRunId`는 `run_events`가 parent run을 세팅하지 않아 항상 없음) |
+| `RUN_FINISHED` | 열린 프레임 닫기 → `RUN_FINISHED` 또는 `RUN_ERROR` |
+| `STEP_STARTED`/`STEP_FINISHED` | `STEP_STARTED`/`STEP_FINISHED` |
+| `STATE_SNAPSHOT` | `STATE_SNAPSHOT` (`emit_state_snapshot=true`일 때만) |
+| `STATE_DELTA` | `STATE_DELTA` (JSON Patch) |
+| `ARTIFACT` | `CUSTOM` (name=`artifact`) — AG-UI에 native artifact 이벤트가 없음 |
+
+## 사용법
+
+`@Agent`를 선언하고, FastAPI 앱에 SSE endpoint를 마운트합니다.
+
+```python
+from fastapi import FastAPI
+from ag_ui.encoder import EventEncoder
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+
+from spakky.agent import AgentRunner, RunAgentInput
+from spakky.plugins.agui import (
+    AgUiProjector,
+    AgUiRunDriver,
+    add_agui_endpoint,
+    ingest_decision,
+)
+
+app = FastAPI()
+config = application.container.get(AgUiConfig)
+
+
+def run_driver_factory(
+    core_input: RunAgentInput,
+    ag_ui_input: AgUiRunAgentInput,
+    accept: str | None,
+) -> AgUiRunDriver:
+    assistant = application.container.get(MyAssistant)
+    runner = AgentRunner.for_agent_instance(assistant)
+    if core_input.resume:
+        ingest_decision(ag_ui_input, runner.signals, core_input.state_id)
+    return AgUiRunDriver(
+        runner=runner,
+        run_input=core_input,
+        agent_id="my_assistant",
+        projector=AgUiProjector(config),
+        encoder=EventEncoder(accept=accept),
+    )
+
+
+add_agui_endpoint(app, run_driver_factory=run_driver_factory, config=config)
+```
+
+`POST /agui`로 AG-UI `RunAgentInput`을 보내면 `text/event-stream` 응답으로 실행
+이벤트가 스트리밍됩니다.
+
+### endpoint 와이어링이 plugin `initialize`에 없는 이유
+
+`initialize`는 `AgUiConfig`만 등록하고 endpoint를 자동 마운트하지 않습니다.
+투영기(projector)는 실행마다 상태를 가지므로(열린 message/reasoning/tool 프레임 추적)
+싱글턴 Pod이 될 수 없고, 어떤 `@Agent`가 요청에 응답할지는 애플리케이션마다 다르기
+때문입니다. 따라서 애플리케이션 작성자가 `run_driver_factory`를 자기 Agent에 바인딩하여
+`add_agui_endpoint`를 직접 호출합니다 (pydantic-ai의 `add_*_fastapi_endpoint` 패턴과 동일).
+
+## HITL — deferred-tool 승인 흐름
+
+AG-UI에는 1급 승인 이벤트가 없으므로, 승인 요청은 **deferred tool call**로 표면화됩니다.
+`run_events()`는 승인 이벤트를 방출하지 않습니다 — 승인이 필요한 도구는 dispatch 없이
+결과를 내보내지 않고, 런너는 그 멈춤을 durable한 `WAIT_FOR_APPROVAL` 상태(상태 `INTERRUPTED`,
+사유 `APPROVAL_REQUIRED`)로 기록합니다. 따라서 승인 요청은 어댑터가 그 상태를 읽어 표면화합니다.
+
+1. 런너가 승인이 필요한 도구에서 멈추면, `run_events()` 스트림은 결과 없이 종료되고 durable
+   상태에 승인 요청이 남습니다. `AgUiRunDriver`는 종단 `RUN_FINISHED` 직전에 그 상태를 읽어
+   (`project_pending_approval`), 승인을 `hitl_approval` 도구의 `TOOL_CALL_START`/`ARGS`/`END`
+   프레임으로 투영합니다 — **결과(result) 프레임은 없습니다** (결과가 지연되었기 때문).
+2. 클라이언트는 이 deferred tool을 렌더링하고 사람의 결정을 받습니다.
+3. 클라이언트는 다음 `RunAgentInput`에 그 결정을 담아 다시 POST합니다 — deferred call id를
+   향한 tool-result 메시지로, 또는 `forwardedProps.approvalDecision`으로.
+4. `ingest_decision`이 그 결정을 디코딩하여 durable signal queue에 `APPROVAL_DECISION`
+   signal로 적재하면, 런너가 `run_events()`를 다시 돌며 멈췄던 지점을 재개합니다 — APPROVE는
+   도구 결과와 `RUN_FINISHED`로, REJECT는 결과 없이 종단으로 이어집니다.
+
+## 매핑 충실도
+
+도구·메시지·실행 이벤트 매핑은 `run_events()`를 통해 **완전 무손실(lossless)**입니다. 런너가
+메시지/추론 delta, 도구 호출 `start`/`args-delta`/`end`/`result` 생명주기, run/step 경계를
+각각 별개의 중립 `AgentEvent`로 native 방출하므로, 어댑터는 거친 yield를 재구성하지 않고
+1:1로 투영합니다. `run_events()`는 reasoning을 지원하지 않는 모델에서는 `REASONING_DELTA`를
+생략하며(graceful degrade), 현재 모델 루프가 생성하지 않는 `STATE_SNAPSHOT`/`STATE_DELTA`/
+`ARTIFACT`는 live 런에서 방출되지 않습니다. projector는 taxonomy 완전성을 위해 이들 종류도
+계속 처리합니다.

--- a/plugins/spakky-agui/pyproject.toml
+++ b/plugins/spakky-agui/pyproject.toml
@@ -1,0 +1,88 @@
+[project]
+name = "spakky-agui"
+version = "6.9.1"
+description = "AG-UI protocol adapter plugin for Spakky Agent"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
+dependencies = [
+    "ag-ui-protocol>=0.1.19",
+    "fastapi[standard]>=0.135.3",
+    "pydantic-settings>=2.13.1",
+    "spakky>=6.9.1",
+    "spakky-agent>=6.9.1",
+]
+
+[project.entry-points."spakky.plugins"]
+spakky-agui = "spakky.plugins.agui.main:initialize"
+
+[build-system]
+requires = ["uv_build>=0.10.10,<0.12.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-root = "src"
+module-name = "spakky.plugins.agui"
+
+[tool.pyrefly]
+python-version = "3.12"
+search_path = [
+    "src",
+    ".",
+    "../../core/spakky/src",
+    "../../core/spakky-agent/src",
+]
+project_excludes = ["**/__pycache__", "**/*.pyc"]
+
+[tool.ruff]
+builtins = ["_"]
+cache-dir = "~/.cache/ruff"
+
+[tool.pytest.ini_options]
+pythonpath = [
+    "src",
+    "../../core/spakky/src",
+    "../../core/spakky-agent/src",
+]
+testpaths = "tests"
+python_files = ["test_*.py"]
+asyncio_mode = "auto"
+markers = ["known_issue(reason): 알려진 버그"]
+addopts = """
+    --cov
+    --cov-report=term
+    --cov-report=xml
+    --no-cov-on-fail
+    --strict-markers
+    --dist=loadfile
+    -p no:warnings
+    -n auto
+    --spec
+"""
+spec_test_format = "{result} {docstring_summary}"
+
+[tool.coverage.run]
+include = ["src/spakky/plugins/agui/**/*.py"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+precision = 2
+fail_under = 100
+skip_empty = true
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "@(abc\\.)?abstractmethod",
+    "@(typing\\.)?overload",
+    "\\.\\.\\.",
+    "pass",
+]
+
+[tool.uv.sources]
+spakky = { workspace = true }
+spakky-agent = { workspace = true }

--- a/plugins/spakky-agui/src/spakky/plugins/agui/__init__.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/__init__.py
@@ -1,0 +1,38 @@
+"""AG-UI protocol adapter plugin for Spakky Agent."""
+
+from spakky.core.application.plugin import Plugin
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.endpoint import RunDriverFactory, add_agui_endpoint
+from spakky.plugins.agui.error import (
+    AbstractAgUiError,
+    AgUiApprovalDecodeError,
+    AgUiPendingApprovalError,
+    AgUiRunResolutionError,
+)
+from spakky.plugins.agui.hitl import (
+    ingest_decision,
+    project_approval,
+    project_pending_approval,
+)
+from spakky.plugins.agui.projector import AgUiProjector
+from spakky.plugins.agui.transport import AgUiRunDriver
+
+PLUGIN_NAME = Plugin(name="spakky-agui")
+"""Plugin identifier for the AG-UI adapter package."""
+
+__all__ = [
+    "AbstractAgUiError",
+    "AgUiApprovalDecodeError",
+    "AgUiConfig",
+    "AgUiPendingApprovalError",
+    "AgUiProjector",
+    "AgUiRunDriver",
+    "AgUiRunResolutionError",
+    "PLUGIN_NAME",
+    "RunDriverFactory",
+    "add_agui_endpoint",
+    "ingest_decision",
+    "project_approval",
+    "project_pending_approval",
+]

--- a/plugins/spakky-agui/src/spakky/plugins/agui/config.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/config.py
@@ -1,0 +1,39 @@
+"""Configuration for the spakky-agui plugin."""
+
+from typing import ClassVar
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from spakky.core.stereotype.configuration import Configuration
+
+SPAKKY_AGUI_CONFIG_ENV_PREFIX = "SPAKKY_AGUI_"
+"""Environment prefix for AG-UI adapter settings."""
+
+DEFAULT_AGUI_SSE_PATH = "/agui"
+"""Default mount path for the AG-UI SSE endpoint."""
+
+
+@Configuration()
+class AgUiConfig(BaseSettings):
+    """Settings for the AG-UI SSE adapter."""
+
+    model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
+        env_prefix=SPAKKY_AGUI_CONFIG_ENV_PREFIX,
+        env_file_encoding="utf-8",
+        env_nested_delimiter="__",
+    )
+
+    sse_path: str = DEFAULT_AGUI_SSE_PATH
+    """Path the AG-UI SSE endpoint is mounted at on the FastAPI application."""
+
+    emit_state_snapshot: bool = True
+    """Whether STATE_SNAPSHOT neutral events are projected to AG-UI; when False
+    the projector drops them so a client that ignores shared state is not sent
+    redundant snapshots."""
+
+    messages_snapshot_enabled: bool = False
+    """Whether a single MESSAGES_SNAPSHOT is emitted before RUN_FINISHED; the
+    framework runner emits no message history, so this defaults off and is only
+    enabled by a client that wants a (currently empty) snapshot frame."""
+
+    def __init__(self) -> None:
+        super().__init__()

--- a/plugins/spakky-agui/src/spakky/plugins/agui/endpoint.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/endpoint.py
@@ -1,0 +1,92 @@
+"""Mount the AG-UI SSE endpoint on a FastAPI application.
+
+``add_agui_endpoint`` registers a single ``POST {config.sse_path}`` route that
+accepts an AG-UI ``RunAgentInput`` and streams the run back as
+``text/event-stream``. It owns the protocol-boundary translation that neither
+the bridge nor the projector should know about: it maps the AG-UI input shape
+(``threadId`` / ``runId`` / ``messages`` / ``parentRunId``) onto the neutral core
+``RunAgentInput`` and, when the input carries a resumed approval decision, queues
+that decision before the run is driven.
+
+The application author supplies a ``run_driver_factory`` that resolves the
+concrete ``@Agent`` for the request and returns a ready ``AgUiRunDriver``. The
+endpoint stays agnostic about which agent answers, mirroring pydantic-ai's
+``add_*_fastapi_endpoint`` pattern and depending on third-party ``fastapi``
+directly (ADR-0013 §2) rather than importing the ``spakky-fastapi`` plugin.
+"""
+
+from collections.abc import Callable
+
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+from spakky.agent.inbound import RunAgentInput
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.error import AgUiRunResolutionError
+from spakky.plugins.agui.hitl import carries_approval_decision
+from spakky.plugins.agui.transport import AgUiRunDriver
+
+SSE_MEDIA_TYPE = "text/event-stream"
+"""Media type for the AG-UI server-sent event stream."""
+
+type RunDriverFactory = Callable[
+    [RunAgentInput, AgUiRunAgentInput, str | None],
+    AgUiRunDriver,
+]
+"""Resolves the agent run for a request and returns a ready SSE driver.
+
+Receives the mapped core ``RunAgentInput``, the raw AG-UI input (so the factory
+can ingest an approval decision against its own signal repository), and the
+request ``Accept`` header for the event encoder.
+"""
+
+
+def add_agui_endpoint(
+    app: FastAPI,
+    *,
+    run_driver_factory: RunDriverFactory,
+    config: AgUiConfig,
+) -> None:
+    """Register the AG-UI SSE endpoint on ``app`` at ``config.sse_path``."""
+
+    async def run_agui(request: Request) -> StreamingResponse:
+        ag_ui_input = AgUiRunAgentInput.model_validate(await request.json())
+        core_input = _to_core_input(ag_ui_input)
+        driver = run_driver_factory(
+            core_input,
+            ag_ui_input,
+            request.headers.get("accept"),
+        )
+        return StreamingResponse(driver, media_type=SSE_MEDIA_TYPE)
+
+    app.add_api_route(config.sse_path, run_agui, methods=["POST"])
+
+
+def _to_core_input(ag_ui_input: AgUiRunAgentInput) -> RunAgentInput:
+    """Map an AG-UI run input onto the neutral core run input.
+
+    ``runId`` is the durable run/state id, ``threadId`` the conversation, and the
+    last user message seeds the instruction. ``resume`` is set when the input
+    carries an approval decision so the runner replays its paused boundary.
+    ``parentRunId`` is not forwarded: ``run_events`` does not set a parent run on
+    its attribution, so a delegation parent has no neutral channel to flow through.
+    """
+    return RunAgentInput(
+        state_id=ag_ui_input.run_id,
+        instruction=_last_user_text(ag_ui_input),
+        conversation_id=ag_ui_input.thread_id,
+        resume=carries_approval_decision(ag_ui_input),
+    )
+
+
+def _last_user_text(ag_ui_input: AgUiRunAgentInput) -> str:
+    """Return the most recent user message text seeding the model request."""
+    for message in reversed(ag_ui_input.messages):
+        if message.role != "user":
+            continue
+        content = message.content
+        if isinstance(content, str) and content.strip():
+            return content
+    raise AgUiRunResolutionError

--- a/plugins/spakky-agui/src/spakky/plugins/agui/error.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/error.py
@@ -1,0 +1,51 @@
+"""Error classes for the spakky-agui plugin."""
+
+from abc import ABC
+
+from spakky.core.common.error import AbstractSpakkyFrameworkError
+
+
+class AbstractAgUiError(AbstractSpakkyFrameworkError, ABC):
+    """Base class for AG-UI adapter errors."""
+
+    ...
+
+
+class AgUiApprovalDecodeError(AbstractAgUiError):
+    """Raised when a resume input claims an approval decision it cannot supply.
+
+    The AG-UI resume carries an approval decision either as a tool-result
+    message addressed to the deferred ``hitl_approval`` call or as a
+    ``forwardedProps.approvalDecision`` object. This error is raised when that
+    payload is present but malformed: the request id is missing, the decision
+    string is absent, or the decision is not a member of ``ApprovalDecision``.
+    """
+
+    message = "AG-UI approval decision payload is missing or invalid"
+
+
+class AgUiPendingApprovalError(AbstractAgUiError):
+    """Raised when a paused-for-approval state carries malformed approval metadata.
+
+    After ``run_events`` ends, the transport reads the durable WAIT_FOR_APPROVAL
+    state to surface the deferred-tool approval request. The runner stores the
+    ``AgentApprovalRequest`` under ``metadata["approval"]`` with the prompt in
+    ``current_activity``; this error is raised when a state flagged
+    ``APPROVAL_REQUIRED`` is missing that metadata, omits the prompt, or carries
+    an unknown decision — an impossible state the adapter refuses to paper over.
+    """
+
+    message = "AG-UI pending approval state is missing or has invalid metadata"
+
+
+class AgUiRunResolutionError(AbstractAgUiError):
+    """Raised when an SSE request references a run the driver cannot resolve.
+
+    The endpoint maps an AG-UI ``RunAgentInput`` to a core run, then asks the
+    run-driver factory to build a driver for it. This error is raised when the
+    factory cannot produce a runner for the requested agent/run — for example,
+    the AG-UI input omits the last user message the core run requires to seed a
+    model request.
+    """
+
+    message = "AG-UI run request could not be resolved to a runnable agent run"

--- a/plugins/spakky-agui/src/spakky/plugins/agui/hitl.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/hitl.py
@@ -1,0 +1,261 @@
+"""Human-in-the-loop projection and decision ingestion for the AG-UI adapter.
+
+AG-UI has no first-class approval event, so an approval request surfaces as a
+*deferred tool call*: a ``TOOL_CALL_START``/``ARGS``/``END`` triple naming the
+synthetic ``hitl_approval`` tool, deliberately with **no** result frame. The
+client renders it, collects the human decision, and returns that decision on the
+next ``RunAgentInput`` (as the deferred tool's result message, or as
+``forwardedProps.approvalDecision``). ``ingest_decision`` decodes that decision
+and appends it to the durable signal queue the runner polls (ADR-0013 §5), which
+is the only channel the core run accepts an approval decision through.
+
+The core ``run_events`` stream emits **no** approval event when a tool pauses
+for approval — it dispatches nothing and emits no result. The pause is instead
+durable: the runner saves a WAIT_FOR_APPROVAL state (status ``INTERRUPTED``,
+reason ``APPROVAL_REQUIRED``) carrying the ``AgentApprovalRequest`` metadata.
+``project_pending_approval`` reads that durable state after the stream ends and
+rebuilds the deferred-tool frame, which is the adapter's only hook to surface a
+pending approval the lossless event stream does not carry.
+"""
+
+import uuid
+from collections.abc import Mapping
+from json import JSONDecodeError, loads
+
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+from ag_ui.core import ToolMessage
+
+from spakky.agent.event import (
+    AgentEvent,
+    AgentEventAttribution,
+    ToolCallArgsDeltaEvent,
+    ToolCallEndEvent,
+    ToolCallStartEvent,
+)
+from spakky.agent.execution import AgentSignalKind
+from spakky.agent.interfaces.repository import IAgentSignalRepository
+from spakky.agent.signal import AgentSignal, ApprovalDecision
+from spakky.agent.state import AgentState, AgentStateReason, AgentStatus
+from spakky.agent.types import JsonObject, JsonValue
+from spakky.agent.yield_ import Approval
+
+from spakky.plugins.agui.error import (
+    AgUiApprovalDecodeError,
+    AgUiPendingApprovalError,
+)
+from spakky.plugins.agui.serialization import dump_json
+
+HITL_APPROVAL_TOOL_NAME = "hitl_approval"
+"""Synthetic tool name carrying an approval request as a deferred tool call."""
+
+APPROVAL_DECISION_FORWARDED_KEY = "approvalDecision"
+"""forwardedProps key a client may use to return an approval decision."""
+
+APPROVAL_STATE_METADATA_KEY = "approval"
+"""State-metadata key under which the runner stores the approval request."""
+
+
+def project_approval(
+    approval: Approval,
+    attribution: AgentEventAttribution,
+) -> list[AgentEvent]:
+    """Render an approval request as a deferred-tool frame (no result).
+
+    The deferred call id is the approval id, so the resume tool-result message
+    addresses the same call. The args carry the human-facing prompt, the allowed
+    decisions, and any approval metadata the runner attached.
+    """
+    args: JsonObject = {
+        "prompt": approval.prompt,
+        "allowed_decisions": [
+            decision.value for decision in approval.allowed_decisions
+        ],
+        **approval.metadata,
+    }
+    return [
+        ToolCallStartEvent(
+            attribution=attribution,
+            call_id=approval.id,
+            tool_name=HITL_APPROVAL_TOOL_NAME,
+        ),
+        ToolCallArgsDeltaEvent(
+            attribution=attribution,
+            call_id=approval.id,
+            args_delta=dump_json(args),
+        ),
+        ToolCallEndEvent(attribution=attribution, call_id=approval.id),
+    ]
+
+
+def find_pending_approval(state: AgentState) -> Approval | None:
+    """Reconstruct the pending approval from a durable WAIT_FOR_APPROVAL state.
+
+    The runner saves the paused boundary as an ``INTERRUPTED`` state whose reason
+    is ``APPROVAL_REQUIRED``, carrying the ``AgentApprovalRequest`` metadata under
+    ``metadata["approval"]`` and the human-facing prompt in ``current_activity``.
+    Returns the rebuilt approval when the state is paused for approval, otherwise
+    ``None`` (the run finished or paused for some other reason).
+    """
+    if (
+        state.status is not AgentStatus.INTERRUPTED
+        or state.reason is not AgentStateReason.APPROVAL_REQUIRED
+    ):
+        return None
+    approval_metadata = state.metadata.get(APPROVAL_STATE_METADATA_KEY)
+    if not isinstance(approval_metadata, Mapping) or state.current_activity is None:
+        raise AgUiPendingApprovalError
+    return Approval(
+        id=_require_text(approval_metadata, "id"),
+        prompt=state.current_activity,
+        allowed_decisions=_decode_allowed_decisions(approval_metadata),
+        metadata=_approval_request_metadata(approval_metadata),
+    )
+
+
+def project_pending_approval(
+    state: AgentState,
+    attribution: AgentEventAttribution,
+) -> list[AgentEvent]:
+    """Project a durable pending approval into the deferred-tool request frame.
+
+    The transport calls this after the ``run_events`` stream ends, since that
+    stream emits no approval event: the pause lives only in the durable state.
+    Returns an empty list when the state is not paused for approval.
+    """
+    approval = find_pending_approval(state)
+    if approval is None:
+        return []
+    return project_approval(approval, attribution)
+
+
+def _decode_allowed_decisions(
+    approval_metadata: Mapping[str, JsonValue],
+) -> tuple[ApprovalDecision, ...]:
+    decisions = approval_metadata.get("allowed_decisions")
+    if not isinstance(decisions, list):
+        raise AgUiPendingApprovalError
+    return tuple(_decode_decision(decision) for decision in decisions)
+
+
+def _decode_decision(value: JsonValue) -> ApprovalDecision:
+    if not isinstance(value, str):
+        raise AgUiPendingApprovalError
+    try:
+        return ApprovalDecision(value)
+    except ValueError as error:
+        raise AgUiPendingApprovalError from error
+
+
+def _approval_request_metadata(
+    approval_metadata: Mapping[str, JsonValue],
+) -> JsonObject:
+    nested = approval_metadata.get("metadata")
+    if not isinstance(nested, Mapping):
+        raise AgUiPendingApprovalError
+    return dict(nested)
+
+
+def _require_text(approval_metadata: Mapping[str, JsonValue], key: str) -> str:
+    value = approval_metadata.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise AgUiPendingApprovalError
+    return value
+
+
+def ingest_decision(
+    ag_ui_input: AgUiRunAgentInput,
+    signals: IAgentSignalRepository,
+    state_id: str,
+) -> None:
+    """Decode an approval decision from an AG-UI input and queue it as a signal.
+
+    Reads the decision from the ``hitl_approval`` tool-result message when
+    present, otherwise from ``forwardedProps.approvalDecision``. The decoded
+    decision is appended as an ``APPROVAL_DECISION`` signal carrying the request
+    id the runner correlates against, plus optional modified payload and comment.
+    """
+    decision_payload = _extract_decision_payload(ag_ui_input)
+    request_id = decision_payload.get("request_id")
+    decision_value = decision_payload.get("decision")
+    if not isinstance(request_id, str) or not isinstance(decision_value, str):
+        raise AgUiApprovalDecodeError
+    decision = _parse_decision(decision_value)
+    payload: dict[str, JsonValue] = {
+        "request_id": request_id,
+        "decision": decision.value,
+    }
+    modified_payload = decision_payload.get("modified_payload")
+    if modified_payload is not None:
+        payload["modified_payload"] = modified_payload
+    comment = decision_payload.get("comment")
+    if comment is not None:
+        payload["comment"] = comment
+    signals.append(
+        AgentSignal(
+            id=f"agui-approval:{uuid.uuid4().hex}",
+            agent_state_id=state_id,
+            kind=AgentSignalKind.APPROVAL_DECISION,
+            payload=payload,
+        )
+    )
+
+
+def carries_approval_decision(ag_ui_input: AgUiRunAgentInput) -> bool:
+    """Return whether the AG-UI input carries an approval decision to resume on."""
+    return _decision_source(ag_ui_input) is not None
+
+
+def _parse_decision(value: str) -> ApprovalDecision:
+    try:
+        return ApprovalDecision(value)
+    except ValueError as error:
+        raise AgUiApprovalDecodeError from error
+
+
+def _extract_decision_payload(
+    ag_ui_input: AgUiRunAgentInput,
+) -> Mapping[str, JsonValue]:
+    payload = _decision_source(ag_ui_input)
+    if payload is None:
+        raise AgUiApprovalDecodeError
+    return payload
+
+
+def _decision_source(
+    ag_ui_input: AgUiRunAgentInput,
+) -> Mapping[str, JsonValue] | None:
+    """Return the decision payload from a tool-result message or forwardedProps.
+
+    A tool-result message addressed to a ``hitl_approval`` call takes priority;
+    its JSON ``content`` is the decision payload. Otherwise a
+    ``forwardedProps.approvalDecision`` mapping is used when present.
+    """
+    for message in reversed(ag_ui_input.messages):
+        if not isinstance(message, ToolMessage):
+            continue
+        content = _decode_tool_content(message.content)
+        if content is not None:
+            return content
+    forwarded = ag_ui_input.forwarded_props
+    if isinstance(forwarded, Mapping):
+        decision = forwarded.get(APPROVAL_DECISION_FORWARDED_KEY)
+        if isinstance(decision, Mapping):
+            return decision
+    return None
+
+
+def _decode_tool_content(content: str) -> Mapping[str, JsonValue] | None:
+    parsed = _load_json_object(content)
+    if parsed is None or "decision" not in parsed:
+        return None
+    return parsed
+
+
+def _load_json_object(content: str) -> Mapping[str, JsonValue] | None:
+    try:
+        parsed = loads(content)
+    except JSONDecodeError:
+        return None
+    if isinstance(parsed, Mapping):
+        return parsed
+    return None

--- a/plugins/spakky-agui/src/spakky/plugins/agui/main.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/main.py
@@ -1,0 +1,37 @@
+"""Plugin initialization for the AG-UI SSE adapter.
+
+Design decision — public hook over live auto-wiring:
+
+``initialize`` registers only ``AgUiConfig``. It deliberately does **not** try to
+resolve a FastAPI Pod and auto-mount the endpoint, for two reasons that make the
+public hook the cleaner of the two options the spec allows:
+
+1. The projector is stateful *per run* (it tracks the open message, reasoning,
+   and tool frames), so it cannot be a shared singleton Pod — it must be
+   constructed per request inside the driver. Registering it as a Pod would be
+   misleading rather than useful.
+2. ``add_agui_endpoint`` needs a ``run_driver_factory`` that resolves *which*
+   declared ``@Agent`` answers a request and builds its ``AgentRunner``. That
+   choice is application-specific; the plugin cannot guess it from the container
+   without inventing an agent-selection convention the framework does not have.
+
+So the application author calls ``add_agui_endpoint(app, run_driver_factory=...,
+config=...)`` explicitly, resolving ``AgUiConfig`` from the container and binding
+the factory to their agent. This mirrors pydantic-ai's
+``add_*_fastapi_endpoint`` hook and keeps the plugin from importing the
+``spakky-fastapi`` plugin (depending on third-party ``fastapi`` directly is
+allowed; importing a sibling plugin's ``src`` is not — .agents/rules/plugin.md).
+"""
+
+from spakky.core.application.application import SpakkyApplication
+
+from spakky.plugins.agui.config import AgUiConfig
+
+
+def initialize(app: SpakkyApplication) -> None:
+    """Register AG-UI configuration for the SSE adapter.
+
+    Endpoint wiring is the application author's call via ``add_agui_endpoint``;
+    see the module docstring for why auto-wiring is not attempted here.
+    """
+    app.add(AgUiConfig)

--- a/plugins/spakky-agui/src/spakky/plugins/agui/projector.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/projector.py
@@ -1,0 +1,338 @@
+"""Project neutral ``AgentEvent``s into AG-UI protocol events.
+
+This is the fidelity-bearing half of the adapter. The neutral taxonomy carries
+*deltas* (``MESSAGE_DELTA``, ``REASONING_DELTA``, ``TOOL_CALL_*``), but AG-UI
+demands well-framed lifecycles: every text message is a
+``TEXT_MESSAGE_START`` / ``…CONTENT`` / ``…END`` triple, every reasoning message
+a ``REASONING_START`` / ``REASONING_MESSAGE_START`` / ``…CONTENT`` / ``…END`` /
+``REASONING_END`` sequence, every tool call a
+``TOOL_CALL_START`` / ``…ARGS`` / ``…END`` (with the result as a separate
+``TOOL_CALL_RESULT``). The projector is the state machine that opens, continues,
+and closes those frames as deltas arrive.
+
+It is stateful for the span of one run: it tracks the currently open message,
+the currently open reasoning message, and the set of open tool calls so that a
+delta with a new id closes the previous frame, and so ``finish()`` can flush any
+frame still open when the neutral stream ends (a truncated run stays well-formed
+on the wire).
+"""
+
+from ag_ui.core import (
+    BaseEvent,
+    CustomEvent,
+    MessagesSnapshotEvent,
+    ReasoningEndEvent,
+    ReasoningMessageContentEvent,
+    ReasoningMessageEndEvent,
+    ReasoningMessageStartEvent,
+    ReasoningStartEvent,
+    RunErrorEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    StateDeltaEvent,
+    StateSnapshotEvent,
+    StepFinishedEvent,
+    StepStartedEvent,
+    TextMessageContentEvent,
+    TextMessageEndEvent,
+    TextMessageStartEvent,
+    ToolCallArgsEvent,
+    ToolCallEndEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+
+from spakky.agent.event import (
+    AgentEvent,
+)
+from spakky.agent.event import (
+    ArtifactEvent as NeutralArtifactEvent,
+)
+from spakky.agent.event import (
+    MessageDeltaEvent as NeutralMessageDeltaEvent,
+)
+from spakky.agent.event import (
+    ReasoningDeltaEvent as NeutralReasoningDeltaEvent,
+)
+from spakky.agent.event import (
+    RunFinishedEvent as NeutralRunFinishedEvent,
+)
+from spakky.agent.event import (
+    RunStartedEvent as NeutralRunStartedEvent,
+)
+from spakky.agent.event import (
+    StateDeltaEvent as NeutralStateDeltaEvent,
+)
+from spakky.agent.event import (
+    StateSnapshotEvent as NeutralStateSnapshotEvent,
+)
+from spakky.agent.event import (
+    StepFinishedEvent as NeutralStepFinishedEvent,
+)
+from spakky.agent.event import (
+    StepStartedEvent as NeutralStepStartedEvent,
+)
+from spakky.agent.event import (
+    ToolCallArgsDeltaEvent as NeutralToolCallArgsDeltaEvent,
+)
+from spakky.agent.event import (
+    ToolCallEndEvent as NeutralToolCallEndEvent,
+)
+from spakky.agent.event import (
+    ToolCallResultEvent as NeutralToolCallResultEvent,
+)
+from spakky.agent.event import (
+    ToolCallStartEvent as NeutralToolCallStartEvent,
+)
+
+from spakky.agent.types import JsonObject, JsonValue
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.serialization import dump_json
+
+ASSISTANT_ROLE = "assistant"
+"""AG-UI text message role for model-authored assistant messages."""
+
+REASONING_ROLE = "reasoning"
+"""AG-UI reasoning message role required by ``REASONING_MESSAGE_START``."""
+
+ARTIFACT_CUSTOM_EVENT_NAME = "artifact"
+"""``CustomEvent`` name carrying a neutral artifact (no native AG-UI artifact)."""
+
+
+class AgUiProjector:
+    """Stateful per-run projector from neutral events to AG-UI events."""
+
+    def __init__(self, config: AgUiConfig) -> None:
+        self._config = config
+        self._open_message_id: str | None = None
+        self._open_reasoning_id: str | None = None
+        # Insertion-ordered set of in-flight tool-call ids (dict keys, value unused)
+        # so a truncated stream flushes END frames in a deterministic open order.
+        self._open_tool_call_ids: dict[str, None] = {}
+
+    def project(self, event: AgentEvent) -> list[BaseEvent]:
+        """Project one neutral event into zero or more AG-UI events.
+
+        The neutral ``kind`` field is typed ``AgentEventKind`` (not a per-class
+        ``Literal``), so it does not narrow the union; matching on the event
+        *type* does, which keeps each handler statically typed without casts.
+        """
+        match event:
+            case NeutralMessageDeltaEvent():
+                return self._project_message_delta(event)
+            case NeutralReasoningDeltaEvent():
+                return self._project_reasoning_delta(event)
+            case NeutralToolCallStartEvent():
+                return self._project_tool_start(event)
+            case NeutralToolCallArgsDeltaEvent():
+                return self._project_tool_args(event)
+            case NeutralToolCallEndEvent():
+                return self._project_tool_end(event)
+            case NeutralToolCallResultEvent():
+                return self._project_tool_result(event)
+            case NeutralRunStartedEvent():
+                return self._project_run_started(event)
+            case NeutralRunFinishedEvent():
+                return self._project_run_finished(event)
+            case NeutralStepStartedEvent():
+                return self._project_step_started(event)
+            case NeutralStepFinishedEvent():
+                return self._project_step_finished(event)
+            case NeutralStateSnapshotEvent():
+                return self._project_state_snapshot(event)
+            case NeutralStateDeltaEvent():
+                return self._project_state_delta(event)
+            case NeutralArtifactEvent():  # pragma: no branch - exhaustive AgentEvent union
+                return self._project_artifact(event)
+
+    def finish(self) -> list[BaseEvent]:
+        """Flush any open message, reasoning, or tool frames as END events.
+
+        Called once after the neutral stream ends so a stream truncated mid-frame
+        (no RUN_FINISHED, or a model that stopped mid-message) still produces a
+        balanced AG-UI sequence on the wire.
+        """
+        return self._close_open_frames()
+
+    def _project_message_delta(
+        self, event: NeutralMessageDeltaEvent
+    ) -> list[BaseEvent]:
+        # Phase 1: a new message id closes the previous text/reasoning frame.
+        events = self._open_text_message(event.message_id)
+        # Phase 2: emit content only for a non-empty delta (AG-UI rejects empty).
+        if event.delta:
+            events.append(
+                TextMessageContentEvent(message_id=event.message_id, delta=event.delta)
+            )
+        return events
+
+    def _project_reasoning_delta(
+        self, event: NeutralReasoningDeltaEvent
+    ) -> list[BaseEvent]:
+        events = self._open_reasoning_message(event.reasoning_id)
+        if event.delta:
+            events.append(
+                ReasoningMessageContentEvent(
+                    message_id=event.reasoning_id, delta=event.delta
+                )
+            )
+        return events
+
+    def _project_tool_start(self, event: NeutralToolCallStartEvent) -> list[BaseEvent]:
+        self._open_tool_call_ids[event.call_id] = None
+        parent_message_id = event.parent_message_id or self._open_message_id
+        return [
+            ToolCallStartEvent(
+                tool_call_id=event.call_id,
+                tool_call_name=event.tool_name,
+                parent_message_id=parent_message_id,
+            )
+        ]
+
+    def _project_tool_args(
+        self, event: NeutralToolCallArgsDeltaEvent
+    ) -> list[BaseEvent]:
+        if not event.args_delta:
+            return []
+        return [ToolCallArgsEvent(tool_call_id=event.call_id, delta=event.args_delta)]
+
+    def _project_tool_end(self, event: NeutralToolCallEndEvent) -> list[BaseEvent]:
+        self._open_tool_call_ids.pop(event.call_id, None)
+        return [ToolCallEndEvent(tool_call_id=event.call_id)]
+
+    def _project_tool_result(
+        self, event: NeutralToolCallResultEvent
+    ) -> list[BaseEvent]:
+        return [
+            ToolCallResultEvent(
+                message_id=event.message_id,
+                tool_call_id=event.call_id,
+                content=dump_json(event.result),
+            )
+        ]
+
+    def _project_run_started(self, event: NeutralRunStartedEvent) -> list[BaseEvent]:
+        attribution = event.attribution
+        return [
+            RunStartedEvent(
+                thread_id=attribution.conversation_id,
+                run_id=attribution.run_id,
+                parent_run_id=attribution.parent_run_id,
+            )
+        ]
+
+    def _project_run_finished(self, event: NeutralRunFinishedEvent) -> list[BaseEvent]:
+        # Phase 1: close any frame still open before the terminal event.
+        events = self._close_open_frames()
+        # Phase 2: optionally emit a (currently empty) messages snapshot.
+        if self._config.messages_snapshot_enabled:
+            events.append(MessagesSnapshotEvent(messages=[]))
+        # Phase 3: a carried error becomes RUN_ERROR, otherwise RUN_FINISHED.
+        attribution = event.attribution
+        if event.error is not None:
+            events.append(
+                RunErrorEvent(
+                    message=_error_message(event.error),
+                    code=_error_code(event.error),
+                )
+            )
+            return events
+        events.append(
+            RunFinishedEvent(
+                thread_id=attribution.conversation_id,
+                run_id=attribution.run_id,
+                result=event.metadata.get("output"),
+            )
+        )
+        return events
+
+    def _project_step_started(self, event: NeutralStepStartedEvent) -> list[BaseEvent]:
+        return [StepStartedEvent(step_name=event.step_name)]
+
+    def _project_step_finished(
+        self, event: NeutralStepFinishedEvent
+    ) -> list[BaseEvent]:
+        return [StepFinishedEvent(step_name=event.step_name)]
+
+    def _project_state_snapshot(
+        self, event: NeutralStateSnapshotEvent
+    ) -> list[BaseEvent]:
+        if not self._config.emit_state_snapshot:
+            return []
+        return [StateSnapshotEvent(snapshot=event.snapshot)]
+
+    def _project_state_delta(self, event: NeutralStateDeltaEvent) -> list[BaseEvent]:
+        return [StateDeltaEvent(delta=list(_as_patch_operations(event.patch)))]
+
+    def _project_artifact(self, event: NeutralArtifactEvent) -> list[BaseEvent]:
+        return [
+            CustomEvent(
+                name=ARTIFACT_CUSTOM_EVENT_NAME,
+                value={
+                    "artifactId": event.artifact_id,
+                    "name": event.name,
+                    "content": event.content,
+                },
+            )
+        ]
+
+    def _open_text_message(self, message_id: str) -> list[BaseEvent]:
+        if self._open_message_id == message_id:
+            return []
+        events = self._close_open_frames()
+        self._open_message_id = message_id
+        events.append(TextMessageStartEvent(message_id=message_id, role=ASSISTANT_ROLE))
+        return events
+
+    def _open_reasoning_message(self, reasoning_id: str) -> list[BaseEvent]:
+        if self._open_reasoning_id == reasoning_id:
+            return []
+        events = self._close_open_frames()
+        self._open_reasoning_id = reasoning_id
+        events.append(ReasoningStartEvent(message_id=reasoning_id))
+        events.append(
+            ReasoningMessageStartEvent(message_id=reasoning_id, role=REASONING_ROLE)
+        )
+        return events
+
+    def _close_open_frames(self) -> list[BaseEvent]:
+        events: list[BaseEvent] = []
+        if self._open_message_id is not None:
+            events.append(TextMessageEndEvent(message_id=self._open_message_id))
+            self._open_message_id = None
+        if self._open_reasoning_id is not None:
+            events.append(ReasoningMessageEndEvent(message_id=self._open_reasoning_id))
+            events.append(ReasoningEndEvent(message_id=self._open_reasoning_id))
+            self._open_reasoning_id = None
+        # A tool call left open by a truncated stream (no TOOL_CALL_END) is closed
+        # here in open order so the AG-UI sequence stays balanced on the wire.
+        events.extend(
+            ToolCallEndEvent(tool_call_id=call_id)
+            for call_id in self._open_tool_call_ids
+        )
+        self._open_tool_call_ids.clear()
+        return events
+
+
+def _error_message(error: JsonObject) -> str:
+    message = error.get("message")
+    if isinstance(message, str):
+        return message
+    reason = error.get("reason")
+    if isinstance(reason, str):
+        return reason
+    return dump_json(error)
+
+
+def _error_code(error: JsonObject) -> str | None:
+    code = error.get("code")
+    if isinstance(code, str):
+        return code
+    return None
+
+
+def _as_patch_operations(patch: JsonValue) -> list[JsonValue]:
+    if isinstance(patch, list):
+        return list(patch)
+    return [patch]

--- a/plugins/spakky-agui/src/spakky/plugins/agui/serialization.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/serialization.py
@@ -1,0 +1,15 @@
+"""Shared JSON serialization for AG-UI adapter frames.
+
+The projector serializes tool results and run output, and HITL serializes
+approval args — both need the same neutral ``JsonValue`` -> JSON-text encoding,
+so it lives at module scope rather than being inlined twice.
+"""
+
+from json import dumps
+
+from spakky.agent.types import JsonValue
+
+
+def dump_json(value: JsonValue) -> str:
+    """Serialize a neutral JSON value to compact JSON text."""
+    return dumps(value, separators=(",", ":"), ensure_ascii=False)

--- a/plugins/spakky-agui/src/spakky/plugins/agui/transport.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/transport.py
@@ -1,0 +1,95 @@
+"""Drive an agent run and stream it as AG-UI server-sent events.
+
+``AgUiRunDriver`` is the pipe that connects the runner to the wire: it pulls the
+framework runner's native neutral ``AgentEvent`` stream off ``run_events`` —
+the lossless taxonomy AG-UI projects one-to-one (ADR-0013 §3) — runs each event
+through the projector (``AgentEvent`` -> AG-UI ``BaseEvent``), and encodes each
+AG-UI event into an SSE ``data:`` frame.
+
+``run_events`` emits no approval event: when a tool pauses for human approval it
+dispatches nothing and the pause lives only in the durable WAIT_FOR_APPROVAL
+state. So before the run's terminal ``RUN_FINISHED``, the driver reads that
+durable state and, when an approval is pending, injects the deferred-tool request
+frame (the AG-UI HITL idiom) ahead of the terminal. After the stream ends it
+flushes the projector's open-frame closures so a stream the runner left
+mid-message is still well-formed on the wire.
+"""
+
+from collections.abc import AsyncIterator
+
+from ag_ui.core import BaseEvent
+from ag_ui.encoder import EventEncoder
+
+from spakky.agent.event import (
+    AgentEvent,
+    AgentEventAttribution,
+    RunFinishedEvent,
+)
+from spakky.agent.inbound import RunAgentInput
+from spakky.agent.runner import AgentRunner
+
+from spakky.plugins.agui.hitl import project_pending_approval
+from spakky.plugins.agui.projector import AgUiProjector
+
+
+class AgUiRunDriver:
+    """Streams one agent run as encoded AG-UI SSE frames."""
+
+    def __init__(
+        self,
+        runner: AgentRunner,
+        run_input: RunAgentInput,
+        agent_id: str,
+        projector: AgUiProjector,
+        encoder: EventEncoder,
+    ) -> None:
+        self._runner = runner
+        self._run_input = run_input
+        self._attribution = AgentEventAttribution(
+            agent_id=agent_id,
+            run_id=run_input.state_id,
+            conversation_id=run_input.effective_conversation_id,
+        )
+        self._projector = projector
+        self._encoder = encoder
+
+    async def __aiter__(self) -> AsyncIterator[str]:
+        """Yield SSE frames for the full run, including the flush tail."""
+        # Phase 1: project every neutral runner event, surfacing a pending
+        # approval as a deferred-tool frame just before the terminal RUN_FINISHED.
+        async for event in self._runner.run_events(self._run_input):
+            for frame in self._frames_for(event):
+                yield frame
+        # Phase 2: flush any projector frame left open by a truncated stream.
+        for frame in self._encode(self._projector.finish()):
+            yield frame
+
+    def _frames_for(self, event: AgentEvent) -> list[str]:
+        if isinstance(event, RunFinishedEvent):
+            return self._encode(
+                [
+                    *self._project_pending_approval(),
+                    *self._projector.project(event),
+                ]
+            )
+        return self._encode(self._projector.project(event))
+
+    def _project_pending_approval(self) -> list[BaseEvent]:
+        """Project the durable pending approval, if any, before the terminal.
+
+        A stateless run has no state repository and never pauses, so there is
+        nothing to read; a durable run reads its run state and emits the
+        deferred-tool request only when it is paused for approval.
+        """
+        if self._runner.states is None:
+            return []
+        state = self._runner.states.get_or_none(self._run_input.state_id)
+        if state is None:
+            return []
+        projected: list[BaseEvent] = []
+        for approval_event in project_pending_approval(state, self._attribution):
+            projected.extend(self._projector.project(approval_event))
+        return projected
+
+    def _encode(self, events: list[BaseEvent]) -> list[str]:
+        return [self._encoder.encode(event) for event in events]

--- a/plugins/spakky-agui/tests/__init__.py
+++ b/plugins/spakky-agui/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the spakky-agui plugin."""

--- a/plugins/spakky-agui/tests/acceptance/__init__.py
+++ b/plugins/spakky-agui/tests/acceptance/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the spakky-agui plugin."""

--- a/plugins/spakky-agui/tests/acceptance/test_agui_acceptance.py
+++ b/plugins/spakky-agui/tests/acceptance/test_agui_acceptance.py
@@ -1,0 +1,126 @@
+"""Acceptance: a declared @Agent streams as a full neutral->ag_ui SSE run.
+
+A CI-safe fake ``IAgentModel`` drives a declaration-only ``@Agent`` through the
+framework runner via ``runner_backed_execute``, and the resulting public stream
+is projected end to end (run_events -> projector -> EventEncoder) into AG-UI SSE
+frames. The assertion fixes the developer-visible contract: a run surfaces as
+``RUN_STARTED`` -> ``TEXT_MESSAGE_*`` -> ``TOOL_CALL_*`` -> ``RUN_FINISHED``.
+"""
+
+from collections.abc import AsyncIterator
+from json import loads
+from typing import override
+
+from ag_ui.encoder import EventEncoder
+
+from spakky.agent import (
+    Agent,
+    AgentExecutionSpec,
+    AgentRunner,
+    EvidenceCapture,
+    Idempotency,
+    ModelCapability,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    RunAgentInput,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+from spakky.agent.interfaces.model import IAgentModel
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.projector import AgUiProjector
+from spakky.plugins.agui.transport import AgUiRunDriver
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="agui_assistant",
+        objective="answer with one tool",
+    )
+)
+class AgUiAssistant:
+    """Stateless declaration-only agent for the acceptance scenario."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model
+
+    @agent_tool(
+        schema_name="lookup",
+        description="Look up a fact.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def lookup(self, topic: str) -> str:
+        """Look up a topic."""
+        return f"fact:{topic}"
+
+
+class _ScriptedModel(IAgentModel):
+    """Fake model streaming a token then one tool call then done."""
+
+    @property
+    @override
+    def capability(self) -> ModelCapability:
+        return ModelCapability()
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        return ModelResponse(content="scripted")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        call = ModelToolCall(
+            name="lookup", arguments={"topic": "agents"}, call_id="call-1"
+        )
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOKEN_DELTA, token_delta="planning"
+        )
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOOL_CALL_START, tool_call=call
+        )
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOOL_CALL_ARGS_DELTA,
+            tool_call=call,
+            tool_call_args_delta='{"topic":"agents"}',
+        )
+        yield ModelStreamEvent(kind=ModelStreamEventKind.TOOL_CALL_END, tool_call=call)
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE, tool_call=call
+        )
+        yield ModelStreamEvent(kind=ModelStreamEventKind.DONE)
+
+
+async def test_declared_agent_streams_full_agui_sse_run() -> None:
+    """선언형 @Agent가 RUN_STARTED→TEXT_MESSAGE_*→TOOL_CALL_*→RUN_FINISHED로 스트리밍된다."""
+    run_input = RunAgentInput(
+        state_id="run-1", instruction="look up agents", conversation_id="conv-1"
+    )
+    runner = AgentRunner.for_agent_instance(AgUiAssistant(_ScriptedModel()))
+    driver = AgUiRunDriver(
+        runner=runner,
+        run_input=run_input,
+        agent_id="agui_assistant",
+        projector=AgUiProjector(AgUiConfig()),
+        encoder=EventEncoder(),
+    )
+
+    frames = [loads(frame.removeprefix("data: ").strip()) async for frame in driver]
+    types = [frame["type"] for frame in frames]
+
+    assert types[0] == "RUN_STARTED"
+    assert "TEXT_MESSAGE_START" in types
+    assert "TEXT_MESSAGE_CONTENT" in types
+    assert types.index("TOOL_CALL_START") < types.index("TOOL_CALL_RESULT")
+    assert types[-1] == "RUN_FINISHED"
+    # Attribution flows end to end onto the AG-UI run frames.
+    assert frames[0]["threadId"] == "conv-1"
+    assert frames[0]["runId"] == "run-1"
+    tool_result = next(f for f in frames if f["type"] == "TOOL_CALL_RESULT")
+    assert tool_result["content"] == '"fact:agents"'

--- a/plugins/spakky-agui/tests/integration/__init__.py
+++ b/plugins/spakky-agui/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the spakky-agui plugin."""

--- a/plugins/spakky-agui/tests/integration/test_hitl_resume.py
+++ b/plugins/spakky-agui/tests/integration/test_hitl_resume.py
@@ -1,0 +1,317 @@
+"""Integration: deferred-tool HITL surfaces an approval and resumes on decision.
+
+Run 1 reaches a REQUIRED-approval tool, pauses, and streams the deferred
+``hitl_approval`` tool frame with no result. Run 2 POSTs the human decision; the
+endpoint ingests it as a durable signal and the runner resumes from the paused
+boundary. APPROVE proceeds to the tool result and RUN_FINISHED; REJECT
+terminates without a tool result.
+"""
+
+from collections.abc import AsyncIterator, Sequence
+from json import loads
+from typing import override
+
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+from ag_ui.encoder import EventEncoder
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from spakky.agent import (
+    Agent,
+    AgentEvidence,
+    AgentExecutionSpec,
+    AgentRunner,
+    AgentSignal,
+    AgentSignalKind,
+    AgentState,
+    AgentStatus,
+    EvidenceCapture,
+    Idempotency,
+    ModelCapability,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    RecoveryStrategy,
+    RunAgentInput,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+from spakky.agent.error import AgentDefinitionError
+from spakky.agent.interfaces.model import IAgentModel
+from spakky.agent.interfaces.repository import (
+    IAgentEvidenceRepository,
+    IAgentSignalRepository,
+    IAgentStateRepository,
+)
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.endpoint import add_agui_endpoint
+from spakky.plugins.agui.hitl import ingest_decision
+from spakky.plugins.agui.projector import AgUiProjector
+from spakky.plugins.agui.transport import AgUiRunDriver
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="hitl_assistant",
+        objective="write after approval",
+        accepted_signals=(
+            AgentSignalKind.APPROVAL_DECISION,
+            AgentSignalKind.CANCEL,
+        ),
+        recovery=RecoveryStrategy.ACTION_BOUNDARY,
+    )
+)
+class HitlAssistant:
+    """Durable agent whose write tool requires human approval."""
+
+    def __init__(
+        self,
+        model: IAgentModel,
+        states: IAgentStateRepository,
+        signals: IAgentSignalRepository,
+        evidence: IAgentEvidenceRepository,
+    ) -> None:
+        self._model = model
+        self._states = states
+        self._signals = signals
+        self._evidence = evidence
+
+    @agent_tool(
+        schema_name="note.write",
+        description="Write a note after human approval.",
+        effects=ToolEffects.write_state(),
+        idempotency=Idempotency.CONDITIONALLY_IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.REQUIRED,
+    )
+    def note_write(self, topic: str) -> str:
+        """Write a note for a topic after approval."""
+        return f"write:{topic}"
+
+
+class _ScriptedModel(IAgentModel):
+    @property
+    @override
+    def capability(self) -> ModelCapability:
+        return ModelCapability()
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        return ModelResponse(content="scripted")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+            tool_call=ModelToolCall(
+                name="note.write", arguments={"topic": "agents"}, call_id="write-1"
+            ),
+        )
+        yield ModelStreamEvent(kind=ModelStreamEventKind.DONE)
+
+
+class _MemoryStateRepository(IAgentStateRepository):
+    def __init__(self) -> None:
+        self._states: dict[str, AgentState] = {}
+
+    @override
+    def get(self, state_id: str) -> AgentState:
+        state = self._states.get(state_id)
+        if state is None:
+            raise AgentDefinitionError("Missing state")
+        return state
+
+    @override
+    def get_or_none(self, state_id: str) -> AgentState | None:
+        return self._states.get(state_id)
+
+    @override
+    def save(self, state: AgentState) -> AgentState:
+        self._states[state.id] = state
+        return state
+
+    @override
+    def list_by_status(self, status: AgentStatus) -> Sequence[AgentState]:
+        return tuple(s for s in self._states.values() if s.status is status)
+
+    @override
+    def list_resume_candidates(self) -> Sequence[AgentState]:
+        return ()
+
+
+class _MemorySignalRepository(IAgentSignalRepository):
+    def __init__(self) -> None:
+        self._signals: tuple[AgentSignal, ...] = ()
+        self._consumed: set[str] = set()
+
+    @override
+    def append(self, signal: AgentSignal) -> AgentSignal:
+        self._signals = (*self._signals, signal)
+        return signal
+
+    @override
+    def list_pending(self, state_id: str) -> Sequence[AgentSignal]:
+        return tuple(
+            s
+            for s in self._signals
+            if s.agent_state_id == state_id and s.id not in self._consumed
+        )
+
+    @override
+    def mark_consumed(self, signal_id: str) -> AgentSignal:
+        for signal in self._signals:
+            if signal.id == signal_id:
+                self._consumed.add(signal_id)
+                return signal
+        raise AgentDefinitionError("Missing signal")
+
+    def all_appended(self) -> tuple[AgentSignal, ...]:
+        return self._signals
+
+
+class _MemoryEvidenceRepository(IAgentEvidenceRepository):
+    def __init__(self) -> None:
+        self._evidence: dict[str, AgentEvidence] = {}
+
+    @override
+    def append(self, evidence: AgentEvidence) -> AgentEvidence:
+        self._evidence[evidence.id] = evidence
+        return evidence
+
+    @override
+    def get(self, evidence_id: str) -> AgentEvidence:
+        evidence = self._evidence.get(evidence_id)
+        if evidence is None:
+            raise AgentDefinitionError("Missing evidence")
+        return evidence
+
+    @override
+    def list_by_state(self, state_id: str) -> Sequence[AgentEvidence]:
+        return tuple(a for a in self._evidence.values() if a.agent_state_id == state_id)
+
+    @override
+    def list_by_manifest_ref(self, manifest_ref: str) -> Sequence[AgentEvidence]:
+        return ()
+
+
+def _build_app(
+    signals: _MemorySignalRepository,
+) -> FastAPI:
+    app = FastAPI()
+    config = AgUiConfig()
+    assistant = HitlAssistant(
+        _ScriptedModel(), _MemoryStateRepository(), signals, _MemoryEvidenceRepository()
+    )
+
+    def run_driver_factory(
+        core_input: RunAgentInput,
+        ag_ui_input: AgUiRunAgentInput,
+        accept: str | None,
+    ) -> AgUiRunDriver:
+        runner = AgentRunner.for_agent_instance(assistant)
+        if core_input.resume:
+            ingest_decision(ag_ui_input, signals, core_input.state_id)
+        return AgUiRunDriver(
+            runner=runner,
+            run_input=core_input,
+            agent_id="hitl_assistant",
+            projector=AgUiProjector(config),
+            encoder=EventEncoder(accept=accept or ""),
+        )
+
+    add_agui_endpoint(app, run_driver_factory=run_driver_factory, config=config)
+    return app
+
+
+def _initial_input() -> dict[str, object]:
+    return {
+        "threadId": "conv-1",
+        "runId": "run-1",
+        "state": None,
+        "messages": [{"id": "u1", "role": "user", "content": "write a note"}],
+        "tools": [],
+        "context": [],
+        "forwardedProps": None,
+    }
+
+
+def _resume_input(decision: str) -> dict[str, object]:
+    return {
+        "threadId": "conv-1",
+        "runId": "run-1",
+        "state": None,
+        "messages": [
+            {"id": "u1", "role": "user", "content": "write a note"},
+            {
+                "id": "t1",
+                "role": "tool",
+                "toolCallId": "approval:run-1:note.write",
+                "content": (
+                    '{"request_id": "approval:run-1:note.write",'
+                    f' "decision": "{decision}"}}'
+                ),
+            },
+        ],
+        "tools": [],
+        "context": [],
+        "forwardedProps": None,
+    }
+
+
+def _types(text: str) -> list[str]:
+    frames = [line for line in text.split("\n\n") if line.startswith("data: ")]
+    return [loads(frame.removeprefix("data: ").strip())["type"] for frame in frames]
+
+
+def test_hitl_run1_surfaces_deferred_approval_then_pauses() -> None:
+    """run1이 hitl_approval deferred-tool 프레임을 스트리밍하고 결과 없이 멈춘다."""
+    signals = _MemorySignalRepository()
+    client = TestClient(_build_app(signals))
+
+    response = client.post("/agui", json=_initial_input())
+    text = response.text
+    types = _types(text)
+
+    assert "TOOL_CALL_START" in types
+    assert "hitl_approval" in text
+    # The approval has no result frame — it is deferred to the next input.
+    assert "TOOL_CALL_RESULT" not in types
+
+
+def test_hitl_resume_with_approve_writes_signal_and_streams_result() -> None:
+    """run2 APPROVE가 signal을 적재하고 런너가 재개해 tool result+RUN_FINISHED를 흘린다."""
+    signals = _MemorySignalRepository()
+    client = TestClient(_build_app(signals))
+    client.post("/agui", json=_initial_input())
+
+    response = client.post("/agui", json=_resume_input("approve"))
+    types = _types(response.text)
+
+    approval_signals = [
+        s for s in signals.all_appended() if s.kind is AgentSignalKind.APPROVAL_DECISION
+    ]
+    assert len(approval_signals) == 1
+    assert approval_signals[0].payload["decision"] == "approve"
+    assert "TOOL_CALL_RESULT" in types
+    assert types[-1] == "RUN_FINISHED"
+
+
+def test_hitl_resume_with_reject_terminates_without_tool_result() -> None:
+    """run2 REJECT가 signal을 적재하고 도구 결과 없이 종단으로 끝난다."""
+    signals = _MemorySignalRepository()
+    client = TestClient(_build_app(signals))
+    client.post("/agui", json=_initial_input())
+
+    response = client.post("/agui", json=_resume_input("reject"))
+    types = _types(response.text)
+
+    approval_signals = [
+        s for s in signals.all_appended() if s.kind is AgentSignalKind.APPROVAL_DECISION
+    ]
+    assert approval_signals[0].payload["decision"] == "reject"
+    assert "TOOL_CALL_RESULT" not in types
+    assert types[-1] == "RUN_FINISHED"

--- a/plugins/spakky-agui/tests/integration/test_sse_endpoint.py
+++ b/plugins/spakky-agui/tests/integration/test_sse_endpoint.py
@@ -1,0 +1,141 @@
+"""Integration: the AG-UI SSE endpoint streams a well-formed event stream."""
+
+from collections.abc import AsyncIterator
+from json import loads
+from typing import override
+
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+from ag_ui.encoder import EventEncoder
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from spakky.agent import (
+    Agent,
+    AgentExecutionSpec,
+    AgentRunner,
+    EvidenceCapture,
+    Idempotency,
+    ModelCapability,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    RunAgentInput,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+from spakky.agent.interfaces.model import IAgentModel
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.endpoint import add_agui_endpoint
+from spakky.plugins.agui.projector import AgUiProjector
+from spakky.plugins.agui.transport import AgUiRunDriver
+
+
+@Agent(spec=AgentExecutionSpec(name="sse_assistant", objective="answer with a tool"))
+class SseAssistant:
+    """Stateless agent exercised through the SSE endpoint."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model
+
+    @agent_tool(
+        schema_name="lookup",
+        description="Look up a fact.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def lookup(self, topic: str) -> str:
+        """Look up a topic."""
+        return f"fact:{topic}"
+
+
+class _ScriptedModel(IAgentModel):
+    @property
+    @override
+    def capability(self) -> ModelCapability:
+        return ModelCapability()
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        return ModelResponse(content="scripted")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOKEN_DELTA, token_delta="hello"
+        )
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+            tool_call=ModelToolCall(
+                name="lookup", arguments={"topic": "agents"}, call_id="call-1"
+            ),
+        )
+        yield ModelStreamEvent(kind=ModelStreamEventKind.DONE)
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    config = AgUiConfig()
+    assistant = SseAssistant(_ScriptedModel())
+
+    def run_driver_factory(
+        core_input: RunAgentInput,
+        ag_ui_input: AgUiRunAgentInput,
+        accept: str | None,
+    ) -> AgUiRunDriver:
+        runner = AgentRunner.for_agent_instance(assistant)
+        return AgUiRunDriver(
+            runner=runner,
+            run_input=core_input,
+            agent_id="sse_assistant",
+            projector=AgUiProjector(config),
+            encoder=EventEncoder(accept=accept or ""),
+        )
+
+    add_agui_endpoint(app, run_driver_factory=run_driver_factory, config=config)
+    return app
+
+
+def _run_agent_input() -> dict[str, object]:
+    return {
+        "threadId": "conv-1",
+        "runId": "run-1",
+        "state": None,
+        "messages": [{"id": "u1", "role": "user", "content": "look up agents"}],
+        "tools": [],
+        "context": [],
+        "forwardedProps": None,
+    }
+
+
+def test_sse_endpoint_streams_event_stream_frames_in_order() -> None:
+    """POST /agui가 순서가 보존된 valid SSE 프레임의 text/event-stream을 반환한다."""
+    client = TestClient(_build_app())
+
+    response = client.post("/agui", json=_run_agent_input())
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    frames = [line for line in response.text.split("\n\n") if line.startswith("data: ")]
+    types = [loads(frame.removeprefix("data: ").strip())["type"] for frame in frames]
+    assert types[0] == "RUN_STARTED"
+    assert "TOOL_CALL_RESULT" in types
+    assert types[-1] == "RUN_FINISHED"
+
+
+def test_sse_endpoint_rejects_missing_user_message() -> None:
+    """user 메시지가 없는 입력은 AgUiRunResolutionError로 거부된다."""
+    client = TestClient(_build_app(), raise_server_exceptions=True)
+    payload = _run_agent_input()
+    payload["messages"] = []
+
+    from spakky.plugins.agui.error import AgUiRunResolutionError
+    from pytest import raises
+
+    with raises(AgUiRunResolutionError):
+        client.post("/agui", json=payload)

--- a/plugins/spakky-agui/tests/unit/__init__.py
+++ b/plugins/spakky-agui/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the spakky-agui plugin."""

--- a/plugins/spakky-agui/tests/unit/test_config.py
+++ b/plugins/spakky-agui/tests/unit/test_config.py
@@ -1,0 +1,29 @@
+"""Tests for AG-UI adapter configuration."""
+
+from pytest import MonkeyPatch
+
+from spakky.plugins.agui.config import AgUiConfig
+
+
+def test_agui_config_defaults_expect_documented_values() -> None:
+    """AgUiConfig가 문서화된 기본값(sse_path/snapshot 게이트)을 노출한다."""
+    config = AgUiConfig()
+
+    assert config.sse_path == "/agui"
+    assert config.emit_state_snapshot is True
+    assert config.messages_snapshot_enabled is False
+
+
+def test_agui_config_env_override_expect_environment_values(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """SPAKKY_AGUI_ 환경변수가 설정 필드를 재정의한다."""
+    monkeypatch.setenv("SPAKKY_AGUI_SSE_PATH", "/stream/agui")
+    monkeypatch.setenv("SPAKKY_AGUI_EMIT_STATE_SNAPSHOT", "false")
+    monkeypatch.setenv("SPAKKY_AGUI_MESSAGES_SNAPSHOT_ENABLED", "true")
+
+    config = AgUiConfig()
+
+    assert config.sse_path == "/stream/agui"
+    assert config.emit_state_snapshot is False
+    assert config.messages_snapshot_enabled is True

--- a/plugins/spakky-agui/tests/unit/test_endpoint_mapping.py
+++ b/plugins/spakky-agui/tests/unit/test_endpoint_mapping.py
@@ -1,0 +1,132 @@
+"""Tests for the AG-UI -> core RunAgentInput mapping at the endpoint boundary."""
+
+from collections.abc import AsyncIterator
+from typing import cast
+
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pytest import raises
+
+from spakky.agent.inbound import RunAgentInput
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.endpoint import add_agui_endpoint, _to_core_input
+from spakky.plugins.agui.error import AgUiRunResolutionError
+from spakky.plugins.agui.transport import AgUiRunDriver
+
+
+class _StaticDriver:
+    async def __aiter__(self) -> AsyncIterator[str]:
+        yield 'data: {"type":"RUN_FINISHED"}\n\n'
+
+
+def _ag_ui_input(
+    messages: list[dict[str, object]], parent: str | None = None
+) -> AgUiRunAgentInput:
+    return AgUiRunAgentInput.model_validate(
+        {
+            "threadId": "conv-1",
+            "runId": "run-1",
+            "parentRunId": parent,
+            "state": None,
+            "messages": messages,
+            "tools": [],
+            "context": [],
+            "forwardedProps": None,
+        }
+    )
+
+
+def test_to_core_input_maps_ids_and_last_user_message() -> None:
+    """AG-UI 입력이 state/conversation/instruction 코어 필드로 매핑된다."""
+    core = _to_core_input(
+        _ag_ui_input(
+            [
+                {"id": "u1", "role": "user", "content": "first"},
+                {"id": "a1", "role": "assistant", "content": "ack"},
+                {"id": "u2", "role": "user", "content": "second"},
+            ]
+        )
+    )
+
+    assert core.state_id == "run-1"
+    assert core.conversation_id == "conv-1"
+    assert core.instruction == "second"
+    assert core.resume is False
+
+
+def test_to_core_input_does_not_forward_parent_run_id() -> None:
+    """parentRunId는 코어로 전달되지 않는다(run_events가 parent run을 세팅하지 않음)."""
+    core = _to_core_input(
+        _ag_ui_input([{"id": "u1", "role": "user", "content": "hi"}], parent="parent-9")
+    )
+
+    assert core.metadata == {}
+
+
+def test_to_core_input_skips_non_text_user_message() -> None:
+    """가장 최근 user 메시지의 content가 텍스트가 아니면 그 앞의 텍스트로 fallback한다."""
+    core = _to_core_input(
+        _ag_ui_input(
+            [
+                {"id": "u1", "role": "user", "content": "earlier text"},
+                {
+                    "id": "u2",
+                    "role": "user",
+                    "content": [{"type": "text", "text": "multimodal"}],
+                },
+            ]
+        )
+    )
+
+    assert core.instruction == "earlier text"
+
+
+def test_to_core_input_without_user_message_raises() -> None:
+    """user 메시지가 없으면 AgUiRunResolutionError를 던진다."""
+    with raises(AgUiRunResolutionError):
+        _to_core_input(
+            _ag_ui_input([{"id": "a1", "role": "assistant", "content": "ack"}])
+        )
+
+
+def test_add_agui_endpoint_invokes_driver_factory_with_mapped_input() -> None:
+    """FastAPI endpoint가 AG-UI JSON을 코어 입력으로 변환해 driver에 연결한다."""
+    captured: list[tuple[RunAgentInput, AgUiRunAgentInput, str | None]] = []
+    app = FastAPI()
+
+    def run_driver_factory(
+        core_input: RunAgentInput,
+        ag_ui_input: AgUiRunAgentInput,
+        accept: str | None,
+    ) -> AgUiRunDriver:
+        captured.append((core_input, ag_ui_input, accept))
+        return cast(AgUiRunDriver, _StaticDriver())
+
+    add_agui_endpoint(
+        app,
+        run_driver_factory=run_driver_factory,
+        config=AgUiConfig(),
+    )
+
+    response = TestClient(app).post(
+        "/agui",
+        json={
+            "threadId": "conv-1",
+            "runId": "run-1",
+            "state": None,
+            "messages": [{"id": "u1", "role": "user", "content": "hello"}],
+            "tools": [],
+            "context": [],
+            "forwardedProps": None,
+        },
+        headers={"accept": "text/event-stream"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert response.text == 'data: {"type":"RUN_FINISHED"}\n\n'
+    core_input, ag_ui_input, accept = captured[0]
+    assert core_input.instruction == "hello"
+    assert ag_ui_input.thread_id == "conv-1"
+    assert accept == "text/event-stream"

--- a/plugins/spakky-agui/tests/unit/test_hitl.py
+++ b/plugins/spakky-agui/tests/unit/test_hitl.py
@@ -1,0 +1,415 @@
+"""Tests for AG-UI human-in-the-loop projection and decision ingestion."""
+
+from collections.abc import Sequence
+from typing import override
+
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+from pytest import mark, raises
+
+from spakky.agent.event import (
+    AgentEventAttribution,
+    ToolCallArgsDeltaEvent,
+    ToolCallEndEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+from spakky.agent.execution import AgentSignalKind
+from spakky.agent.interfaces.repository import IAgentSignalRepository
+from spakky.agent.signal import AgentSignal, ApprovalDecision
+from spakky.agent.state import (
+    AgentState,
+    AgentStateReason,
+    AgentStateTransition,
+    AgentStatus,
+)
+from spakky.agent.types import JsonObject, JsonValue
+from spakky.agent.yield_ import Approval
+
+from spakky.plugins.agui.error import AgUiApprovalDecodeError, AgUiPendingApprovalError
+from spakky.plugins.agui.hitl import (
+    carries_approval_decision,
+    find_pending_approval,
+    ingest_decision,
+    project_approval,
+    project_pending_approval,
+)
+
+_DEFAULT_APPROVAL: JsonObject = {
+    "id": "approval:run-1:note.write",
+    "allowed_decisions": ["approve", "reject"],
+    "metadata": {"tool_name": "note_write"},
+}
+"""Well-formed approval metadata the runner stores on a WAIT_FOR_APPROVAL state."""
+
+
+class _FakeSignalRepository(IAgentSignalRepository):
+    def __init__(self) -> None:
+        self.appended: list[AgentSignal] = []
+
+    @override
+    def append(self, signal: AgentSignal) -> AgentSignal:
+        self.appended.append(signal)
+        return signal
+
+    @override
+    def list_pending(self, state_id: str) -> Sequence[AgentSignal]:
+        return tuple(s for s in self.appended if s.agent_state_id == state_id)
+
+    @override
+    def mark_consumed(self, signal_id: str) -> AgentSignal:
+        return next(s for s in self.appended if s.id == signal_id)
+
+
+def _attribution() -> AgentEventAttribution:
+    return AgentEventAttribution(
+        agent_id="assistant", run_id="run-1", conversation_id="conv-1"
+    )
+
+
+def _tool_result_input(content: str) -> AgUiRunAgentInput:
+    return AgUiRunAgentInput.model_validate(
+        {
+            "threadId": "conv-1",
+            "runId": "run-1",
+            "state": None,
+            "messages": [
+                {
+                    "id": "msg-1",
+                    "role": "tool",
+                    "content": content,
+                    "toolCallId": "appr-1",
+                }
+            ],
+            "tools": [],
+            "context": [],
+            "forwardedProps": None,
+        }
+    )
+
+
+def _forwarded_input(forwarded: object) -> AgUiRunAgentInput:
+    return AgUiRunAgentInput.model_validate(
+        {
+            "threadId": "conv-1",
+            "runId": "run-1",
+            "state": None,
+            "messages": [],
+            "tools": [],
+            "context": [],
+            "forwardedProps": forwarded,
+        }
+    )
+
+
+def test_project_approval_emits_deferred_tool_frame_without_result() -> None:
+    """승인 요청이 결과 없는 hitl_approval deferred-tool 프레임으로 투영된다."""
+    approval = Approval(
+        id="appr-1",
+        prompt="approve write?",
+        allowed_decisions=(ApprovalDecision.APPROVE, ApprovalDecision.REJECT),
+        metadata={"tool": "note.write"},
+    )
+
+    events = project_approval(approval, _attribution())
+
+    assert isinstance(events[0], ToolCallStartEvent)
+    assert events[0].call_id == "appr-1"
+    assert events[0].tool_name == "hitl_approval"
+    assert isinstance(events[1], ToolCallArgsDeltaEvent)
+    assert '"prompt":"approve write?"' in events[1].args_delta
+    assert '"allowed_decisions":["approve","reject"]' in events[1].args_delta
+    assert '"tool":"note.write"' in events[1].args_delta
+    assert isinstance(events[2], ToolCallEndEvent)
+    assert not any(isinstance(e, ToolCallResultEvent) for e in events)
+
+
+def test_ingest_decision_from_tool_result_writes_approval_signal() -> None:
+    """tool-result 메시지의 결정이 APPROVAL_DECISION signal로 적재된다."""
+    signals = _FakeSignalRepository()
+    ag_ui_input = _tool_result_input('{"request_id": "appr-1", "decision": "approve"}')
+
+    ingest_decision(ag_ui_input, signals, "run-1")
+
+    assert len(signals.appended) == 1
+    signal = signals.appended[0]
+    assert signal.agent_state_id == "run-1"
+    assert signal.kind is AgentSignalKind.APPROVAL_DECISION
+    assert signal.payload == {"request_id": "appr-1", "decision": "approve"}
+
+
+def test_ingest_decision_carries_modified_payload_and_comment() -> None:
+    """modified_payload/comment가 있으면 signal payload에 함께 적재된다."""
+    signals = _FakeSignalRepository()
+    ag_ui_input = _tool_result_input(
+        '{"request_id": "appr-1", "decision": "modify",'
+        ' "modified_payload": {"topic": "x"}, "comment": "ok"}'
+    )
+
+    ingest_decision(ag_ui_input, signals, "run-1")
+
+    payload = signals.appended[0].payload
+    assert payload["modified_payload"] == {"topic": "x"}
+    assert payload["comment"] == "ok"
+
+
+def test_ingest_decision_from_forwarded_props_writes_signal() -> None:
+    """forwardedProps.approvalDecision의 결정도 signal로 적재된다."""
+    signals = _FakeSignalRepository()
+    ag_ui_input = _forwarded_input(
+        {"approvalDecision": {"request_id": "appr-1", "decision": "reject"}}
+    )
+
+    ingest_decision(ag_ui_input, signals, "run-1")
+
+    assert signals.appended[0].payload["decision"] == "reject"
+
+
+@mark.parametrize("decision", list(ApprovalDecision))
+def test_ingest_decision_accepts_every_approval_decision(
+    decision: ApprovalDecision,
+) -> None:
+    """모든 ApprovalDecision 멤버가 디코딩되어 signal로 적재된다."""
+    signals = _FakeSignalRepository()
+    ag_ui_input = _tool_result_input(
+        f'{{"request_id": "appr-1", "decision": "{decision.value}"}}'
+    )
+
+    ingest_decision(ag_ui_input, signals, "run-1")
+
+    assert signals.appended[0].payload["decision"] == decision.value
+
+
+def test_ingest_decision_without_any_decision_raises() -> None:
+    """결정 페이로드가 전혀 없으면 AgUiApprovalDecodeError를 던진다."""
+    signals = _FakeSignalRepository()
+    ag_ui_input = _forwarded_input(None)
+
+    with raises(AgUiApprovalDecodeError):
+        ingest_decision(ag_ui_input, signals, "run-1")
+
+
+def test_ingest_decision_with_missing_request_id_raises() -> None:
+    """request_id가 빠진 결정은 AgUiApprovalDecodeError를 던진다."""
+    signals = _FakeSignalRepository()
+    ag_ui_input = _tool_result_input('{"decision": "approve"}')
+
+    with raises(AgUiApprovalDecodeError):
+        ingest_decision(ag_ui_input, signals, "run-1")
+
+
+def test_ingest_decision_with_invalid_decision_raises() -> None:
+    """ApprovalDecision에 없는 값은 AgUiApprovalDecodeError를 던진다."""
+    signals = _FakeSignalRepository()
+    ag_ui_input = _tool_result_input('{"request_id": "appr-1", "decision": "explode"}')
+
+    with raises(AgUiApprovalDecodeError):
+        ingest_decision(ag_ui_input, signals, "run-1")
+
+
+def test_ingest_decision_with_non_string_decision_raises() -> None:
+    """decision 값이 문자열이 아니면 AgUiApprovalDecodeError를 던진다."""
+    signals = _FakeSignalRepository()
+    ag_ui_input = _tool_result_input('{"request_id": "appr-1", "decision": 7}')
+
+    with raises(AgUiApprovalDecodeError):
+        ingest_decision(ag_ui_input, signals, "run-1")
+
+
+def test_ingest_decision_ignores_malformed_tool_content() -> None:
+    """JSON이 아닌 tool content는 결정원으로 무시되어 디코드 에러로 떨어진다."""
+    signals = _FakeSignalRepository()
+    ag_ui_input = _tool_result_input("not-json")
+
+    with raises(AgUiApprovalDecodeError):
+        ingest_decision(ag_ui_input, signals, "run-1")
+
+
+def test_ingest_decision_ignores_non_object_tool_content() -> None:
+    """JSON 배열 등 object가 아닌 tool content는 결정원으로 무시된다."""
+    signals = _FakeSignalRepository()
+    ag_ui_input = _tool_result_input("[1, 2, 3]")
+
+    with raises(AgUiApprovalDecodeError):
+        ingest_decision(ag_ui_input, signals, "run-1")
+
+
+def test_ingest_decision_ignores_tool_content_without_decision_key() -> None:
+    """decision 키가 없는 tool-result content는 결정원으로 무시된다."""
+    signals = _FakeSignalRepository()
+    ag_ui_input = _tool_result_input('{"result": "unrelated"}')
+
+    with raises(AgUiApprovalDecodeError):
+        ingest_decision(ag_ui_input, signals, "run-1")
+
+
+def test_carries_approval_decision_true_for_tool_result() -> None:
+    """tool-result 결정이 있으면 carries_approval_decision이 True다."""
+    ag_ui_input = _tool_result_input('{"request_id": "appr-1", "decision": "approve"}')
+
+    assert carries_approval_decision(ag_ui_input) is True
+
+
+def test_carries_approval_decision_false_without_decision() -> None:
+    """결정이 없으면 carries_approval_decision이 False다."""
+    ag_ui_input = _forwarded_input({"unrelated": True})
+
+    assert carries_approval_decision(ag_ui_input) is False
+
+
+def _paused_state(
+    *,
+    status: AgentStatus = AgentStatus.INTERRUPTED,
+    reason: AgentStateReason | None = AgentStateReason.APPROVAL_REQUIRED,
+    current_activity: str | None = "Approve tool invocation: note_write",
+    approval: JsonValue = _DEFAULT_APPROVAL,
+    include_approval: bool = True,
+) -> AgentState:
+    metadata: JsonObject = {"approval": approval} if include_approval else {}
+    return AgentState(
+        id="run-1",
+        agent_type="assistant",
+        status=status,
+        transition=AgentStateTransition.WAITING_APPROVAL,
+        reason=reason,
+        current_activity=current_activity,
+        metadata=metadata,
+    )
+
+
+def test_find_pending_approval_rebuilds_approval_from_paused_state() -> None:
+    """WAIT_FOR_APPROVAL 상태에서 approval 메타데이터로 Approval을 복원한다."""
+    approval = find_pending_approval(_paused_state())
+
+    assert approval is not None
+    assert approval.id == "approval:run-1:note.write"
+    assert approval.prompt == "Approve tool invocation: note_write"
+    assert approval.allowed_decisions == (
+        ApprovalDecision.APPROVE,
+        ApprovalDecision.REJECT,
+    )
+    assert approval.metadata == {"tool_name": "note_write"}
+
+
+def test_find_pending_approval_returns_none_when_not_interrupted() -> None:
+    """INTERRUPTED가 아니면 pending approval이 없다."""
+    assert find_pending_approval(_paused_state(status=AgentStatus.COMPLETED)) is None
+
+
+def test_find_pending_approval_returns_none_when_reason_not_approval() -> None:
+    """reason이 approval_required가 아니면 pending approval이 없다."""
+    assert find_pending_approval(_paused_state(reason=AgentStateReason.TIMEOUT)) is None
+
+
+def test_find_pending_approval_without_metadata_raises() -> None:
+    """approval 메타데이터가 없는 paused 상태는 AgUiPendingApprovalError를 던진다."""
+    with raises(AgUiPendingApprovalError):
+        find_pending_approval(_paused_state(include_approval=False))
+
+
+def test_find_pending_approval_without_prompt_raises() -> None:
+    """prompt(current_activity)가 없는 paused 상태는 AgUiPendingApprovalError를 던진다."""
+    with raises(AgUiPendingApprovalError):
+        find_pending_approval(_paused_state(current_activity=None))
+
+
+def test_find_pending_approval_with_blank_id_raises() -> None:
+    """approval id가 공백이면 AgUiPendingApprovalError를 던진다."""
+    with raises(AgUiPendingApprovalError):
+        find_pending_approval(
+            _paused_state(
+                approval={
+                    "id": "   ",
+                    "allowed_decisions": ["approve"],
+                    "metadata": {},
+                }
+            )
+        )
+
+
+def test_find_pending_approval_with_non_string_id_raises() -> None:
+    """approval id가 문자열이 아니면 AgUiPendingApprovalError를 던진다."""
+    with raises(AgUiPendingApprovalError):
+        find_pending_approval(
+            _paused_state(
+                approval={"id": 7, "allowed_decisions": ["approve"], "metadata": {}}
+            )
+        )
+
+
+def test_find_pending_approval_with_non_list_decisions_raises() -> None:
+    """allowed_decisions가 리스트가 아니면 AgUiPendingApprovalError를 던진다."""
+    with raises(AgUiPendingApprovalError):
+        find_pending_approval(
+            _paused_state(
+                approval={
+                    "id": "appr-1",
+                    "allowed_decisions": "approve",
+                    "metadata": {},
+                }
+            )
+        )
+
+
+def test_find_pending_approval_with_non_string_decision_raises() -> None:
+    """allowed_decisions 원소가 문자열이 아니면 AgUiPendingApprovalError를 던진다."""
+    with raises(AgUiPendingApprovalError):
+        find_pending_approval(
+            _paused_state(
+                approval={"id": "appr-1", "allowed_decisions": [7], "metadata": {}}
+            )
+        )
+
+
+def test_find_pending_approval_with_unknown_decision_raises() -> None:
+    """allowed_decisions에 모르는 값이 있으면 AgUiPendingApprovalError를 던진다."""
+    with raises(AgUiPendingApprovalError):
+        find_pending_approval(
+            _paused_state(
+                approval={
+                    "id": "appr-1",
+                    "allowed_decisions": ["explode"],
+                    "metadata": {},
+                }
+            )
+        )
+
+
+def test_find_pending_approval_with_non_mapping_metadata_raises() -> None:
+    """approval metadata가 매핑이 아니면 AgUiPendingApprovalError를 던진다."""
+    with raises(AgUiPendingApprovalError):
+        find_pending_approval(
+            _paused_state(
+                approval={
+                    "id": "appr-1",
+                    "allowed_decisions": ["approve"],
+                    "metadata": "x",
+                }
+            )
+        )
+
+
+def test_find_pending_approval_with_non_mapping_approval_raises() -> None:
+    """approval 항목 자체가 매핑이 아니면 AgUiPendingApprovalError를 던진다."""
+    with raises(AgUiPendingApprovalError):
+        find_pending_approval(_paused_state(approval=["not", "a", "mapping"]))
+
+
+def test_project_pending_approval_emits_deferred_tool_frame() -> None:
+    """paused 상태가 deferred-tool 승인 프레임으로 투영된다."""
+    events = project_pending_approval(_paused_state(), _attribution())
+
+    assert isinstance(events[0], ToolCallStartEvent)
+    assert events[0].tool_name == "hitl_approval"
+    assert events[0].call_id == "approval:run-1:note.write"
+    assert isinstance(events[-1], ToolCallEndEvent)
+    assert not any(isinstance(event, ToolCallResultEvent) for event in events)
+
+
+def test_project_pending_approval_returns_empty_when_not_paused() -> None:
+    """paused가 아니면 빈 목록을 반환한다."""
+    assert (
+        project_pending_approval(
+            _paused_state(status=AgentStatus.COMPLETED), _attribution()
+        )
+        == []
+    )

--- a/plugins/spakky-agui/tests/unit/test_main.py
+++ b/plugins/spakky-agui/tests/unit/test_main.py
@@ -1,0 +1,18 @@
+"""Tests for AG-UI plugin initialization."""
+
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.main import initialize
+
+
+def test_initialize_registers_agui_config_pod() -> None:
+    """initialize()가 AgUiConfig Pod을 컨테이너에 등록한다."""
+    app = SpakkyApplication(ApplicationContext())
+
+    initialize(app)
+
+    assert app.container.contains(AgUiConfig)
+    app.start()
+    assert isinstance(app.container.get(AgUiConfig), AgUiConfig)

--- a/plugins/spakky-agui/tests/unit/test_projector.py
+++ b/plugins/spakky-agui/tests/unit/test_projector.py
@@ -1,0 +1,543 @@
+"""Tests for the neutral AgentEvent -> AG-UI BaseEvent projector."""
+
+from ag_ui.core import (
+    CustomEvent,
+    ReasoningEndEvent,
+    ReasoningMessageContentEvent,
+    ReasoningMessageEndEvent,
+    ReasoningMessageStartEvent,
+    ReasoningStartEvent,
+    RunErrorEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    StateDeltaEvent,
+    StateSnapshotEvent,
+    StepFinishedEvent,
+    StepStartedEvent,
+    TextMessageContentEvent,
+    TextMessageEndEvent,
+    TextMessageStartEvent,
+    ToolCallArgsEvent,
+    ToolCallEndEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+from ag_ui.encoder import EventEncoder
+
+from spakky.agent.event import (
+    AgentEventAttribution,
+    ArtifactEvent,
+    MessageDeltaEvent,
+    ReasoningDeltaEvent,
+    RunFinishedEvent as NeutralRunFinishedEvent,
+    RunStartedEvent as NeutralRunStartedEvent,
+    StateDeltaEvent as NeutralStateDeltaEvent,
+    StateSnapshotEvent as NeutralStateSnapshotEvent,
+    StepFinishedEvent as NeutralStepFinishedEvent,
+    StepStartedEvent as NeutralStepStartedEvent,
+    ToolCallArgsDeltaEvent,
+    ToolCallEndEvent as NeutralToolCallEndEvent,
+    ToolCallResultEvent as NeutralToolCallResultEvent,
+    ToolCallStartEvent as NeutralToolCallStartEvent,
+)
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.projector import AgUiProjector
+
+
+def _attribution(parent: str | None = None) -> AgentEventAttribution:
+    return AgentEventAttribution(
+        agent_id="assistant",
+        run_id="run-1",
+        conversation_id="conv-1",
+        parent_run_id=parent,
+    )
+
+
+def _projector(
+    *, emit_state_snapshot: bool = True, messages_snapshot: bool = False
+) -> AgUiProjector:
+    config = AgUiConfig()
+    config.emit_state_snapshot = emit_state_snapshot
+    config.messages_snapshot_enabled = messages_snapshot
+    return AgUiProjector(config)
+
+
+def test_message_delta_opens_message_then_content() -> None:
+    """첫 MESSAGE_DELTA가 TEXT_MESSAGE_START + CONTENT를 연다."""
+    projector = _projector()
+
+    events = projector.project(
+        MessageDeltaEvent(attribution=_attribution(), message_id="m1", delta="hello")
+    )
+
+    assert isinstance(events[0], TextMessageStartEvent)
+    assert events[0].message_id == "m1"
+    assert events[0].role == "assistant"
+    assert isinstance(events[1], TextMessageContentEvent)
+    assert events[1].delta == "hello"
+
+
+def test_message_delta_same_id_does_not_reopen() -> None:
+    """동일 message_id의 연속 delta는 START를 다시 열지 않는다."""
+    projector = _projector()
+    projector.project(
+        MessageDeltaEvent(attribution=_attribution(), message_id="m1", delta="a")
+    )
+
+    events = projector.project(
+        MessageDeltaEvent(attribution=_attribution(), message_id="m1", delta="b")
+    )
+
+    assert all(not isinstance(e, TextMessageStartEvent) for e in events)
+    assert isinstance(events[0], TextMessageContentEvent)
+
+
+def test_message_delta_new_id_closes_previous_message() -> None:
+    """새 message_id는 이전 메시지를 END로 닫고 새 START를 연다."""
+    projector = _projector()
+    projector.project(
+        MessageDeltaEvent(attribution=_attribution(), message_id="m1", delta="a")
+    )
+
+    events = projector.project(
+        MessageDeltaEvent(attribution=_attribution(), message_id="m2", delta="b")
+    )
+
+    assert isinstance(events[0], TextMessageEndEvent)
+    assert events[0].message_id == "m1"
+    assert isinstance(events[1], TextMessageStartEvent)
+    assert events[1].message_id == "m2"
+
+
+def test_message_delta_empty_delta_skips_content() -> None:
+    """빈 delta는 CONTENT를 생략한다(AG-UI가 빈 CONTENT를 거부)."""
+    projector = _projector()
+
+    events = projector.project(
+        MessageDeltaEvent(attribution=_attribution(), message_id="m1", delta="")
+    )
+
+    assert isinstance(events[0], TextMessageStartEvent)
+    assert all(not isinstance(e, TextMessageContentEvent) for e in events)
+
+
+def test_reasoning_delta_opens_full_reasoning_lifecycle() -> None:
+    """REASONING_DELTA가 REASONING_START + MESSAGE_START + CONTENT를 연다."""
+    projector = _projector()
+
+    events = projector.project(
+        ReasoningDeltaEvent(
+            attribution=_attribution(), reasoning_id="r1", delta="think"
+        )
+    )
+
+    assert isinstance(events[0], ReasoningStartEvent)
+    assert isinstance(events[1], ReasoningMessageStartEvent)
+    assert events[1].role == "reasoning"
+    assert isinstance(events[2], ReasoningMessageContentEvent)
+    assert events[2].delta == "think"
+
+
+def test_reasoning_delta_empty_skips_content() -> None:
+    """빈 reasoning delta는 CONTENT를 생략한다."""
+    projector = _projector()
+
+    events = projector.project(
+        ReasoningDeltaEvent(attribution=_attribution(), reasoning_id="r1", delta="")
+    )
+
+    assert all(not isinstance(e, ReasoningMessageContentEvent) for e in events)
+
+
+def test_reasoning_delta_same_id_does_not_reopen() -> None:
+    """동일 reasoning_id의 연속 delta는 lifecycle을 다시 열지 않는다."""
+    projector = _projector()
+    projector.project(
+        ReasoningDeltaEvent(attribution=_attribution(), reasoning_id="r1", delta="a")
+    )
+
+    events = projector.project(
+        ReasoningDeltaEvent(attribution=_attribution(), reasoning_id="r1", delta="b")
+    )
+
+    assert all(not isinstance(e, ReasoningStartEvent) for e in events)
+
+
+def test_finish_closes_open_message() -> None:
+    """열린 메시지가 있으면 finish()가 END로 닫는다."""
+    projector = _projector()
+    projector.project(
+        MessageDeltaEvent(attribution=_attribution(), message_id="m1", delta="a")
+    )
+
+    tail = projector.finish()
+
+    assert isinstance(tail[0], TextMessageEndEvent)
+    assert tail[0].message_id == "m1"
+
+
+def test_finish_closes_open_reasoning() -> None:
+    """열린 reasoning이 있으면 finish()가 MESSAGE_END + REASONING_END로 닫는다."""
+    projector = _projector()
+    projector.project(
+        ReasoningDeltaEvent(attribution=_attribution(), reasoning_id="r1", delta="a")
+    )
+
+    tail = projector.finish()
+
+    assert isinstance(tail[0], ReasoningMessageEndEvent)
+    assert isinstance(tail[1], ReasoningEndEvent)
+
+
+def test_finish_without_open_frames_is_empty() -> None:
+    """열린 프레임이 없으면 finish()는 빈 목록을 반환한다."""
+    projector = _projector()
+
+    assert projector.finish() == []
+
+
+def test_tool_start_uses_explicit_parent_message_id() -> None:
+    """TOOL_CALL_START가 명시적 parent_message_id를 보존한다."""
+    projector = _projector()
+
+    events = projector.project(
+        NeutralToolCallStartEvent(
+            attribution=_attribution(),
+            call_id="c1",
+            tool_name="lookup",
+            parent_message_id="m9",
+        )
+    )
+
+    assert isinstance(events[0], ToolCallStartEvent)
+    assert events[0].tool_call_id == "c1"
+    assert events[0].tool_call_name == "lookup"
+    assert events[0].parent_message_id == "m9"
+
+
+def test_tool_start_falls_back_to_open_message() -> None:
+    """parent_message_id가 없으면 열린 메시지로 fallback한다."""
+    projector = _projector()
+    projector.project(
+        MessageDeltaEvent(attribution=_attribution(), message_id="m1", delta="a")
+    )
+
+    events = projector.project(
+        NeutralToolCallStartEvent(
+            attribution=_attribution(), call_id="c1", tool_name="lookup"
+        )
+    )
+
+    assert isinstance(events[0], ToolCallStartEvent)
+    assert events[0].parent_message_id == "m1"
+
+
+def test_tool_args_empty_delta_is_dropped() -> None:
+    """빈 args_delta는 TOOL_CALL_ARGS를 방출하지 않는다."""
+    projector = _projector()
+
+    events = projector.project(
+        ToolCallArgsDeltaEvent(attribution=_attribution(), call_id="c1", args_delta="")
+    )
+
+    assert events == []
+
+
+def test_tool_args_non_empty_delta_emits_args() -> None:
+    """비어있지 않은 args_delta는 TOOL_CALL_ARGS를 방출한다."""
+    projector = _projector()
+
+    events = projector.project(
+        ToolCallArgsDeltaEvent(
+            attribution=_attribution(), call_id="c1", args_delta='{"x":1}'
+        )
+    )
+
+    assert isinstance(events[0], ToolCallArgsEvent)
+    assert events[0].delta == '{"x":1}'
+
+
+def test_tool_end_emits_tool_call_end() -> None:
+    """TOOL_CALL_END가 그대로 방출된다."""
+    projector = _projector()
+
+    events = projector.project(
+        NeutralToolCallEndEvent(attribution=_attribution(), call_id="c1")
+    )
+
+    assert isinstance(events[0], ToolCallEndEvent)
+    assert events[0].tool_call_id == "c1"
+
+
+def test_finish_closes_open_tool_call_left_unended() -> None:
+    """TOOL_CALL_END 없이 열린 도구 호출은 finish()가 TOOL_CALL_END로 닫는다."""
+    projector = _projector()
+    projector.project(
+        NeutralToolCallStartEvent(
+            attribution=_attribution(), call_id="c1", tool_name="lookup"
+        )
+    )
+
+    tail = projector.finish()
+
+    assert [type(e).__name__ for e in tail] == ["ToolCallEndEvent"]
+    assert isinstance(tail[0], ToolCallEndEvent)
+    assert tail[0].tool_call_id == "c1"
+
+
+def test_finish_closes_open_tool_calls_in_open_order_after_message() -> None:
+    """열린 메시지와 도구 호출이 함께 있으면 메시지 END 후 도구 END를 open 순서로 닫는다."""
+    projector = _projector()
+    projector.project(
+        MessageDeltaEvent(attribution=_attribution(), message_id="m1", delta="a")
+    )
+    projector.project(
+        NeutralToolCallStartEvent(
+            attribution=_attribution(), call_id="c1", tool_name="first"
+        )
+    )
+    projector.project(
+        NeutralToolCallStartEvent(
+            attribution=_attribution(), call_id="c2", tool_name="second"
+        )
+    )
+
+    tail = projector.finish()
+
+    assert [type(e).__name__ for e in tail] == [
+        "TextMessageEndEvent",
+        "ToolCallEndEvent",
+        "ToolCallEndEvent",
+    ]
+    assert [e.tool_call_id for e in tail if isinstance(e, ToolCallEndEvent)] == [
+        "c1",
+        "c2",
+    ]
+
+
+def test_ended_tool_call_is_not_reclosed_by_finish() -> None:
+    """이미 TOOL_CALL_END로 닫힌 도구 호출은 finish()가 다시 닫지 않는다."""
+    projector = _projector()
+    projector.project(
+        NeutralToolCallStartEvent(
+            attribution=_attribution(), call_id="c1", tool_name="lookup"
+        )
+    )
+    projector.project(NeutralToolCallEndEvent(attribution=_attribution(), call_id="c1"))
+
+    assert projector.finish() == []
+
+
+def test_tool_result_serializes_result_content() -> None:
+    """TOOL_CALL_RESULT의 content가 result의 JSON 텍스트로 직렬화된다."""
+    projector = _projector()
+
+    events = projector.project(
+        NeutralToolCallResultEvent(
+            attribution=_attribution(),
+            call_id="c1",
+            tool_name="lookup",
+            message_id="m2",
+            result={"temp": 20},
+        )
+    )
+
+    assert isinstance(events[0], ToolCallResultEvent)
+    assert events[0].message_id == "m2"
+    assert events[0].tool_call_id == "c1"
+    assert events[0].content == '{"temp":20}'
+
+
+def test_run_started_maps_attribution_to_thread_run_parent() -> None:
+    """RUN_STARTED가 attribution을 threadId/runId/parentRunId로 매핑한다."""
+    projector = _projector()
+
+    events = projector.project(
+        NeutralRunStartedEvent(attribution=_attribution(parent="parent-1"))
+    )
+
+    assert isinstance(events[0], RunStartedEvent)
+    assert events[0].thread_id == "conv-1"
+    assert events[0].run_id == "run-1"
+    assert events[0].parent_run_id == "parent-1"
+    encoded = EventEncoder().encode(events[0])
+    assert '"threadId":"conv-1"' in encoded
+    assert '"parentRunId":"parent-1"' in encoded
+
+
+def test_run_finished_success_emits_run_finished_with_result() -> None:
+    """error 없는 RUN_FINISHED가 result를 담은 RunFinishedEvent를 방출한다."""
+    projector = _projector()
+
+    events = projector.project(
+        NeutralRunFinishedEvent(
+            attribution=_attribution(), error=None, metadata={"output": {"a": 1}}
+        )
+    )
+
+    finished = next(e for e in events if isinstance(e, RunFinishedEvent))
+    assert finished.thread_id == "conv-1"
+    assert finished.run_id == "run-1"
+    assert finished.result == {"a": 1}
+
+
+def test_run_finished_closes_open_message_before_terminal() -> None:
+    """RUN_FINISHED는 종단 전에 열린 메시지를 닫는다."""
+    projector = _projector()
+    projector.project(
+        MessageDeltaEvent(attribution=_attribution(), message_id="m1", delta="a")
+    )
+
+    events = projector.project(
+        NeutralRunFinishedEvent(attribution=_attribution(), error=None, metadata={})
+    )
+
+    assert isinstance(events[0], TextMessageEndEvent)
+    assert isinstance(events[-1], RunFinishedEvent)
+
+
+def test_run_finished_with_error_emits_run_error() -> None:
+    """error가 있는 RUN_FINISHED는 message/code를 담은 RUN_ERROR를 방출한다."""
+    projector = _projector()
+
+    events = projector.project(
+        NeutralRunFinishedEvent(
+            attribution=_attribution(),
+            error={"code": "boom", "message": "failed"},
+            metadata={},
+        )
+    )
+
+    error = next(e for e in events if isinstance(e, RunErrorEvent))
+    assert error.message == "failed"
+    assert error.code == "boom"
+
+
+def test_run_finished_error_reason_only_uses_reason_as_message() -> None:
+    """message 없이 reason만 있는 error는 reason을 RUN_ERROR message로 쓴다."""
+    projector = _projector()
+
+    events = projector.project(
+        NeutralRunFinishedEvent(
+            attribution=_attribution(), error={"reason": "cancelled"}, metadata={}
+        )
+    )
+
+    error = next(e for e in events if isinstance(e, RunErrorEvent))
+    assert error.message == "cancelled"
+    assert error.code is None
+
+
+def test_run_finished_error_without_message_or_reason_serializes() -> None:
+    """message/reason이 모두 없는 error는 JSON 직렬화 텍스트를 message로 쓴다."""
+    projector = _projector()
+
+    events = projector.project(
+        NeutralRunFinishedEvent(
+            attribution=_attribution(), error={"detail": "x"}, metadata={}
+        )
+    )
+
+    error = next(e for e in events if isinstance(e, RunErrorEvent))
+    assert error.message == '{"detail":"x"}'
+
+
+def test_messages_snapshot_emitted_before_run_finished_when_enabled() -> None:
+    """messages_snapshot_enabled면 RUN_FINISHED 직전에 MESSAGES_SNAPSHOT을 방출한다."""
+    projector = _projector(messages_snapshot=True)
+
+    events = projector.project(
+        NeutralRunFinishedEvent(attribution=_attribution(), error=None, metadata={})
+    )
+
+    kinds = [type(e).__name__ for e in events]
+    assert "MessagesSnapshotEvent" in kinds
+    assert kinds.index("MessagesSnapshotEvent") < kinds.index("RunFinishedEvent")
+
+
+def test_step_started_and_finished_map_by_name() -> None:
+    """STEP_STARTED/FINISHED가 step_name을 보존하여 매핑된다."""
+    projector = _projector()
+
+    started = projector.project(
+        NeutralStepStartedEvent(attribution=_attribution(), step_name="plan")
+    )
+    finished = projector.project(
+        NeutralStepFinishedEvent(attribution=_attribution(), step_name="plan")
+    )
+
+    assert isinstance(started[0], StepStartedEvent)
+    assert started[0].step_name == "plan"
+    assert isinstance(finished[0], StepFinishedEvent)
+    assert finished[0].step_name == "plan"
+
+
+def test_state_snapshot_emitted_when_enabled() -> None:
+    """emit_state_snapshot=True면 STATE_SNAPSHOT이 방출된다."""
+    projector = _projector(emit_state_snapshot=True)
+
+    events = projector.project(
+        NeutralStateSnapshotEvent(attribution=_attribution(), snapshot={"count": 1})
+    )
+
+    assert isinstance(events[0], StateSnapshotEvent)
+    assert events[0].snapshot == {"count": 1}
+
+
+def test_state_snapshot_dropped_when_disabled() -> None:
+    """emit_state_snapshot=False면 STATE_SNAPSHOT은 드롭된다."""
+    projector = _projector(emit_state_snapshot=False)
+
+    events = projector.project(
+        NeutralStateSnapshotEvent(attribution=_attribution(), snapshot={"count": 1})
+    )
+
+    assert events == []
+
+
+def test_state_delta_relays_patch_list() -> None:
+    """STATE_DELTA가 JSON Patch 리스트를 그대로 전달한다."""
+    projector = _projector()
+    patch = [{"op": "add", "path": "/x", "value": 1}]
+
+    events = projector.project(
+        NeutralStateDeltaEvent(attribution=_attribution(), patch=patch)
+    )
+
+    assert isinstance(events[0], StateDeltaEvent)
+    assert events[0].delta == patch
+
+
+def test_state_delta_wraps_non_list_patch() -> None:
+    """리스트가 아닌 patch는 단일 원소 리스트로 감싼다."""
+    projector = _projector()
+
+    events = projector.project(
+        NeutralStateDeltaEvent(attribution=_attribution(), patch={"op": "replace"})
+    )
+
+    assert isinstance(events[0], StateDeltaEvent)
+    assert events[0].delta == [{"op": "replace"}]
+
+
+def test_artifact_maps_to_custom_event() -> None:
+    """ARTIFACT가 name=artifact의 CUSTOM 이벤트로 매핑된다."""
+    projector = _projector()
+
+    events = projector.project(
+        ArtifactEvent(
+            attribution=_attribution(),
+            artifact_id="a1",
+            content={"k": "v"},
+            name="result",
+        )
+    )
+
+    assert isinstance(events[0], CustomEvent)
+    assert events[0].name == "artifact"
+    assert events[0].value == {
+        "artifactId": "a1",
+        "name": "result",
+        "content": {"k": "v"},
+    }

--- a/plugins/spakky-agui/tests/unit/test_public_api.py
+++ b/plugins/spakky-agui/tests/unit/test_public_api.py
@@ -1,0 +1,35 @@
+"""Tests for spakky-agui public API exports."""
+
+import spakky.plugins.agui as agui_api
+from spakky.plugins.agui import (
+    AbstractAgUiError,
+    AgUiApprovalDecodeError,
+    AgUiConfig,
+    AgUiPendingApprovalError,
+    AgUiProjector,
+    AgUiRunDriver,
+    AgUiRunResolutionError,
+    PLUGIN_NAME,
+    RunDriverFactory,
+    add_agui_endpoint,
+    ingest_decision,
+    project_approval,
+    project_pending_approval,
+)
+
+
+def test_public_api_exports_agui_surface() -> None:
+    """public API가 plugin id, config, adapter 구성요소, 에러, hook을 노출한다."""
+    assert PLUGIN_NAME.name == "spakky-agui"
+    assert AgUiConfig is agui_api.AgUiConfig
+    assert AgUiProjector is agui_api.AgUiProjector
+    assert AgUiRunDriver is agui_api.AgUiRunDriver
+    assert add_agui_endpoint is agui_api.add_agui_endpoint
+    assert ingest_decision is agui_api.ingest_decision
+    assert project_approval is agui_api.project_approval
+    assert project_pending_approval is agui_api.project_pending_approval
+    assert RunDriverFactory is agui_api.RunDriverFactory
+    assert AbstractAgUiError is agui_api.AbstractAgUiError
+    assert AgUiApprovalDecodeError is agui_api.AgUiApprovalDecodeError
+    assert AgUiPendingApprovalError is agui_api.AgUiPendingApprovalError
+    assert AgUiRunResolutionError is agui_api.AgUiRunResolutionError

--- a/plugins/spakky-agui/tests/unit/test_serialization.py
+++ b/plugins/spakky-agui/tests/unit/test_serialization.py
@@ -1,0 +1,8 @@
+"""Tests for AG-UI adapter JSON serialization helpers."""
+
+from spakky.plugins.agui.serialization import dump_json
+
+
+def test_dump_json_renders_compact_unicode_text() -> None:
+    """dump_json이 공백 없는 compact JSON을 (비 ASCII 보존하여) 만든다."""
+    assert dump_json({"city": "서울", "n": 1}) == '{"city":"서울","n":1}'

--- a/plugins/spakky-agui/tests/unit/test_transport.py
+++ b/plugins/spakky-agui/tests/unit/test_transport.py
@@ -1,0 +1,217 @@
+"""Tests for the AG-UI SSE run driver consuming the neutral event stream."""
+
+from collections.abc import AsyncGenerator
+from json import loads
+from typing import cast
+
+from ag_ui.encoder import EventEncoder
+
+from spakky.agent.event import (
+    AgentEvent,
+    AgentEventAttribution,
+    MessageDeltaEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    StepFinishedEvent,
+    StepStartedEvent,
+    ToolCallEndEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+from spakky.agent.inbound import RunAgentInput
+from spakky.agent.runner import AgentRunner
+from spakky.agent.state import (
+    AgentState,
+    AgentStateReason,
+    AgentStateTransition,
+    AgentStatus,
+)
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.projector import AgUiProjector
+from spakky.plugins.agui.transport import AgUiRunDriver
+
+_ATTRIBUTION = AgentEventAttribution(
+    agent_id="assistant", run_id="run-1", conversation_id="conv-1"
+)
+
+
+class _ScriptedRunner:
+    """Fake runner replaying a fixed neutral AgentEvent script over run_events."""
+
+    def __init__(
+        self,
+        script: tuple[AgentEvent, ...],
+        states: object | None = None,
+    ) -> None:
+        self._script = script
+        self.states = states
+
+    async def run_events(
+        self, run_input: RunAgentInput
+    ) -> AsyncGenerator[AgentEvent, None]:
+        for event in self._script:
+            yield event
+
+
+class _PausedStateRepository:
+    """Fake state repository returning a single state for the run by id."""
+
+    def __init__(self, state: AgentState) -> None:
+        self._state = state
+
+    def get_or_none(self, state_id: str) -> AgentState | None:
+        if state_id == self._state.id:
+            return self._state
+        return None
+
+
+def _run_input() -> RunAgentInput:
+    return RunAgentInput(
+        state_id="run-1", instruction="do it", conversation_id="conv-1"
+    )
+
+
+def _driver(
+    script: tuple[AgentEvent, ...],
+    states: object | None = None,
+) -> AgUiRunDriver:
+    return AgUiRunDriver(
+        runner=cast(AgentRunner, _ScriptedRunner(script, states)),
+        run_input=_run_input(),
+        agent_id="assistant",
+        projector=AgUiProjector(AgUiConfig()),
+        encoder=EventEncoder(),
+    )
+
+
+def _paused_state() -> AgentState:
+    return AgentState(
+        id="run-1",
+        agent_type="assistant",
+        status=AgentStatus.INTERRUPTED,
+        transition=AgentStateTransition.WAITING_APPROVAL,
+        reason=AgentStateReason.APPROVAL_REQUIRED,
+        current_activity="Approve tool invocation: note_write",
+        metadata={
+            "approval": {
+                "id": "approval:run-1:note.write",
+                "allowed_decisions": ["approve", "reject"],
+                "metadata": {"tool_name": "note_write"},
+            }
+        },
+    )
+
+
+async def test_driver_streams_ordered_sse_frames_with_finish_flush() -> None:
+    """neutral event 스트림이 순서대로 SSE 프레임으로 흐르고 finish() flush가 닫는다."""
+    driver = _driver(
+        (
+            RunStartedEvent(attribution=_ATTRIBUTION),
+            StepStartedEvent(attribution=_ATTRIBUTION, step_name="model-call"),
+            MessageDeltaEvent(attribution=_ATTRIBUTION, message_id="m1", delta="hi"),
+            ToolCallStartEvent(
+                attribution=_ATTRIBUTION,
+                call_id="c1",
+                tool_name="lookup",
+                parent_message_id="m1",
+            ),
+            ToolCallEndEvent(attribution=_ATTRIBUTION, call_id="c1"),
+            ToolCallResultEvent(
+                attribution=_ATTRIBUTION,
+                call_id="c1",
+                tool_name="lookup",
+                message_id="m1",
+                result={"answer": "ok"},
+            ),
+            StepFinishedEvent(attribution=_ATTRIBUTION, step_name="model-call"),
+            RunFinishedEvent(attribution=_ATTRIBUTION),
+        )
+    )
+
+    frames = [frame async for frame in driver]
+
+    assert all(
+        frame.startswith("data: ") and frame.endswith("\n\n") for frame in frames
+    )
+    types = [_event_type(frame) for frame in frames]
+    assert types[0] == "RUN_STARTED"
+    assert "TEXT_MESSAGE_START" in types
+    assert "TEXT_MESSAGE_CONTENT" in types
+    # The text message END is flushed before the terminal RUN_FINISHED.
+    assert types.index("TOOL_CALL_RESULT") < types.index("TEXT_MESSAGE_END")
+    assert types[-1] == "RUN_FINISHED"
+
+
+async def test_driver_flushes_open_message_when_stream_truncated() -> None:
+    """종단 이벤트 없이 끝난 스트림도 driver의 projector.finish()가 열린 메시지를 닫는다."""
+    driver = _driver(
+        (MessageDeltaEvent(attribution=_ATTRIBUTION, message_id="m1", delta="hi"),)
+    )
+
+    frames = [frame async for frame in driver]
+    types = [_event_type(frame) for frame in frames]
+
+    assert types == ["TEXT_MESSAGE_START", "TEXT_MESSAGE_CONTENT", "TEXT_MESSAGE_END"]
+
+
+async def test_driver_stateless_run_emits_no_pending_approval() -> None:
+    """states가 None인 stateless run은 deferred-tool 승인 프레임을 내지 않는다."""
+    driver = _driver(
+        (
+            RunStartedEvent(attribution=_ATTRIBUTION),
+            RunFinishedEvent(attribution=_ATTRIBUTION),
+        ),
+        states=None,
+    )
+
+    frames = [frame async for frame in driver]
+
+    assert "hitl_approval" not in "".join(frames)
+    assert _event_type(frames[-1]) == "RUN_FINISHED"
+
+
+async def test_driver_durable_run_without_pending_approval_emits_no_frame() -> None:
+    """durable run이지만 해당 run 상태가 없으면 승인 프레임을 내지 않는다."""
+    other_state = AgentState(
+        id="other", agent_type="assistant", status=AgentStatus.COMPLETED
+    )
+    driver = _driver(
+        (
+            RunStartedEvent(attribution=_ATTRIBUTION),
+            RunFinishedEvent(attribution=_ATTRIBUTION),
+        ),
+        states=_PausedStateRepository(other_state),
+    )
+
+    frames = [frame async for frame in driver]
+
+    assert "hitl_approval" not in "".join(frames)
+
+
+async def test_driver_surfaces_pending_approval_before_run_finished() -> None:
+    """paused 상태가 있으면 deferred-tool 승인 프레임을 RUN_FINISHED 직전에 주입한다."""
+    driver = _driver(
+        (
+            RunStartedEvent(attribution=_ATTRIBUTION),
+            StepStartedEvent(attribution=_ATTRIBUTION, step_name="model-call"),
+            StepFinishedEvent(attribution=_ATTRIBUTION, step_name="model-call"),
+            RunFinishedEvent(attribution=_ATTRIBUTION),
+        ),
+        states=_PausedStateRepository(_paused_state()),
+    )
+
+    frames = [frame async for frame in driver]
+    types = [_event_type(frame) for frame in frames]
+    text = "".join(frames)
+
+    assert "hitl_approval" in text
+    assert types.index("TOOL_CALL_START") < types.index("RUN_FINISHED")
+    assert "TOOL_CALL_END" in types
+    # The deferred approval is unresolved — no result frame is emitted.
+    assert "TOOL_CALL_RESULT" not in types
+    assert types[-1] == "RUN_FINISHED"
+
+
+def _event_type(frame: str) -> str:
+    return loads(frame.removeprefix("data: ").strip())["type"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ version_files = [
   "plugins/spakky-grpc/pyproject.toml:version",
   "plugins/spakky-redis/pyproject.toml:version",
   "plugins/spakky-vllm/pyproject.toml:version",
+  "plugins/spakky-agui/pyproject.toml:version",
   "plugins/spakky-oidc/pyproject.toml:version",
   "plugins/spakky-policy/pyproject.toml:version",
   "plugins/spakky-mcp/pyproject.toml:version",
@@ -91,6 +92,7 @@ members = [
   "plugins/spakky-grpc",
   "plugins/spakky-redis",
   "plugins/spakky-vllm",
+  "plugins/spakky-agui",
   "plugins/spakky-oidc",
   "plugins/spakky-policy",
   "plugins/spakky-mcp",
@@ -123,6 +125,7 @@ spakky-grpc = { workspace = true }
 spakky-saga = { workspace = true }
 spakky-redis = { workspace = true }
 spakky-vllm = { workspace = true }
+spakky-agui = { workspace = true }
 spakky-oidc = { workspace = true }
 spakky-policy = { workspace = true }
 spakky-mcp = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ members = [
     "spakky",
     "spakky-actuator",
     "spakky-agent",
+    "spakky-agui",
     "spakky-auth",
     "spakky-cache",
     "spakky-celery",
@@ -38,6 +39,18 @@ members = [
     "spakky-tracing",
     "spakky-typer",
     "spakky-vllm",
+]
+
+[[package]]
+name = "ag-ui-protocol"
+version = "0.1.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/10/4ad299267a7d04b89935aa99eef62979758fcf95aee9f8bb5d70c35b1be1/ag_ui_protocol-0.1.19.tar.gz", hash = "sha256:43c27f60d41712dcad0e9e0a203cbdf1c8e248b22417374c5c68321c448af4ea", size = 10720, upload-time = "2026-06-02T17:26:15.627Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/0a/bcad8116eb058e4b4a305e3fc37ebd7efc879deeb86b854f1c5b8b6e97dd/ag_ui_protocol-0.1.19-py3-none-any.whl", hash = "sha256:898843b1410d378824da0c6a776486288b9c5828689d0bf563118868e37f390f", size = 13490, upload-time = "2026-06-02T17:26:16.313Z" },
 ]
 
 [[package]]
@@ -3054,11 +3067,15 @@ actuator = [
 agent = [
     { name = "spakky-agent" },
     { name = "spakky-mcp" },
+    { name = "spakky-agui" },
     { name = "spakky-sqlalchemy" },
     { name = "spakky-vllm" },
 ]
 agent-core = [
     { name = "spakky-agent" },
+]
+agui = [
+    { name = "spakky-agui" },
 ]
 auth = [
     { name = "spakky-auth" },
@@ -3126,6 +3143,7 @@ fastapi = [
 full = [
     { name = "spakky-actuator" },
     { name = "spakky-agent" },
+    { name = "spakky-agui" },
     { name = "spakky-auth" },
     { name = "spakky-cache" },
     { name = "spakky-celery" },
@@ -3238,6 +3256,8 @@ worker = [
 [package.metadata]
 requires-dist = [
     { name = "psycopg", extras = ["binary"], marker = "extra == 'database-postgres'", specifier = ">=3.3.3" },
+    { name = "spakky", extras = ["agui"], marker = "extra == 'agent'", editable = "core/spakky" },
+    { name = "spakky", extras = ["agui"], marker = "extra == 'full'", editable = "core/spakky" },
     { name = "spakky", extras = ["celery"], marker = "extra == 'full'", editable = "core/spakky" },
     { name = "spakky", extras = ["celery"], marker = "extra == 'worker'", editable = "core/spakky" },
     { name = "spakky", extras = ["cryptography"], marker = "extra == 'full'", editable = "core/spakky" },
@@ -3286,6 +3306,7 @@ requires-dist = [
     { name = "spakky-agent", marker = "extra == 'agent'", editable = "core/spakky-agent" },
     { name = "spakky-agent", marker = "extra == 'agent-core'", editable = "core/spakky-agent" },
     { name = "spakky-agent", marker = "extra == 'full'", editable = "core/spakky-agent" },
+    { name = "spakky-agui", marker = "extra == 'agui'", editable = "plugins/spakky-agui" },
     { name = "spakky-auth", marker = "extra == 'auth'", editable = "core/spakky-auth" },
     { name = "spakky-auth", marker = "extra == 'full'", editable = "core/spakky-auth" },
     { name = "spakky-auth", marker = "extra == 'security'", editable = "core/spakky-auth" },
@@ -3332,7 +3353,7 @@ requires-dist = [
     { name = "spakky-vllm", marker = "extra == 'vllm'", editable = "plugins/spakky-vllm" },
     { name = "uuid7", specifier = ">=0.1.0" },
 ]
-provides-extras = ["minimal", "domain", "data", "event", "task", "agent-core", "actuator", "cache-core", "tracing", "outbox", "auth", "logging", "cryptography", "oidc", "policy", "openfga", "fastapi", "typer", "rabbitmq", "kafka", "sqlalchemy", "celery", "opentelemetry", "grpc", "redis", "vllm", "mcp", "saga", "web", "cli", "database", "database-postgres", "events-rabbitmq", "events-kafka", "events-outbox-sqlalchemy", "event-driven", "worker", "security", "observability", "cache-app", "agent", "recommended", "full"]
+provides-extras = ["minimal", "domain", "data", "event", "task", "agent-core", "agui", "actuator", "cache-core", "tracing", "outbox", "auth", "logging", "cryptography", "oidc", "policy", "openfga", "fastapi", "typer", "rabbitmq", "kafka", "sqlalchemy", "celery", "opentelemetry", "grpc", "redis", "vllm", "mcp", "saga", "web", "cli", "database", "database-postgres", "events-rabbitmq", "events-kafka", "events-outbox-sqlalchemy", "event-driven", "worker", "security", "observability", "cache-app", "agent", "recommended", "full"]
 
 [[package]]
 name = "spakky-actuator"
@@ -3370,6 +3391,27 @@ requires-dist = [{ name = "spakky", editable = "core/spakky" }]
 dev = [
     { name = "spakky-fastapi", editable = "plugins/spakky-fastapi" },
     { name = "spakky-typer", editable = "plugins/spakky-typer" },
+]
+
+[[package]]
+name = "spakky-agui"
+version = "6.9.1"
+source = { editable = "plugins/spakky-agui" }
+dependencies = [
+    { name = "ag-ui-protocol" },
+    { name = "fastapi", extra = ["standard"] },
+    { name = "pydantic-settings" },
+    { name = "spakky" },
+    { name = "spakky-agent" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "ag-ui-protocol", specifier = ">=0.1.19" },
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
+    { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "spakky", editable = "core/spakky" },
+    { name = "spakky-agent", editable = "core/spakky-agent" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add spakky-agui workspace plugin for neutral AgentEvent to ag_ui mapping and SSE streaming
- surface HITL approval pauses as deferred hitl_approval tool calls and ingest resume decisions from RunAgentInput
- preserve paused durable state in run_events by completing only ACTIVE states
- document AG-UI adapter usage and register the package in workspace metadata

## Verification
- uv lock --check
- core/spakky-agent: uv run ruff format .; uv run ruff check .; uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text; uv run pytest tests/unit/test_runner.py -q --no-cov
- plugins/spakky-agui: uv run ruff format .; uv run ruff check .; uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text; uv run pytest -q
- uv run mkdocs build --strict

Closes #414