### PR TITLE
feat(agui): add HTTP streaming endpoint (#419)

### DIFF
--- a/plugins/spakky-agui/README.md
+++ b/plugins/spakky-agui/README.md
@@ -1,15 +1,15 @@
 # spakky-agui
 
 > `spakky-agui`는 `spakky-agent`를 위한 공식 AG-UI (Agent User Interaction) protocol adapter plugin입니다.
-> 선언형 `@Agent` 실행 스트림을 AG-UI 이벤트로 투영(project)하여 SSE (Server-Sent Events)와
-> WebSocket으로 노출하고, deferred-tool 방식의 HITL (Human-in-the-loop) 승인 흐름을 지원합니다.
+> 선언형 `@Agent` 실행 스트림을 AG-UI 이벤트로 투영(project)하여 SSE (Server-Sent Events),
+> HTTP streaming, WebSocket으로 노출하고, deferred-tool 방식의 HITL (Human-in-the-loop) 승인 흐름을 지원합니다.
 
 ## 언제 필요한가
 
 애플리케이션이 선언형 `@Agent` workflow를 실행하고, 그 실행 이벤트(토큰, 도구 호출,
 승인 요청, 종료)를 AG-UI 호환 프런트엔드에 실시간 스트리밍하려 할 때 사용합니다.
 렌더링(프런트엔드 UI)은 본 plugin의 범위 밖입니다 — 본 plugin은 와이어 프로토콜(SSE
-프레임 또는 WebSocket text message)만 책임집니다.
+프레임, HTTP JSON-line chunk, 또는 WebSocket text message)만 책임집니다.
 
 ## 설치
 
@@ -18,7 +18,8 @@ pip install spakky-agui
 ```
 
 durable Agent 실행(state·signal·evidence repository)과 모델 어댑터(`IAgentModel`)는
-별도 provider가 제공합니다. `spakky-agui`는 inbound SSE/WebSocket 어댑터만 제공합니다.
+별도 provider가 제공합니다. `spakky-agui`는 inbound SSE/HTTP streaming/WebSocket 어댑터만
+제공합니다.
 
 ## 설정
 
@@ -28,6 +29,7 @@ durable Agent 실행(state·signal·evidence repository)과 모델 어댑터(`IA
 |------|--------|------|
 | `SPAKKY_AGUI_SSE_PATH` | `/agui` | SSE endpoint가 마운트되는 경로 |
 | `SPAKKY_AGUI_WEBSOCKET_PATH` | `/agui/ws` | WebSocket endpoint가 마운트되는 경로 |
+| `SPAKKY_AGUI_HTTP_STREAM_PATH` | `/agui/stream` | HTTP streaming endpoint가 마운트되는 경로 |
 | `SPAKKY_AGUI_EMIT_STATE_SNAPSHOT` | `true` | 중립 `STATE_SNAPSHOT` 이벤트를 AG-UI로 투영할지 여부 |
 | `SPAKKY_AGUI_MESSAGES_SNAPSHOT_ENABLED` | `false` | `RUN_FINISHED` 직전에 `MESSAGES_SNAPSHOT` 프레임을 1회 방출할지 여부 |
 
@@ -37,6 +39,7 @@ durable Agent 실행(state·signal·evidence repository)과 모델 어댑터(`IA
 AgentRunner.run_events() → 중립 AgentEvent  (런너가 native로 방출)
 중립 AgentEvent  ──(AgUiProjector)──▶  AG-UI BaseEvent
 AG-UI BaseEvent  ──(EventEncoder)──▶  "data: {...}\n\n" SSE 프레임
+                                      또는 "{...}\n" HTTP streaming chunk
                                       또는 WebSocket text message
 ```
 
@@ -82,6 +85,7 @@ from spakky.plugins.agui import (
     AgUiProjector,
     AgUiRunDriver,
     add_agui_endpoint,
+    add_agui_http_stream_endpoint,
     add_agui_websocket_endpoint,
     ingest_decision,
 )
@@ -109,11 +113,14 @@ def run_driver_factory(
 
 
 add_agui_endpoint(app, run_driver_factory=run_driver_factory, config=config)
+add_agui_http_stream_endpoint(app, run_driver_factory=run_driver_factory, config=config)
 add_agui_websocket_endpoint(app, run_driver_factory=run_driver_factory, config=config)
 ```
 
 `POST /agui`로 AG-UI `RunAgentInput`을 보내면 `text/event-stream` 응답으로 실행
-이벤트가 스트리밍됩니다. WebSocket 클라이언트는 `/agui/ws`에 연결한 뒤 같은 AG-UI
+이벤트가 스트리밍됩니다. `POST /agui/stream`은 같은 AG-UI event payload를 SSE `data:`
+프레이밍 없이 `application/x-ndjson` HTTP response chunks로 순차 전달합니다.
+WebSocket 클라이언트는 `/agui/ws`에 연결한 뒤 같은 AG-UI
 `RunAgentInput` JSON을 text/JSON message로 보내고, 실행 이벤트를 AG-UI encoded text
 message로 순서대로 받습니다. 같은 연결에서 후속 `RunAgentInput`을 보내 승인 결정
 (`forwardedProps.approvalDecision` 또는 deferred tool-result message)을 전달할 수 있습니다.

--- a/plugins/spakky-agui/src/spakky/plugins/agui/__init__.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/__init__.py
@@ -15,6 +15,7 @@ from spakky.plugins.agui.hitl import (
     project_approval,
     project_pending_approval,
 )
+from spakky.plugins.agui.http_stream import add_agui_http_stream_endpoint
 from spakky.plugins.agui.projector import AgUiProjector
 from spakky.plugins.agui.transport import AgUiRunDriver
 from spakky.plugins.agui.websocket import add_agui_websocket_endpoint
@@ -33,6 +34,7 @@ __all__ = [
     "PLUGIN_NAME",
     "RunDriverFactory",
     "add_agui_endpoint",
+    "add_agui_http_stream_endpoint",
     "add_agui_websocket_endpoint",
     "ingest_decision",
     "project_approval",

--- a/plugins/spakky-agui/src/spakky/plugins/agui/config.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/config.py
@@ -14,6 +14,9 @@ DEFAULT_AGUI_SSE_PATH = "/agui"
 DEFAULT_AGUI_WEBSOCKET_PATH = "/agui/ws"
 """Default mount path for the AG-UI WebSocket endpoint."""
 
+DEFAULT_AGUI_HTTP_STREAM_PATH = "/agui/stream"
+"""Default mount path for the AG-UI HTTP streaming endpoint."""
+
 
 @Configuration()
 class AgUiConfig(BaseSettings):
@@ -30,6 +33,9 @@ class AgUiConfig(BaseSettings):
 
     websocket_path: str = DEFAULT_AGUI_WEBSOCKET_PATH
     """Path the AG-UI WebSocket endpoint is mounted at on the FastAPI application."""
+
+    http_stream_path: str = DEFAULT_AGUI_HTTP_STREAM_PATH
+    """Path the AG-UI HTTP streaming endpoint is mounted at on the FastAPI app."""
 
     emit_state_snapshot: bool = True
     """Whether STATE_SNAPSHOT neutral events are projected to AG-UI; when False

--- a/plugins/spakky-agui/src/spakky/plugins/agui/http_stream.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/http_stream.py
@@ -1,0 +1,60 @@
+"""Mount the AG-UI HTTP chunked streaming endpoint on a FastAPI application.
+
+``add_agui_http_stream_endpoint`` registers a ``POST {config.http_stream_path}``
+route that accepts an AG-UI ``RunAgentInput`` and streams encoded AG-UI event
+payloads as sequential JSON-line response chunks. It intentionally does not emit
+SSE ``data:`` framing; clients that want SSE should keep using
+``add_agui_endpoint``.
+"""
+
+from collections.abc import AsyncIterator
+
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.endpoint import RunDriverFactory, _to_core_input
+from spakky.plugins.agui.transport import AgUiRunDriver
+
+HTTP_STREAM_MEDIA_TYPE = "application/x-ndjson"
+"""Media type for AG-UI HTTP streaming chunks."""
+
+
+def add_agui_http_stream_endpoint(
+    app: FastAPI,
+    *,
+    run_driver_factory: RunDriverFactory,
+    config: AgUiConfig,
+) -> None:
+    """Register the AG-UI HTTP streaming endpoint at ``config.http_stream_path``."""
+
+    async def run_agui_http_stream(request: Request) -> StreamingResponse:
+        ag_ui_input = AgUiRunAgentInput.model_validate(await request.json())
+        core_input = _to_core_input(ag_ui_input)
+        driver = run_driver_factory(
+            core_input,
+            ag_ui_input,
+            request.headers.get("accept"),
+        )
+        return StreamingResponse(
+            _http_stream_chunks(driver),
+            media_type=HTTP_STREAM_MEDIA_TYPE,
+        )
+
+    app.add_api_route(config.http_stream_path, run_agui_http_stream, methods=["POST"])
+
+
+async def _http_stream_chunks(driver: AgUiRunDriver) -> AsyncIterator[str]:
+    async for frame in driver:
+        yield _sse_frame_payload(frame)
+
+
+def _sse_frame_payload(frame: str) -> str:
+    """Convert one AG-UI SSE frame into a raw JSON-line HTTP stream chunk."""
+    payload_lines = [
+        line.removeprefix("data:").lstrip()
+        for line in frame.splitlines()
+        if line.startswith("data:")
+    ]
+    return "\n".join(payload_lines) + "\n"

--- a/plugins/spakky-agui/tests/integration/test_http_stream_endpoint.py
+++ b/plugins/spakky-agui/tests/integration/test_http_stream_endpoint.py
@@ -1,0 +1,133 @@
+"""Integration: the AG-UI HTTP stream endpoint emits sequential chunks."""
+
+from collections.abc import AsyncIterator
+from json import loads
+from typing import override
+
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+from ag_ui.encoder import EventEncoder
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from spakky.agent import (
+    Agent,
+    AgentExecutionSpec,
+    AgentRunner,
+    EvidenceCapture,
+    Idempotency,
+    ModelCapability,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    RunAgentInput,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+from spakky.agent.interfaces.model import IAgentModel
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.http_stream import add_agui_http_stream_endpoint
+from spakky.plugins.agui.projector import AgUiProjector
+from spakky.plugins.agui.transport import AgUiRunDriver
+
+
+@Agent(spec=AgentExecutionSpec(name="http_assistant", objective="answer with a tool"))
+class HttpStreamAssistant:
+    """Stateless agent exercised through the HTTP streaming endpoint."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model
+
+    @agent_tool(
+        schema_name="lookup",
+        description="Look up a fact.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def lookup(self, topic: str) -> str:
+        """Look up a topic."""
+        return f"fact:{topic}"
+
+
+class _ScriptedModel(IAgentModel):
+    @property
+    @override
+    def capability(self) -> ModelCapability:
+        return ModelCapability()
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        return ModelResponse(content="scripted")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOKEN_DELTA, token_delta="hello"
+        )
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+            tool_call=ModelToolCall(
+                name="lookup", arguments={"topic": "agents"}, call_id="call-1"
+            ),
+        )
+        yield ModelStreamEvent(kind=ModelStreamEventKind.DONE)
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    config = AgUiConfig()
+    assistant = HttpStreamAssistant(_ScriptedModel())
+
+    def run_driver_factory(
+        core_input: RunAgentInput,
+        ag_ui_input: AgUiRunAgentInput,
+        accept: str | None,
+    ) -> AgUiRunDriver:
+        runner = AgentRunner.for_agent_instance(assistant)
+        return AgUiRunDriver(
+            runner=runner,
+            run_input=core_input,
+            agent_id="http_assistant",
+            projector=AgUiProjector(config),
+            encoder=EventEncoder(accept=accept or ""),
+        )
+
+    add_agui_http_stream_endpoint(
+        app,
+        run_driver_factory=run_driver_factory,
+        config=config,
+    )
+    return app
+
+
+def _run_agent_input() -> dict[str, object]:
+    return {
+        "threadId": "conv-1",
+        "runId": "run-1",
+        "state": None,
+        "messages": [{"id": "u1", "role": "user", "content": "look up agents"}],
+        "tools": [],
+        "context": [],
+        "forwardedProps": None,
+    }
+
+
+def test_http_stream_endpoint_streams_agui_events_as_sequential_chunks() -> None:
+    """POST /agui/stream이 SSE 프레이밍 없이 AG-UI event JSON chunks를 순서 전달한다."""
+    client = TestClient(_build_app())
+
+    response = client.post("/agui/stream", json=_run_agent_input())
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/x-ndjson")
+    assert "data: " not in response.text
+    chunks = [line for line in response.text.splitlines() if line.strip()]
+    types = [loads(chunk)["type"] for chunk in chunks]
+    assert types[0] == "RUN_STARTED"
+    assert "TOOL_CALL_RESULT" in types
+    assert types[-1] == "RUN_FINISHED"

--- a/plugins/spakky-agui/tests/unit/test_config.py
+++ b/plugins/spakky-agui/tests/unit/test_config.py
@@ -11,6 +11,7 @@ def test_agui_config_defaults_expect_documented_values() -> None:
 
     assert config.sse_path == "/agui"
     assert config.websocket_path == "/agui/ws"
+    assert config.http_stream_path == "/agui/stream"
     assert config.emit_state_snapshot is True
     assert config.messages_snapshot_enabled is False
 
@@ -21,6 +22,7 @@ def test_agui_config_env_override_expect_environment_values(
     """SPAKKY_AGUI_ 환경변수가 설정 필드를 재정의한다."""
     monkeypatch.setenv("SPAKKY_AGUI_SSE_PATH", "/stream/agui")
     monkeypatch.setenv("SPAKKY_AGUI_WEBSOCKET_PATH", "/stream/agui/ws")
+    monkeypatch.setenv("SPAKKY_AGUI_HTTP_STREAM_PATH", "/stream/agui/http")
     monkeypatch.setenv("SPAKKY_AGUI_EMIT_STATE_SNAPSHOT", "false")
     monkeypatch.setenv("SPAKKY_AGUI_MESSAGES_SNAPSHOT_ENABLED", "true")
 
@@ -28,5 +30,6 @@ def test_agui_config_env_override_expect_environment_values(
 
     assert config.sse_path == "/stream/agui"
     assert config.websocket_path == "/stream/agui/ws"
+    assert config.http_stream_path == "/stream/agui/http"
     assert config.emit_state_snapshot is False
     assert config.messages_snapshot_enabled is True

--- a/plugins/spakky-agui/tests/unit/test_public_api.py
+++ b/plugins/spakky-agui/tests/unit/test_public_api.py
@@ -12,6 +12,7 @@ from spakky.plugins.agui import (
     PLUGIN_NAME,
     RunDriverFactory,
     add_agui_endpoint,
+    add_agui_http_stream_endpoint,
     add_agui_websocket_endpoint,
     ingest_decision,
     project_approval,
@@ -26,6 +27,7 @@ def test_public_api_exports_agui_surface() -> None:
     assert AgUiProjector is agui_api.AgUiProjector
     assert AgUiRunDriver is agui_api.AgUiRunDriver
     assert add_agui_endpoint is agui_api.add_agui_endpoint
+    assert add_agui_http_stream_endpoint is agui_api.add_agui_http_stream_endpoint
     assert add_agui_websocket_endpoint is agui_api.add_agui_websocket_endpoint
     assert ingest_decision is agui_api.ingest_decision
     assert project_approval is agui_api.project_approval


### PR DESCRIPTION
## Summary
- add an AG-UI HTTP streaming endpoint at `SPAKKY_AGUI_HTTP_STREAM_PATH` / `/agui/stream`
- reuse the existing `AgUiRunDriver`, projector, and HITL mapping while stripping SSE `data:` framing into JSON-line chunks
- document and export the new endpoint helper without changing existing SSE or WebSocket APIs

## Acceptance Criteria (자가 grep)
acceptance_check: missing — issue #419 has no executable grep/find/rg acceptance lines.

## Verification
- `uv run --with ruff ruff format .`
- `uv run --with ruff ruff check .`
- `uv run --with pyrefly --with pytest pyrefly check --min-severity warn --no-progress-bar --output-format min-text $(git ls-files 'src/**/*.py' 'tests/**/*.py')`\n- `uv run --with pytest --with pytest-asyncio --with pytest-cov --with pytest-xdist --with pytest-spec pytest -q`\n- `uv run mkdocs build --strict`\n\nCloses #419