### PR TITLE
feat(a2a): add REST transport (#422)

### DIFF
--- a/plugins/spakky-a2a/README.md
+++ b/plugins/spakky-a2a/README.md
@@ -2,6 +2,36 @@
 
 A2A (Agent2Agent) protocol server plugin for the Spakky framework.
 
+## REST HTTP+JSON transport
+
+`build_a2a_rest_app()` builds a mountable Starlette app for the official A2A
+HTTP+JSON binding. The transport reuses the same AgentCard derivation,
+`TaskStore`, `SpakkyAgentExecutor`, and neutral agent-event projection used by
+the JSON-RPC and gRPC transports.
+
+```python
+from spakky.plugins.a2a.rest_transport import build_a2a_rest_app
+
+app = build_a2a_rest_app(
+    assistant_agent,
+    base_url="https://agents.example.com/a2a",
+    version="1.0.0",
+)
+```
+
+The SDK route names differ from JSON-RPC method strings:
+
+| A2A operation | REST route |
+|---------------|------------|
+| `message/send` | `POST /message:send` |
+| `message/stream` | `POST /message:stream` |
+| `tasks/get` | `GET /tasks/{id}` |
+| `tasks/cancel` | `POST /tasks/{id}:cancel` |
+| `tasks/subscribe` | `GET /tasks/{id}:subscribe` or `POST /tasks/{id}:subscribe` |
+
+REST request and response bodies use the A2A SDK protobuf JSON encoding. For
+example, send a user message with `{"message":{"role":"ROLE_USER","messageId":"m1","parts":[{"text":"hi"}]}}`.
+
 ## gRPC transport
 
 `build_a2a_grpc_handler()` builds a `grpc.GenericRpcHandler` for the official

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/card/derivation.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/card/derivation.py
@@ -30,13 +30,20 @@ TEAMMATE_DELEGATION_TAG = "delegation"
 class AgentCardFactory:
     """Builds an a2a-sdk ``AgentCard`` from an @Agent Pod declaration."""
 
-    def build(self, agent: Agent, base_url: str, version: str) -> AgentCard:
+    def build(
+        self,
+        agent: Agent,
+        base_url: str,
+        version: str,
+        protocol: TransportProtocol = TransportProtocol.JSONRPC,
+    ) -> AgentCard:
         """Derive an AgentCard from an @Agent spec, tools, and teammates.
 
         Args:
             agent: The @Agent Pod metadata carrying spec and tool catalog.
             base_url: Transport endpoint advertised on the card interface.
             version: Semantic version advertised on the card.
+            protocol: A2A transport protocol advertised for ``base_url``.
 
         Returns:
             A protobuf ``AgentCard`` ready to publish on the well-known route.
@@ -63,7 +70,7 @@ class AgentCardFactory:
             supported_interfaces=[
                 AgentInterface(
                     url=base_url,
-                    protocol_binding=TransportProtocol.JSONRPC.value,
+                    protocol_binding=protocol.value,
                 )
             ],
             capabilities=AgentCapabilities(

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/grpc_transport/builder.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/grpc_transport/builder.py
@@ -1,17 +1,10 @@
 """Assembly helpers for the A2A gRPC transport."""
 
-from a2a.server.request_handlers import DefaultRequestHandler
-from spakky.agent.execution import Agent
+from a2a.utils import TransportProtocol
 
-from spakky.plugins.a2a.card.derivation import AgentCardFactory
-from spakky.plugins.a2a.executor.adapter import SpakkyAgentExecutor
-from spakky.plugins.a2a.executor.event_mapping import AgentEventProjector
 from spakky.plugins.a2a.grpc_transport.handler import A2AGrpcHandler
+from spakky.plugins.a2a.server.request_handler import build_a2a_request_handler
 from spakky.plugins.a2a.store.interfaces import IA2ATaskRepository
-from spakky.plugins.a2a.store.task_store import (
-    InMemoryA2ATaskRepository,
-    SpakkyA2ATaskStore,
-)
 
 
 def build_a2a_grpc_handler(
@@ -34,16 +27,12 @@ def build_a2a_grpc_handler(
     Returns:
         A generic gRPC handler exposing the official A2A service methods.
     """
-    card = AgentCardFactory().build(
-        Agent.get(agent_type or type(agent_instance)),
-        base_url,
-        version,
-    )
-    store = SpakkyA2ATaskStore(repository or InMemoryA2ATaskRepository())
-    executor = SpakkyAgentExecutor(agent_instance, AgentEventProjector())
-    request_handler = DefaultRequestHandler(
-        agent_executor=executor,
-        task_store=store,
-        agent_card=card,
+    request_handler = build_a2a_request_handler(
+        agent_instance,
+        base_url=base_url,
+        version=version,
+        repository=repository,
+        agent_type=agent_type,
+        protocol=TransportProtocol.GRPC,
     )
     return A2AGrpcHandler(request_handler)

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/rest_transport/__init__.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/rest_transport/__init__.py
@@ -1,0 +1,5 @@
+"""HTTP+JSON REST transport bindings for the official A2A routes."""
+
+from spakky.plugins.a2a.rest_transport.builder import build_a2a_rest_app
+
+__all__ = ["build_a2a_rest_app"]

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/rest_transport/builder.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/rest_transport/builder.py
@@ -1,0 +1,58 @@
+"""Assembly helpers for the A2A HTTP+JSON REST transport."""
+
+from a2a.server.routes import create_agent_card_routes, create_rest_routes
+from a2a.utils import TransportProtocol
+from spakky.agent.execution import Agent
+from starlette.applications import Starlette
+
+from spakky.plugins.a2a.card.derivation import AgentCardFactory
+from spakky.plugins.a2a.server.request_handler import build_a2a_request_handler
+from spakky.plugins.a2a.store.interfaces import IA2ATaskRepository
+
+
+def build_a2a_rest_app(
+    agent_instance: object,
+    *,
+    base_url: str,
+    version: str,
+    repository: IA2ATaskRepository | None = None,
+    agent_type: type | None = None,
+    path_prefix: str = "",
+) -> Starlette:
+    """Build a mountable A2A HTTP+JSON REST app for one @Agent instance.
+
+    Args:
+        agent_instance: The @Agent Pod instance to serve.
+        base_url: Transport endpoint advertised on the derived AgentCard.
+        version: Semantic version advertised on the derived AgentCard.
+        repository: Task persistence port; an in-memory store is used when None.
+        agent_type: Original @Agent class, supplied when the instance is proxied.
+        path_prefix: Optional URL prefix for the REST operation routes.
+
+    Returns:
+        A Starlette application exposing AgentCard plus HTTP+JSON A2A routes.
+    """
+    card = AgentCardFactory().build(
+        Agent.get(agent_type or type(agent_instance)),
+        base_url,
+        version,
+        protocol=TransportProtocol.HTTP_JSON,
+    )
+    handler = build_a2a_request_handler(
+        agent_instance,
+        base_url=base_url,
+        version=version,
+        repository=repository,
+        agent_type=agent_type,
+        protocol=TransportProtocol.HTTP_JSON,
+        card=card,
+    )
+    routes = [
+        *create_agent_card_routes(card),
+        *create_rest_routes(
+            handler,
+            enable_v0_3_compat=True,
+            path_prefix=path_prefix,
+        ),
+    ]
+    return Starlette(routes=routes)

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/server/builder.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/server/builder.py
@@ -8,7 +8,6 @@ mounted on a Starlette app the host application can further mount.
 
 from typing import override
 
-from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.routes import create_agent_card_routes, create_jsonrpc_routes
 from a2a.utils import DEFAULT_RPC_URL
 from spakky.agent.execution import Agent
@@ -18,14 +17,9 @@ from spakky.core.pod.interfaces.container import IContainer
 from starlette.applications import Starlette
 
 from spakky.plugins.a2a.card.derivation import AgentCardFactory
-from spakky.plugins.a2a.executor.adapter import SpakkyAgentExecutor
-from spakky.plugins.a2a.executor.event_mapping import AgentEventProjector
+from spakky.plugins.a2a.server.request_handler import build_a2a_request_handler
 from spakky.plugins.a2a.server.registry import A2AAgentRegistry
 from spakky.plugins.a2a.store.interfaces import IA2ATaskRepository
-from spakky.plugins.a2a.store.task_store import (
-    InMemoryA2ATaskRepository,
-    SpakkyA2ATaskStore,
-)
 
 
 def build_a2a_app(
@@ -51,12 +45,12 @@ def build_a2a_app(
         base_url,
         version,
     )
-    store = SpakkyA2ATaskStore(repository or InMemoryA2ATaskRepository())
-    executor = SpakkyAgentExecutor(agent_instance, AgentEventProjector())
-    handler = DefaultRequestHandler(
-        agent_executor=executor,
-        task_store=store,
-        agent_card=card,
+    handler = build_a2a_request_handler(
+        agent_instance,
+        base_url=base_url,
+        version=version,
+        repository=repository,
+        card=card,
     )
     routes = [
         *create_agent_card_routes(card),

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/server/request_handler.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/server/request_handler.py
@@ -1,0 +1,41 @@
+"""Shared A2A request-handler assembly for all server transports."""
+
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.types import AgentCard
+from a2a.utils import TransportProtocol
+from spakky.agent.execution import Agent
+
+from spakky.plugins.a2a.card.derivation import AgentCardFactory
+from spakky.plugins.a2a.executor.adapter import SpakkyAgentExecutor
+from spakky.plugins.a2a.executor.event_mapping import AgentEventProjector
+from spakky.plugins.a2a.store.interfaces import IA2ATaskRepository
+from spakky.plugins.a2a.store.task_store import (
+    InMemoryA2ATaskRepository,
+    SpakkyA2ATaskStore,
+)
+
+
+def build_a2a_request_handler(
+    agent_instance: object,
+    *,
+    base_url: str,
+    version: str,
+    repository: IA2ATaskRepository | None = None,
+    agent_type: type | None = None,
+    protocol: TransportProtocol = TransportProtocol.JSONRPC,
+    card: AgentCard | None = None,
+) -> DefaultRequestHandler:
+    """Build the official SDK request handler shared by A2A transports."""
+    agent_card = card or AgentCardFactory().build(
+        Agent.get(agent_type or type(agent_instance)),
+        base_url,
+        version,
+        protocol=protocol,
+    )
+    store = SpakkyA2ATaskStore(repository or InMemoryA2ATaskRepository())
+    executor = SpakkyAgentExecutor(agent_instance, AgentEventProjector())
+    return DefaultRequestHandler(
+        agent_executor=executor,
+        task_store=store,
+        agent_card=agent_card,
+    )

--- a/plugins/spakky-a2a/tests/integration/test_a2a_rest.py
+++ b/plugins/spakky-a2a/tests/integration/test_a2a_rest.py
@@ -1,0 +1,188 @@
+"""End-to-end A2A REST transport tests over HTTP+JSON routes."""
+
+import json
+from collections.abc import Sequence
+
+import pytest
+from spakky.agent.interfaces.model import ModelStreamEvent
+
+from spakky.plugins.a2a.rest_transport.builder import build_a2a_rest_app
+from tests.integration.conftest import (
+    AssistantAgent,
+    ScriptedModel,
+    make_client,
+)
+from tests.unit.conftest import (
+    FakeEvidenceRepository,
+    FakeSignalRepository,
+    FakeStateRepository,
+)
+
+type JsonObject = dict[str, object]
+
+REST_HEADERS = {"A2A-Version": "1.0"}
+
+
+def _message_request(text: str, message_id: str = "m1") -> JsonObject:
+    return {
+        "message": {
+            "role": "ROLE_USER",
+            "messageId": message_id,
+            "parts": [{"text": text}],
+        }
+    }
+
+
+def _agent(events: Sequence[ModelStreamEvent]) -> AssistantAgent:
+    return AssistantAgent(
+        ScriptedModel(events),
+        FakeStateRepository(),
+        FakeSignalRepository(),
+        FakeEvidenceRepository(),
+    )
+
+
+def _rest_app(events: Sequence[ModelStreamEvent]):
+    return build_a2a_rest_app(
+        _agent(events),
+        base_url="http://assistant.local",
+        version="1.0.0",
+    )
+
+
+def _stream_states(body: str) -> list[str]:
+    states: list[str] = []
+    for line in body.splitlines():
+        if not line.startswith("data:"):
+            continue
+        payload = json.loads(line[len("data:") :].strip())
+        task = payload.get("task")
+        if isinstance(task, dict):
+            status = task.get("status")
+            if isinstance(status, dict) and isinstance(status.get("state"), str):
+                states.append(status["state"])
+        status_update = payload.get("statusUpdate")
+        if isinstance(status_update, dict):
+            status = status_update.get("status")
+            if isinstance(status, dict) and isinstance(status.get("state"), str):
+                states.append(status["state"])
+    return states
+
+
+@pytest.mark.integration
+async def test_agent_card_advertises_http_json_interface(
+    token_events: Sequence[ModelStreamEvent],
+) -> None:
+    """The REST app serves an AgentCard that advertises HTTP+JSON."""
+    async with make_client(_rest_app(token_events)) as client:
+        response = await client.get("/.well-known/agent-card.json")
+
+    card = response.json()
+    interfaces = card["supportedInterfaces"]
+    assert interfaces[0]["protocolBinding"] == "HTTP+JSON"
+
+
+@pytest.mark.integration
+async def test_message_send_runs_agent_to_completion_over_rest(
+    token_events: Sequence[ModelStreamEvent],
+) -> None:
+    """POST /message:send returns a completed task over HTTP+JSON."""
+    async with make_client(_rest_app(token_events)) as client:
+        response = await client.post(
+            "/message:send",
+            json=_message_request("hi"),
+            headers=REST_HEADERS,
+        )
+
+    task = response.json()["task"]
+    assert task["status"]["state"] == "TASK_STATE_COMPLETED"
+    history_text = "".join(
+        part.get("text", "")
+        for message in task.get("history", [])
+        for part in message.get("parts", [])
+    )
+    assert "hello " in history_text and "world" in history_text
+
+
+@pytest.mark.integration
+async def test_message_stream_emits_task_lifecycle_over_rest(
+    token_events: Sequence[ModelStreamEvent],
+) -> None:
+    """POST /message:stream emits submitted, working, and completed SSE events."""
+    async with make_client(_rest_app(token_events)) as client:
+        async with client.stream(
+            "POST",
+            "/message:stream",
+            json=_message_request("hi"),
+            headers=REST_HEADERS,
+        ) as response:
+            assert response.status_code == 200
+            assert "text/event-stream" in response.headers["content-type"]
+            body = await response.aread()
+
+    states = _stream_states(body.decode())
+    assert states[0] == "TASK_STATE_SUBMITTED"
+    assert "TASK_STATE_WORKING" in states
+    assert states[-1] == "TASK_STATE_COMPLETED"
+
+
+@pytest.mark.integration
+async def test_tasks_get_returns_persisted_task_over_rest(
+    token_events: Sequence[ModelStreamEvent],
+) -> None:
+    """GET /tasks/{id} returns the task persisted by a previous REST send."""
+    async with make_client(_rest_app(token_events)) as client:
+        sent = await client.post(
+            "/message:send",
+            json=_message_request("hi"),
+            headers=REST_HEADERS,
+        )
+        task_id = sent.json()["task"]["id"]
+
+        fetched = await client.get(f"/tasks/{task_id}", headers=REST_HEADERS)
+
+    assert fetched.json()["id"] == task_id
+
+
+@pytest.mark.integration
+async def test_tasks_subscribe_route_is_available_over_rest(
+    token_events: Sequence[ModelStreamEvent],
+) -> None:
+    """GET /tasks/{id}:subscribe dispatches to the SDK subscribe endpoint."""
+    async with make_client(_rest_app(token_events)) as client:
+        sent = await client.post(
+            "/message:send",
+            json=_message_request("hi"),
+            headers=REST_HEADERS,
+        )
+        task_id = sent.json()["task"]["id"]
+
+        response = await client.get(
+            f"/tasks/{task_id}:subscribe",
+            headers=REST_HEADERS,
+        )
+
+    assert response.status_code == 400
+    assert "already completed" in response.text
+
+
+@pytest.mark.integration
+async def test_tasks_cancel_marks_input_required_task_canceled_over_rest(
+    approval_events: Sequence[ModelStreamEvent],
+) -> None:
+    """POST /tasks/{id}:cancel appends the cancel signal and returns canceled."""
+    async with make_client(_rest_app(approval_events)) as client:
+        sent = await client.post(
+            "/message:send",
+            json=_message_request("write"),
+            headers=REST_HEADERS,
+        )
+        task = sent.json()["task"]
+
+        canceled = await client.post(
+            f"/tasks/{task['id']}:cancel",
+            headers=REST_HEADERS,
+        )
+
+    assert task["status"]["state"] == "TASK_STATE_INPUT_REQUIRED"
+    assert canceled.json()["status"]["state"] == "TASK_STATE_CANCELED"

--- a/plugins/spakky-a2a/tests/unit/test_rest_builder.py
+++ b/plugins/spakky-a2a/tests/unit/test_rest_builder.py
@@ -1,0 +1,39 @@
+"""Tests for A2A REST app assembly."""
+
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+from spakky.plugins.a2a.rest_transport.builder import build_a2a_rest_app
+from tests.unit._sample_agents import ServedPlannerAgent, StubModel
+
+
+def test_build_a2a_rest_app_assembles_http_json_routes() -> None:
+    """build_a2a_rest_app returns a Starlette app with REST operation routes."""
+    app = build_a2a_rest_app(
+        ServedPlannerAgent(StubModel()),
+        base_url="http://x",
+        version="1.0.0",
+    )
+
+    assert isinstance(app, Starlette)
+    paths = {route.path for route in app.routes if isinstance(route, Route)}
+    assert "/.well-known/agent-card.json" in paths
+    assert "/message:send" in paths
+    assert "/message:stream" in paths
+    assert "/tasks/{id}" in paths
+    assert "/tasks/{id}:cancel" in paths
+    assert "/tasks/{id}:subscribe" in paths
+
+
+def test_build_a2a_rest_app_respects_path_prefix() -> None:
+    """REST operation routes can be mounted under an SDK path prefix."""
+    app = build_a2a_rest_app(
+        ServedPlannerAgent(StubModel()),
+        base_url="http://x/a2a",
+        version="1.0.0",
+        path_prefix="/a2a",
+    )
+
+    paths = {route.path for route in app.routes if isinstance(route, Route)}
+    assert "/a2a/message:send" in paths
+    assert "/a2a/tasks/{id}" in paths


### PR DESCRIPTION
## Summary
- Add `rest_transport` with `build_a2a_rest_app()` for official A2A HTTP+JSON routes.
- Share A2A request-handler assembly across JSON-RPC, gRPC, and REST transports.
- Cover REST AgentCard, message send/stream, task get/cancel/subscribe dispatch, and document the REST route mapping.

## Acceptance Criteria (자가 grep)
acceptance_check: missing

## Verification
- `uv run --with ruff ruff format .`
- `uv run --with ruff ruff check .`
- `uv run --with pyrefly pyrefly check src tests --config pyproject.toml --min-severity warn --progress-bar no --output-format min-text`
- `uv run --with pytest-cov --with pytest-xdist --with pytest-spec pytest -q`
- `uv run mkdocs build --strict`

Closes #422