### PR TITLE
feat(a2a): add grpc transport

### DIFF
--- a/plugins/spakky-a2a/README.md
+++ b/plugins/spakky-a2a/README.md
@@ -1,3 +1,19 @@
 # spakky-a2a
 
 A2A (Agent2Agent) protocol server plugin for the Spakky framework.
+
+## gRPC transport
+
+`build_a2a_grpc_handler()` builds a `grpc.GenericRpcHandler` for the official
+`lf.a2a.v1.A2AService` descriptor. The transport exposes:
+
+- `SendMessage`
+- `SendStreamingMessage`
+- `GetTask`
+- `CancelTask`
+
+The gRPC handler reuses the same AgentCard derivation, `TaskStore`,
+`SpakkyAgentExecutor`, and neutral agent-event projection used by the JSON-RPC
+transport. Add the handler to a `spakky-grpc` `GrpcServerSpec` or another
+`grpc.aio.Server`, then call `/lf.a2a.v1.A2AService/<Method>` with the protobuf
+message classes provided by `a2a-sdk`.

--- a/plugins/spakky-a2a/pyproject.toml
+++ b/plugins/spakky-a2a/pyproject.toml
@@ -8,6 +8,7 @@ license = { text = "MIT" }
 authors = [{ name = "Spakky", email = "sejong418@icloud.com" }]
 dependencies = [
     "a2a-sdk[http-server]>=1.1.0",
+    "grpcio>=1.68.0",
     "pydantic>=2.4",
     "pydantic-settings>=2.13.1",
     "spakky>=6.9.1",
@@ -22,6 +23,8 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-integration-mark>=0.2.0",
     "httpx>=0.28.0",
+    "spakky-grpc>=6.9.1",
+    "types-grpcio>=1.0.0.20260614",
     "types-protobuf>=7.34.1.20260518",
 ]
 
@@ -85,3 +88,4 @@ exclude_lines = [
 [tool.uv.sources]
 spakky = { workspace = true }
 spakky-agent = { workspace = true }
+spakky-grpc = { workspace = true }

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/error.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/error.py
@@ -63,3 +63,23 @@ class InvalidApprovalDecisionError(AbstractSpakkyA2AError):
     def __init__(self, decision: str) -> None:
         super().__init__()
         self.decision = decision
+
+
+class UnsupportedA2AGrpcResultError(AbstractSpakkyA2AError):
+    """Raised when a unary A2A gRPC method returns an unsupported result."""
+
+    message = "A2A gRPC result type is not supported"
+
+    def __init__(self, result_type: type[object]) -> None:
+        super().__init__()
+        self.result_type = result_type
+
+
+class UnsupportedA2AGrpcEventError(AbstractSpakkyA2AError):
+    """Raised when a streaming A2A gRPC event cannot be wrapped."""
+
+    message = "A2A gRPC event type is not supported"
+
+    def __init__(self, event_type: type[object]) -> None:
+        super().__init__()
+        self.event_type = event_type

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/grpc_transport/__init__.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/grpc_transport/__init__.py
@@ -1,0 +1,13 @@
+"""gRPC transport bindings for the official A2A service descriptor."""
+
+from spakky.plugins.a2a.grpc_transport.builder import build_a2a_grpc_handler
+from spakky.plugins.a2a.grpc_transport.handler import (
+    A2A_GRPC_SERVICE,
+    A2AGrpcHandler,
+)
+
+__all__ = [
+    "A2A_GRPC_SERVICE",
+    "A2AGrpcHandler",
+    "build_a2a_grpc_handler",
+]

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/grpc_transport/builder.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/grpc_transport/builder.py
@@ -1,0 +1,49 @@
+"""Assembly helpers for the A2A gRPC transport."""
+
+from a2a.server.request_handlers import DefaultRequestHandler
+from spakky.agent.execution import Agent
+
+from spakky.plugins.a2a.card.derivation import AgentCardFactory
+from spakky.plugins.a2a.executor.adapter import SpakkyAgentExecutor
+from spakky.plugins.a2a.executor.event_mapping import AgentEventProjector
+from spakky.plugins.a2a.grpc_transport.handler import A2AGrpcHandler
+from spakky.plugins.a2a.store.interfaces import IA2ATaskRepository
+from spakky.plugins.a2a.store.task_store import (
+    InMemoryA2ATaskRepository,
+    SpakkyA2ATaskStore,
+)
+
+
+def build_a2a_grpc_handler(
+    agent_instance: object,
+    *,
+    base_url: str,
+    version: str,
+    repository: IA2ATaskRepository | None = None,
+    agent_type: type | None = None,
+) -> A2AGrpcHandler:
+    """Build a gRPC handler for one @Agent-backed A2A server.
+
+    Args:
+        agent_instance: The @Agent Pod instance to serve.
+        base_url: Transport endpoint advertised on the derived AgentCard.
+        version: Semantic version advertised on the derived AgentCard.
+        repository: Task persistence port; an in-memory store is used when None.
+        agent_type: Original @Agent class, supplied when the instance is proxied.
+
+    Returns:
+        A generic gRPC handler exposing the official A2A service methods.
+    """
+    card = AgentCardFactory().build(
+        Agent.get(agent_type or type(agent_instance)),
+        base_url,
+        version,
+    )
+    store = SpakkyA2ATaskStore(repository or InMemoryA2ATaskRepository())
+    executor = SpakkyAgentExecutor(agent_instance, AgentEventProjector())
+    request_handler = DefaultRequestHandler(
+        agent_executor=executor,
+        task_store=store,
+        agent_card=card,
+    )
+    return A2AGrpcHandler(request_handler)

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/grpc_transport/handler.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/grpc_transport/handler.py
@@ -1,0 +1,160 @@
+"""Official A2A gRPC service handler backed by the existing A2A executor.
+
+The a2a-sdk ships protobuf descriptors for ``lf.a2a.v1.A2AService``. This
+handler binds those official method names to the same ``DefaultRequestHandler``
+used by the JSON-RPC transport, so AgentCard derivation, task persistence,
+executor adaptation, and neutral agent-event projection remain shared.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+
+import grpc
+from a2a.server.context import ServerCallContext
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.types import (
+    CancelTaskRequest,
+    GetTaskRequest,
+    Message,
+    SendMessageRequest,
+    SendMessageResponse,
+    StreamResponse,
+    Task,
+    TaskArtifactUpdateEvent,
+    TaskStatusUpdateEvent,
+)
+from google.protobuf.message import Message as ProtobufMessage
+from typing import override
+
+from spakky.plugins.a2a.error import (
+    UnsupportedA2AGrpcEventError,
+    UnsupportedA2AGrpcResultError,
+)
+
+A2A_GRPC_SERVICE = "lf.a2a.v1.A2AService"
+"""Fully qualified official A2A gRPC service name from the a2a-sdk descriptor."""
+
+
+class A2AGrpcHandler(grpc.GenericRpcHandler):
+    """Generic gRPC handler for the official A2A service methods."""
+
+    _handler: DefaultRequestHandler
+    _handlers: dict[str, grpc.RpcMethodHandler]
+
+    def __init__(self, handler: DefaultRequestHandler) -> None:
+        self._handler = handler
+        self._handlers = {
+            self._method("SendMessage"): grpc.unary_unary_rpc_method_handler(
+                self._send_message,
+                request_deserializer=_deserializer(SendMessageRequest),
+                response_serializer=_serializer,
+            ),
+            self._method("SendStreamingMessage"): grpc.unary_stream_rpc_method_handler(
+                self._send_streaming_message,
+                request_deserializer=_deserializer(SendMessageRequest),
+                response_serializer=_serializer,
+            ),
+            self._method("GetTask"): grpc.unary_unary_rpc_method_handler(
+                self._get_task,
+                request_deserializer=_deserializer(GetTaskRequest),
+                response_serializer=_serializer,
+            ),
+            self._method("CancelTask"): grpc.unary_unary_rpc_method_handler(
+                self._cancel_task,
+                request_deserializer=_deserializer(CancelTaskRequest),
+                response_serializer=_serializer,
+            ),
+        }
+
+    @override
+    def service(
+        self,
+        handler_call_details: grpc.HandlerCallDetails,
+    ) -> grpc.RpcMethodHandler | None:
+        """Return the method handler for an official A2A gRPC path."""
+        return self._handlers.get(handler_call_details.method)
+
+    @staticmethod
+    def _method(name: str) -> str:
+        """Return the fully qualified gRPC method path for an A2A method."""
+        return f"/{A2A_GRPC_SERVICE}/{name}"
+
+    async def _send_message(
+        self,
+        request: SendMessageRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> SendMessageResponse:
+        del context
+        result = await self._handler.on_message_send(request, ServerCallContext())
+        if isinstance(result, Task):
+            return SendMessageResponse(task=result)
+        if isinstance(result, Message):
+            return SendMessageResponse(message=result)
+        raise UnsupportedA2AGrpcResultError(type(result))
+
+    async def _send_streaming_message(
+        self,
+        request: SendMessageRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> AsyncIterator[StreamResponse]:
+        del context
+        async for event in self._handler.on_message_send_stream(
+            request, ServerCallContext()
+        ):
+            yield _stream_response(event)
+
+    async def _get_task(
+        self,
+        request: GetTaskRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> Task:
+        del context
+        task = await self._handler.on_get_task(request, ServerCallContext())
+        if task is None:
+            raise UnsupportedA2AGrpcResultError(type(task))
+        return task
+
+    async def _cancel_task(
+        self,
+        request: CancelTaskRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> Task:
+        del context
+        task = await self._handler.on_cancel_task(request, ServerCallContext())
+        if task is None:
+            raise UnsupportedA2AGrpcResultError(type(task))
+        return task
+
+
+def _deserializer[MessageT: ProtobufMessage](
+    message_type: type[MessageT],
+) -> Callable[[bytes], MessageT]:
+    """Build a protobuf bytes deserializer for an A2A SDK message class."""
+
+    def _deserialize(data: bytes) -> MessageT:
+        message = message_type()
+        message.ParseFromString(data)
+        return message
+
+    return _deserialize
+
+
+def _serializer(message: ProtobufMessage) -> bytes:
+    """Serialize an A2A SDK protobuf message."""
+    return message.SerializeToString()
+
+
+def _stream_response(
+    event: Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent,
+) -> StreamResponse:
+    """Wrap an A2A task event in the official streaming response envelope."""
+    if isinstance(event, Task):
+        return StreamResponse(task=event)
+    if isinstance(event, Message):
+        return StreamResponse(message=event)
+    if isinstance(event, TaskStatusUpdateEvent):
+        return StreamResponse(status_update=event)
+    if isinstance(event, TaskArtifactUpdateEvent):
+        return StreamResponse(artifact_update=event)
+    raise UnsupportedA2AGrpcEventError(type(event))

--- a/plugins/spakky-a2a/tests/integration/test_a2a_grpc.py
+++ b/plugins/spakky-a2a/tests/integration/test_a2a_grpc.py
@@ -1,0 +1,213 @@
+"""End-to-end A2A gRPC transport tests over the official service descriptor."""
+
+from collections.abc import AsyncIterator, Callable, Sequence
+
+import grpc.aio
+import pytest
+import pytest_asyncio
+from a2a.types import (
+    CancelTaskRequest,
+    GetTaskRequest,
+    Message,
+    Part,
+    Role,
+    SendMessageRequest,
+    SendMessageResponse,
+    StreamResponse,
+    Task,
+    TaskState,
+)
+from google.protobuf.message import Message as ProtobufMessage
+from spakky.agent.interfaces.model import ModelStreamEvent
+from spakky.plugins.grpc.server_spec import GrpcServerSpec
+
+from spakky.plugins.a2a.grpc_transport.builder import build_a2a_grpc_handler
+from spakky.plugins.a2a.grpc_transport.handler import A2A_GRPC_SERVICE
+from tests.integration.conftest import (
+    AssistantAgent,
+    ScriptedModel,
+)
+from tests.unit.conftest import (
+    FakeEvidenceRepository,
+    FakeSignalRepository,
+    FakeStateRepository,
+)
+
+type MessageDeserializer[MessageT: ProtobufMessage] = Callable[[bytes], MessageT]
+
+
+def _serialize(message: ProtobufMessage) -> bytes:
+    return message.SerializeToString()
+
+
+def _deserialize[MessageT: ProtobufMessage](
+    message_type: type[MessageT],
+) -> MessageDeserializer[MessageT]:
+    def _inner(data: bytes) -> MessageT:
+        message = message_type()
+        message.ParseFromString(data)
+        return message
+
+    return _inner
+
+
+def _method(name: str) -> str:
+    return f"/{A2A_GRPC_SERVICE}/{name}"
+
+
+def _message(text: str, message_id: str = "m1") -> Message:
+    return Message(
+        role=Role.ROLE_USER,
+        message_id=message_id,
+        parts=[Part(text=text)],
+    )
+
+
+def _agent(events: Sequence[ModelStreamEvent]) -> AssistantAgent:
+    return AssistantAgent(
+        ScriptedModel(events),
+        FakeStateRepository(),
+        FakeSignalRepository(),
+        FakeEvidenceRepository(),
+    )
+
+
+@pytest_asyncio.fixture(name="grpc_channel")
+async def get_grpc_channel_fixture(
+    token_events: Sequence[ModelStreamEvent],
+) -> AsyncIterator[grpc.aio.Channel]:
+    """Boot a real gRPC server exposing the official A2A service."""
+    spec = GrpcServerSpec()
+    spec.add_insecure_port("127.0.0.1:0")
+    spec.add_handler(
+        build_a2a_grpc_handler(
+            _agent(token_events),
+            base_url="grpc://assistant.local",
+            version="1.0.0",
+        )
+    )
+    server = spec.build()
+    await server.start()
+    channel = grpc.aio.insecure_channel(f"127.0.0.1:{spec.bound_ports[0]}")
+    try:
+        yield channel
+    finally:
+        await channel.close()
+        await server.stop(grace=0)
+
+
+@pytest_asyncio.fixture(name="approval_grpc_channel")
+async def get_approval_grpc_channel_fixture(
+    approval_events: Sequence[ModelStreamEvent],
+) -> AsyncIterator[grpc.aio.Channel]:
+    """Boot a gRPC server whose scripted agent pauses for approval."""
+    spec = GrpcServerSpec()
+    spec.add_insecure_port("127.0.0.1:0")
+    spec.add_handler(
+        build_a2a_grpc_handler(
+            _agent(approval_events),
+            base_url="grpc://assistant.local",
+            version="1.0.0",
+        )
+    )
+    server = spec.build()
+    await server.start()
+    channel = grpc.aio.insecure_channel(f"127.0.0.1:{spec.bound_ports[0]}")
+    try:
+        yield channel
+    finally:
+        await channel.close()
+        await server.stop(grace=0)
+
+
+@pytest.mark.integration
+async def test_send_message_runs_agent_to_completion_over_grpc(
+    grpc_channel: grpc.aio.Channel,
+) -> None:
+    """SendMessage returns a completed A2A task over the official gRPC method."""
+    call = grpc_channel.unary_unary(
+        _method("SendMessage"),
+        request_serializer=_serialize,
+        response_deserializer=_deserialize(SendMessageResponse),
+    )
+
+    response = await call(SendMessageRequest(message=_message("hi")))
+
+    assert response.HasField("task")
+    assert response.task.status.state == TaskState.TASK_STATE_COMPLETED
+    history_text = "".join(
+        part.text
+        for message in response.task.history
+        for part in message.parts
+        if part.HasField("text")
+    )
+    assert "hello " in history_text and "world" in history_text
+
+
+@pytest.mark.integration
+async def test_send_streaming_message_emits_task_lifecycle_over_grpc(
+    grpc_channel: grpc.aio.Channel,
+) -> None:
+    """SendStreamingMessage yields submitted, working, and completed updates."""
+    call = grpc_channel.unary_stream(
+        _method("SendStreamingMessage"),
+        request_serializer=_serialize,
+        response_deserializer=_deserialize(StreamResponse),
+    )
+
+    states: list[TaskState.ValueType] = []
+    async for response in call(SendMessageRequest(message=_message("hi"))):
+        if response.HasField("task"):
+            states.append(response.task.status.state)
+        if response.HasField("status_update"):
+            states.append(response.status_update.status.state)
+
+    assert states[0] == TaskState.TASK_STATE_SUBMITTED
+    assert TaskState.TASK_STATE_WORKING in states
+    assert states[-1] == TaskState.TASK_STATE_COMPLETED
+
+
+@pytest.mark.integration
+async def test_get_task_returns_persisted_task_over_grpc(
+    grpc_channel: grpc.aio.Channel,
+) -> None:
+    """GetTask returns the task persisted by a previous SendMessage call."""
+    send = grpc_channel.unary_unary(
+        _method("SendMessage"),
+        request_serializer=_serialize,
+        response_deserializer=_deserialize(SendMessageResponse),
+    )
+    get = grpc_channel.unary_unary(
+        _method("GetTask"),
+        request_serializer=_serialize,
+        response_deserializer=_deserialize(Task),
+    )
+    sent = await send(SendMessageRequest(message=_message("hi")))
+
+    task = await get(GetTaskRequest(id=sent.task.id))
+
+    assert task.id == sent.task.id
+    assert task.status.state == TaskState.TASK_STATE_COMPLETED
+
+
+@pytest.mark.integration
+async def test_cancel_task_marks_input_required_task_canceled_over_grpc(
+    approval_grpc_channel: grpc.aio.Channel,
+) -> None:
+    """CancelTask appends the cancel signal and returns a canceled task."""
+    send = approval_grpc_channel.unary_unary(
+        _method("SendMessage"),
+        request_serializer=_serialize,
+        response_deserializer=_deserialize(SendMessageResponse),
+    )
+    cancel = approval_grpc_channel.unary_unary(
+        _method("CancelTask"),
+        request_serializer=_serialize,
+        response_deserializer=_deserialize(Task),
+    )
+    paused = await send(SendMessageRequest(message=_message("write")))
+
+    canceled = await cancel(CancelTaskRequest(id=paused.task.id))
+
+    assert paused.task.status.state == TaskState.TASK_STATE_INPUT_REQUIRED
+    assert canceled.status.state == TaskState.TASK_STATE_CANCELED

--- a/plugins/spakky-a2a/tests/unit/test_grpc_handler.py
+++ b/plugins/spakky-a2a/tests/unit/test_grpc_handler.py
@@ -1,0 +1,199 @@
+"""Unit coverage for A2A gRPC handler dispatch and envelopes."""
+
+from collections.abc import AsyncIterator
+from typing import cast
+
+import grpc
+import pytest
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.context import ServerCallContext
+from a2a.types import (
+    CancelTaskRequest,
+    GetTaskRequest,
+    Message,
+    Part,
+    Role,
+    SendMessageRequest,
+    Task,
+    TaskArtifactUpdateEvent,
+    TaskState,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+)
+
+from spakky.plugins.a2a.error import (
+    UnsupportedA2AGrpcEventError,
+    UnsupportedA2AGrpcResultError,
+)
+from spakky.plugins.a2a.grpc_transport.handler import (
+    A2A_GRPC_SERVICE,
+    A2AGrpcHandler,
+    _deserializer,
+    _serializer,
+    _stream_response,
+)
+
+
+class _CallDetails(grpc.HandlerCallDetails):
+    def __init__(self, method: str) -> None:
+        self.method = method
+        self.invocation_metadata = ()
+
+
+class _FakeRequestHandler:
+    result: object
+    task: Task | None
+
+    def __init__(self, result: object | None = None, task: Task | None = None) -> None:
+        self.result = result
+        self.task = task
+
+    async def on_message_send(
+        self,
+        params: SendMessageRequest,
+        context: ServerCallContext,
+    ) -> object:
+        del params, context
+        return self.result
+
+    async def on_message_send_stream(
+        self,
+        params: SendMessageRequest,
+        context: ServerCallContext,
+    ) -> AsyncIterator[object]:
+        del params, context
+        yield self.result
+
+    async def on_get_task(
+        self,
+        params: GetTaskRequest,
+        context: ServerCallContext,
+    ) -> Task | None:
+        del params, context
+        return self.task
+
+    async def on_cancel_task(
+        self,
+        params: CancelTaskRequest,
+        context: ServerCallContext,
+    ) -> Task | None:
+        del params, context
+        return self.task
+
+
+def _request() -> SendMessageRequest:
+    return SendMessageRequest(
+        message=Message(
+            role=Role.ROLE_USER,
+            message_id="m1",
+            parts=[Part(text="hi")],
+        )
+    )
+
+
+def _handler(
+    result: object | None = None, task: Task | None = None
+) -> DefaultRequestHandler:
+    return cast(DefaultRequestHandler, _FakeRequestHandler(result=result, task=task))
+
+
+def _context() -> grpc.aio.ServicerContext:
+    return cast(grpc.aio.ServicerContext, None)
+
+
+def _task(state: str = "TASK_STATE_COMPLETED") -> Task:
+    return Task(id="t1", context_id="c1", status=TaskStatus(state=state))
+
+
+def test_service_resolves_official_methods() -> None:
+    """Official A2A gRPC paths resolve to method handlers."""
+    handler = A2AGrpcHandler(_handler())
+
+    resolved = handler.service(_CallDetails(f"/{A2A_GRPC_SERVICE}/SendMessage"))
+    missing = handler.service(_CallDetails(f"/{A2A_GRPC_SERVICE}/Unknown"))
+
+    assert resolved is not None
+    assert missing is None
+
+
+async def test_send_message_wraps_message_result() -> None:
+    """Message-only A2A results are wrapped in SendMessageResponse.message."""
+    message = Message(role=Role.ROLE_AGENT, message_id="m2", parts=[Part(text="hi")])
+    handler = A2AGrpcHandler(_handler(result=message))
+
+    response = await handler._send_message(_request(), context=_context())
+
+    assert response.HasField("message")
+    assert response.message.message_id == "m2"
+
+
+async def test_send_message_rejects_unknown_result() -> None:
+    """Unexpected unary results raise the A2A gRPC result error."""
+    handler = A2AGrpcHandler(_handler(result=object()))
+
+    with pytest.raises(UnsupportedA2AGrpcResultError):
+        await handler._send_message(_request(), context=_context())
+
+
+async def test_get_task_rejects_missing_task() -> None:
+    """A missing task result is rejected before gRPC serialization."""
+    handler = A2AGrpcHandler(_handler(task=None))
+
+    with pytest.raises(UnsupportedA2AGrpcResultError):
+        await handler._get_task(GetTaskRequest(id="t1"), context=_context())
+
+
+async def test_cancel_task_rejects_missing_task() -> None:
+    """A missing cancel result is rejected before gRPC serialization."""
+    handler = A2AGrpcHandler(_handler(task=None))
+
+    with pytest.raises(UnsupportedA2AGrpcResultError):
+        await handler._cancel_task(CancelTaskRequest(id="t1"), context=_context())
+
+
+async def test_streaming_method_wraps_events() -> None:
+    """Streaming handler wraps each emitted A2A event."""
+    handler = A2AGrpcHandler(_handler(result=_task()))
+    responses = [
+        response
+        async for response in handler._send_streaming_message(_request(), _context())
+    ]
+
+    assert responses[0].HasField("task")
+
+
+def test_stream_response_wraps_every_supported_event() -> None:
+    """Task, message, status, and artifact events map to StreamResponse oneofs."""
+    task = _task()
+    message = Message(role=Role.ROLE_AGENT, message_id="m2", parts=[Part(text="hi")])
+    status = TaskStatusUpdateEvent(
+        task_id="t1",
+        context_id="c1",
+        status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+    )
+    artifact = TaskArtifactUpdateEvent(task_id="t1", context_id="c1")
+
+    assert _stream_response(task).HasField("task")
+    assert _stream_response(message).HasField("message")
+    assert _stream_response(status).HasField("status_update")
+    assert _stream_response(artifact).HasField("artifact_update")
+
+
+def test_stream_response_rejects_unknown_event() -> None:
+    """Unsupported streaming events raise the A2A gRPC event error."""
+    with pytest.raises(UnsupportedA2AGrpcEventError):
+        _stream_response(
+            cast(
+                Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent,
+                object(),
+            )
+        )
+
+
+def test_serializer_and_deserializer_round_trip_a2a_messages() -> None:
+    """A2A protobuf messages round-trip through handler wire helpers."""
+    request = _request()
+
+    decoded = _deserializer(SendMessageRequest)(_serializer(request))
+
+    assert decoded.message.message_id == "m1"

--- a/uv.lock
+++ b/uv.lock
@@ -3503,6 +3503,7 @@ version = "6.9.1"
 source = { editable = "plugins/spakky-a2a" }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },
+    { name = "grpcio" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "spakky" },
@@ -3514,12 +3515,15 @@ dev = [
     { name = "httpx" },
     { name = "pytest-asyncio" },
     { name = "pytest-integration-mark" },
+    { name = "spakky-grpc" },
+    { name = "types-grpcio" },
     { name = "types-protobuf" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", extras = ["http-server"], specifier = ">=1.1.0" },
+    { name = "grpcio", specifier = ">=1.68.0" },
     { name = "pydantic", specifier = ">=2.4" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "spakky", editable = "core/spakky" },
@@ -3531,6 +3535,8 @@ dev = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-integration-mark", specifier = ">=0.2.0" },
+    { name = "spakky-grpc", editable = "plugins/spakky-grpc" },
+    { name = "types-grpcio", specifier = ">=1.0.0.20260614" },
     { name = "types-protobuf", specifier = ">=7.34.1.20260518" },
 ]
 


### PR DESCRIPTION
## Summary
- Add an official lf.a2a.v1.A2AService gRPC handler for SendMessage, SendStreamingMessage, GetTask, and CancelTask.
- Reuse AgentCard derivation, SpakkyAgentExecutor, AgentEventProjector, and TaskStore instead of duplicating A2A mapping logic.
- Cover transport behavior with real grpc.aio integration tests hosted through spakky-grpc GrpcServerSpec plus unit envelope/dispatch tests.
- Document how to attach the handler to spakky-grpc or another grpc.aio server.

## Acceptance Criteria
- Issue body contains no literal grep/rg/find acceptance commands, so Phase 4.5 acceptance-grep is missing by workflow definition.
- SC-1 is covered by integration tests for SendMessage, SendStreamingMessage, GetTask, and CancelTask over a real gRPC server.

## Verification
- `cd plugins/spakky-a2a && uv run --with ruff ruff format . && uv run --with ruff ruff check .`
- `cd plugins/spakky-a2a && uv run --with pyrefly pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text`
- `cd plugins/spakky-a2a && uv run --group dev --with pytest-cov --with pytest-xdist --with pytest-spec pytest -q`
- `uv lock --check`

Closes #421