### PR TITLE
feat(agui): add WebSocket AG-UI endpoint (#418)

### DIFF
--- a/docs/guides/agent-ag-ui.md
+++ b/docs/guides/agent-ag-ui.md
@@ -1,12 +1,12 @@
 # AG-UI 어댑터
 
 > 선언형 Agent를 AG-UI (Agent User Interaction) 프로토콜로 노출해, Agent 실행 이벤트를
-> UI에 SSE (Server-Sent Events)로 스트리밍하는 어댑터 가이드입니다. 렌더링(프런트엔드)은
-> 범위 밖이며, 본 가이드는 와이어 프로토콜까지를 다룹니다.
+> UI에 SSE (Server-Sent Events) 또는 WebSocket으로 스트리밍하는 어댑터 가이드입니다.
+> 렌더링(프런트엔드)은 범위 밖이며, 본 가이드는 와이어 프로토콜까지를 다룹니다.
 
-`spakky-agui` plugin은 선언형 `@Agent`의 실행 스트림을 AG-UI 이벤트로 투영하여 SSE로
-노출합니다. 승인이 필요한 도구는 deferred-tool 방식의 HITL (Human-in-the-loop) 흐름으로
-표면화됩니다.
+`spakky-agui` plugin은 선언형 `@Agent`의 실행 스트림을 AG-UI 이벤트로 투영하여
+SSE/WebSocket으로 노출합니다. 승인이 필요한 도구는 deferred-tool 방식의 HITL
+(Human-in-the-loop) 흐름으로 표면화됩니다.
 
 ## 1. `@Agent` 선언
 
@@ -50,11 +50,12 @@ class Assistant:
         return f"write:{topic}"
 ```
 
-## 2. SSE endpoint 마운트
+## 2. endpoint 마운트
 
-`add_agui_endpoint`로 FastAPI 앱에 `POST {sse_path}` 라우트를 등록합니다. plugin은
-`fastapi` 서드파티에 직접 의존하며(`StreamingResponse`), `spakky-fastapi` plugin을
-import하지 않습니다.
+`add_agui_endpoint`로 FastAPI 앱에 `POST {sse_path}` SSE 라우트를 등록하고,
+`add_agui_websocket_endpoint`로 `WebSocket {websocket_path}` 라우트를 등록합니다. plugin은
+`fastapi` 서드파티에 직접 의존하며(`StreamingResponse`, `WebSocket`), `spakky-fastapi`
+plugin을 import하지 않습니다.
 
 ```python
 from fastapi import FastAPI
@@ -64,7 +65,7 @@ from ag_ui.core import RunAgentInput as AgUiRunAgentInput
 from spakky.agent import AgentRunner, RunAgentInput
 from spakky.plugins.agui import (
     AgUiProjector, AgUiRunDriver,
-    AgUiConfig, add_agui_endpoint, ingest_decision,
+    AgUiConfig, add_agui_endpoint, add_agui_websocket_endpoint, ingest_decision,
 )
 
 app = FastAPI()
@@ -86,7 +87,14 @@ def run_driver_factory(core_input, ag_ui_input, accept):
 
 
 add_agui_endpoint(app, run_driver_factory=run_driver_factory, config=config)
+add_agui_websocket_endpoint(app, run_driver_factory=run_driver_factory, config=config)
 ```
+
+SSE 클라이언트는 `POST /agui` body로 AG-UI `RunAgentInput`을 보내고 `text/event-stream`
+응답을 받습니다. WebSocket 클라이언트는 `/agui/ws`에 연결한 뒤 같은 `RunAgentInput` JSON을
+text/JSON message로 보내고, AG-UI encoded event frame을 text message로 순서대로 받습니다.
+같은 WebSocket 연결에서 후속 `RunAgentInput`을 보내 승인 결정(`forwardedProps.approvalDecision`
+또는 deferred tool-result message)을 전달할 수 있습니다.
 
 `initialize`는 `AgUiConfig`만 등록합니다. 투영기는 실행마다 상태를 가지므로 싱글턴 Pod이
 될 수 없고, 어떤 Agent가 응답할지는 애플리케이션마다 다르기 때문에 endpoint 와이어링은
@@ -97,6 +105,7 @@ add_agui_endpoint(app, run_driver_factory=run_driver_factory, config=config)
 | 환경변수 | 기본값 | 목적 |
 |---------|--------|------|
 | `SPAKKY_AGUI_SSE_PATH` | `/agui` | SSE endpoint 경로 |
+| `SPAKKY_AGUI_WEBSOCKET_PATH` | `/agui/ws` | WebSocket endpoint 경로 |
 | `SPAKKY_AGUI_EMIT_STATE_SNAPSHOT` | `true` | `STATE_SNAPSHOT` 투영 여부 |
 | `SPAKKY_AGUI_MESSAGES_SNAPSHOT_ENABLED` | `false` | `RUN_FINISHED` 직전 `MESSAGES_SNAPSHOT` 방출 여부 |
 
@@ -128,8 +137,9 @@ dispatch 없이 결과를 내보내지 않고, 그 멈춤은 durable한 `WAIT_FO
    승인 요청이 남습니다. `AgUiRunDriver`는 종단 `RUN_FINISHED` 직전에 그 상태를 읽어
    (`project_pending_approval`), `hitl_approval`의 `TOOL_CALL_START`/`ARGS`/`END` 프레임을
    주입합니다 — **결과 프레임은 없습니다** (결과 지연).
-2. 클라이언트가 사람의 결정을 수집해 다음 `RunAgentInput`에 담아 다시 POST합니다 (deferred
-   call id를 향한 tool-result 메시지, 또는 `forwardedProps.approvalDecision`).
+2. 클라이언트가 사람의 결정을 수집해 다음 `RunAgentInput`에 담아 다시 전송합니다 (SSE에서는
+   POST, WebSocket에서는 같은 연결의 후속 message; deferred call id를 향한 tool-result 메시지,
+   또는 `forwardedProps.approvalDecision`).
 3. `ingest_decision`이 결정을 디코딩하여 durable signal queue에 `APPROVAL_DECISION`
    signal로 적재하면 런너가 `run_events()`를 다시 돌며 재개합니다. `APPROVE`/`MODIFY`는
    도구를 진행시키고, `REJECT`는 종료로 이어집니다.

--- a/docs/guides/agents-advanced.md
+++ b/docs/guides/agents-advanced.md
@@ -388,12 +388,12 @@ AG-UI는 `AgentYield`와 다른 wire protocol입니다. 공식 AG-UI HTTP agent�
 
 현재 Spakky 상태를 정확히 말하면 다음과 같습니다.
 
-- `spakky-agent`는 AG-UI와 개념적으로 맞는 stream/event building block을 제공합니다.
+- `spakky-agent`는 AG-UI와 개념적으로 맞는 중립 `AgentEvent` stream building block을 제공합니다.
 - `AgentYield` 자체는 AG-UI event가 아닙니다.
-- 현재 repository에는 built-in `spakky-agent-agui` adapter나 AG-UI event class가 없습니다.
-- CopilotKit은 AG-UI `HttpAgent`로 Spakky backend에 붙을 수 있지만, Spakky 쪽에 AG-UI HTTP/SSE adapter endpoint를 구현해야 합니다.
+- `spakky-agui` plugin은 `AgentRunner.run_events()`를 AG-UI event로 투영하고 FastAPI SSE/WebSocket endpoint를 등록합니다.
+- CopilotKit은 AG-UI `HttpAgent`로 `spakky-agui` SSE endpoint에 붙을 수 있습니다. WebSocket이 필요한 클라이언트는 같은 `RunAgentInput`을 WebSocket message로 보내고 AG-UI encoded event frame을 text message로 받습니다.
 
-권장 mapping은 다음과 같습니다.
+수동 adapter를 직접 작성할 때의 권장 mapping은 다음과 같습니다.
 
 | Spakky `AgentYieldKind` | AG-UI event | 설명 |
 |-------------------------|-------------|------|
@@ -406,7 +406,7 @@ AG-UI는 `AgentYield`와 다른 wire protocol입니다. 공식 AG-UI HTTP agent�
 | `FINAL` | `TEXT_MESSAGE_END` + `RUN_FINISHED` | token message가 열려 있으면 먼저 닫습니다. |
 | `ERROR` | `RUN_ERROR` | `Error.message`를 AG-UI error message로 보냅니다. |
 
-정리하면 CopilotKit으로 붙일 수는 있습니다. 단, Spakky endpoint가 CopilotKit `HttpAgent`가 기대하는 AG-UI request/response를 구현해야 합니다. `AgentYield`를 그대로 SSE로 흘리는 Spakky-native endpoint는 CopilotKit용 endpoint가 아닙니다.
+정리하면 CopilotKit으로 붙일 수 있습니다. 단, endpoint는 CopilotKit `HttpAgent`가 기대하는 AG-UI request/response를 구현해야 합니다. `AgentYield`를 그대로 SSE로 흘리는 Spakky-native endpoint는 CopilotKit용 endpoint가 아닙니다. 기본 구현은 [AG-UI 어댑터](agent-ag-ui.md)를 사용합니다.
 
 ## 테스트 전략
 
@@ -440,7 +440,7 @@ uv run pytest tests/acceptance/test_code_assistant_demo_acceptance.py -q --no-co
 - 긴 멀티턴 Agent는 `AgentCompactionPolicy`를 spec에 선언합니다.
 - Durable path를 쓰면 state/signal/evidence repository contribution이 등록되어 있습니다.
 - Inbound adapter는 `AgentYieldKind.APPROVAL`을 사용자 decision signal로 연결합니다.
-- CopilotKit 연동 endpoint는 Spakky-native `AgentYield` JSON이 아니라 AG-UI `type` event stream을 반환합니다.
+- CopilotKit 연동 endpoint는 Spakky-native `AgentYield` JSON이 아니라 AG-UI `type` event stream을 반환합니다. 기본 구현은 `spakky-agui`의 SSE/WebSocket endpoint를 사용합니다.
 - Cancel은 cancellation lifecycle로 처리하고 즉시 terminal state로 덮지 않습니다.
 - Evidence는 append-only로 남깁니다.
 - 테스트는 실제 model server 없이 scripted stream으로 주요 branch를 검증합니다.

--- a/plugins/spakky-agui/README.md
+++ b/plugins/spakky-agui/README.md
@@ -1,15 +1,15 @@
 # spakky-agui
 
 > `spakky-agui`는 `spakky-agent`를 위한 공식 AG-UI (Agent User Interaction) protocol adapter plugin입니다.
-> 선언형 `@Agent` 실행 스트림을 AG-UI 이벤트로 투영(project)하여 SSE (Server-Sent Events)로 노출하고,
-> deferred-tool 방식의 HITL (Human-in-the-loop) 승인 흐름을 지원합니다.
+> 선언형 `@Agent` 실행 스트림을 AG-UI 이벤트로 투영(project)하여 SSE (Server-Sent Events)와
+> WebSocket으로 노출하고, deferred-tool 방식의 HITL (Human-in-the-loop) 승인 흐름을 지원합니다.
 
 ## 언제 필요한가
 
 애플리케이션이 선언형 `@Agent` workflow를 실행하고, 그 실행 이벤트(토큰, 도구 호출,
 승인 요청, 종료)를 AG-UI 호환 프런트엔드에 실시간 스트리밍하려 할 때 사용합니다.
 렌더링(프런트엔드 UI)은 본 plugin의 범위 밖입니다 — 본 plugin은 와이어 프로토콜(SSE
-프레임)만 책임집니다.
+프레임 또는 WebSocket text message)만 책임집니다.
 
 ## 설치
 
@@ -18,7 +18,7 @@ pip install spakky-agui
 ```
 
 durable Agent 실행(state·signal·evidence repository)과 모델 어댑터(`IAgentModel`)는
-별도 provider가 제공합니다. `spakky-agui`는 inbound SSE 어댑터만 제공합니다.
+별도 provider가 제공합니다. `spakky-agui`는 inbound SSE/WebSocket 어댑터만 제공합니다.
 
 ## 설정
 
@@ -27,6 +27,7 @@ durable Agent 실행(state·signal·evidence repository)과 모델 어댑터(`IA
 | 설정 | 기본값 | 목적 |
 |------|--------|------|
 | `SPAKKY_AGUI_SSE_PATH` | `/agui` | SSE endpoint가 마운트되는 경로 |
+| `SPAKKY_AGUI_WEBSOCKET_PATH` | `/agui/ws` | WebSocket endpoint가 마운트되는 경로 |
 | `SPAKKY_AGUI_EMIT_STATE_SNAPSHOT` | `true` | 중립 `STATE_SNAPSHOT` 이벤트를 AG-UI로 투영할지 여부 |
 | `SPAKKY_AGUI_MESSAGES_SNAPSHOT_ENABLED` | `false` | `RUN_FINISHED` 직전에 `MESSAGES_SNAPSHOT` 프레임을 1회 방출할지 여부 |
 
@@ -36,6 +37,7 @@ durable Agent 실행(state·signal·evidence repository)과 모델 어댑터(`IA
 AgentRunner.run_events() → 중립 AgentEvent  (런너가 native로 방출)
 중립 AgentEvent  ──(AgUiProjector)──▶  AG-UI BaseEvent
 AG-UI BaseEvent  ──(EventEncoder)──▶  "data: {...}\n\n" SSE 프레임
+                                      또는 WebSocket text message
 ```
 
 - **`AgentRunner.run_events()`**: 런너가 중립 `AgentEvent` taxonomy를 native로 방출하는
@@ -80,6 +82,7 @@ from spakky.plugins.agui import (
     AgUiProjector,
     AgUiRunDriver,
     add_agui_endpoint,
+    add_agui_websocket_endpoint,
     ingest_decision,
 )
 
@@ -106,10 +109,14 @@ def run_driver_factory(
 
 
 add_agui_endpoint(app, run_driver_factory=run_driver_factory, config=config)
+add_agui_websocket_endpoint(app, run_driver_factory=run_driver_factory, config=config)
 ```
 
 `POST /agui`로 AG-UI `RunAgentInput`을 보내면 `text/event-stream` 응답으로 실행
-이벤트가 스트리밍됩니다.
+이벤트가 스트리밍됩니다. WebSocket 클라이언트는 `/agui/ws`에 연결한 뒤 같은 AG-UI
+`RunAgentInput` JSON을 text/JSON message로 보내고, 실행 이벤트를 AG-UI encoded text
+message로 순서대로 받습니다. 같은 연결에서 후속 `RunAgentInput`을 보내 승인 결정
+(`forwardedProps.approvalDecision` 또는 deferred tool-result message)을 전달할 수 있습니다.
 
 ### endpoint 와이어링이 plugin `initialize`에 없는 이유
 

--- a/plugins/spakky-agui/src/spakky/plugins/agui/__init__.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/__init__.py
@@ -17,6 +17,7 @@ from spakky.plugins.agui.hitl import (
 )
 from spakky.plugins.agui.projector import AgUiProjector
 from spakky.plugins.agui.transport import AgUiRunDriver
+from spakky.plugins.agui.websocket import add_agui_websocket_endpoint
 
 PLUGIN_NAME = Plugin(name="spakky-agui")
 """Plugin identifier for the AG-UI adapter package."""
@@ -32,6 +33,7 @@ __all__ = [
     "PLUGIN_NAME",
     "RunDriverFactory",
     "add_agui_endpoint",
+    "add_agui_websocket_endpoint",
     "ingest_decision",
     "project_approval",
     "project_pending_approval",

--- a/plugins/spakky-agui/src/spakky/plugins/agui/config.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/config.py
@@ -11,10 +11,13 @@ SPAKKY_AGUI_CONFIG_ENV_PREFIX = "SPAKKY_AGUI_"
 DEFAULT_AGUI_SSE_PATH = "/agui"
 """Default mount path for the AG-UI SSE endpoint."""
 
+DEFAULT_AGUI_WEBSOCKET_PATH = "/agui/ws"
+"""Default mount path for the AG-UI WebSocket endpoint."""
+
 
 @Configuration()
 class AgUiConfig(BaseSettings):
-    """Settings for the AG-UI SSE adapter."""
+    """Settings for the AG-UI adapter."""
 
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
         env_prefix=SPAKKY_AGUI_CONFIG_ENV_PREFIX,
@@ -24,6 +27,9 @@ class AgUiConfig(BaseSettings):
 
     sse_path: str = DEFAULT_AGUI_SSE_PATH
     """Path the AG-UI SSE endpoint is mounted at on the FastAPI application."""
+
+    websocket_path: str = DEFAULT_AGUI_WEBSOCKET_PATH
+    """Path the AG-UI WebSocket endpoint is mounted at on the FastAPI application."""
 
     emit_state_snapshot: bool = True
     """Whether STATE_SNAPSHOT neutral events are projected to AG-UI; when False

--- a/plugins/spakky-agui/src/spakky/plugins/agui/websocket.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/websocket.py
@@ -1,0 +1,42 @@
+"""Mount the AG-UI WebSocket endpoint on a FastAPI application.
+
+``add_agui_websocket_endpoint`` registers a bidirectional WebSocket route. Each
+client JSON message is parsed as an AG-UI ``RunAgentInput``, mapped through the
+same protocol boundary as the SSE endpoint, and streamed back as encoded AG-UI
+event frames over WebSocket text messages.
+"""
+
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.endpoint import RunDriverFactory, _to_core_input
+
+
+def add_agui_websocket_endpoint(
+    app: FastAPI,
+    *,
+    run_driver_factory: RunDriverFactory,
+    config: AgUiConfig,
+) -> None:
+    """Register the AG-UI WebSocket endpoint on ``app`` at ``config.websocket_path``."""
+
+    async def run_agui_websocket(websocket: WebSocket) -> None:
+        await websocket.accept()
+        try:
+            while True:
+                ag_ui_input = AgUiRunAgentInput.model_validate(
+                    await websocket.receive_json()
+                )
+                core_input = _to_core_input(ag_ui_input)
+                driver = run_driver_factory(
+                    core_input,
+                    ag_ui_input,
+                    websocket.headers.get("accept"),
+                )
+                async for frame in driver:
+                    await websocket.send_text(frame)
+        except WebSocketDisconnect:
+            return
+
+    app.add_api_websocket_route(config.websocket_path, run_agui_websocket)

--- a/plugins/spakky-agui/tests/integration/test_websocket_endpoint.py
+++ b/plugins/spakky-agui/tests/integration/test_websocket_endpoint.py
@@ -1,0 +1,196 @@
+"""Integration: the AG-UI WebSocket endpoint streams encoded event frames."""
+
+from collections.abc import AsyncIterator
+from json import loads
+from typing import cast, override
+
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+from ag_ui.encoder import EventEncoder
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from spakky.agent import (
+    Agent,
+    AgentExecutionSpec,
+    AgentRunner,
+    EvidenceCapture,
+    Idempotency,
+    ModelCapability,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    RunAgentInput,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+from spakky.agent.interfaces.model import IAgentModel
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.projector import AgUiProjector
+from spakky.plugins.agui.transport import AgUiRunDriver
+from spakky.plugins.agui.websocket import add_agui_websocket_endpoint
+
+
+@Agent(spec=AgentExecutionSpec(name="ws_assistant", objective="answer with a tool"))
+class WebSocketAssistant:
+    """Stateless agent exercised through the WebSocket endpoint."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model
+
+    @agent_tool(
+        schema_name="lookup",
+        description="Look up a fact.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def lookup(self, topic: str) -> str:
+        """Look up a topic."""
+        return f"fact:{topic}"
+
+
+class _ScriptedModel(IAgentModel):
+    @property
+    @override
+    def capability(self) -> ModelCapability:
+        return ModelCapability()
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        return ModelResponse(content="scripted")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOKEN_DELTA, token_delta="hello"
+        )
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+            tool_call=ModelToolCall(
+                name="lookup", arguments={"topic": "agents"}, call_id="call-1"
+            ),
+        )
+        yield ModelStreamEvent(kind=ModelStreamEventKind.DONE)
+
+
+class _StaticDriver:
+    async def __aiter__(self) -> AsyncIterator[str]:
+        yield 'data: {"type":"RUN_FINISHED"}\n\n'
+
+
+def _build_runner_app() -> FastAPI:
+    app = FastAPI()
+    config = AgUiConfig()
+    assistant = WebSocketAssistant(_ScriptedModel())
+
+    def run_driver_factory(
+        core_input: RunAgentInput,
+        ag_ui_input: AgUiRunAgentInput,
+        accept: str | None,
+    ) -> AgUiRunDriver:
+        runner = AgentRunner.for_agent_instance(assistant)
+        return AgUiRunDriver(
+            runner=runner,
+            run_input=core_input,
+            agent_id="ws_assistant",
+            projector=AgUiProjector(config),
+            encoder=EventEncoder(accept=accept or ""),
+        )
+
+    add_agui_websocket_endpoint(
+        app, run_driver_factory=run_driver_factory, config=config
+    )
+    return app
+
+
+def _build_capture_app(
+    captured: list[tuple[RunAgentInput, AgUiRunAgentInput, str | None]],
+) -> FastAPI:
+    app = FastAPI()
+
+    def run_driver_factory(
+        core_input: RunAgentInput,
+        ag_ui_input: AgUiRunAgentInput,
+        accept: str | None,
+    ) -> AgUiRunDriver:
+        captured.append((core_input, ag_ui_input, accept))
+        return cast(AgUiRunDriver, _StaticDriver())
+
+    add_agui_websocket_endpoint(
+        app,
+        run_driver_factory=run_driver_factory,
+        config=AgUiConfig(),
+    )
+    return app
+
+
+def _run_agent_input() -> dict[str, object]:
+    return {
+        "threadId": "conv-1",
+        "runId": "run-1",
+        "state": None,
+        "messages": [{"id": "u1", "role": "user", "content": "look up agents"}],
+        "tools": [],
+        "context": [],
+        "forwardedProps": None,
+    }
+
+
+def _resume_input() -> dict[str, object]:
+    payload = _run_agent_input()
+    payload["forwardedProps"] = {
+        "approvalDecision": {
+            "request_id": "approval:run-1:note.write",
+            "decision": "approve",
+        }
+    }
+    return payload
+
+
+def _event_type(frame: str) -> str:
+    return str(loads(frame.removeprefix("data: ").strip())["type"])
+
+
+def _receive_until_finished(client: TestClient) -> list[str]:
+    frames: list[str] = []
+    with client.websocket_connect("/agui/ws") as websocket:
+        websocket.send_json(_run_agent_input())
+        while True:
+            frame = websocket.receive_text()
+            frames.append(frame)
+            if _event_type(frame) == "RUN_FINISHED":
+                return frames
+
+
+def test_websocket_endpoint_streams_encoded_frames_in_order() -> None:
+    """WS /agui/ws가 AG-UI encoded frame을 순서대로 text message로 스트리밍한다."""
+    frames = _receive_until_finished(TestClient(_build_runner_app()))
+
+    types = [_event_type(frame) for frame in frames]
+    assert types[0] == "RUN_STARTED"
+    assert "TOOL_CALL_RESULT" in types
+    assert types[-1] == "RUN_FINISHED"
+
+
+def test_websocket_endpoint_accepts_followup_run_input_on_same_connection() -> None:
+    """같은 WS 연결에서 다음 RunAgentInput을 받아 resume approval을 매핑한다."""
+    captured: list[tuple[RunAgentInput, AgUiRunAgentInput, str | None]] = []
+    client = TestClient(_build_capture_app(captured))
+
+    with client.websocket_connect(
+        "/agui/ws", headers={"accept": "text/event-stream"}
+    ) as websocket:
+        websocket.send_json(_run_agent_input())
+        assert _event_type(websocket.receive_text()) == "RUN_FINISHED"
+        websocket.send_json(_resume_input())
+        assert _event_type(websocket.receive_text()) == "RUN_FINISHED"
+
+    assert captured[0][0].resume is False
+    assert captured[1][0].resume is True
+    assert captured[1][1].forwarded_props is not None
+    assert captured[1][2] == "text/event-stream"

--- a/plugins/spakky-agui/tests/unit/test_config.py
+++ b/plugins/spakky-agui/tests/unit/test_config.py
@@ -6,10 +6,11 @@ from spakky.plugins.agui.config import AgUiConfig
 
 
 def test_agui_config_defaults_expect_documented_values() -> None:
-    """AgUiConfig가 문서화된 기본값(sse_path/snapshot 게이트)을 노출한다."""
+    """AgUiConfig가 문서화된 기본값(path/snapshot 게이트)을 노출한다."""
     config = AgUiConfig()
 
     assert config.sse_path == "/agui"
+    assert config.websocket_path == "/agui/ws"
     assert config.emit_state_snapshot is True
     assert config.messages_snapshot_enabled is False
 
@@ -19,11 +20,13 @@ def test_agui_config_env_override_expect_environment_values(
 ) -> None:
     """SPAKKY_AGUI_ 환경변수가 설정 필드를 재정의한다."""
     monkeypatch.setenv("SPAKKY_AGUI_SSE_PATH", "/stream/agui")
+    monkeypatch.setenv("SPAKKY_AGUI_WEBSOCKET_PATH", "/stream/agui/ws")
     monkeypatch.setenv("SPAKKY_AGUI_EMIT_STATE_SNAPSHOT", "false")
     monkeypatch.setenv("SPAKKY_AGUI_MESSAGES_SNAPSHOT_ENABLED", "true")
 
     config = AgUiConfig()
 
     assert config.sse_path == "/stream/agui"
+    assert config.websocket_path == "/stream/agui/ws"
     assert config.emit_state_snapshot is False
     assert config.messages_snapshot_enabled is True

--- a/plugins/spakky-agui/tests/unit/test_public_api.py
+++ b/plugins/spakky-agui/tests/unit/test_public_api.py
@@ -12,6 +12,7 @@ from spakky.plugins.agui import (
     PLUGIN_NAME,
     RunDriverFactory,
     add_agui_endpoint,
+    add_agui_websocket_endpoint,
     ingest_decision,
     project_approval,
     project_pending_approval,
@@ -25,6 +26,7 @@ def test_public_api_exports_agui_surface() -> None:
     assert AgUiProjector is agui_api.AgUiProjector
     assert AgUiRunDriver is agui_api.AgUiRunDriver
     assert add_agui_endpoint is agui_api.add_agui_endpoint
+    assert add_agui_websocket_endpoint is agui_api.add_agui_websocket_endpoint
     assert ingest_decision is agui_api.ingest_decision
     assert project_approval is agui_api.project_approval
     assert project_pending_approval is agui_api.project_pending_approval


### PR DESCRIPTION
## Summary
- add FastAPI WebSocket registration for AG-UI RunAgentInput messages
- stream existing AgUiRunDriver encoded frames back over WebSocket text messages
- document SSE/WebSocket usage and config

## Acceptance Criteria (자가 grep)
acceptance_check: missing (issue #418 has no grep/find/rg acceptance lines)

## Verification
- uv run --with ruff==0.15.9 ruff format .
- uv run --with ruff==0.15.9 ruff check .
- uv run --with pyrefly==0.59.1 --with pytest==9.0.3 --with pytest-asyncio==1.3.0 pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text
- uv run --with pytest==9.0.3 --with pytest-asyncio==1.3.0 --with pytest-cov==7.1.0 --with pytest-spec==6.0.0 --with pytest-xdist==3.8.0 pytest -q
- uv run --with mkdocs==1.6.1 --with mkdocs-material==9.7.0 mkdocs build --strict

## Review Note
- Isolated review agent was unavailable in this session, so the /review-code checklist was applied in-context before final verification.

Closes #418