### PR TITLE
feat(a2a): add A2A server adapter

### DIFF
--- a/core/spakky/pyproject.toml
+++ b/core/spakky/pyproject.toml
@@ -18,6 +18,7 @@ event = ["spakky-event>=6.9.1"]
 task = ["spakky-task>=6.9.1"]
 agent-core = ["spakky-agent>=6.9.1"]
 agui = ["spakky-agui>=6.9.1"]
+a2a = ["spakky-a2a>=6.9.1"]
 actuator = ["spakky-actuator>=6.9.1"]
 cache-core = ["spakky-cache>=6.9.1"]
 tracing = ["spakky-tracing>=6.9.1"]
@@ -101,6 +102,7 @@ agent = [
     "spakky[vllm]>=6.5.0",
     "spakky[mcp]>=6.5.0",
     "spakky[agui]>=6.5.0",
+    "spakky[a2a]>=6.5.0",
     "spakky[sqlalchemy]>=6.5.0",
 ]
 recommended = [
@@ -120,6 +122,7 @@ full = [
     "spakky-saga>=6.9.1",
     "spakky-task>=6.9.1",
     "spakky-tracing>=6.9.1",
+    "spakky[a2a]>=6.5.0",
     "spakky[agui]>=6.5.0",
     "spakky[celery]>=6.5.0",
     "spakky[cryptography]>=6.5.0",

--- a/plugins/spakky-a2a/README.md
+++ b/plugins/spakky-a2a/README.md
@@ -1,0 +1,3 @@
+# spakky-a2a
+
+A2A (Agent2Agent) protocol server plugin for the Spakky framework.

--- a/plugins/spakky-a2a/pyproject.toml
+++ b/plugins/spakky-a2a/pyproject.toml
@@ -1,0 +1,87 @@
+[project]
+name = "spakky-a2a"
+version = "6.9.1"
+description = "A2A (Agent2Agent) protocol server plugin for Spakky framework"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
+dependencies = [
+    "a2a-sdk[http-server]>=1.1.0",
+    "pydantic>=2.4",
+    "pydantic-settings>=2.13.1",
+    "spakky>=6.9.1",
+    "spakky-agent>=6.9.1",
+]
+
+[project.entry-points."spakky.plugins"]
+spakky-a2a = "spakky.plugins.a2a.main:initialize"
+
+[dependency-groups]
+dev = [
+    "pytest-asyncio>=1.3.0",
+    "pytest-integration-mark>=0.2.0",
+    "httpx>=0.28.0",
+    "types-protobuf>=7.34.1.20260518",
+]
+
+[build-system]
+requires = ["uv_build>=0.10.10,<0.12.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-root = "src"
+module-name = "spakky.plugins.a2a"
+
+[tool.pyrefly]
+python-version = "3.12"
+search_path = ["src", "."]
+project_excludes = ["**/__pycache__", "**/*.pyc"]
+
+[tool.ruff]
+builtins = ["_"]
+cache-dir = "~/.cache/ruff"
+
+[tool.pytest.ini_options]
+pythonpath = "src/spakky/plugins/a2a"
+testpaths = "tests"
+python_files = ["test_*.py"]
+asyncio_mode = "auto"
+markers = ["known_issue(reason): 알려진 버그"]
+addopts = """
+    --cov
+    --cov-report=term
+    --cov-report=xml
+    --no-cov-on-fail
+    --strict-markers
+    --dist=load
+    -p no:warnings
+    -n auto
+    --spec
+    --with-integration
+"""
+spec_test_format = "{result} {docstring_summary}"
+
+[tool.coverage.run]
+include = ["src/spakky/plugins/a2a/**/*.py"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+precision = 2
+fail_under = 100
+skip_empty = true
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "@(abc\\.)?abstractmethod",
+    "@(typing\\.)?overload",
+    "\\.\\.\\.",
+    "pass",
+]
+
+[tool.uv.sources]
+spakky = { workspace = true }
+spakky-agent = { workspace = true }

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/__init__.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/__init__.py
@@ -1,0 +1,25 @@
+"""A2A (Agent2Agent) protocol server plugin for the Spakky framework.
+
+Exposes a spakky ``@Agent`` as an A2A protocol server: an AgentCard is derived
+from the agent's spec, tools, and teammates, and JSON-RPC/HTTP plus SSE routes
+are mounted from the official ``a2a-sdk``. Marker, config, and plugin identifier
+are re-exported; transport types live under ``a2a-sdk``.
+"""
+
+from spakky.core.application.plugin import Plugin
+
+from spakky.plugins.a2a.config import (
+    SPAKKY_A2A_CONFIG_ENV_PREFIX,
+    A2AConfig,
+)
+from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+
+PLUGIN_NAME = Plugin(name="spakky-a2a")
+"""Plugin identifier for the A2A integration."""
+
+__all__ = [
+    "PLUGIN_NAME",
+    "SPAKKY_A2A_CONFIG_ENV_PREFIX",
+    "A2AConfig",
+    "A2AAgentServer",
+]

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/card/__init__.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/card/__init__.py
@@ -1,0 +1,1 @@
+"""A2A plugin card package."""

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/card/derivation.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/card/derivation.py
@@ -1,0 +1,108 @@
+"""AgentCard derivation from an @Agent declaration.
+
+Maps a spakky ``@Agent`` spec, its discovered tool catalog, and its declared
+teammates onto an a2a-sdk ``AgentCard``. The a2a-sdk 1.x ``AgentCard`` is a
+protobuf message (``a2a_pb2``) whose transport endpoint is expressed as an
+``AgentInterface`` entry rather than a flat ``url`` field, so the base URL is
+advertised through ``supported_interfaces``.
+"""
+
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
+    AgentSkill,
+)
+from a2a.utils import TransportProtocol
+from spakky.agent.execution import Agent, AgentTeammate, StreamingExposureMode
+from spakky.agent.tooling import AgentToolDescriptor, AgentToolMetadata
+
+JSON_CONTENT_TYPE = "application/json"
+"""Tool skills advertise JSON-shaped input and output payloads."""
+
+TEXT_CONTENT_TYPE = "text/plain"
+"""The card's default conversational input and output content type."""
+
+TEAMMATE_DELEGATION_TAG = "delegation"
+"""Tag attached to a skill derived from a declared teammate."""
+
+
+class AgentCardFactory:
+    """Builds an a2a-sdk ``AgentCard`` from an @Agent Pod declaration."""
+
+    def build(self, agent: Agent, base_url: str, version: str) -> AgentCard:
+        """Derive an AgentCard from an @Agent spec, tools, and teammates.
+
+        Args:
+            agent: The @Agent Pod metadata carrying spec and tool catalog.
+            base_url: Transport endpoint advertised on the card interface.
+            version: Semantic version advertised on the card.
+
+        Returns:
+            A protobuf ``AgentCard`` ready to publish on the well-known route.
+        """
+        spec = agent.spec
+        name = spec.name or agent.target.__name__
+        description = spec.objective or spec.instructions or name
+        # A guarded final-only profile suppresses incremental streaming exposure.
+        streaming = (
+            spec.streaming_exposure_mode
+            is not StreamingExposureMode.NO_STREAM_UNTIL_FINAL_GUARDED
+        )
+        tool_skills = [
+            self._tool_skill(descriptor)
+            for descriptor in agent.tool_catalog.descriptors
+        ]
+        teammate_skills = [
+            self._teammate_skill(teammate) for teammate in spec.teammates
+        ]
+        return AgentCard(
+            name=name,
+            description=description,
+            version=version,
+            supported_interfaces=[
+                AgentInterface(
+                    url=base_url,
+                    protocol_binding=TransportProtocol.JSONRPC.value,
+                )
+            ],
+            capabilities=AgentCapabilities(
+                streaming=streaming,
+                push_notifications=False,
+            ),
+            default_input_modes=[TEXT_CONTENT_TYPE],
+            default_output_modes=[TEXT_CONTENT_TYPE],
+            skills=[*tool_skills, *teammate_skills],
+        )
+
+    @staticmethod
+    def _tool_skill(descriptor: AgentToolDescriptor) -> AgentSkill:
+        """Project one tool descriptor onto an AgentSkill."""
+        return AgentSkill(
+            id=descriptor.identity.key,
+            name=descriptor.identity.name,
+            description=descriptor.description or descriptor.identity.name,
+            tags=AgentCardFactory._skill_tags(descriptor.metadata),
+            input_modes=[JSON_CONTENT_TYPE],
+            output_modes=[JSON_CONTENT_TYPE],
+        )
+
+    @staticmethod
+    def _teammate_skill(teammate: AgentTeammate) -> AgentSkill:
+        """Project one declared teammate onto a delegation AgentSkill."""
+        return AgentSkill(
+            id=f"teammate:{teammate.name}",
+            name=teammate.name,
+            description="Delegated teammate",
+            tags=[TEAMMATE_DELEGATION_TAG],
+        )
+
+    @staticmethod
+    def _skill_tags(metadata: AgentToolMetadata) -> list[str]:
+        """Derive deterministic skill tags from typed tool metadata."""
+        return [
+            *(permission.name for permission in metadata.permissions),
+            metadata.data_access.value,
+            metadata.externality.value,
+            metadata.idempotency.value,
+        ]

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/config.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/config.py
@@ -1,0 +1,35 @@
+"""A2A plugin configuration."""
+
+from typing import ClassVar
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from spakky.core.stereotype.configuration import Configuration
+
+SPAKKY_A2A_CONFIG_ENV_PREFIX = "SPAKKY_A2A_"
+"""Environment prefix for A2A plugin settings."""
+
+DEFAULT_A2A_BASE_URL = "http://localhost:8000"
+"""Fallback base URL advertised on a derived AgentCard interface."""
+
+DEFAULT_A2A_VERSION = "1.0.0"
+"""Fallback semantic version advertised on a derived AgentCard."""
+
+
+@Configuration()
+class A2AConfig(BaseSettings):
+    """Configuration for the A2A protocol server integration."""
+
+    model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
+        env_prefix=SPAKKY_A2A_CONFIG_ENV_PREFIX,
+        env_file_encoding="utf-8",
+        env_nested_delimiter="__",
+    )
+
+    default_base_url: str = DEFAULT_A2A_BASE_URL
+    """Base URL advertised on a derived AgentCard transport interface."""
+
+    default_version: str = DEFAULT_A2A_VERSION
+    """Semantic version advertised on a derived AgentCard."""
+
+    def __init__(self) -> None:
+        super().__init__()

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/error.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/error.py
@@ -1,0 +1,65 @@
+"""A2A plugin error hierarchy.
+
+Provides the base error class plus concrete errors raised while deriving an
+AgentCard, projecting neutral agent events onto A2A task events, and resolving a
+registered A2A agent server.
+"""
+
+from abc import ABC
+from spakky.core.common.error import AbstractSpakkyFrameworkError
+
+
+class AbstractSpakkyA2AError(AbstractSpakkyFrameworkError, ABC):
+    """Base exception for all Spakky A2A plugin errors."""
+
+    ...
+
+
+class A2AAgentServerNotRegisteredError(AbstractSpakkyA2AError):
+    """Raised when no A2A agent server is registered for a requested name."""
+
+    message = "No A2A agent server is registered for the agent name"
+
+    def __init__(self, agent_name: str) -> None:
+        super().__init__()
+        self.agent_name = agent_name
+
+
+class A2AAgentCardDerivationError(AbstractSpakkyA2AError):
+    """Raised when an AgentCard cannot be derived from an @Agent declaration."""
+
+    message = "Cannot derive an AgentCard from the agent declaration"
+
+    def __init__(self, agent_name: str) -> None:
+        super().__init__()
+        self.agent_name = agent_name
+
+
+class UnsupportedAgentEventError(AbstractSpakkyA2AError):
+    """Raised when an AgentEvent kind has no A2A task-event projection."""
+
+    message = "Agent event kind cannot be projected to an A2A event"
+
+    def __init__(self, kind: str) -> None:
+        super().__init__()
+        self.kind = kind
+
+
+class UnsupportedFinalOutputError(AbstractSpakkyA2AError):
+    """Raised when a final agent output cannot be projected to an A2A part."""
+
+    message = "Agent final output cannot be projected to an A2A part"
+
+    def __init__(self, output_type: type[object]) -> None:
+        super().__init__()
+        self.output_type = output_type
+
+
+class InvalidApprovalDecisionError(AbstractSpakkyA2AError):
+    """Raised when an inbound approval-decision part carries an unknown decision."""
+
+    message = "Inbound approval decision is not a known ApprovalDecision"
+
+    def __init__(self, decision: str) -> None:
+        super().__init__()
+        self.decision = decision

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/executor/__init__.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/executor/__init__.py
@@ -1,0 +1,1 @@
+"""A2A plugin executor package."""

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/executor/adapter.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/executor/adapter.py
@@ -1,0 +1,317 @@
+"""a2a-sdk ``AgentExecutor`` bound to a spakky @Agent instance.
+
+Drives the framework-owned :class:`~spakky.agent.runner.AgentRunner` for one A2A
+request over the neutral ``run_events()`` stream and projects each ``AgentEvent``
+onto A2A task events. The A2A task id seeds the agent's durable ``state_id`` so a
+human-approval pause resumes on the same run when the caller sends the next
+message with the same task id and an approval-decision data part.
+
+The runner's ``run_events()`` always emits ``RUN_FINISHED`` even when a tool call
+paused on an approval gate, leaving the durable state ``reason`` at
+``APPROVAL_REQUIRED`` while forcing its status to completed. This executor
+therefore reconciles the single terminal A2A transition after draining the
+stream: an approval pause becomes ``input-required``; otherwise the run's
+``RUN_FINISHED`` outcome becomes completed or failed.
+"""
+
+from collections.abc import AsyncGenerator, Sequence
+from dataclasses import dataclass
+from typing import override
+
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.tasks import TaskUpdater
+from a2a.types import Part, Task, TaskState, TaskStatus
+from google.protobuf.json_format import MessageToDict, ParseDict
+from google.protobuf.struct_pb2 import Value
+from spakky.agent.event import AgentEvent
+from spakky.agent.execution import AgentSignalKind
+from spakky.agent.inbound import RunAgentInput
+from spakky.agent.interfaces.repository import (
+    IAgentSignalRepository,
+    IAgentStateRepository,
+)
+from spakky.agent.runner import AgentRunner
+from spakky.agent.signal import AgentSignal, ApprovalDecision
+from spakky.agent.state import AgentStateReason
+from spakky.agent.types import JsonObject
+
+from spakky.plugins.a2a.error import InvalidApprovalDecisionError
+from spakky.plugins.a2a.executor.event_mapping import AgentEventProjector, RunOutcome
+
+APPROVAL_ID_PART_KEY = "approval_id"
+"""Inbound data-part key carrying the approval request id to resume."""
+
+APPROVAL_DECISION_PART_KEY = "decision"
+"""Inbound data-part key carrying the chosen approval decision value."""
+
+APPROVAL_METADATA_KEY = "approval"
+"""Durable state metadata key holding the pending approval request."""
+
+APPROVAL_ALLOWED_DECISIONS_KEY = "allowed_decisions"
+"""Approval metadata key listing the decisions the client may return."""
+
+RUN_FAILED_FALLBACK_MESSAGE = "run failed"
+"""Status message used when a failed run carries no error message."""
+
+APPROVAL_PROMPT_FALLBACK = "Approval required to continue."
+"""Status message used when the pending approval carries no prompt."""
+
+
+@dataclass(frozen=True, slots=True)
+class _InboundApproval:
+    """An approval id and decision parsed from an inbound A2A data part."""
+
+    approval_id: str
+    decision: ApprovalDecision
+
+
+class SpakkyAgentExecutor(AgentExecutor):
+    """Bridges A2A request execution onto the spakky agent event stream."""
+
+    _agent: object
+    _projector: AgentEventProjector
+
+    def __init__(self, agent: object, projector: AgentEventProjector) -> None:
+        self._agent = agent
+        self._projector = projector
+
+    @override
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        task = await self._ensure_task(context, event_queue)
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        await updater.start_work()
+        approval = self._inbound_approval(context)
+        if approval is not None:
+            self._append_approval_signal(task.id, approval)
+        run_input = RunAgentInput(
+            state_id=task.id,
+            instruction=self._instruction(context),
+            conversation_id=context.context_id,
+            resume=approval is not None,
+        )
+        outcome: RunOutcome | None = None
+        async for event in self._run_events(run_input):
+            projected = await self._projector.project(event, updater)
+            if projected is not None:
+                outcome = projected
+        await self._reconcile_terminal(task.id, outcome, updater)
+
+    def _run_events(self, run_input: RunAgentInput) -> AsyncGenerator[AgentEvent, None]:
+        """Drive the runner's neutral event stream for one run."""
+        return AgentRunner.for_agent_instance(self._agent).run_events(run_input)
+
+    async def _reconcile_terminal(
+        self,
+        task_id: str,
+        outcome: RunOutcome | None,
+        updater: TaskUpdater,
+    ) -> None:
+        """Apply the single terminal A2A transition after draining the stream.
+
+        A pending approval (durable state ``reason`` ``APPROVAL_REQUIRED``) takes
+        precedence over the runner's forced ``RUN_FINISHED`` success, becoming an
+        ``input-required`` pause; otherwise the run's outcome decides completion.
+        """
+        pause = self._pending_approval(task_id)
+        if pause is not None:
+            await self._project_approval_pause(pause, updater)
+            return
+        if outcome is not None and outcome.error is not None:
+            await self._project_run_failure(outcome.error, updater)
+            return
+        await updater.complete()
+
+    async def _project_approval_pause(
+        self,
+        approval: JsonObject,
+        updater: TaskUpdater,
+    ) -> None:
+        """Pause the task for human input, echoing the approval id and choices."""
+        approval_id = approval.get("id")
+        allowed = approval.get(APPROVAL_ALLOWED_DECISIONS_KEY)
+        prompt = approval.get("prompt")
+        await updater.requires_input(
+            updater.new_agent_message(
+                [
+                    Part(
+                        text=prompt
+                        if isinstance(prompt, str)
+                        else APPROVAL_PROMPT_FALLBACK
+                    ),
+                    _data_part(
+                        {
+                            APPROVAL_ID_PART_KEY: approval_id,
+                            APPROVAL_ALLOWED_DECISIONS_KEY: allowed,
+                        }
+                    ),
+                ]
+            )
+        )
+
+    @staticmethod
+    async def _project_run_failure(error: JsonObject, updater: TaskUpdater) -> None:
+        """Mark the task failed, surfacing the runner's terminal error payload."""
+        message = error.get("message")
+        await updater.update_status(
+            TaskState.TASK_STATE_FAILED,
+            updater.new_agent_message(
+                [
+                    Part(
+                        text=message
+                        if isinstance(message, str)
+                        else RUN_FAILED_FALLBACK_MESSAGE
+                    ),
+                    _data_part(error),
+                ]
+            ),
+        )
+
+    def _pending_approval(self, task_id: str) -> JsonObject | None:
+        """Return the pending approval request when the run paused for one.
+
+        ``run_events()`` forces the durable status to completed even on an approval
+        pause, but preserves ``reason == APPROVAL_REQUIRED`` and the approval
+        request in ``metadata['approval']`` — that pair is the lossless pause signal.
+        """
+        states = self._state_repository()
+        if states is None:
+            return None
+        state = states.get_or_none(task_id)
+        if state is None or state.reason is not AgentStateReason.APPROVAL_REQUIRED:
+            return None
+        approval = state.metadata.get(APPROVAL_METADATA_KEY)
+        if not isinstance(approval, dict):
+            return None
+        return approval
+
+    @override
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        task_id = context.task_id or ""
+        # Queue a durable cancel so an in-flight or resumed runner turn observes it,
+        # then publish the canceled task state the A2A caller awaits in this turn.
+        signals = self._signal_repository()
+        if signals is not None:
+            signals.append(
+                AgentSignal(
+                    id=f"cancel:{task_id}",
+                    agent_state_id=task_id,
+                    kind=AgentSignalKind.CANCEL,
+                )
+            )
+        updater = TaskUpdater(event_queue, task_id, context.context_id or "")
+        await updater.cancel()
+
+    @staticmethod
+    async def _ensure_task(context: RequestContext, event_queue: EventQueue) -> Task:
+        """Return the resumed task or enqueue a freshly submitted one.
+
+        The a2a-sdk requires a ``Task`` event before any status update, so a new
+        run enqueues the submitted task before the updater publishes transitions.
+        """
+        if context.current_task is not None:
+            return context.current_task
+        task = Task(
+            id=context.task_id or "",
+            context_id=context.context_id or "",
+            status=TaskStatus(state=TaskState.TASK_STATE_SUBMITTED),
+        )
+        await event_queue.enqueue_event(task)
+        return task
+
+    @staticmethod
+    def _instruction(context: RequestContext) -> str:
+        """Return the inbound user text, defaulting to a resume marker.
+
+        A2A resume turns may carry only an approval data part with no text, but
+        ``RunAgentInput`` rejects a blank instruction, so a non-blank marker seeds
+        the resumed run whose real continuation comes from the durable signal.
+        """
+        return context.get_user_input() or "resume"
+
+    def _inbound_approval(
+        self,
+        context: RequestContext,
+    ) -> "_InboundApproval | None":
+        """Extract an approval id and decision from an inbound data part.
+
+        The client echoes the ``approval_id`` it received on the pause; that id is
+        the runner's approval request id, so it is preserved verbatim to match the
+        pending approval rather than being re-derived from the task id.
+        """
+        message = context.message
+        if message is None:
+            return None
+        for part in message.parts:
+            if not part.HasField("data"):
+                continue
+            data = MessageToDict(part.data)
+            approval_id = data.get(APPROVAL_ID_PART_KEY)
+            if not isinstance(approval_id, str):
+                continue
+            return _InboundApproval(
+                approval_id=approval_id,
+                decision=self._parse_decision(data.get(APPROVAL_DECISION_PART_KEY)),
+            )
+        return None
+
+    @staticmethod
+    def _parse_decision(value: object) -> ApprovalDecision:
+        """Narrow a raw decision value to a known ``ApprovalDecision``."""
+        if not isinstance(value, str):
+            raise InvalidApprovalDecisionError(str(value))
+        try:
+            return ApprovalDecision(value)
+        except ValueError as e:
+            raise InvalidApprovalDecisionError(value) from e
+
+    def _append_approval_signal(
+        self,
+        task_id: str,
+        approval: "_InboundApproval",
+    ) -> None:
+        """Append an APPROVAL_DECISION signal so the runner resumes the pause."""
+        signals = self._signal_repository()
+        if signals is None:
+            raise InvalidApprovalDecisionError(approval.decision.value)
+        signals.append(
+            AgentSignal(
+                id=f"approval:{approval.approval_id}",
+                agent_state_id=task_id,
+                kind=AgentSignalKind.APPROVAL_DECISION,
+                payload={
+                    "request_id": approval.approval_id,
+                    "decision": approval.decision.value,
+                },
+            )
+        )
+
+    def _signal_repository(self) -> IAgentSignalRepository | None:
+        """Resolve the agent's signal repository by type from its attributes.
+
+        Mirrors ``AgentRunner.for_agent_instance``: constructor-injected ports are
+        instance attributes, read from ``vars(instance)`` (not the banned
+        ``getattr``) and matched by runtime type since attribute names vary.
+        """
+        return self._resolve(tuple(vars(self._agent).values()), IAgentSignalRepository)
+
+    def _state_repository(self) -> IAgentStateRepository | None:
+        """Resolve the agent's state repository by type from its attributes."""
+        return self._resolve(tuple(vars(self._agent).values()), IAgentStateRepository)
+
+    @staticmethod
+    def _resolve[PortT](
+        attributes: Sequence[object],
+        port_type: type[PortT],
+    ) -> PortT | None:
+        for attribute in attributes:
+            if isinstance(attribute, port_type):
+                return attribute
+        return None
+
+
+def _data_part(payload: JsonObject) -> Part:
+    """Build a protobuf data ``Part`` from a JSON-compatible mapping."""
+    value = Value()
+    ParseDict(dict(payload), value)
+    return Part(data=value)

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/executor/event_mapping.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/executor/event_mapping.py
@@ -1,0 +1,239 @@
+"""Projection of neutral AgentEvent items onto A2A task events.
+
+The runner's ``run_events()`` emits the protocol-neutral ``AgentEvent`` taxonomy
+(ADR-0013 §3); this projector reproduces each event one-to-one as an a2a-sdk task
+update. A2A 1.x parts are protobuf messages: text is ``Part(text=...)`` and
+structured data is ``Part(data=<google.protobuf.Value>)``, built from a
+JSON-compatible value via ``ParseDict``.
+
+``RUN_FINISHED`` is not applied as a terminal transition here. The runner's
+``run_events()`` always emits ``RUN_FINISHED`` even when a tool call paused on a
+human approval gate, so the executor reconciles the real terminal state (complete,
+fail, or input-required) once after draining the stream. This projector therefore
+returns the run's terminal outcome rather than calling ``complete()`` itself.
+"""
+
+from dataclasses import dataclass
+
+from a2a.server.tasks import TaskUpdater
+from a2a.types import Part, TaskState
+from google.protobuf.json_format import ParseDict
+from google.protobuf.struct_pb2 import Value
+from spakky.agent.event import (
+    AgentEvent,
+    AgentEventKind,
+    ArtifactEvent,
+    MessageDeltaEvent,
+    ReasoningDeltaEvent,
+    RunFinishedEvent,
+    StateDeltaEvent,
+    StateSnapshotEvent,
+    StepFinishedEvent,
+    StepStartedEvent,
+    ToolCallArgsDeltaEvent,
+    ToolCallEndEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+from spakky.agent.types import JsonObject, JsonValue
+
+from spakky.plugins.a2a.error import UnsupportedAgentEventError
+
+
+@dataclass(frozen=True, slots=True)
+class RunOutcome:
+    """Terminal result of one run, reconciled by the executor after draining.
+
+    ``error`` is ``None`` for a successful run and carries the runner's terminal
+    failure payload otherwise. The executor applies the single terminal task
+    transition, since an approval pause must override a runner-reported success.
+    """
+
+    error: JsonObject | None
+
+
+class AgentEventProjector:
+    """Projects neutral AgentEvent items onto a2a-sdk task-event updates."""
+
+    async def project(
+        self,
+        event: AgentEvent,
+        updater: TaskUpdater,
+    ) -> RunOutcome | None:
+        """Publish A2A events for one agent event via the task updater.
+
+        Args:
+            event: The neutral event emitted by the agent runner.
+            updater: The a2a-sdk updater bound to the running task.
+
+        Returns:
+            The run's terminal outcome for a ``RUN_FINISHED`` event, else None.
+
+        Raises:
+            UnsupportedAgentEventError: The event kind has no A2A projection.
+        """
+        match event.kind:
+            case AgentEventKind.RUN_STARTED:
+                await updater.start_work()
+            case AgentEventKind.RUN_FINISHED:
+                return RunOutcome(error=_as(event, RunFinishedEvent).error)
+            case AgentEventKind.STEP_STARTED:
+                await self._project_step(
+                    _as(event, StepStartedEvent).step_name, updater
+                )
+            case AgentEventKind.STEP_FINISHED:
+                await self._project_step(
+                    _as(event, StepFinishedEvent).step_name, updater
+                )
+            case AgentEventKind.MESSAGE_DELTA:
+                await self._project_message_delta(event, updater)
+            case AgentEventKind.REASONING_DELTA:
+                await self._project_reasoning_delta(event, updater)
+            case AgentEventKind.TOOL_CALL_START:
+                await self._project_tool_call_start(event, updater)
+            case AgentEventKind.TOOL_CALL_ARGS_DELTA:
+                await self._project_tool_call_args(event, updater)
+            case AgentEventKind.TOOL_CALL_END:
+                await self._project_tool_call_end(event, updater)
+            case AgentEventKind.TOOL_CALL_RESULT:
+                await self._project_tool_call_result(event, updater)
+            case AgentEventKind.ARTIFACT:
+                await self._project_artifact(event, updater)
+            case AgentEventKind.STATE_SNAPSHOT:
+                await self._project_state_snapshot(event, updater)
+            case AgentEventKind.STATE_DELTA:
+                await self._project_state_delta(event, updater)
+            case _:  # pragma: no cover - exhaustive AgentEventKind StrEnum
+                raise UnsupportedAgentEventError(str(event.kind))
+        return None
+
+    @staticmethod
+    async def _project_step(step_name: str, updater: TaskUpdater) -> None:
+        await updater.update_status(
+            TaskState.TASK_STATE_WORKING,
+            metadata={"step_name": step_name},
+        )
+
+    @staticmethod
+    async def _project_message_delta(event: AgentEvent, updater: TaskUpdater) -> None:
+        message = _as(event, MessageDeltaEvent)
+        await updater.update_status(
+            TaskState.TASK_STATE_WORKING,
+            updater.new_agent_message(
+                [Part(text=message.delta)],
+                metadata={"message_id": message.message_id},
+            ),
+        )
+
+    @staticmethod
+    async def _project_reasoning_delta(event: AgentEvent, updater: TaskUpdater) -> None:
+        reasoning = _as(event, ReasoningDeltaEvent)
+        await updater.update_status(
+            TaskState.TASK_STATE_WORKING,
+            updater.new_agent_message(
+                [Part(text=reasoning.delta)],
+                metadata={"reasoning_id": reasoning.reasoning_id, "reasoning": True},
+            ),
+        )
+
+    @staticmethod
+    async def _project_tool_call_start(event: AgentEvent, updater: TaskUpdater) -> None:
+        start = _as(event, ToolCallStartEvent)
+        await updater.update_status(
+            TaskState.TASK_STATE_WORKING,
+            metadata={
+                "tool_call": start.tool_name,
+                "call_id": start.call_id,
+                "phase": "start",
+            },
+        )
+
+    @staticmethod
+    async def _project_tool_call_args(event: AgentEvent, updater: TaskUpdater) -> None:
+        args = _as(event, ToolCallArgsDeltaEvent)
+        await updater.update_status(
+            TaskState.TASK_STATE_WORKING,
+            metadata={"call_id": args.call_id, "args_delta": args.args_delta},
+        )
+
+    @staticmethod
+    async def _project_tool_call_end(event: AgentEvent, updater: TaskUpdater) -> None:
+        end = _as(event, ToolCallEndEvent)
+        await updater.update_status(
+            TaskState.TASK_STATE_WORKING,
+            metadata={"call_id": end.call_id, "phase": "end"},
+        )
+
+    @staticmethod
+    async def _project_tool_call_result(
+        event: AgentEvent, updater: TaskUpdater
+    ) -> None:
+        result = _as(event, ToolCallResultEvent)
+        data = _data_part(
+            {
+                "tool": result.tool_name,
+                "call_id": result.call_id,
+                "result": result.result,
+            }
+        )
+        await updater.add_artifact([data], name=result.tool_name)
+
+    @staticmethod
+    async def _project_artifact(event: AgentEvent, updater: TaskUpdater) -> None:
+        artifact = _as(event, ArtifactEvent)
+        name = artifact.name or artifact.artifact_id
+        part = (
+            Part(text=artifact.content)
+            if isinstance(artifact.content, str)
+            else _data_part_from_value(artifact.content)
+        )
+        await updater.add_artifact([part], name=name)
+
+    @staticmethod
+    async def _project_state_snapshot(event: AgentEvent, updater: TaskUpdater) -> None:
+        snapshot = _as(event, StateSnapshotEvent)
+        await updater.update_status(
+            TaskState.TASK_STATE_WORKING,
+            updater.new_agent_message(
+                [_data_part_from_value(snapshot.snapshot)],
+                metadata={"state_snapshot": True},
+            ),
+        )
+
+    @staticmethod
+    async def _project_state_delta(event: AgentEvent, updater: TaskUpdater) -> None:
+        delta = _as(event, StateDeltaEvent)
+        await updater.update_status(
+            TaskState.TASK_STATE_WORKING,
+            updater.new_agent_message(
+                [_data_part_from_value(delta.patch)],
+                metadata={"state_delta": True},
+            ),
+        )
+
+
+def _data_part(payload: JsonObject) -> Part:
+    """Build a protobuf data ``Part`` from a JSON-compatible mapping."""
+    value = Value()
+    ParseDict(dict(payload), value)
+    return Part(data=value)
+
+
+def _data_part_from_value(content: JsonValue) -> Part:
+    """Build a protobuf data ``Part`` from any JSON-compatible value."""
+    value = Value()
+    # protobuf-stubs type ParseDict's js_dict as dict, but a Value target accepts
+    # any JSON value (scalar, list, object) at runtime — the stub is too narrow.
+    ParseDict(content, value)  # type: ignore[arg-type] - protobuf Value accepts any JSON value
+    return Part(data=value)
+
+
+def _as[EventT: AgentEvent](event: AgentEvent, event_type: type[EventT]) -> EventT:
+    """Narrow an event to its declared member type.
+
+    The runner pairs each ``AgentEventKind`` with a fixed event class, so a
+    mismatch is an internal contract violation rather than a recoverable state.
+    """
+    if not isinstance(event, event_type):
+        raise UnsupportedAgentEventError(event_type.__name__)
+    return event

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/main.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/main.py
@@ -1,0 +1,27 @@
+"""Plugin initialization for the A2A protocol server integration.
+
+Registers the plugin configuration, the agent-server registry, the container-aware
+app-builder spec, and the post-processor that discovers @A2AAgentServer-marked
+@Agent Pods. This function is called automatically during plugin loading.
+"""
+
+from spakky.core.application.application import SpakkyApplication
+
+from spakky.plugins.a2a.config import A2AConfig
+from spakky.plugins.a2a.post_processors.register_agent_servers import (
+    RegisterA2AAgentServersPostProcessor,
+)
+from spakky.plugins.a2a.server.builder import A2AAgentServerSpec
+from spakky.plugins.a2a.server.registry import A2AAgentRegistry
+
+
+def initialize(app: SpakkyApplication) -> None:
+    """Initialize the A2A plugin.
+
+    Args:
+        app: The Spakky application instance.
+    """
+    app.add(A2AConfig)
+    app.add(A2AAgentRegistry)
+    app.add(A2AAgentServerSpec)
+    app.add(RegisterA2AAgentServersPostProcessor)

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/post_processors/__init__.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/post_processors/__init__.py
@@ -1,0 +1,1 @@
+"""A2A plugin post_processors package."""

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/post_processors/register_agent_servers.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/post_processors/register_agent_servers.py
@@ -1,0 +1,55 @@
+"""Post-processor registering @A2AAgentServer-marked @Agent Pods."""
+
+from logging import getLogger
+from typing import override
+
+from spakky.agent.execution import Agent
+from spakky.core.common.constants import DYNAMIC_PROXY_CLASS_NAME_SUFFIX
+from spakky.core.pod.annotations.order import Order
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.core.pod.interfaces.post_processor import IPostProcessor
+
+from spakky.plugins.a2a.server.registry import A2AAgentRegistry
+from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+
+logger = getLogger(__name__)
+
+
+@Order(0)
+@Pod()
+class RegisterA2AAgentServersPostProcessor(IPostProcessor, IContainerAware):
+    """Registers Pods carrying both @Agent and @A2AAgentServer in the registry."""
+
+    _container: IContainer
+
+    @override
+    def set_container(self, container: IContainer) -> None:
+        self._container = container
+
+    @staticmethod
+    def _unwrap_proxy_type(pod_type: type) -> type:
+        """Return the original class when *pod_type* is an AOP dynamic proxy.
+
+        ``AspectPostProcessor`` may replace a Pod with a dynamic subclass whose
+        name ends with ``@DynamicProxy``; ``__bases__[0]`` recovers the original
+        @Agent class carrying the A2A marker.
+        """
+        if pod_type.__name__.endswith(DYNAMIC_PROXY_CLASS_NAME_SUFFIX):
+            return pod_type.__bases__[0]
+        return pod_type
+
+    @override
+    def post_process(self, pod: object) -> object:
+        """Register *pod* when it is an @A2AAgentServer-marked @Agent.
+
+        Pods missing either marker are returned unchanged.
+        """
+        pod_type = self._unwrap_proxy_type(type(pod))
+        if not (A2AAgentServer.exists(pod_type) and Agent.exists(pod_type)):
+            return pod
+        registry = self._container.get(A2AAgentRegistry)
+        registry.register(pod, A2AAgentServer.get(pod_type))
+        logger.info("Registered A2A agent server from %s", pod_type.__qualname__)
+        return pod

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/server/__init__.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/server/__init__.py
@@ -1,0 +1,1 @@
+"""A2A plugin server package."""

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/server/builder.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/server/builder.py
@@ -1,0 +1,98 @@
+"""Assembly of a mountable A2A ASGI application for one @Agent instance.
+
+The a2a-sdk 1.x server is assembled from route factories rather than a single
+application class: the agent-card route plus the JSON-RPC routes (with v0.3
+compatibility enabling the ``message/send`` / ``tasks/get`` method names) are
+mounted on a Starlette app the host application can further mount.
+"""
+
+from typing import override
+
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.routes import create_agent_card_routes, create_jsonrpc_routes
+from a2a.utils import DEFAULT_RPC_URL
+from spakky.agent.execution import Agent
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from starlette.applications import Starlette
+
+from spakky.plugins.a2a.card.derivation import AgentCardFactory
+from spakky.plugins.a2a.executor.adapter import SpakkyAgentExecutor
+from spakky.plugins.a2a.executor.event_mapping import AgentEventProjector
+from spakky.plugins.a2a.server.registry import A2AAgentRegistry
+from spakky.plugins.a2a.store.interfaces import IA2ATaskRepository
+from spakky.plugins.a2a.store.task_store import (
+    InMemoryA2ATaskRepository,
+    SpakkyA2ATaskStore,
+)
+
+
+def build_a2a_app(
+    agent_instance: object,
+    *,
+    base_url: str,
+    version: str,
+    repository: IA2ATaskRepository | None = None,
+) -> Starlette:
+    """Assemble a mountable A2A ASGI application for an @Agent instance.
+
+    Args:
+        agent_instance: The @Agent Pod instance to serve.
+        base_url: Transport endpoint advertised on the derived AgentCard.
+        version: Semantic version advertised on the derived AgentCard.
+        repository: Task persistence port; an in-memory store is used when None.
+
+    Returns:
+        A Starlette application exposing the agent-card and JSON-RPC routes.
+    """
+    card = AgentCardFactory().build(
+        Agent.get(type(agent_instance)),
+        base_url,
+        version,
+    )
+    store = SpakkyA2ATaskStore(repository or InMemoryA2ATaskRepository())
+    executor = SpakkyAgentExecutor(agent_instance, AgentEventProjector())
+    handler = DefaultRequestHandler(
+        agent_executor=executor,
+        task_store=store,
+        agent_card=card,
+    )
+    routes = [
+        *create_agent_card_routes(card),
+        *create_jsonrpc_routes(handler, DEFAULT_RPC_URL, enable_v0_3_compat=True),
+    ]
+    return Starlette(routes=routes)
+
+
+@Pod()
+class A2AAgentServerSpec(IContainerAware):
+    """Container-aware factory that builds A2A apps for registered agents."""
+
+    _container: IContainer
+
+    @override
+    def set_container(self, container: IContainer) -> None:
+        self._container = container
+
+    def build_app_for(self, agent_name: str) -> Starlette:
+        """Build a mountable A2A app for a registered agent name.
+
+        Resolves the registry entry, then an optional task repository Pod from the
+        container, falling back to an in-memory store when none is registered.
+
+        Args:
+            agent_name: The registered agent name to serve.
+
+        Returns:
+            A Starlette application for the named agent.
+        """
+        entry = self._container.get(A2AAgentRegistry).get(agent_name)
+        # Repository Pod is optional; absent one, persistence stays in-process.
+        repository = self._container.get_or_none(IA2ATaskRepository)
+        return build_a2a_app(
+            entry.instance,
+            base_url=entry.metadata.base_url,
+            version=entry.metadata.version,
+            repository=repository,
+        )

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/server/registry.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/server/registry.py
@@ -1,0 +1,56 @@
+"""Registry of @Agent instances exposed as A2A servers."""
+
+from dataclasses import dataclass
+
+from spakky.agent.execution import Agent
+from spakky.core.pod.annotations.pod import Pod
+
+from spakky.plugins.a2a.error import A2AAgentServerNotRegisteredError
+from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+
+
+@dataclass(frozen=True, slots=True)
+class A2AAgentServerEntry:
+    """A discovered @Agent instance paired with its A2A transport metadata."""
+
+    instance: object
+    metadata: A2AAgentServer
+
+
+@Pod()
+class A2AAgentRegistry:
+    """Holds the @Agent instances discovered as A2A servers, keyed by name."""
+
+    _entries: dict[str, A2AAgentServerEntry]
+
+    def __init__(self) -> None:
+        self._entries = {}
+
+    def register(self, instance: object, metadata: A2AAgentServer) -> None:
+        """Register an @Agent instance under its resolved agent name.
+
+        Args:
+            instance: The @Agent Pod instance to serve.
+            metadata: The A2A transport metadata declared on the agent class.
+        """
+        self._entries[self._agent_name(instance)] = A2AAgentServerEntry(
+            instance=instance,
+            metadata=metadata,
+        )
+
+    def get(self, agent_name: str) -> A2AAgentServerEntry:
+        """Return the registered entry for an agent name.
+
+        Raises:
+            A2AAgentServerNotRegisteredError: No entry exists for the name.
+        """
+        entry = self._entries.get(agent_name)
+        if entry is None:
+            raise A2AAgentServerNotRegisteredError(agent_name)
+        return entry
+
+    @staticmethod
+    def _agent_name(instance: object) -> str:
+        """Resolve an agent's registry name from its spec name or class name."""
+        agent = Agent.get(type(instance))
+        return agent.spec.name or type(instance).__name__

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/stereotypes/__init__.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/stereotypes/__init__.py
@@ -1,0 +1,1 @@
+"""A2A plugin stereotypes package."""

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/stereotypes/a2a_agent_server.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/stereotypes/a2a_agent_server.py
@@ -1,0 +1,27 @@
+"""@A2AAgentServer marker for exposing an @Agent over the A2A protocol.
+
+Unlike ``@GrpcController`` (which subclasses ``Controller`` and registers its own
+Pod), this marker subclasses :class:`~spakky.core.pod.annotations.tag.Tag`: the
+``@Agent`` decorator already registers the Pod, so this tag only records the A2A
+transport metadata and stacks above ``@Agent`` on the same class.
+"""
+
+from dataclasses import dataclass
+
+from spakky.core.pod.annotations.tag import Tag
+
+
+@dataclass(eq=False)
+class A2AAgentServer(Tag):
+    """Marks an @Agent class to be served as an A2A protocol endpoint.
+
+    Attributes:
+        base_url: Transport endpoint advertised on the derived AgentCard.
+        version: Semantic version advertised on the derived AgentCard.
+    """
+
+    base_url: str
+    """Transport endpoint advertised on the derived AgentCard interface."""
+
+    version: str
+    """Semantic version advertised on the derived AgentCard."""

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/store/__init__.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/store/__init__.py
@@ -1,0 +1,1 @@
+"""A2A plugin store package."""

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/store/interfaces.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/store/interfaces.py
@@ -1,0 +1,36 @@
+"""Plugin-owned persistence port for A2A task state.
+
+The a2a-sdk ``TaskStore`` ABC is async and threads a ``ServerCallContext``
+through every call. This plugin owns a narrower synchronous repository port so
+that adapters (in-memory today, a database-backed implementation later) stay
+free of a2a-sdk server types; the async bridge lives in ``task_store``.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from a2a.types import Task
+
+
+class IA2ATaskRepository(ABC):
+    """Synchronous persistence port for A2A ``Task`` snapshots."""
+
+    @abstractmethod
+    def get_or_none(self, task_id: str) -> Task | None:
+        """Return a persisted task by id, or None when absent."""
+        ...
+
+    @abstractmethod
+    def save(self, task: Task) -> None:
+        """Persist or overwrite a task snapshot."""
+        ...
+
+    @abstractmethod
+    def delete(self, task_id: str) -> None:
+        """Remove a task snapshot by id."""
+        ...
+
+    @abstractmethod
+    def list_all(self) -> Sequence[Task]:
+        """Return every persisted task snapshot."""
+        ...

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/store/task_store.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/store/task_store.py
@@ -1,0 +1,81 @@
+"""In-memory task repository plus the async a2a-sdk ``TaskStore`` bridge."""
+
+from collections.abc import Sequence
+from typing import override
+
+from a2a.server.context import ServerCallContext
+from a2a.server.tasks import TaskStore
+from a2a.types import ListTasksRequest, ListTasksResponse, Task
+
+from spakky.plugins.a2a.store.interfaces import IA2ATaskRepository
+
+
+class InMemoryA2ATaskRepository(IA2ATaskRepository):
+    """Dictionary-backed synchronous A2A task repository."""
+
+    _tasks: dict[str, Task]
+
+    def __init__(self) -> None:
+        self._tasks = {}
+
+    @override
+    def get_or_none(self, task_id: str) -> Task | None:
+        return self._tasks.get(task_id)
+
+    @override
+    def save(self, task: Task) -> None:
+        self._tasks[task.id] = task
+
+    @override
+    def delete(self, task_id: str) -> None:
+        self._tasks.pop(task_id, None)
+
+    @override
+    def list_all(self) -> Sequence[Task]:
+        return tuple(self._tasks.values())
+
+
+class SpakkyA2ATaskStore(TaskStore):
+    """Async a2a-sdk ``TaskStore`` delegating to a synchronous repository.
+
+    The a2a-sdk request handler awaits every store call, but the plugin's
+    repository port is synchronous; each async method calls straight through to
+    the in-process repository, which performs no I/O of its own.
+    """
+
+    _repository: IA2ATaskRepository
+
+    def __init__(self, repository: IA2ATaskRepository) -> None:
+        self._repository = repository
+
+    @override
+    async def save(self, task: Task, context: ServerCallContext) -> None:
+        self._repository.save(task)
+
+    @override
+    async def get(self, task_id: str, context: ServerCallContext) -> Task | None:
+        return self._repository.get_or_none(task_id)
+
+    @override
+    async def delete(self, task_id: str, context: ServerCallContext) -> None:
+        self._repository.delete(task_id)
+
+    @override
+    async def list(
+        self,
+        params: ListTasksRequest,
+        context: ServerCallContext,
+    ) -> ListTasksResponse:
+        tasks = [
+            task for task in self._repository.list_all() if self._matches(task, params)
+        ]
+        return ListTasksResponse(tasks=tasks, total_size=len(tasks))
+
+    @staticmethod
+    def _matches(task: Task, params: ListTasksRequest) -> bool:
+        """Return whether a task satisfies the context and status filters."""
+        if params.context_id and task.context_id != params.context_id:
+            return False
+        if params.status and task.status.state != params.status:
+            return False
+        return True

--- a/plugins/spakky-a2a/tests/integration/conftest.py
+++ b/plugins/spakky-a2a/tests/integration/conftest.py
@@ -1,0 +1,166 @@
+"""Integration fixtures driving the assembled A2A ASGI app in-process.
+
+A scripted ``IAgentModel`` feeds the framework-owned ``AgentRunner`` so the full
+message/send and message/stream lifecycle runs without any live LLM or network.
+The served agent is durable (it accepts signals), so in-memory state, signal,
+and evidence repositories are injected to satisfy the runner's durable path.
+"""
+
+from collections.abc import AsyncIterator, Iterator, Sequence
+from typing import override
+
+import httpx
+import pytest
+from a2a.utils import DEFAULT_RPC_URL
+from spakky.agent.execution import (
+    Agent,
+    AgentExecutionSpec,
+    AgentSignalKind,
+    RecoveryStrategy,
+)
+from spakky.agent.interfaces.model import (
+    IAgentModel,
+    ModelCapability,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+)
+from spakky.agent.tooling import (
+    Idempotency,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+from starlette.applications import Starlette
+
+from spakky.plugins.a2a.server.builder import build_a2a_app
+from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+from tests.unit.conftest import (
+    FakeEvidenceRepository,
+    FakeSignalRepository,
+    FakeStateRepository,
+)
+
+DURABLE_SPEC = AgentExecutionSpec(
+    name="assistant",
+    objective="Answer questions and gate writes on approval.",
+    accepted_signals=(
+        AgentSignalKind.USER_MESSAGE,
+        AgentSignalKind.APPROVAL_DECISION,
+        AgentSignalKind.CANCEL,
+    ),
+    recovery=RecoveryStrategy.ACTION_BOUNDARY,
+)
+
+
+class ScriptedModel(IAgentModel):
+    """Model double replaying a fixed list of stream events per run."""
+
+    def __init__(self, events: Sequence[ModelStreamEvent]) -> None:
+        self._events = tuple(events)
+
+    @property
+    @override
+    def capability(self) -> ModelCapability:
+        return ModelCapability()
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        return ModelResponse(content="scripted")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        for event in self._events:
+            yield event
+
+
+def _token(text: str) -> ModelStreamEvent:
+    return ModelStreamEvent(kind=ModelStreamEventKind.TOKEN_DELTA, token_delta=text)
+
+
+def _tool(name: str) -> ModelStreamEvent:
+    return ModelStreamEvent(
+        kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+        tool_call=ModelToolCall(name=name, arguments={"value": "x"}, call_id="c1"),
+    )
+
+
+@A2AAgentServer(base_url="http://assistant.local", version="1.0.0")
+@Agent(spec=DURABLE_SPEC)
+class AssistantAgent:
+    """Durable served agent exercised through the A2A transport."""
+
+    def __init__(
+        self,
+        model: IAgentModel,
+        states: FakeStateRepository,
+        signals: FakeSignalRepository,
+        evidence: FakeEvidenceRepository,
+    ) -> None:
+        self._model = model
+        self._states = states
+        self._signals = signals
+        self._evidence = evidence
+
+    @agent_tool(
+        schema_name="write_note",
+        description="Persist a note after approval.",
+        effects=ToolEffects.write_state(),
+        idempotency=Idempotency.CONDITIONALLY_IDEMPOTENT,
+        approval=ToolApprovalRequirement.REQUIRED,
+    )
+    def write_note(self, value: str) -> str:
+        """Write a note value and echo it back."""
+        return f"wrote {value}"
+
+
+def _build_agent(events: Sequence[ModelStreamEvent]) -> AssistantAgent:
+    return AssistantAgent(
+        ScriptedModel(events),
+        FakeStateRepository(),
+        FakeSignalRepository(),
+        FakeEvidenceRepository(),
+    )
+
+
+def build_app(events: Sequence[ModelStreamEvent]) -> Starlette:
+    """Assemble an A2A app over an assistant driven by scripted model events."""
+    return build_a2a_app(
+        _build_agent(events),
+        base_url="http://assistant.local",
+        version="1.0.0",
+    )
+
+
+@pytest.fixture
+def rpc_url() -> str:
+    """Expose the JSON-RPC mount path for request bodies."""
+    return DEFAULT_RPC_URL
+
+
+@pytest.fixture
+def token_events() -> tuple[ModelStreamEvent, ...]:
+    """A simple run streaming one token then terminating to a final output."""
+    return (_token("hello "), _token("world"))
+
+
+@pytest.fixture
+def approval_events() -> tuple[ModelStreamEvent, ...]:
+    """A run whose write tool requires approval, pausing for input."""
+    return (_tool("write_note"),)
+
+
+def make_client(app: Starlette) -> httpx.AsyncClient:
+    """Open an httpx client bound to the in-process ASGI app."""
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    )
+
+
+@pytest.fixture
+def token_app(token_events: Sequence[ModelStreamEvent]) -> Iterator[Starlette]:
+    """Provide an assembled app whose agent streams tokens to completion."""
+    yield build_app(token_events)

--- a/plugins/spakky-a2a/tests/integration/test_a2a_server.py
+++ b/plugins/spakky-a2a/tests/integration/test_a2a_server.py
@@ -1,0 +1,210 @@
+"""End-to-end A2A transport tests over the assembled ASGI app."""
+
+import json
+from collections.abc import Sequence
+
+import pytest
+from spakky.agent.execution import Agent, AgentSignalKind
+from spakky.agent.interfaces.model import ModelStreamEvent
+
+from tests.integration.conftest import (
+    AssistantAgent,
+    build_app,
+    make_client,
+)
+
+type JsonObject = dict[str, object]
+
+
+def _send(method: str, params: JsonObject, request_id: str = "1") -> JsonObject:
+    return {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+
+
+def _user_message(text: str, message_id: str = "m1") -> JsonObject:
+    return {
+        "message": {
+            "role": "user",
+            "parts": [{"kind": "text", "text": text}],
+            "messageId": message_id,
+        }
+    }
+
+
+def _approval_id_from(task_result: JsonObject) -> str:
+    """Pull the echoed approval id out of a paused task's status message."""
+    status = task_result["status"]
+    message = status["message"] if isinstance(status, dict) else {}
+    parts = message["parts"] if isinstance(message, dict) else []
+    for part in parts if isinstance(parts, list) else []:
+        data = part.get("data") if isinstance(part, dict) else None
+        if isinstance(data, dict) and isinstance(data.get("approval_id"), str):
+            return data["approval_id"]
+    raise AssertionError("paused task carried no approval id")
+
+
+def _sse_status_states(body: str) -> list[str]:
+    """Extract the ordered task-status states from an SSE response body."""
+    states: list[str] = []
+    for line in body.splitlines():
+        if not line.startswith("data:"):
+            continue
+        result = json.loads(line[len("data:") :].strip())["result"]
+        if "status" in result:
+            states.append(result["status"]["state"])
+    return states
+
+
+@pytest.mark.integration
+async def test_agent_card_endpoint_serves_derived_card(
+    token_events: Sequence[ModelStreamEvent],
+) -> None:
+    """The well-known route serves the AgentCard derived from the @Agent."""
+    async with make_client(build_app(token_events)) as client:
+        response = await client.get("/.well-known/agent-card.json")
+
+    assert response.status_code == 200
+    card = response.json()
+    assert card["name"] == "assistant"
+    assert any(skill["id"].endswith(":write_note") for skill in card["skills"])
+
+
+@pytest.mark.integration
+async def test_message_send_runs_agent_to_completion(
+    token_events: Sequence[ModelStreamEvent],
+    rpc_url: str,
+) -> None:
+    """A message/send drives the agent to a completed task carrying streamed text."""
+    async with make_client(build_app(token_events)) as client:
+        response = await client.post(
+            rpc_url, json=_send("message/send", _user_message("hi"))
+        )
+
+    result = response.json()["result"]
+    assert result["status"]["state"] == "completed"
+    history_text = "".join(
+        part.get("text", "")
+        for message in result.get("history", [])
+        for part in message.get("parts", [])
+    )
+    assert "hello " in history_text and "world" in history_text
+
+
+@pytest.mark.integration
+async def test_message_stream_emits_ordered_lifecycle(
+    token_events: Sequence[ModelStreamEvent],
+    rpc_url: str,
+) -> None:
+    """A message/stream emits submitted -> working -> completed over SSE."""
+    async with make_client(build_app(token_events)) as client:
+        async with client.stream(
+            "POST", rpc_url, json=_send("message/stream", _user_message("hi"))
+        ) as response:
+            assert response.status_code == 200
+            assert "text/event-stream" in response.headers["content-type"]
+            body = await response.aread()
+
+    states = _sse_status_states(body.decode())
+    assert states[0] == "submitted"
+    assert "working" in states
+    assert states[-1] == "completed"
+
+
+@pytest.mark.integration
+async def test_tasks_get_returns_persisted_task(
+    token_events: Sequence[ModelStreamEvent],
+    rpc_url: str,
+) -> None:
+    """tasks/get returns the persisted task after a completed run."""
+    async with make_client(build_app(token_events)) as client:
+        sent = await client.post(
+            rpc_url, json=_send("message/send", _user_message("hi"))
+        )
+        task_id = sent.json()["result"]["id"]
+
+        fetched = await client.post(rpc_url, json=_send("tasks/get", {"id": task_id}))
+
+    assert fetched.json()["result"]["id"] == task_id
+
+
+@pytest.mark.integration
+async def test_tasks_resubscribe_streams_existing_task(
+    token_events: Sequence[ModelStreamEvent],
+    rpc_url: str,
+) -> None:
+    """tasks/resubscribe opens an SSE stream for an existing task."""
+    async with make_client(build_app(token_events)) as client:
+        sent = await client.post(
+            rpc_url, json=_send("message/send", _user_message("hi"))
+        )
+        task_id = sent.json()["result"]["id"]
+
+        async with client.stream(
+            "POST", rpc_url, json=_send("tasks/resubscribe", {"id": task_id})
+        ) as response:
+            assert response.status_code == 200
+            assert "text/event-stream" in response.headers["content-type"]
+
+
+@pytest.mark.integration
+async def test_tasks_cancel_marks_task_canceled(
+    approval_events: Sequence[ModelStreamEvent],
+    rpc_url: str,
+) -> None:
+    """tasks/cancel appends a cancel signal and reports a canceled task."""
+    async with make_client(build_app(approval_events)) as client:
+        sent = await client.post(
+            rpc_url, json=_send("message/send", _user_message("write"))
+        )
+        task_id = sent.json()["result"]["id"]
+
+        canceled = await client.post(
+            rpc_url, json=_send("tasks/cancel", {"id": task_id})
+        )
+
+    assert canceled.json()["result"]["status"]["state"] == "canceled"
+
+
+@pytest.mark.integration
+async def test_hitl_approval_pause_then_resume_completes(
+    approval_events: Sequence[ModelStreamEvent],
+    rpc_url: str,
+) -> None:
+    """A write tool pauses for input, then an approval decision resumes to done."""
+    async with make_client(build_app(approval_events)) as client:
+        paused = await client.post(
+            rpc_url, json=_send("message/send", _user_message("write"))
+        )
+        paused_result = paused.json()["result"]
+        assert paused_result["status"]["state"] == "input-required"
+        task_id = paused_result["id"]
+        context_id = paused_result["contextId"]
+        approval_id = _approval_id_from(paused_result)
+
+        resume_message: JsonObject = {
+            "message": {
+                "role": "user",
+                "taskId": task_id,
+                "contextId": context_id,
+                "parts": [
+                    {
+                        "kind": "data",
+                        "data": {"approval_id": approval_id, "decision": "approve"},
+                    }
+                ],
+                "messageId": "m2",
+            }
+        }
+        resumed = await client.post(
+            rpc_url, json=_send("message/send", resume_message, request_id="2")
+        )
+
+    assert resumed.json()["result"]["status"]["state"] == "completed"
+
+
+@pytest.mark.integration
+async def test_durable_agent_accepts_signal_kinds() -> None:
+    """The served durable agent declares the HITL signal kinds it consumes."""
+    accepted = Agent.get(AssistantAgent).spec.accepted_signals
+
+    assert AgentSignalKind.APPROVAL_DECISION in accepted
+    assert AgentSignalKind.CANCEL in accepted

--- a/plugins/spakky-a2a/tests/unit/_sample_agents.py
+++ b/plugins/spakky-a2a/tests/unit/_sample_agents.py
@@ -1,0 +1,65 @@
+"""Sample @Agent declarations shared across A2A unit tests."""
+
+from collections.abc import AsyncIterator
+from typing import override
+
+from spakky.agent.execution import Agent, AgentExecutionSpec
+from spakky.agent.interfaces.model import (
+    IAgentModel,
+    ModelCapability,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+)
+from spakky.agent.tooling import (
+    Idempotency,
+    ToolEffects,
+    agent_tool,
+)
+
+from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+
+
+class StubModel(IAgentModel):
+    """Minimal model double; never invoked by registry/builder tests."""
+
+    @property
+    @override
+    def capability(self) -> ModelCapability:
+        return ModelCapability()
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        return ModelResponse(content="")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        return
+        yield  # pragma: no cover - empty async generator body
+
+
+@A2AAgentServer(base_url="http://planner.local", version="1.2.3")
+@Agent(spec=AgentExecutionSpec(name="planner", objective="Plan things."))
+class ServedPlannerAgent:
+    """Agent marked for A2A serving, used by registry and builder tests."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model
+
+    @agent_tool(
+        schema_name="plan",
+        description="Make a plan.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+    )
+    def plan(self, goal: str) -> str:
+        """Return a plan for a goal."""
+        return f"plan for {goal}"
+
+
+@Agent(spec=AgentExecutionSpec(name="unserved"))
+class UnservedAgent:
+    """An @Agent without the A2A marker, used to verify it is skipped."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model

--- a/plugins/spakky-a2a/tests/unit/conftest.py
+++ b/plugins/spakky-a2a/tests/unit/conftest.py
@@ -1,0 +1,158 @@
+"""Shared unit-test fakes for the A2A plugin.
+
+Provides a recording ``EventQueue`` so projections can be asserted against the
+real ``TaskUpdater``, plus in-memory agent repository fakes mirrored from the
+spakky-agent core test doubles.
+"""
+
+from collections.abc import Sequence
+from typing import override
+
+import pytest
+from a2a.server.events import EventQueue
+from a2a.server.tasks import TaskUpdater
+from a2a.types import (
+    TaskArtifactUpdateEvent,
+    TaskStatusUpdateEvent,
+)
+from spakky.agent.error import AgentDefinitionError
+from spakky.agent.evidence import AgentEvidence
+from spakky.agent.interfaces.repository import (
+    IAgentEvidenceRepository,
+    IAgentSignalRepository,
+    IAgentStateRepository,
+)
+from spakky.agent.signal import AgentSignal
+from spakky.agent.state import AgentState, AgentStatus
+
+type RecordedEvent = object
+
+
+class RecordingEventQueue(EventQueue):
+    """EventQueue test double capturing every enqueued event in order."""
+
+    events: list[RecordedEvent]
+
+    def __init__(self) -> None:
+        self.events = []
+
+    @override
+    async def enqueue_event(self, event: RecordedEvent) -> None:
+        self.events.append(event)
+
+    def status_updates(self) -> list[TaskStatusUpdateEvent]:
+        """Return only the recorded status-update events."""
+        return [e for e in self.events if isinstance(e, TaskStatusUpdateEvent)]
+
+    def artifact_updates(self) -> list[TaskArtifactUpdateEvent]:
+        """Return only the recorded artifact-update events."""
+        return [e for e in self.events if isinstance(e, TaskArtifactUpdateEvent)]
+
+
+@pytest.fixture
+def queue() -> RecordingEventQueue:
+    """Provide a fresh recording event queue per test."""
+    return RecordingEventQueue()
+
+
+@pytest.fixture
+def updater(queue: RecordingEventQueue) -> TaskUpdater:
+    """Provide a TaskUpdater bound to the recording queue and a fixed task."""
+    return TaskUpdater(queue, task_id="task-1", context_id="ctx-1")
+
+
+class FakeStateRepository(IAgentStateRepository):
+    """State repository test double mirroring the core agent test fake."""
+
+    def __init__(self) -> None:
+        self._states: dict[str, AgentState] = {}
+
+    @override
+    def get(self, state_id: str) -> AgentState:
+        state = self._states.get(state_id)
+        if state is None:
+            raise AgentDefinitionError("Missing test state")
+        return state
+
+    @override
+    def get_or_none(self, state_id: str) -> AgentState | None:
+        return self._states.get(state_id)
+
+    @override
+    def save(self, state: AgentState) -> AgentState:
+        self._states[state.id] = state
+        return state
+
+    @override
+    def list_by_status(self, status: AgentStatus) -> Sequence[AgentState]:
+        return tuple(s for s in self._states.values() if s.status is status)
+
+    @override
+    def list_resume_candidates(self) -> Sequence[AgentState]:
+        return tuple(
+            s
+            for s in self._states.values()
+            if s.status in (AgentStatus.ACTIVE, AgentStatus.INTERRUPTED)
+        )
+
+
+class FakeSignalRepository(IAgentSignalRepository):
+    """Signal repository test double mirroring the core agent test fake."""
+
+    def __init__(self, signals: Sequence[AgentSignal] = ()) -> None:
+        self._signals = tuple(signals)
+        self._consumed: set[str] = set()
+
+    @override
+    def append(self, signal: AgentSignal) -> AgentSignal:
+        self._signals = (*self._signals, signal)
+        return signal
+
+    @override
+    def list_pending(self, state_id: str) -> Sequence[AgentSignal]:
+        return tuple(
+            s
+            for s in self._signals
+            if s.agent_state_id == state_id and s.id not in self._consumed
+        )
+
+    @override
+    def mark_consumed(self, signal_id: str) -> AgentSignal:
+        for signal in self._signals:
+            if signal.id == signal_id:
+                self._consumed.add(signal_id)
+                return signal
+        raise AgentDefinitionError("Missing test signal")
+
+    def appended(self) -> tuple[AgentSignal, ...]:
+        """Return every signal currently held, for append assertions."""
+        return self._signals
+
+
+class FakeEvidenceRepository(IAgentEvidenceRepository):
+    """Evidence repository test double mirroring the core agent test fake."""
+
+    def __init__(self) -> None:
+        self._evidence: dict[str, AgentEvidence] = {}
+
+    @override
+    def append(self, evidence: AgentEvidence) -> AgentEvidence:
+        self._evidence[evidence.id] = evidence
+        return evidence
+
+    @override
+    def get(self, evidence_id: str) -> AgentEvidence:
+        evidence = self._evidence.get(evidence_id)
+        if evidence is None:
+            raise AgentDefinitionError("Missing test evidence")
+        return evidence
+
+    @override
+    def list_by_state(self, state_id: str) -> Sequence[AgentEvidence]:
+        return tuple(a for a in self._evidence.values() if a.agent_state_id == state_id)
+
+    @override
+    def list_by_manifest_ref(self, manifest_ref: str) -> Sequence[AgentEvidence]:
+        return tuple(
+            a for a in self._evidence.values() if a.manifest_ref == manifest_ref
+        )

--- a/plugins/spakky-a2a/tests/unit/test_a2a_agent_server_stereotype.py
+++ b/plugins/spakky-a2a/tests/unit/test_a2a_agent_server_stereotype.py
@@ -1,0 +1,43 @@
+"""Tests for the @A2AAgentServer marker."""
+
+from spakky.agent.execution import Agent, AgentExecutionSpec
+from spakky.agent.interfaces.model import IAgentModel
+from spakky.core.pod.annotations.pod import Pod
+
+from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+
+
+def test_marker_does_not_register_its_own_pod() -> None:
+    """@A2AAgentServer alone records metadata without registering a Pod."""
+
+    @A2AAgentServer(base_url="http://x", version="1.0.0")
+    class PlainClass:
+        pass
+
+    assert not Pod.exists(PlainClass)
+    assert A2AAgentServer.exists(PlainClass)
+
+
+def test_marker_stacks_above_agent_preserving_agent_pod() -> None:
+    """Stacked above @Agent, the marker coexists with the agent's Pod."""
+
+    @A2AAgentServer(base_url="http://x", version="2.0.0")
+    @Agent(spec=AgentExecutionSpec(name="stacked"))
+    class StackedAgent:
+        def __init__(self, model: IAgentModel) -> None:
+            self._model = model
+
+    assert Agent.exists(StackedAgent)
+    assert A2AAgentServer.exists(StackedAgent)
+
+
+def test_marker_stores_base_url_and_version() -> None:
+    """The marker preserves the declared base url and version."""
+
+    @A2AAgentServer(base_url="http://host:9000", version="3.1.4")
+    class Marked:
+        pass
+
+    marker = A2AAgentServer.get(Marked)
+    assert marker.base_url == "http://host:9000"
+    assert marker.version == "3.1.4"

--- a/plugins/spakky-a2a/tests/unit/test_adapter.py
+++ b/plugins/spakky-a2a/tests/unit/test_adapter.py
@@ -1,0 +1,333 @@
+"""Unit tests for the SpakkyAgentExecutor request/cancel branches."""
+
+import pytest
+from a2a.server.agent_execution import RequestContext
+from a2a.server.context import ServerCallContext
+from a2a.server.tasks import TaskUpdater
+from a2a.types import (
+    Message,
+    Part,
+    Role,
+    SendMessageRequest,
+    Task,
+    TaskState,
+    TaskStatus,
+)
+from google.protobuf.json_format import MessageToDict, ParseDict
+from google.protobuf.struct_pb2 import Value
+from spakky.agent.execution import (
+    Agent,
+    AgentExecutionSpec,
+    AgentSignalKind,
+    RecoveryStrategy,
+)
+from spakky.agent.interfaces.model import IAgentModel
+from spakky.agent.signal import ApprovalDecision
+from spakky.agent.state import AgentState, AgentStateReason, AgentStatus
+from spakky.agent.types import JsonObject
+
+from spakky.plugins.a2a.error import InvalidApprovalDecisionError
+from spakky.plugins.a2a.executor.adapter import (
+    SpakkyAgentExecutor,
+    _InboundApproval,
+)
+from spakky.plugins.a2a.executor.event_mapping import AgentEventProjector, RunOutcome
+from tests.unit._sample_agents import StubModel
+from tests.unit.conftest import (
+    FakeEvidenceRepository,
+    FakeSignalRepository,
+    FakeStateRepository,
+    RecordingEventQueue,
+)
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="durable",
+        accepted_signals=(AgentSignalKind.CANCEL,),
+        recovery=RecoveryStrategy.ACTION_BOUNDARY,
+    )
+)
+class _DurableAgent:
+    """Durable agent exposing a signal repository for cancel/approval tests."""
+
+    def __init__(
+        self,
+        model: IAgentModel,
+        signals: FakeSignalRepository,
+        states: FakeStateRepository,
+        evidence: FakeEvidenceRepository,
+    ) -> None:
+        self._model = model
+        self._signals = signals
+        self._states = states
+        self._evidence = evidence
+
+
+@Agent(spec=AgentExecutionSpec(name="stateless"))
+class _StatelessAgent:
+    """Stateless agent with no durable signal repository injected."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model
+
+
+def _data_part(payload: dict[str, object]) -> Part:
+    value = Value()
+    ParseDict(payload, value)
+    return Part(data=value)
+
+
+def _context(parts: list[Part]) -> RequestContext:
+    request = SendMessageRequest(
+        message=Message(role=Role.ROLE_USER, message_id="m1", parts=parts)
+    )
+    return RequestContext(
+        call_context=ServerCallContext(),
+        request=request,
+        task_id="t1",
+        context_id="c1",
+    )
+
+
+def _durable_executor() -> tuple[SpakkyAgentExecutor, FakeSignalRepository]:
+    signals = FakeSignalRepository()
+    agent = _DurableAgent(
+        StubModel(), signals, FakeStateRepository(), FakeEvidenceRepository()
+    )
+    return SpakkyAgentExecutor(agent, AgentEventProjector()), signals
+
+
+def test_inbound_approval_absent_without_message() -> None:
+    """A request context carrying no message yields no inbound approval."""
+    executor, _ = _durable_executor()
+
+    context = RequestContext(
+        call_context=ServerCallContext(),
+        task_id="t1",
+        context_id="c1",
+    )
+
+    assert executor._inbound_approval(context) is None
+
+
+def test_inbound_approval_absent_without_data_part() -> None:
+    """A message with only text parts yields no inbound approval."""
+    executor, _ = _durable_executor()
+
+    assert executor._inbound_approval(_context([Part(text="hi")])) is None
+
+
+def test_inbound_approval_absent_without_approval_id() -> None:
+    """A data part lacking an approval id yields no inbound approval."""
+    executor, _ = _durable_executor()
+
+    context = _context([_data_part({"decision": "approve"})])
+
+    assert executor._inbound_approval(context) is None
+
+
+def test_inbound_approval_parsed_from_data_part() -> None:
+    """A data part with approval id and decision yields a parsed approval."""
+    executor, _ = _durable_executor()
+
+    context = _context([_data_part({"approval_id": "a1", "decision": "approve"})])
+
+    approval = executor._inbound_approval(context)
+    assert approval is not None
+    assert approval.approval_id == "a1"
+
+
+def test_parse_decision_rejects_non_string() -> None:
+    """A non-string decision value is rejected as an invalid decision."""
+    executor, _ = _durable_executor()
+
+    context = _context([_data_part({"approval_id": "a1", "decision": 1})])
+
+    with pytest.raises(InvalidApprovalDecisionError):
+        executor._inbound_approval(context)
+
+
+def test_parse_decision_rejects_unknown_value() -> None:
+    """An unknown decision string is rejected as an invalid decision."""
+    executor, _ = _durable_executor()
+
+    context = _context([_data_part({"approval_id": "a1", "decision": "maybe"})])
+
+    with pytest.raises(InvalidApprovalDecisionError):
+        executor._inbound_approval(context)
+
+
+def test_append_approval_signal_without_repository_raises() -> None:
+    """A stateless agent cannot accept an approval decision signal."""
+    executor = SpakkyAgentExecutor(_StatelessAgent(StubModel()), AgentEventProjector())
+    approval = _InboundApproval(approval_id="a1", decision=ApprovalDecision.APPROVE)
+
+    with pytest.raises(InvalidApprovalDecisionError):
+        executor._append_approval_signal("t1", approval)
+
+
+async def test_cancel_without_repository_publishes_canceled(
+    queue: RecordingEventQueue,
+) -> None:
+    """A stateless agent cancel publishes a canceled status with no signal repo."""
+    executor = SpakkyAgentExecutor(_StatelessAgent(StubModel()), AgentEventProjector())
+
+    await executor.cancel(_context([Part(text="x")]), queue)
+
+    states = [status.status.state for status in queue.status_updates()]
+    assert TaskState.TASK_STATE_CANCELED in states
+
+
+async def test_cancel_with_repository_appends_cancel_signal(
+    queue: RecordingEventQueue,
+) -> None:
+    """A durable agent cancel appends a cancel signal and publishes canceled."""
+    executor, signals = _durable_executor()
+
+    await executor.cancel(_context([Part(text="x")]), queue)
+
+    appended = signals.appended()
+    assert any(signal.kind is AgentSignalKind.CANCEL for signal in appended)
+    states = [status.status.state for status in queue.status_updates()]
+    assert TaskState.TASK_STATE_CANCELED in states
+
+
+async def test_ensure_task_enqueues_submitted_task_when_absent(
+    queue: RecordingEventQueue,
+) -> None:
+    """A fresh request enqueues a submitted Task before any status update."""
+    task = await SpakkyAgentExecutor._ensure_task(_context([Part(text="x")]), queue)
+
+    assert task.status.state == TaskState.TASK_STATE_SUBMITTED
+    assert any(isinstance(event, Task) for event in queue.events)
+
+
+async def test_ensure_task_reuses_current_task_on_resume(
+    queue: RecordingEventQueue,
+) -> None:
+    """A resume request reuses the existing current task without re-enqueuing."""
+    existing = Task(
+        id="t1", context_id="c1", status=TaskStatus(state=TaskState.TASK_STATE_WORKING)
+    )
+    context = _context([Part(text="x")])
+    context.current_task = existing
+
+    task = await SpakkyAgentExecutor._ensure_task(context, queue)
+
+    assert task is existing
+    assert queue.events == []
+
+
+def _interrupted_state(metadata: JsonObject) -> AgentState:
+    return AgentState(
+        id="t1",
+        agent_type="durable",
+        status=AgentStatus.COMPLETED,
+        reason=AgentStateReason.APPROVAL_REQUIRED,
+        metadata=metadata,
+    )
+
+
+async def test_reconcile_terminal_completes_a_clean_run(
+    queue: RecordingEventQueue,
+) -> None:
+    """With no pause and a successful outcome the task completes."""
+    executor, _ = _durable_executor()
+    updater = TaskUpdater(queue, task_id="t1", context_id="c1")
+
+    await executor._reconcile_terminal("t1", RunOutcome(error=None), updater)
+
+    states = [status.status.state for status in queue.status_updates()]
+    assert TaskState.TASK_STATE_COMPLETED in states
+
+
+async def test_reconcile_terminal_fails_on_error_outcome(
+    queue: RecordingEventQueue,
+) -> None:
+    """A RUN_FINISHED error outcome marks the task failed with the error text."""
+    executor, _ = _durable_executor()
+    updater = TaskUpdater(queue, task_id="t1", context_id="c1")
+
+    await executor._reconcile_terminal(
+        "t1", RunOutcome(error={"code": "boom", "message": "exploded"}), updater
+    )
+
+    status = queue.status_updates()[0]
+    assert status.status.state == TaskState.TASK_STATE_FAILED
+    assert MessageToDict(status.status.message.parts[0]) == {"text": "exploded"}
+
+
+async def test_reconcile_terminal_failure_uses_fallback_message(
+    queue: RecordingEventQueue,
+) -> None:
+    """A failure outcome without a message falls back to a generic failure text."""
+    executor, _ = _durable_executor()
+    updater = TaskUpdater(queue, task_id="t1", context_id="c1")
+
+    await executor._reconcile_terminal("t1", RunOutcome(error={"code": "x"}), updater)
+
+    status = queue.status_updates()[0]
+    assert MessageToDict(status.status.message.parts[0]) == {"text": "run failed"}
+
+
+async def test_reconcile_terminal_pauses_for_approval(
+    queue: RecordingEventQueue,
+) -> None:
+    """A durable APPROVAL_REQUIRED state pauses the task for input."""
+    signals = FakeSignalRepository()
+    states = FakeStateRepository()
+    states.save(
+        _interrupted_state(
+            {"approval": {"id": "approval:t1:write", "allowed_decisions": ["approve"]}}
+        )
+    )
+    agent = _DurableAgent(StubModel(), signals, states, FakeEvidenceRepository())
+    executor = SpakkyAgentExecutor(agent, AgentEventProjector())
+    updater = TaskUpdater(queue, task_id="t1", context_id="c1")
+
+    await executor._reconcile_terminal("t1", RunOutcome(error=None), updater)
+
+    status = queue.status_updates()[0]
+    assert status.status.state == TaskState.TASK_STATE_INPUT_REQUIRED
+    parts = [MessageToDict(part) for part in status.status.message.parts]
+    assert parts[1]["data"]["approval_id"] == "approval:t1:write"
+
+
+async def test_reconcile_terminal_approval_uses_prompt_fallback(
+    queue: RecordingEventQueue,
+) -> None:
+    """A pending approval without a prompt falls back to a generic pause message."""
+    states = FakeStateRepository()
+    states.save(_interrupted_state({"approval": {"id": "approval:t1:write"}}))
+    agent = _DurableAgent(
+        StubModel(), FakeSignalRepository(), states, FakeEvidenceRepository()
+    )
+    executor = SpakkyAgentExecutor(agent, AgentEventProjector())
+    updater = TaskUpdater(queue, task_id="t1", context_id="c1")
+
+    await executor._reconcile_terminal("t1", RunOutcome(error=None), updater)
+
+    status = queue.status_updates()[0]
+    assert MessageToDict(status.status.message.parts[0]) == {
+        "text": "Approval required to continue."
+    }
+
+
+def test_pending_approval_absent_without_state_repository() -> None:
+    """A stateless agent never reports a pending approval pause."""
+    executor = SpakkyAgentExecutor(_StatelessAgent(StubModel()), AgentEventProjector())
+
+    assert executor._pending_approval("t1") is None
+
+
+def test_pending_approval_absent_when_metadata_is_malformed() -> None:
+    """An APPROVAL_REQUIRED state with non-mapping approval metadata reports None."""
+    states = FakeStateRepository()
+    states.save(_interrupted_state({"approval": "not-a-mapping"}))
+    agent = _DurableAgent(
+        StubModel(), FakeSignalRepository(), states, FakeEvidenceRepository()
+    )
+    executor = SpakkyAgentExecutor(agent, AgentEventProjector())
+
+    assert executor._pending_approval("t1") is None

--- a/plugins/spakky-a2a/tests/unit/test_builder.py
+++ b/plugins/spakky-a2a/tests/unit/test_builder.py
@@ -1,0 +1,92 @@
+"""Tests for A2A app assembly and the container-aware server spec."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from spakky.core.pod.interfaces.container import IContainer
+from starlette.applications import Starlette
+
+from spakky.plugins.a2a.error import A2AAgentServerNotRegisteredError
+from spakky.plugins.a2a.server.builder import A2AAgentServerSpec, build_a2a_app
+from spakky.plugins.a2a.server.registry import A2AAgentRegistry
+from spakky.plugins.a2a.store.interfaces import IA2ATaskRepository
+from spakky.plugins.a2a.store.task_store import InMemoryA2ATaskRepository
+from tests.unit._sample_agents import ServedPlannerAgent, StubModel
+
+
+def test_build_a2a_app_assembles_a_starlette_app() -> None:
+    """build_a2a_app returns a Starlette app carrying card and rpc routes."""
+    app = build_a2a_app(
+        ServedPlannerAgent(StubModel()),
+        base_url="http://x",
+        version="1.0.0",
+    )
+
+    assert isinstance(app, Starlette)
+    paths = {getattr(route, "path", None) for route in app.routes}
+    assert "/.well-known/agent-card.json" in paths
+
+
+def test_build_a2a_app_uses_default_in_memory_store_when_none() -> None:
+    """An omitted repository still yields a working app (in-memory store)."""
+    app = build_a2a_app(
+        ServedPlannerAgent(StubModel()),
+        base_url="http://x",
+        version="1.0.0",
+        repository=None,
+    )
+
+    assert isinstance(app, Starlette)
+
+
+def _spec_with_container(container: IContainer) -> A2AAgentServerSpec:
+    spec = A2AAgentServerSpec()
+    spec.set_container(container)
+    return spec
+
+
+def test_server_spec_builds_app_for_registered_agent() -> None:
+    """The spec resolves a registered agent and builds its app."""
+    registry = A2AAgentRegistry()
+    registry.register(
+        ServedPlannerAgent(StubModel()),
+        _planner_marker(),
+    )
+    container = MagicMock(spec=IContainer)
+    container.get = MagicMock(return_value=registry)
+    container.get_or_none = MagicMock(return_value=None)
+
+    app = _spec_with_container(container).build_app_for("planner")
+
+    assert isinstance(app, Starlette)
+
+
+def test_server_spec_unknown_agent_raises() -> None:
+    """Building an app for an unregistered agent raises the registry error."""
+    container = MagicMock(spec=IContainer)
+    container.get = MagicMock(return_value=A2AAgentRegistry())
+    container.get_or_none = MagicMock(return_value=None)
+
+    with pytest.raises(A2AAgentServerNotRegisteredError):
+        _spec_with_container(container).build_app_for("absent")
+
+
+def test_server_spec_uses_container_repository_when_present() -> None:
+    """A repository Pod resolved from the container is passed to the builder."""
+    registry = A2AAgentRegistry()
+    registry.register(ServedPlannerAgent(StubModel()), _planner_marker())
+    repository = InMemoryA2ATaskRepository()
+    container = MagicMock(spec=IContainer)
+    container.get = MagicMock(return_value=registry)
+    container.get_or_none = MagicMock(return_value=repository)
+
+    app = _spec_with_container(container).build_app_for("planner")
+
+    assert isinstance(app, Starlette)
+    container.get_or_none.assert_called_once_with(IA2ATaskRepository)
+
+
+def _planner_marker():
+    from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+
+    return A2AAgentServer(base_url="http://planner.local", version="1.2.3")

--- a/plugins/spakky-a2a/tests/unit/test_card_derivation.py
+++ b/plugins/spakky-a2a/tests/unit/test_card_derivation.py
@@ -1,0 +1,183 @@
+"""Tests for AgentCard derivation from an @Agent declaration."""
+
+import pytest
+from spakky.agent.execution import (
+    Agent,
+    AgentExecutionSpec,
+    AgentTeammate,
+    StreamingExposureMode,
+)
+from spakky.agent.interfaces.model import IAgentModel
+from spakky.agent.tooling import (
+    DataAccess,
+    Externality,
+    Idempotency,
+    ToolEffects,
+    ToolPermission,
+    agent_tool,
+)
+
+from spakky.plugins.a2a.card.derivation import (
+    JSON_CONTENT_TYPE,
+    TEXT_CONTENT_TYPE,
+    AgentCardFactory,
+)
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="planner",
+        objective="Plan a route across the city.",
+        streaming_exposure_mode=StreamingExposureMode.BALANCED,
+    )
+)
+class PlannerAgent:
+    """Agent declaring one tool used to verify skill derivation."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model
+
+    @agent_tool(
+        schema_name="lookup_route",
+        description="Look up a route.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        permissions=(ToolPermission(name="maps:read"),),
+    )
+    def lookup_route(self, origin: str) -> str:
+        """Return a route description for an origin."""
+        return f"route from {origin}"
+
+
+@Agent(spec=AgentExecutionSpec())
+class AnonymousToollessAgent:
+    """Agent with neither a name nor tools nor teammates."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model
+
+
+def test_build_uses_spec_name_and_objective() -> None:
+    """The card name and description come from the spec name and objective."""
+    card = AgentCardFactory().build(Agent.get(PlannerAgent), "http://x", "1.0.0")
+
+    assert card.name == "planner"
+    assert card.description == "Plan a route across the city."
+    assert card.version == "1.0.0"
+    assert card.supported_interfaces[0].url == "http://x"
+
+
+def test_build_falls_back_to_class_name_when_spec_name_absent() -> None:
+    """The card name falls back to the class name when the spec omits a name."""
+    card = AgentCardFactory().build(
+        Agent.get(AnonymousToollessAgent), "http://x", "1.0.0"
+    )
+
+    assert card.name == "AnonymousToollessAgent"
+    assert card.description == "AnonymousToollessAgent"
+
+
+def test_build_disables_push_notifications() -> None:
+    """The derived card never advertises push notifications."""
+    card = AgentCardFactory().build(Agent.get(PlannerAgent), "http://x", "1.0.0")
+
+    assert card.capabilities.push_notifications is False
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_streaming"),
+    [
+        (StreamingExposureMode.LOW_LATENCY, True),
+        (StreamingExposureMode.BALANCED, True),
+        (StreamingExposureMode.STRICT, True),
+        (StreamingExposureMode.NO_STREAM_UNTIL_FINAL_GUARDED, False),
+    ],
+)
+def test_build_streaming_capability_tracks_exposure_mode(
+    mode: StreamingExposureMode,
+    expected_streaming: bool,
+) -> None:
+    """Streaming capability is off only for the guarded final-only mode."""
+
+    @Agent(
+        spec=AgentExecutionSpec(
+            name=f"probe_{mode.value}", streaming_exposure_mode=mode
+        )
+    )
+    class StreamingProbeAgent:
+        """Probe agent parametrized over each streaming exposure mode."""
+
+        def __init__(self, model: IAgentModel) -> None:
+            self._model = model
+
+    card = AgentCardFactory().build(Agent.get(StreamingProbeAgent), "http://x", "1.0.0")
+
+    assert card.capabilities.streaming is expected_streaming
+
+
+def test_build_emits_one_skill_per_tool_descriptor() -> None:
+    """Each tool descriptor projects to exactly one AgentSkill."""
+    card = AgentCardFactory().build(Agent.get(PlannerAgent), "http://x", "1.0.0")
+
+    descriptor = Agent.get(PlannerAgent).tool_catalog.descriptors[0]
+    assert len(card.skills) == 1
+    skill = card.skills[0]
+    assert skill.id == descriptor.identity.key
+    assert skill.name == descriptor.identity.name
+    assert skill.description == "Look up a route."
+    assert list(skill.input_modes) == [JSON_CONTENT_TYPE]
+    assert list(skill.output_modes) == [JSON_CONTENT_TYPE]
+
+
+def test_build_derives_skill_tags_from_tool_metadata() -> None:
+    """Skill tags include permission names plus access, externality, idempotency."""
+    card = AgentCardFactory().build(Agent.get(PlannerAgent), "http://x", "1.0.0")
+
+    tags = list(card.skills[0].tags)
+    assert tags == [
+        "maps:read",
+        DataAccess.READ.value,
+        Externality.LOCAL.value,
+        Idempotency.IDEMPOTENT.value,
+    ]
+
+
+def test_build_emits_one_skill_per_teammate() -> None:
+    """Each declared teammate projects to a delegation AgentSkill."""
+
+    @Agent(
+        spec=AgentExecutionSpec(
+            name="coordinator",
+            teammates=(AgentTeammate(name="researcher", card_url="https://r.example"),),
+        )
+    )
+    class CoordinatorAgent:
+        """Agent declaring a remote teammate."""
+
+        def __init__(self, model: IAgentModel) -> None:
+            self._model = model
+
+    card = AgentCardFactory().build(Agent.get(CoordinatorAgent), "http://x", "1.0.0")
+
+    assert len(card.skills) == 1
+    skill = card.skills[0]
+    assert skill.id == "teammate:researcher"
+    assert skill.name == "researcher"
+    assert list(skill.tags) == ["delegation"]
+
+
+def test_build_default_modes_are_text_plain() -> None:
+    """Default input and output modes advertise plain text conversation."""
+    card = AgentCardFactory().build(Agent.get(PlannerAgent), "http://x", "1.0.0")
+
+    assert list(card.default_input_modes) == [TEXT_CONTENT_TYPE]
+    assert list(card.default_output_modes) == [TEXT_CONTENT_TYPE]
+
+
+def test_build_emits_no_skills_for_empty_catalog_and_no_teammates() -> None:
+    """An agent with no tools and no teammates yields an empty skills list."""
+    card = AgentCardFactory().build(
+        Agent.get(AnonymousToollessAgent), "http://x", "1.0.0"
+    )
+
+    assert len(card.skills) == 0

--- a/plugins/spakky-a2a/tests/unit/test_config.py
+++ b/plugins/spakky-a2a/tests/unit/test_config.py
@@ -1,0 +1,34 @@
+"""Tests for A2A plugin configuration."""
+
+import pytest
+
+from spakky.plugins.a2a.config import (
+    DEFAULT_A2A_BASE_URL,
+    DEFAULT_A2A_VERSION,
+    SPAKKY_A2A_CONFIG_ENV_PREFIX,
+    A2AConfig,
+)
+
+
+def test_a2a_config_uses_defaults_when_env_absent() -> None:
+    """A2AConfig falls back to default base url and version without env."""
+    config = A2AConfig()
+
+    assert config.default_base_url == DEFAULT_A2A_BASE_URL
+    assert config.default_version == DEFAULT_A2A_VERSION
+
+
+def test_a2a_config_loads_base_url_and_version_from_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A2AConfig reads base url and version from SPAKKY_A2A_* env."""
+    monkeypatch.setenv(
+        f"{SPAKKY_A2A_CONFIG_ENV_PREFIX}DEFAULT_BASE_URL",
+        "https://agents.example.com",
+    )
+    monkeypatch.setenv(f"{SPAKKY_A2A_CONFIG_ENV_PREFIX}DEFAULT_VERSION", "2.3.4")
+
+    config = A2AConfig()
+
+    assert config.default_base_url == "https://agents.example.com"
+    assert config.default_version == "2.3.4"

--- a/plugins/spakky-a2a/tests/unit/test_error.py
+++ b/plugins/spakky-a2a/tests/unit/test_error.py
@@ -1,0 +1,53 @@
+"""Tests for the A2A plugin error hierarchy."""
+
+from spakky.core.common.error import AbstractSpakkyFrameworkError
+
+from spakky.plugins.a2a.error import (
+    AbstractSpakkyA2AError,
+    A2AAgentCardDerivationError,
+    A2AAgentServerNotRegisteredError,
+    InvalidApprovalDecisionError,
+    UnsupportedAgentEventError,
+    UnsupportedFinalOutputError,
+)
+
+
+def test_a2a_errors_inherit_framework_base() -> None:
+    """Every A2A error inherits the framework error base for uniform handling."""
+    assert issubclass(AbstractSpakkyA2AError, AbstractSpakkyFrameworkError)
+
+
+def test_not_registered_error_carries_agent_name() -> None:
+    """A2AAgentServerNotRegisteredError preserves the missing agent name."""
+    error = A2AAgentServerNotRegisteredError("planner")
+
+    assert error.agent_name == "planner"
+    assert error.message == "No A2A agent server is registered for the agent name"
+
+
+def test_card_derivation_error_carries_agent_name() -> None:
+    """A2AAgentCardDerivationError preserves the offending agent name."""
+    error = A2AAgentCardDerivationError("planner")
+
+    assert error.agent_name == "planner"
+
+
+def test_unsupported_event_error_carries_kind() -> None:
+    """UnsupportedAgentEventError preserves the unprojectable event kind."""
+    error = UnsupportedAgentEventError("mystery")
+
+    assert error.kind == "mystery"
+
+
+def test_unsupported_final_output_error_carries_type() -> None:
+    """UnsupportedFinalOutputError preserves the offending output type."""
+    error = UnsupportedFinalOutputError(int)
+
+    assert error.output_type is int
+
+
+def test_invalid_approval_decision_error_carries_decision() -> None:
+    """InvalidApprovalDecisionError preserves the unknown decision string."""
+    error = InvalidApprovalDecisionError("maybe")
+
+    assert error.decision == "maybe"

--- a/plugins/spakky-a2a/tests/unit/test_event_mapping.py
+++ b/plugins/spakky-a2a/tests/unit/test_event_mapping.py
@@ -1,0 +1,277 @@
+"""Tests for projecting neutral AgentEvent items onto A2A task events."""
+
+from collections.abc import Iterable
+
+import pytest
+from a2a.server.tasks import TaskUpdater
+from a2a.types import Part, TaskState
+from google.protobuf.json_format import MessageToDict
+from spakky.agent.event import (
+    AgentEvent,
+    AgentEventAttribution,
+    ArtifactEvent,
+    MessageDeltaEvent,
+    ReasoningDeltaEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    StateDeltaEvent,
+    StateSnapshotEvent,
+    StepFinishedEvent,
+    StepStartedEvent,
+    ToolCallArgsDeltaEvent,
+    ToolCallEndEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+
+from spakky.plugins.a2a.error import UnsupportedAgentEventError
+from spakky.plugins.a2a.executor.event_mapping import AgentEventProjector, RunOutcome
+from tests.unit.conftest import RecordingEventQueue
+
+ATTRIBUTION = AgentEventAttribution(
+    agent_id="assistant",
+    run_id="task-1",
+    conversation_id="ctx-1",
+)
+
+
+def _part_dicts(parts: Iterable[Part]) -> list[dict[str, object]]:
+    return [MessageToDict(part) for part in parts]
+
+
+async def _project(
+    event: AgentEvent,
+    updater: TaskUpdater,
+) -> RunOutcome | None:
+    return await AgentEventProjector().project(event, updater)
+
+
+async def test_run_started_starts_work(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """RUN_STARTED transitions the task to working."""
+    await _project(RunStartedEvent(ATTRIBUTION), updater)
+
+    assert queue.status_updates()[0].status.state == TaskState.TASK_STATE_WORKING
+
+
+async def test_run_finished_success_returns_outcome_without_error(
+    updater: TaskUpdater,
+) -> None:
+    """RUN_FINISHED without error returns a success outcome for the executor."""
+    outcome = await _project(RunFinishedEvent(ATTRIBUTION), updater)
+
+    assert outcome == RunOutcome(error=None)
+
+
+async def test_run_finished_error_returns_outcome_with_error(
+    updater: TaskUpdater,
+) -> None:
+    """RUN_FINISHED with error returns a failure outcome for the executor."""
+    outcome = await _project(
+        RunFinishedEvent(ATTRIBUTION, error={"code": "boom", "message": "x"}),
+        updater,
+    )
+
+    assert outcome == RunOutcome(error={"code": "boom", "message": "x"})
+
+
+async def test_step_started_emits_working_with_step_name(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """STEP_STARTED emits a working status carrying the step name."""
+    await _project(StepStartedEvent(ATTRIBUTION, step_name="model-call"), updater)
+
+    status = queue.status_updates()[0]
+    assert status.status.state == TaskState.TASK_STATE_WORKING
+    assert status.metadata["step_name"] == "model-call"
+
+
+async def test_step_finished_emits_working_with_step_name(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """STEP_FINISHED emits a working status carrying the step name."""
+    await _project(StepFinishedEvent(ATTRIBUTION, step_name="model-call"), updater)
+
+    assert queue.status_updates()[0].metadata["step_name"] == "model-call"
+
+
+async def test_message_delta_streams_text(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """MESSAGE_DELTA streams the assistant text as a working status update."""
+    await _project(
+        MessageDeltaEvent(ATTRIBUTION, message_id="msg-1", delta="hello"),
+        updater,
+    )
+
+    status = queue.status_updates()[0]
+    assert status.status.state == TaskState.TASK_STATE_WORKING
+    assert _part_dicts(status.status.message.parts) == [{"text": "hello"}]
+    assert status.status.message.metadata["message_id"] == "msg-1"
+
+
+async def test_reasoning_delta_streams_text_with_reasoning_flag(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """REASONING_DELTA streams reasoning text flagged distinctly from messages."""
+    await _project(
+        ReasoningDeltaEvent(ATTRIBUTION, reasoning_id="r-1", delta="thinking"),
+        updater,
+    )
+
+    status = queue.status_updates()[0]
+    assert MessageToDict(status.status.message.parts[0]) == {"text": "thinking"}
+    assert status.status.message.metadata["reasoning"] is True
+
+
+async def test_tool_call_start_emits_start_phase_metadata(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """TOOL_CALL_START emits a working status tagged with the start phase."""
+    await _project(
+        ToolCallStartEvent(ATTRIBUTION, call_id="c1", tool_name="search"),
+        updater,
+    )
+
+    metadata = queue.status_updates()[0].metadata
+    assert metadata["tool_call"] == "search"
+    assert metadata["call_id"] == "c1"
+    assert metadata["phase"] == "start"
+
+
+async def test_tool_call_args_delta_emits_args_metadata(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """TOOL_CALL_ARGS_DELTA emits a working status carrying the args delta."""
+    await _project(
+        ToolCallArgsDeltaEvent(ATTRIBUTION, call_id="c1", args_delta='{"q":'),
+        updater,
+    )
+
+    metadata = queue.status_updates()[0].metadata
+    assert metadata["call_id"] == "c1"
+    assert metadata["args_delta"] == '{"q":'
+
+
+async def test_tool_call_end_emits_end_phase_metadata(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """TOOL_CALL_END emits a working status tagged with the end phase."""
+    await _project(ToolCallEndEvent(ATTRIBUTION, call_id="c1"), updater)
+
+    metadata = queue.status_updates()[0].metadata
+    assert metadata["call_id"] == "c1"
+    assert metadata["phase"] == "end"
+
+
+async def test_tool_call_result_adds_named_data_artifact(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """TOOL_CALL_RESULT adds an artifact carrying the result named after the tool."""
+    await _project(
+        ToolCallResultEvent(
+            ATTRIBUTION,
+            call_id="c1",
+            tool_name="search",
+            message_id="msg-1",
+            result={"hits": 2},
+        ),
+        updater,
+    )
+
+    artifact = queue.artifact_updates()[0].artifact
+    assert artifact.name == "search"
+    assert MessageToDict(artifact.parts[0].data) == {
+        "tool": "search",
+        "call_id": "c1",
+        "result": {"hits": 2},
+    }
+
+
+async def test_artifact_str_content_adds_named_text_artifact(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """ARTIFACT with string content adds a text artifact under its name."""
+    await _project(
+        ArtifactEvent(ATTRIBUTION, artifact_id="a1", content="report", name="summary"),
+        updater,
+    )
+
+    artifact = queue.artifact_updates()[0].artifact
+    assert artifact.name == "summary"
+    assert MessageToDict(artifact.parts[0]) == {"text": "report"}
+
+
+async def test_artifact_structured_content_falls_back_to_artifact_id(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """ARTIFACT with structured content and no name uses the artifact id."""
+    await _project(
+        ArtifactEvent(ATTRIBUTION, artifact_id="a1", content={"k": "v"}),
+        updater,
+    )
+
+    artifact = queue.artifact_updates()[0].artifact
+    assert artifact.name == "a1"
+    assert MessageToDict(artifact.parts[0].data) == {"k": "v"}
+
+
+async def test_state_snapshot_emits_working_with_snapshot_data(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """STATE_SNAPSHOT emits a working status carrying the snapshot as data."""
+    await _project(
+        StateSnapshotEvent(ATTRIBUTION, snapshot={"count": 3}),
+        updater,
+    )
+
+    status = queue.status_updates()[0]
+    assert status.status.message.metadata["state_snapshot"] is True
+    assert MessageToDict(status.status.message.parts[0].data) == {"count": 3}
+
+
+async def test_state_delta_emits_working_with_patch_data(
+    queue: RecordingEventQueue,
+    updater: TaskUpdater,
+) -> None:
+    """STATE_DELTA emits a working status carrying the JSON patch as data."""
+    await _project(
+        StateDeltaEvent(ATTRIBUTION, patch=[{"op": "add", "path": "/x", "value": 1}]),
+        updater,
+    )
+
+    status = queue.status_updates()[0]
+    assert status.status.message.metadata["state_delta"] is True
+    assert MessageToDict(status.status.message.parts[0].data) == [
+        {"op": "add", "path": "/x", "value": 1}
+    ]
+
+
+async def test_event_type_mismatching_its_kind_raises(updater: TaskUpdater) -> None:
+    """An event whose instance type mismatches its kind is rejected.
+
+    The kind is forced to MESSAGE_DELTA on a ToolCallEndEvent, so the projector
+    dispatches to the message-delta path and the type narrowing fails.
+    """
+    mismatched = ToolCallEndEvent(ATTRIBUTION, call_id="c1")
+    object.__setattr__(
+        mismatched,
+        "kind",
+        MessageDeltaEvent(ATTRIBUTION, message_id="m", delta="").kind,
+    )
+
+    with pytest.raises(UnsupportedAgentEventError):
+        await _project(mismatched, updater)

--- a/plugins/spakky-a2a/tests/unit/test_main.py
+++ b/plugins/spakky-a2a/tests/unit/test_main.py
@@ -1,0 +1,31 @@
+"""Unit tests for the A2A plugin initialize function."""
+
+from unittest.mock import MagicMock, call
+
+from spakky.core.application.application import SpakkyApplication
+
+from spakky.plugins.a2a.config import A2AConfig
+from spakky.plugins.a2a.main import initialize
+from spakky.plugins.a2a.post_processors.register_agent_servers import (
+    RegisterA2AAgentServersPostProcessor,
+)
+from spakky.plugins.a2a.server.builder import A2AAgentServerSpec
+from spakky.plugins.a2a.server.registry import A2AAgentRegistry
+
+
+def test_initialize_registers_plugin_pods() -> None:
+    """initialize() registers config, registry, server spec, and post-processor."""
+    app = MagicMock(spec=SpakkyApplication)
+
+    initialize(app)
+
+    app.add.assert_has_calls(
+        [
+            call(A2AConfig),
+            call(A2AAgentRegistry),
+            call(A2AAgentServerSpec),
+            call(RegisterA2AAgentServersPostProcessor),
+        ],
+        any_order=False,
+    )
+    assert app.add.call_count == 4

--- a/plugins/spakky-a2a/tests/unit/test_register_agent_servers.py
+++ b/plugins/spakky-a2a/tests/unit/test_register_agent_servers.py
@@ -1,0 +1,96 @@
+"""Tests for the @A2AAgentServer registration post-processor."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from spakky.core.common.constants import DYNAMIC_PROXY_CLASS_NAME_SUFFIX
+from spakky.core.pod.interfaces.container import IContainer
+
+from spakky.plugins.a2a.error import A2AAgentServerNotRegisteredError
+from spakky.plugins.a2a.post_processors.register_agent_servers import (
+    RegisterA2AAgentServersPostProcessor,
+)
+from spakky.plugins.a2a.server.registry import A2AAgentRegistry
+from tests.unit._sample_agents import (
+    ServedPlannerAgent,
+    StubModel,
+    UnservedAgent,
+)
+
+
+@pytest.fixture
+def registry() -> A2AAgentRegistry:
+    """Provide a fresh registry per test."""
+    return A2AAgentRegistry()
+
+
+@pytest.fixture
+def processor(registry: A2AAgentRegistry) -> RegisterA2AAgentServersPostProcessor:
+    """Provide a processor wired to a container returning the registry."""
+    container = MagicMock(spec=IContainer)
+    container.get = MagicMock(return_value=registry)
+    processor = RegisterA2AAgentServersPostProcessor()
+    processor.set_container(container)
+    return processor
+
+
+def test_registers_marked_agent_pod(
+    processor: RegisterA2AAgentServersPostProcessor,
+    registry: A2AAgentRegistry,
+) -> None:
+    """A Pod with both @Agent and @A2AAgentServer is registered by name."""
+    pod = ServedPlannerAgent(StubModel())
+
+    result = processor.post_process(pod)
+
+    assert result is pod
+    entry = registry.get("planner")
+    assert entry.instance is pod
+    assert entry.metadata.base_url == "http://planner.local"
+
+
+def test_ignores_agent_without_marker(
+    processor: RegisterA2AAgentServersPostProcessor,
+    registry: A2AAgentRegistry,
+) -> None:
+    """An @Agent Pod lacking the A2A marker is returned unchanged and unregistered."""
+    pod = UnservedAgent(StubModel())
+
+    result = processor.post_process(pod)
+
+    assert result is pod
+    with pytest.raises(A2AAgentServerNotRegisteredError):
+        registry.get("unserved")
+
+
+def test_ignores_non_agent_pod(
+    processor: RegisterA2AAgentServersPostProcessor,
+) -> None:
+    """A plain Pod that is neither agent nor marker is returned unchanged."""
+
+    class PlainPod:
+        pass
+
+    pod = PlainPod()
+
+    assert processor.post_process(pod) is pod
+
+
+def test_unwraps_aop_proxy_type_before_registering(
+    processor: RegisterA2AAgentServersPostProcessor,
+    registry: A2AAgentRegistry,
+) -> None:
+    """A dynamic AOP proxy subclass is unwrapped to find the marked base class."""
+
+    class ServedPlannerAgent_DynamicProxy(ServedPlannerAgent):
+        pass
+
+    ServedPlannerAgent_DynamicProxy.__name__ = (
+        f"ServedPlannerAgent{DYNAMIC_PROXY_CLASS_NAME_SUFFIX}"
+    )
+    proxy = ServedPlannerAgent_DynamicProxy(StubModel())
+
+    result = processor.post_process(proxy)
+
+    assert result is proxy
+    assert registry.get("planner").instance is proxy

--- a/plugins/spakky-a2a/tests/unit/test_task_store.py
+++ b/plugins/spakky-a2a/tests/unit/test_task_store.py
@@ -1,0 +1,132 @@
+"""Tests for the A2A task repository and the async TaskStore bridge."""
+
+from a2a.server.context import ServerCallContext
+from a2a.types import ListTasksRequest, Task, TaskState, TaskStatus
+
+from spakky.plugins.a2a.store.task_store import (
+    InMemoryA2ATaskRepository,
+    SpakkyA2ATaskStore,
+)
+
+
+def _task(
+    task_id: str, *, context_id: str = "ctx", state: TaskState | None = None
+) -> Task:
+    status = TaskStatus(state=state) if state is not None else TaskStatus()
+    return Task(id=task_id, context_id=context_id, status=status)
+
+
+def test_repository_round_trips_a_saved_task() -> None:
+    """A saved task is returned by id from the in-memory repository."""
+    repository = InMemoryA2ATaskRepository()
+    task = _task("t1")
+
+    repository.save(task)
+
+    assert repository.get_or_none("t1") == task
+
+
+def test_repository_returns_none_for_missing_task() -> None:
+    """An unknown task id resolves to None."""
+    assert InMemoryA2ATaskRepository().get_or_none("absent") is None
+
+
+def test_repository_delete_removes_a_task() -> None:
+    """Deleting a task removes it from the repository."""
+    repository = InMemoryA2ATaskRepository()
+    repository.save(_task("t1"))
+
+    repository.delete("t1")
+
+    assert repository.get_or_none("t1") is None
+
+
+def test_repository_delete_missing_task_is_a_no_op() -> None:
+    """Deleting an absent task leaves the repository unchanged."""
+    repository = InMemoryA2ATaskRepository()
+    repository.save(_task("t1"))
+
+    repository.delete("absent")
+
+    assert repository.get_or_none("t1") is not None
+
+
+def test_repository_list_all_returns_every_task() -> None:
+    """list_all enumerates every persisted task."""
+    repository = InMemoryA2ATaskRepository()
+    repository.save(_task("t1"))
+    repository.save(_task("t2"))
+
+    assert {task.id for task in repository.list_all()} == {"t1", "t2"}
+
+
+async def test_store_get_delegates_to_repository() -> None:
+    """The async store get returns the repository's snapshot."""
+    repository = InMemoryA2ATaskRepository()
+    repository.save(_task("t1"))
+    store = SpakkyA2ATaskStore(repository)
+
+    result = await store.get("t1", ServerCallContext())
+
+    assert result is not None
+    assert result.id == "t1"
+
+
+async def test_store_save_then_get_round_trips() -> None:
+    """The async store save persists through to the repository."""
+    store = SpakkyA2ATaskStore(InMemoryA2ATaskRepository())
+
+    await store.save(_task("t1"), ServerCallContext())
+
+    assert await store.get("t1", ServerCallContext()) is not None
+
+
+async def test_store_delete_delegates_to_repository() -> None:
+    """The async store delete removes the snapshot from the repository."""
+    repository = InMemoryA2ATaskRepository()
+    repository.save(_task("t1"))
+    store = SpakkyA2ATaskStore(repository)
+
+    await store.delete("t1", ServerCallContext())
+
+    assert repository.get_or_none("t1") is None
+
+
+async def test_store_list_filters_by_context_id() -> None:
+    """The async store list returns only tasks matching the requested context."""
+    repository = InMemoryA2ATaskRepository()
+    repository.save(_task("t1", context_id="a"))
+    repository.save(_task("t2", context_id="b"))
+    store = SpakkyA2ATaskStore(repository)
+
+    response = await store.list(ListTasksRequest(context_id="a"), ServerCallContext())
+
+    assert [task.id for task in response.tasks] == ["t1"]
+    assert response.total_size == 1
+
+
+async def test_store_list_filters_by_status() -> None:
+    """The async store list returns only tasks matching the requested status."""
+    repository = InMemoryA2ATaskRepository()
+    repository.save(_task("t1", state=TaskState.TASK_STATE_WORKING))
+    repository.save(_task("t2", state=TaskState.TASK_STATE_COMPLETED))
+    store = SpakkyA2ATaskStore(repository)
+
+    response = await store.list(
+        ListTasksRequest(status=TaskState.TASK_STATE_WORKING),
+        ServerCallContext(),
+    )
+
+    assert [task.id for task in response.tasks] == ["t1"]
+
+
+async def test_store_list_without_filters_returns_all() -> None:
+    """The async store list returns every task when no filter is set."""
+    repository = InMemoryA2ATaskRepository()
+    repository.save(_task("t1"))
+    repository.save(_task("t2"))
+    store = SpakkyA2ATaskStore(repository)
+
+    response = await store.list(ListTasksRequest(), ServerCallContext())
+
+    assert {task.id for task in response.tasks} == {"t1", "t2"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ version_files = [
   "plugins/spakky-redis/pyproject.toml:version",
   "plugins/spakky-vllm/pyproject.toml:version",
   "plugins/spakky-agui/pyproject.toml:version",
+  "plugins/spakky-a2a/pyproject.toml:version",
   "plugins/spakky-oidc/pyproject.toml:version",
   "plugins/spakky-policy/pyproject.toml:version",
   "plugins/spakky-mcp/pyproject.toml:version",
@@ -93,6 +94,7 @@ members = [
   "plugins/spakky-redis",
   "plugins/spakky-vllm",
   "plugins/spakky-agui",
+  "plugins/spakky-a2a",
   "plugins/spakky-oidc",
   "plugins/spakky-policy",
   "plugins/spakky-mcp",
@@ -126,6 +128,7 @@ spakky-saga = { workspace = true }
 spakky-redis = { workspace = true }
 spakky-vllm = { workspace = true }
 spakky-agui = { workspace = true }
+spakky-a2a = { workspace = true }
 spakky-oidc = { workspace = true }
 spakky-policy = { workspace = true }
 spakky-mcp = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 [manifest]
 members = [
     "spakky",
+    "spakky-a2a",
     "spakky-actuator",
     "spakky-agent",
     "spakky-agui",
@@ -39,6 +40,32 @@ members = [
     "spakky-tracing",
     "spakky-typer",
     "spakky-vllm",
+]
+
+[[package]]
+name = "a2a-sdk"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "culsans", marker = "python_full_version < '3.13'" },
+    { name = "google-api-core" },
+    { name = "googleapis-common-protos" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "json-rpc" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/7e/8ac10bbf8b15b16574355f39b17dbdf617a282c27b41c7ff2116e30336df/a2a_sdk-1.1.0.tar.gz", hash = "sha256:e8102dad1b36709dbdc3d19319e38e6dfa3b3a79c30416030eb2d482576be204", size = 375726, upload-time = "2026-05-29T09:34:43.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/ea/3a5b160cfd51c67759b08748051094d9365ceff18127633d0021950c9860/a2a_sdk-1.1.0-py3-none-any.whl", hash = "sha256:d7f5846caf18033d8bf3108b11ec827dd8dd32f867c98848ede0e39474be93be", size = 241886, upload-time = "2026-05-29T09:34:41.484Z" },
+]
+
+[package.optional-dependencies]
+http-server = [
+    { name = "sse-starlette" },
+    { name = "starlette" },
 ]
 
 [[package]]
@@ -204,6 +231,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/c4/9841118a2157e913e8ebfbc0a2b58f7b60f1f7202040c3e1df8925ed1184/aiokafka-0.14.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1cd651e1f56571baae306fdd0b5509047ab9625797a24cd75902e139c5a20318", size = 1098571, upload-time = "2026-04-29T10:42:59.356Z" },
     { url = "https://files.pythonhosted.org/packages/d6/a1/0af8a37849a4108ae227f46c4c62f6beab31863cf66ba318fb73b0be5b26/aiokafka-0.14.0-cp314-cp314-win32.whl", hash = "sha256:128127eb96dab98150b636bb5f480c80e15f02f82a118eec206a521c8cf7cf7c", size = 314107, upload-time = "2026-04-29T10:43:01.111Z" },
     { url = "https://files.pythonhosted.org/packages/fa/18/fb46c65f758900c71d0f1c73b7802720f99cabcb1f4a11676573f9bc1b8f/aiokafka-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:aa385039aa9b235359319bbdcf48c9c86a75d81c9c547d645056d00361238903", size = 333320, upload-time = "2026-04-29T10:43:02.424Z" },
+]
+
+[[package]]
+name = "aiologic"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sniffio", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/a7/809482759f40079f4c4328c7318bf569ae25d457f5017aad30a1b9aafedc/aiologic-0.17.0.tar.gz", hash = "sha256:65aa058e858c94cd208badb188e7f00b54dcabb3ba85b34f794db98074d108b9", size = 251625, upload-time = "2026-06-14T12:24:35.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6b/5f75d6194b597ac32bbdbb7b524a28fb1fa98bd0ddcefce94b313a818cc0/aiologic-0.17.0-py3-none-any.whl", hash = "sha256:1bf4d3e4314df2bcb06a9e696417204e206ab50e10ec98d28d157e2e57634f74", size = 161084, upload-time = "2026-06-14T12:24:34.146Z" },
 ]
 
 [[package]]
@@ -861,6 +902,19 @@ wheels = [
 ]
 
 [[package]]
+name = "culsans"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiologic", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/5d/9fb19fb38f6d6120422064279ea5532e22b84aa2be8831d49607194feda3/culsans-0.11.0-py3-none-any.whl", hash = "sha256:278d118f63fc75b9db11b664b436a1b83cc30d9577127848ba41420e66eb5a47", size = 21811, upload-time = "2025-12-31T23:15:37.189Z" },
+]
+
+[[package]]
 name = "decli"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1221,6 +1275,35 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.55.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/1c/70b23fc52b2bb3c70b379f3bd05c4a60ab3a873e30c6bd21c57e0154848a/google_auth-2.55.0.tar.gz", hash = "sha256:fcd3a130f575fa36403d38774af1c64a4fbfbca09215f0589d2372b5119697cb", size = 349379, upload-time = "2026-06-15T22:33:16.466Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/71/c0321dc6d63d99946da45f7c06299b934e4f7f7da5c4f14d101bcb39adf1/google_auth-2.55.0-py3-none-any.whl", hash = "sha256:a17cef9dedf98c4ebae2fb0c48c8f75952c877cbc2efe09f329ef16c2783d88a", size = 252400, upload-time = "2026-06-15T22:33:14.992Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1468,6 +1551,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "json-rpc"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/9e/59f4a5b7855ced7346ebf40a2e9a8942863f644378d956f68bcef2c88b90/json-rpc-1.15.0.tar.gz", hash = "sha256:e6441d56c1dcd54241c937d0a2dcd193bdf0bdc539b5316524713f554b7f85b9", size = 28854, upload-time = "2023-06-11T09:45:49.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/9e/820c4b086ad01ba7d77369fb8b11470a01fac9b4977f02e18659cf378b6b/json_rpc-1.15.0-py2.py3-none-any.whl", hash = "sha256:4a4668bbbe7116feb4abbd0f54e64a4adcf4b8f648f19ffa0848ad0f6606a9bf", size = 39450, upload-time = "2023-06-11T09:45:47.136Z" },
 ]
 
 [[package]]
@@ -2247,6 +2339,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2317,6 +2421,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
     { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
     { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -3044,6 +3169,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3061,13 +3195,17 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+a2a = [
+    { name = "spakky-a2a" },
+]
 actuator = [
     { name = "spakky-actuator" },
 ]
 agent = [
+    { name = "spakky-a2a" },
     { name = "spakky-agent" },
-    { name = "spakky-mcp" },
     { name = "spakky-agui" },
+    { name = "spakky-mcp" },
     { name = "spakky-sqlalchemy" },
     { name = "spakky-vllm" },
 ]
@@ -3141,6 +3279,7 @@ fastapi = [
     { name = "spakky-fastapi" },
 ]
 full = [
+    { name = "spakky-a2a" },
     { name = "spakky-actuator" },
     { name = "spakky-agent" },
     { name = "spakky-agui" },
@@ -3256,6 +3395,8 @@ worker = [
 [package.metadata]
 requires-dist = [
     { name = "psycopg", extras = ["binary"], marker = "extra == 'database-postgres'", specifier = ">=3.3.3" },
+    { name = "spakky", extras = ["a2a"], marker = "extra == 'agent'", editable = "core/spakky" },
+    { name = "spakky", extras = ["a2a"], marker = "extra == 'full'", editable = "core/spakky" },
     { name = "spakky", extras = ["agui"], marker = "extra == 'agent'", editable = "core/spakky" },
     { name = "spakky", extras = ["agui"], marker = "extra == 'full'", editable = "core/spakky" },
     { name = "spakky", extras = ["celery"], marker = "extra == 'full'", editable = "core/spakky" },
@@ -3300,6 +3441,7 @@ requires-dist = [
     { name = "spakky", extras = ["vllm"], marker = "extra == 'agent'", editable = "core/spakky" },
     { name = "spakky", extras = ["vllm"], marker = "extra == 'full'", editable = "core/spakky" },
     { name = "spakky", extras = ["web"], marker = "extra == 'recommended'", editable = "core/spakky" },
+    { name = "spakky-a2a", marker = "extra == 'a2a'", editable = "plugins/spakky-a2a" },
     { name = "spakky-actuator", marker = "extra == 'actuator'", editable = "core/spakky-actuator" },
     { name = "spakky-actuator", marker = "extra == 'full'", editable = "core/spakky-actuator" },
     { name = "spakky-actuator", marker = "extra == 'observability'", editable = "core/spakky-actuator" },
@@ -3353,7 +3495,44 @@ requires-dist = [
     { name = "spakky-vllm", marker = "extra == 'vllm'", editable = "plugins/spakky-vllm" },
     { name = "uuid7", specifier = ">=0.1.0" },
 ]
-provides-extras = ["minimal", "domain", "data", "event", "task", "agent-core", "agui", "actuator", "cache-core", "tracing", "outbox", "auth", "logging", "cryptography", "oidc", "policy", "openfga", "fastapi", "typer", "rabbitmq", "kafka", "sqlalchemy", "celery", "opentelemetry", "grpc", "redis", "vllm", "mcp", "saga", "web", "cli", "database", "database-postgres", "events-rabbitmq", "events-kafka", "events-outbox-sqlalchemy", "event-driven", "worker", "security", "observability", "cache-app", "agent", "recommended", "full"]
+provides-extras = ["minimal", "domain", "data", "event", "task", "agent-core", "agui", "a2a", "actuator", "cache-core", "tracing", "outbox", "auth", "logging", "cryptography", "oidc", "policy", "openfga", "fastapi", "typer", "rabbitmq", "kafka", "sqlalchemy", "celery", "opentelemetry", "grpc", "redis", "vllm", "mcp", "saga", "web", "cli", "database", "database-postgres", "events-rabbitmq", "events-kafka", "events-outbox-sqlalchemy", "event-driven", "worker", "security", "observability", "cache-app", "agent", "recommended", "full"]
+
+[[package]]
+name = "spakky-a2a"
+version = "6.9.1"
+source = { editable = "plugins/spakky-a2a" }
+dependencies = [
+    { name = "a2a-sdk", extra = ["http-server"] },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "spakky" },
+    { name = "spakky-agent" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-integration-mark" },
+    { name = "types-protobuf" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=1.1.0" },
+    { name = "pydantic", specifier = ">=2.4" },
+    { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "spakky", editable = "core/spakky" },
+    { name = "spakky-agent", editable = "core/spakky-agent" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.28.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-integration-mark", specifier = ">=0.2.0" },
+    { name = "types-protobuf", specifier = ">=7.34.1.20260518" },
+]
 
 [[package]]
 name = "spakky-actuator"


### PR DESCRIPTION
## Summary
- add spakky-a2a workspace plugin with AgentCard derivation and JSON-RPC/SSE A2A server assembly
- bridge neutral agent events and TaskStore persistence into A2A task/message/artifact lifecycle updates
- support input-required HITL resume via durable state.reason approval metadata; auth-required remains follow-up #446
- expose the a2a extra from core spakky while preserving spakky-agui metadata from develop

## Verification
- uv run ruff format . (plugins/spakky-a2a)
- uv run ruff check . (plugins/spakky-a2a)
- uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text (plugins/spakky-a2a)
- uv run pytest -q (plugins/spakky-a2a, 86 passed, 100% coverage)
- uv lock --check
- uv run python .agents/skills/check/scripts/validate_python_harness.py
- pre-commit hooks on commit

Closes #415