### PR TITLE
feat(agui): add CLI stdio protocol boundary

### DIFF
--- a/plugins/spakky-agui/README.md
+++ b/plugins/spakky-agui/README.md
@@ -2,14 +2,15 @@
 
 > `spakky-agui`는 `spakky-agent`를 위한 공식 AG-UI (Agent User Interaction) protocol adapter plugin입니다.
 > 선언형 `@Agent` 실행 스트림을 AG-UI 이벤트로 투영(project)하여 SSE (Server-Sent Events),
-> HTTP streaming, WebSocket으로 노출하고, deferred-tool 방식의 HITL (Human-in-the-loop) 승인 흐름을 지원합니다.
+> HTTP streaming, WebSocket, CLI stdio로 노출하고, deferred-tool 방식의 HITL (Human-in-the-loop) 승인 흐름을 지원합니다.
 
 ## 언제 필요한가
 
 애플리케이션이 선언형 `@Agent` workflow를 실행하고, 그 실행 이벤트(토큰, 도구 호출,
 승인 요청, 종료)를 AG-UI 호환 프런트엔드에 실시간 스트리밍하려 할 때 사용합니다.
 렌더링(프런트엔드 UI)은 본 plugin의 범위 밖입니다 — 본 plugin은 와이어 프로토콜(SSE
-프레임, HTTP JSON-line chunk, 또는 WebSocket text message)만 책임집니다.
+프레임, HTTP JSON-line chunk, WebSocket text message, 또는 stdout JSON-line payload)만
+책임집니다.
 
 ## 설치
 
@@ -18,8 +19,8 @@ pip install spakky-agui
 ```
 
 durable Agent 실행(state·signal·evidence repository)과 모델 어댑터(`IAgentModel`)는
-별도 provider가 제공합니다. `spakky-agui`는 inbound SSE/HTTP streaming/WebSocket 어댑터만
-제공합니다.
+별도 provider가 제공합니다. `spakky-agui`는 inbound SSE/HTTP streaming/WebSocket/stdio
+프로토콜 어댑터만 제공합니다.
 
 ## 설정
 
@@ -41,6 +42,7 @@ AgentRunner.run_events() → 중립 AgentEvent  (런너가 native로 방출)
 AG-UI BaseEvent  ──(EventEncoder)──▶  "data: {...}\n\n" SSE 프레임
                                       또는 "{...}\n" HTTP streaming chunk
                                       또는 WebSocket text message
+                                      또는 stdout "{...}\n" stdio payload
 ```
 
 - **`AgentRunner.run_events()`**: 런너가 중립 `AgentEvent` taxonomy를 native로 방출하는
@@ -124,6 +126,25 @@ WebSocket 클라이언트는 `/agui/ws`에 연결한 뒤 같은 AG-UI
 `RunAgentInput` JSON을 text/JSON message로 보내고, 실행 이벤트를 AG-UI encoded text
 message로 순서대로 받습니다. 같은 연결에서 후속 `RunAgentInput`을 보내 승인 결정
 (`forwardedProps.approvalDecision` 또는 deferred tool-result message)을 전달할 수 있습니다.
+
+CLI stdio 경계는 `RunAgentInput` JSON 문서를 stdin 또는 문자열 인자로 받고 stdout에 AG-UI
+event payload를 한 줄에 하나씩 출력합니다. Typer 같은 CLI plugin은 이 callable을 command로
+등록하면 됩니다.
+
+```python
+from sys import stdin, stdout
+
+from spakky.plugins.agui import AgUiStdioCommand
+
+agui_stdio = AgUiStdioCommand(
+    run_driver_factory=run_driver_factory,
+    input_stream=stdin,
+    output_stream=stdout,
+)
+
+# CLI command body에서:
+# await agui_stdio(run_input_json=None)  # stdin 사용
+```
 
 ### endpoint 와이어링이 plugin `initialize`에 없는 이유
 

--- a/plugins/spakky-agui/src/spakky/plugins/agui/__init__.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/__init__.py
@@ -17,6 +17,12 @@ from spakky.plugins.agui.hitl import (
 )
 from spakky.plugins.agui.http_stream import add_agui_http_stream_endpoint
 from spakky.plugins.agui.projector import AgUiProjector
+from spakky.plugins.agui.stdio import (
+    AgUiStdioCommand,
+    agui_stdio_payloads,
+    read_agui_run_input,
+    run_agui_stdio,
+)
 from spakky.plugins.agui.transport import AgUiRunDriver
 from spakky.plugins.agui.websocket import add_agui_websocket_endpoint
 
@@ -30,13 +36,17 @@ __all__ = [
     "AgUiPendingApprovalError",
     "AgUiProjector",
     "AgUiRunDriver",
+    "AgUiStdioCommand",
     "AgUiRunResolutionError",
     "PLUGIN_NAME",
     "RunDriverFactory",
     "add_agui_endpoint",
     "add_agui_http_stream_endpoint",
     "add_agui_websocket_endpoint",
+    "agui_stdio_payloads",
     "ingest_decision",
     "project_approval",
     "project_pending_approval",
+    "read_agui_run_input",
+    "run_agui_stdio",
 ]

--- a/plugins/spakky-agui/src/spakky/plugins/agui/http_stream.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/http_stream.py
@@ -15,6 +15,7 @@ from fastapi.responses import StreamingResponse
 
 from spakky.plugins.agui.config import AgUiConfig
 from spakky.plugins.agui.endpoint import RunDriverFactory, _to_core_input
+from spakky.plugins.agui.serialization import sse_frame_payload
 from spakky.plugins.agui.transport import AgUiRunDriver
 
 HTTP_STREAM_MEDIA_TYPE = "application/x-ndjson"
@@ -47,14 +48,4 @@ def add_agui_http_stream_endpoint(
 
 async def _http_stream_chunks(driver: AgUiRunDriver) -> AsyncIterator[str]:
     async for frame in driver:
-        yield _sse_frame_payload(frame)
-
-
-def _sse_frame_payload(frame: str) -> str:
-    """Convert one AG-UI SSE frame into a raw JSON-line HTTP stream chunk."""
-    payload_lines = [
-        line.removeprefix("data:").lstrip()
-        for line in frame.splitlines()
-        if line.startswith("data:")
-    ]
-    return "\n".join(payload_lines) + "\n"
+        yield sse_frame_payload(frame)

--- a/plugins/spakky-agui/src/spakky/plugins/agui/serialization.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/serialization.py
@@ -13,3 +13,13 @@ from spakky.agent.types import JsonValue
 def dump_json(value: JsonValue) -> str:
     """Serialize a neutral JSON value to compact JSON text."""
     return dumps(value, separators=(",", ":"), ensure_ascii=False)
+
+
+def sse_frame_payload(frame: str) -> str:
+    """Convert one AG-UI SSE frame into a raw JSON-line event payload."""
+    payload_lines = [
+        line.removeprefix("data:").lstrip()
+        for line in frame.splitlines()
+        if line.startswith("data:")
+    ]
+    return "\n".join(payload_lines) + "\n"

--- a/plugins/spakky-agui/src/spakky/plugins/agui/stdio.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/stdio.py
@@ -1,0 +1,74 @@
+"""AG-UI stdio protocol boundary for CLI adapters.
+
+The stdio boundary intentionally emits protocol payloads only: it accepts a
+single AG-UI ``RunAgentInput`` JSON document from stdin or an argument, drives the
+same ``AgUiRunDriver`` used by SSE/HTTP/WebSocket adapters, and writes one AG-UI
+event JSON payload per stdout line. Rendering, colors, and nested views remain
+the responsibility of the consuming UI process.
+"""
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import TextIO
+
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+
+from spakky.plugins.agui.endpoint import RunDriverFactory, _to_core_input
+from spakky.plugins.agui.serialization import sse_frame_payload
+from spakky.plugins.agui.transport import AgUiRunDriver
+
+
+@dataclass(frozen=True, slots=True)
+class AgUiStdioCommand:
+    """Callable command object that CLI plugins can register with their runner."""
+
+    run_driver_factory: RunDriverFactory
+    input_stream: TextIO
+    output_stream: TextIO
+    accept: str | None = None
+
+    async def __call__(self, run_input_json: str | None = None) -> None:
+        """Run one AG-UI input from ``run_input_json`` or stdin over stdio."""
+        await run_agui_stdio(
+            run_driver_factory=self.run_driver_factory,
+            input_stream=self.input_stream,
+            output_stream=self.output_stream,
+            run_input_json=run_input_json,
+            accept=self.accept,
+        )
+
+
+async def run_agui_stdio(
+    *,
+    run_driver_factory: RunDriverFactory,
+    input_stream: TextIO,
+    output_stream: TextIO,
+    run_input_json: str | None = None,
+    accept: str | None = None,
+) -> None:
+    """Drive one AG-UI run from stdio and write AG-UI event payloads to stdout."""
+    ag_ui_input = read_agui_run_input(
+        input_stream=input_stream,
+        run_input_json=run_input_json,
+    )
+    core_input = _to_core_input(ag_ui_input)
+    driver = run_driver_factory(core_input, ag_ui_input, accept)
+    async for payload in agui_stdio_payloads(driver):
+        output_stream.write(payload)
+        output_stream.flush()
+
+
+def read_agui_run_input(
+    *,
+    input_stream: TextIO,
+    run_input_json: str | None = None,
+) -> AgUiRunAgentInput:
+    """Parse an AG-UI ``RunAgentInput`` from an argument or stdin."""
+    payload = run_input_json if run_input_json is not None else input_stream.read()
+    return AgUiRunAgentInput.model_validate_json(payload)
+
+
+async def agui_stdio_payloads(driver: AgUiRunDriver) -> AsyncIterator[str]:
+    """Yield AG-UI event JSON-lines from an ``AgUiRunDriver``-compatible stream."""
+    async for frame in driver:
+        yield sse_frame_payload(frame)

--- a/plugins/spakky-agui/tests/integration/test_stdio.py
+++ b/plugins/spakky-agui/tests/integration/test_stdio.py
@@ -1,0 +1,158 @@
+"""Integration: the AG-UI stdio boundary emits protocol JSON payloads."""
+
+from collections.abc import AsyncIterator
+from io import StringIO
+from json import loads
+from typing import override
+
+from ag_ui.core import RunAgentInput as AgUiRunAgentInput
+from ag_ui.encoder import EventEncoder
+
+from spakky.agent import (
+    Agent,
+    AgentExecutionSpec,
+    AgentRunner,
+    EvidenceCapture,
+    Idempotency,
+    ModelCapability,
+    ModelRequest,
+    ModelResponse,
+    ModelStreamEvent,
+    ModelStreamEventKind,
+    ModelToolCall,
+    RunAgentInput,
+    ToolApprovalRequirement,
+    ToolEffects,
+    agent_tool,
+)
+from spakky.agent.interfaces.model import IAgentModel
+
+from spakky.plugins.agui.config import AgUiConfig
+from spakky.plugins.agui.endpoint import RunDriverFactory
+from spakky.plugins.agui.projector import AgUiProjector
+from spakky.plugins.agui.stdio import AgUiStdioCommand, run_agui_stdio
+from spakky.plugins.agui.transport import AgUiRunDriver
+
+
+@Agent(spec=AgentExecutionSpec(name="stdio_assistant", objective="answer with a tool"))
+class StdioAssistant:
+    """Stateless agent exercised through the stdio protocol boundary."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model
+
+    @agent_tool(
+        schema_name="lookup",
+        description="Look up a fact.",
+        effects=ToolEffects.read_only(),
+        idempotency=Idempotency.IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.NOT_REQUIRED,
+    )
+    def lookup(self, topic: str) -> str:
+        """Look up a topic."""
+        return f"fact:{topic}"
+
+
+class _ScriptedModel(IAgentModel):
+    @property
+    @override
+    def capability(self) -> ModelCapability:
+        return ModelCapability()
+
+    @override
+    async def complete(self, request: ModelRequest) -> ModelResponse:
+        return ModelResponse(content="scripted")
+
+    @override
+    async def stream(self, request: ModelRequest) -> AsyncIterator[ModelStreamEvent]:
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOKEN_DELTA,
+            token_delta="hello",
+        )
+        yield ModelStreamEvent(
+            kind=ModelStreamEventKind.TOOL_CALL_CANDIDATE,
+            tool_call=ModelToolCall(
+                name="lookup",
+                arguments={"topic": "agents"},
+                call_id="call-1",
+            ),
+        )
+        yield ModelStreamEvent(kind=ModelStreamEventKind.DONE)
+
+
+def _run_agent_input_json() -> str:
+    return (
+        '{"threadId":"conv-1","runId":"run-1","state":null,'
+        '"messages":[{"id":"u1","role":"user","content":"look up agents"}],'
+        '"tools":[],"context":[],"forwardedProps":null}'
+    )
+
+
+def _run_driver_factory(
+    captured: list[tuple[RunAgentInput, AgUiRunAgentInput, str | None]],
+) -> RunDriverFactory:
+    assistant = StdioAssistant(_ScriptedModel())
+    config = AgUiConfig()
+
+    def factory(
+        core_input: RunAgentInput,
+        ag_ui_input: AgUiRunAgentInput,
+        accept: str | None,
+    ) -> AgUiRunDriver:
+        captured.append((core_input, ag_ui_input, accept))
+        runner = AgentRunner.for_agent_instance(assistant)
+        return AgUiRunDriver(
+            runner=runner,
+            run_input=core_input,
+            agent_id="stdio_assistant",
+            projector=AgUiProjector(config),
+            encoder=EventEncoder(accept=accept or ""),
+        )
+
+    return factory
+
+
+def _event_types(output: StringIO) -> list[str]:
+    return [loads(line)["type"] for line in output.getvalue().splitlines()]
+
+
+async def test_stdio_streams_agui_event_payloads_from_argument() -> None:
+    """문자열 인자로 받은 RunAgentInput이 stdout AG-UI JSON-lines로 스트리밍된다."""
+    captured: list[tuple[RunAgentInput, AgUiRunAgentInput, str | None]] = []
+    output = StringIO()
+
+    await run_agui_stdio(
+        run_driver_factory=_run_driver_factory(captured),
+        input_stream=StringIO(""),
+        output_stream=output,
+        run_input_json=_run_agent_input_json(),
+        accept="text/event-stream",
+    )
+
+    types = _event_types(output)
+    assert "data: " not in output.getvalue()
+    assert types[0] == "RUN_STARTED"
+    assert "TOOL_CALL_RESULT" in types
+    assert types[-1] == "RUN_FINISHED"
+    assert captured[0][0].instruction == "look up agents"
+    assert captured[0][0].state_id == "run-1"
+    assert captured[0][2] == "text/event-stream"
+
+
+async def test_stdio_command_reads_run_input_from_stdin() -> None:
+    """등록 가능한 command callable은 stdin의 RunAgentInput을 소비한다."""
+    captured: list[tuple[RunAgentInput, AgUiRunAgentInput, str | None]] = []
+    output = StringIO()
+    command = AgUiStdioCommand(
+        run_driver_factory=_run_driver_factory(captured),
+        input_stream=StringIO(_run_agent_input_json()),
+        output_stream=output,
+    )
+
+    await command()
+
+    types = _event_types(output)
+    assert types[0] == "RUN_STARTED"
+    assert types[-1] == "RUN_FINISHED"
+    assert captured[0][0].conversation_id == "conv-1"

--- a/plugins/spakky-agui/tests/unit/test_public_api.py
+++ b/plugins/spakky-agui/tests/unit/test_public_api.py
@@ -9,14 +9,18 @@ from spakky.plugins.agui import (
     AgUiProjector,
     AgUiRunDriver,
     AgUiRunResolutionError,
+    AgUiStdioCommand,
     PLUGIN_NAME,
     RunDriverFactory,
     add_agui_endpoint,
     add_agui_http_stream_endpoint,
     add_agui_websocket_endpoint,
+    agui_stdio_payloads,
     ingest_decision,
     project_approval,
     project_pending_approval,
+    read_agui_run_input,
+    run_agui_stdio,
 )
 
 
@@ -26,12 +30,16 @@ def test_public_api_exports_agui_surface() -> None:
     assert AgUiConfig is agui_api.AgUiConfig
     assert AgUiProjector is agui_api.AgUiProjector
     assert AgUiRunDriver is agui_api.AgUiRunDriver
+    assert AgUiStdioCommand is agui_api.AgUiStdioCommand
     assert add_agui_endpoint is agui_api.add_agui_endpoint
     assert add_agui_http_stream_endpoint is agui_api.add_agui_http_stream_endpoint
     assert add_agui_websocket_endpoint is agui_api.add_agui_websocket_endpoint
+    assert agui_stdio_payloads is agui_api.agui_stdio_payloads
     assert ingest_decision is agui_api.ingest_decision
     assert project_approval is agui_api.project_approval
     assert project_pending_approval is agui_api.project_pending_approval
+    assert read_agui_run_input is agui_api.read_agui_run_input
+    assert run_agui_stdio is agui_api.run_agui_stdio
     assert RunDriverFactory is agui_api.RunDriverFactory
     assert AbstractAgUiError is agui_api.AbstractAgUiError
     assert AgUiApprovalDecodeError is agui_api.AgUiApprovalDecodeError


### PR DESCRIPTION
## Summary
- Add a `spakky.plugins.agui.stdio` protocol boundary that accepts AG-UI `RunAgentInput` JSON from stdin or an argument and writes AG-UI event payload JSON-lines to stdout.
- Reuse the existing `AgUiRunDriver`, projector, encoder, and HITL flow while preserving SSE, HTTP streaming, and WebSocket APIs.
- Document the stdio callable/command wiring surface and add integration coverage for arg and stdin inputs.

## Acceptance Criteria (자가 grep)
- missing: issue #420 has no executable grep/rg acceptance lines. SC-1 is covered by `tests/integration/test_stdio.py`.

## Verification
- `cd plugins/spakky-agui && uv run --with ruff ruff format .`
- `cd plugins/spakky-agui && uv run --with ruff ruff check .`
- `cd plugins/spakky-agui && uv run --with pyrefly --with pytest --with pytest-asyncio --with pytest-cov --with pytest-spec --with pytest-xdist pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text`
- `cd plugins/spakky-agui && uv run --with pytest --with pytest-asyncio --with pytest-cov --with pytest-spec --with pytest-xdist pytest`
- `cd plugins/spakky-agui && uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- `uv run --with mkdocs --with mkdocs-material --with 'mkdocstrings[python]' mkdocs build --strict`

Closes #420