### PR TITLE
feat(a2a): add teammate delegation client wiring (#423)

### DIFF
--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -86,6 +86,7 @@ from spakky.agent.recovery import (
 )
 from spakky.agent.delegation import (
     AgentDelegateTarget,
+    DelegationToolResult,
     DelegationBudget,
     DelegationContextSlice,
     DelegationExpectedOutput,
@@ -185,6 +186,7 @@ from spakky.agent.tooling import (
     AgentToolDescriptor,
     AgentToolIdentity,
     AgentToolMetadata,
+    AgentToolRuntimeContext,
     AgentToolSchemaHandle,
     DataAccess,
     EvidenceCapture,
@@ -299,6 +301,7 @@ __all__ = [
     "AgentToolDispatcher",
     "AgentToolIdentity",
     "AgentToolMetadata",
+    "AgentToolRuntimeContext",
     "AgentToolSchemaHandle",
     "AgentStateReason",
     "AgentStateTransition",
@@ -336,6 +339,7 @@ __all__ = [
     "DelegationPacket",
     "DelegationResult",
     "DelegationReturnPolicy",
+    "DelegationToolResult",
     "DEFAULT_APPROVAL_DECISIONS",
     "Error",
     "DataAccess",

--- a/core/spakky-agent/src/spakky/agent/delegation.py
+++ b/core/spakky-agent/src/spakky/agent/delegation.py
@@ -1,13 +1,29 @@
 """Agent-to-agent delegation contracts."""
 
 from abc import ABC, abstractmethod
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
+from re import sub
 
-from spakky.agent.error import AgentDefinitionError
+from spakky.agent.error import AgentDefinitionError, AgentToolDispatchError
 from spakky.agent.evidence import AgentEvidence, AgentEvidenceKind
+from spakky.agent.event import AgentEvent
+from spakky.agent.inbound import RunAgentInput
+from spakky.agent.tooling import (
+    AgentToolDescriptor,
+    AgentToolIdentity,
+    AgentToolMetadata,
+    AgentToolRuntimeContext,
+    AgentToolSchemaHandle,
+    DataAccess,
+    EvidenceCapture,
+    Externality,
+    Idempotency,
+    ToolApprovalRequirement,
+    ToolEffects,
+)
 from spakky.agent.types import JsonObject, JsonValue
 from spakky.agent.yield_ import AgentYield, AgentYieldKind, Evidence
 
@@ -171,6 +187,41 @@ class DelegationResult:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class DelegationToolResult:
+    """Model-facing result plus child neutral events from a teammate call."""
+
+    summary: str
+    output: JsonValue = None
+    events: tuple[AgentEvent, ...] = ()
+    metadata: JsonObject = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Reject delegated tool results without a model-facing summary."""
+        if not self.summary.strip():
+            raise AgentDefinitionError("Delegation tool result summary cannot be blank")
+
+    @classmethod
+    def from_result(
+        cls,
+        result: DelegationResult,
+        *,
+        events: tuple[AgentEvent, ...] = (),
+    ) -> "DelegationToolResult":
+        """Build a model-facing tool result from a delegation result object."""
+        return cls(
+            summary=result.summary,
+            output=result.output,
+            events=events,
+            metadata={
+                "delegation_id": result.id,
+                "packet_id": result.packet_id,
+                "target_agent_type": result.target.agent_type,
+                **result.metadata,
+            },
+        )
+
+
 class IAgentDelegate(ABC):
     """Execution hook that runs a delegation packet against a delegate target."""
 
@@ -180,3 +231,256 @@ class IAgentDelegate(ABC):
         packet: DelegationPacket,
     ) -> AsyncGenerator[AgentYield[DelegationResult], None]:
         """Execute delegation without prescribing spawn topology or transport."""
+
+    async def delegate_tool_result(
+        self,
+        packet: DelegationPacket,
+    ) -> DelegationToolResult:
+        """Execute delegation and collect the terminal result for a tool call."""
+        terminal: DelegationResult | None = None
+        async for item in self.delegate(packet):
+            if isinstance(item.payload, DelegationResult):
+                terminal = item.payload
+        if terminal is None:
+            raise AgentToolDispatchError("Agent delegate produced no delegation result")
+        return DelegationToolResult.from_result(terminal)
+
+
+def build_teammate_tool_descriptors(
+    owner: type[object],
+    teammates,
+) -> tuple[AgentToolDescriptor, ...]:
+    """Build model-callable delegation tools from an ``@Agent`` teammate spec."""
+    return tuple(
+        _build_teammate_tool_descriptor(owner, teammate) for teammate in teammates
+    )
+
+
+def _build_teammate_tool_descriptor(
+    owner: type[object],
+    teammate,
+) -> AgentToolDescriptor:
+    token = _schema_token(teammate.name)
+    schema_name = f"teammate.{token}.delegate"
+    return AgentToolDescriptor(
+        identity=AgentToolIdentity(
+            owner_module=owner.__module__,
+            owner_qualname=owner.__qualname__,
+            name=f"delegate_{token}",
+        ),
+        owner=owner,
+        callable=_teammate_callable(teammate),
+        schema=AgentToolSchemaHandle(
+            name=schema_name,
+            input_schema_name=f"{schema_name}.input",
+            output_schema_name=f"{schema_name}.output",
+            input_schema={
+                "type": "object",
+                "title": f"{schema_name}.input",
+                "properties": {
+                    "instruction": {
+                        "type": "string",
+                        "description": "Instruction for the delegated teammate.",
+                    },
+                    "task": {
+                        "type": "object",
+                        "description": "Structured task payload for the teammate.",
+                    },
+                    "context_summary": {
+                        "type": "string",
+                        "description": "Optional parent context summary.",
+                    },
+                },
+                "required": ["instruction"],
+                "additionalProperties": False,
+            },
+            output_schema={
+                "type": "object",
+                "title": f"{schema_name}.output",
+                "properties": {
+                    "summary": {"type": "string"},
+                    "output": {},
+                    "metadata": {"type": "object"},
+                },
+                "required": ["summary"],
+            },
+        ),
+        description=f"Delegate work to teammate '{teammate.name}'.",
+        metadata=AgentToolMetadata(
+            effects=ToolEffects(
+                data_access=DataAccess.READ_WRITE,
+                externality=(
+                    Externality.LOCAL
+                    if teammate.pod is not None
+                    else Externality.EXTERNAL
+                ),
+                network=teammate.card_url is not None,
+            ),
+            data_access=DataAccess.READ_WRITE,
+            externality=(
+                Externality.LOCAL if teammate.pod is not None else Externality.EXTERNAL
+            ),
+            idempotency=Idempotency.UNKNOWN,
+            evidence=EvidenceCapture.STRUCTURED,
+            approval=ToolApprovalRequirement.NOT_REQUIRED,
+        ),
+    )
+
+
+def _teammate_callable(teammate):
+    async def delegate_teammate(
+        self: object,
+        runtime_context: AgentToolRuntimeContext,
+        instruction: str,
+        task: Mapping[str, JsonValue] | None = None,
+        context_summary: str | None = None,
+    ) -> DelegationToolResult:
+        return await _run_teammate_tool(
+            self,
+            runtime_context,
+            teammate,
+            instruction,
+            task,
+            context_summary,
+        )
+
+    return delegate_teammate
+
+
+async def _run_teammate_tool(
+    parent: object,
+    runtime_context: AgentToolRuntimeContext,
+    teammate,
+    instruction: str,
+    task: Mapping[str, JsonValue] | None,
+    context_summary: str | None,
+) -> DelegationToolResult:
+    if not instruction.strip():
+        raise AgentToolDispatchError("Teammate delegation instruction cannot be blank")
+    packet = _delegation_packet(
+        runtime_context, teammate, instruction, task, context_summary
+    )
+    if teammate.pod is not None:
+        return await _delegate_local(parent, teammate, packet, runtime_context)
+    delegate = _resolve_delegate(parent)
+    return await delegate.delegate_tool_result(packet)
+
+
+async def _delegate_local(
+    parent: object,
+    teammate,
+    packet: DelegationPacket,
+    runtime_context: AgentToolRuntimeContext,
+) -> DelegationToolResult:
+    from spakky.agent.runner import AgentRunner
+
+    child = _resolve_local_teammate(parent, teammate)
+    child_input = RunAgentInput(
+        state_id=packet.id,
+        instruction=_packet_instruction(packet),
+        conversation_id=runtime_context.conversation_id,
+        parent_run_id=runtime_context.state_id,
+        metadata={"delegation_packet_id": packet.id, "teammate": teammate.name},
+    )
+    events = tuple(
+        [
+            event
+            async for event in AgentRunner.for_agent_instance(child).run_events(
+                child_input
+            )
+        ]
+    )
+    return DelegationToolResult(
+        summary=f"teammate '{teammate.name}' completed",
+        output={"event_count": len(events)},
+        events=events,
+        metadata={
+            "packet_id": packet.id,
+            "target_agent_type": packet.target.agent_type,
+            "teammate": teammate.name,
+        },
+    )
+
+
+def _delegation_packet(
+    runtime_context: AgentToolRuntimeContext,
+    teammate,
+    instruction: str,
+    task: Mapping[str, JsonValue] | None,
+    context_summary: str | None,
+) -> DelegationPacket:
+    task_payload = _task_payload(instruction, task)
+    return DelegationPacket(
+        id=f"{runtime_context.state_id}:{runtime_context.call_id}",
+        parent_agent_state_id=runtime_context.state_id,
+        target=AgentDelegateTarget(
+            agent_type=(
+                teammate.pod.__name__
+                if teammate.pod is not None
+                else f"remote:{teammate.name}"
+            ),
+            agent_name=teammate.name,
+            metadata={
+                **(
+                    {"card_url": teammate.card_url}
+                    if teammate.card_url is not None
+                    else {}
+                ),
+            },
+        ),
+        task=task_payload,
+        context=DelegationContextSlice(summary=context_summary),
+        metadata={"conversation_id": runtime_context.conversation_id},
+    )
+
+
+def _task_payload(
+    instruction: str,
+    task: Mapping[str, JsonValue] | None,
+) -> JsonObject:
+    if task is None:
+        return {"instruction": instruction}
+    payload: dict[str, JsonValue] = {"instruction": instruction}
+    for key, value in task.items():
+        if not isinstance(key, str):
+            raise AgentToolDispatchError(
+                "Teammate delegation task keys must be strings"
+            )
+        payload[key] = value
+    return payload
+
+
+def _packet_instruction(packet: DelegationPacket) -> str:
+    instruction = packet.task.get("instruction")
+    if not isinstance(instruction, str) or not instruction.strip():
+        raise AgentToolDispatchError("Teammate delegation packet lacks instruction")
+    return instruction
+
+
+def _resolve_local_teammate(parent: object, teammate) -> object:
+    matches = tuple(
+        value for value in vars(parent).values() if isinstance(value, teammate.pod)
+    )
+    if len(matches) != 1:
+        raise AgentToolDispatchError(
+            "Local teammate delegation requires exactly one injected teammate pod"
+        )
+    return matches[0]
+
+
+def _resolve_delegate(parent: object) -> IAgentDelegate:
+    matches = tuple(
+        value for value in vars(parent).values() if isinstance(value, IAgentDelegate)
+    )
+    if len(matches) != 1:
+        raise AgentToolDispatchError(
+            "Remote teammate delegation requires exactly one IAgentDelegate port"
+        )
+    return matches[0]
+
+
+def _schema_token(name: str) -> str:
+    token = sub(r"[^a-zA-Z0-9_]+", "_", name.strip()).strip("_").lower()
+    if not token:
+        raise AgentDefinitionError("Agent teammate name cannot form a tool schema")
+    return token

--- a/core/spakky-agent/src/spakky/agent/dispatcher.py
+++ b/core/spakky-agent/src/spakky/agent/dispatcher.py
@@ -18,9 +18,11 @@ from spakky.agent.tooling import (
     AgentToolCallable,
     AgentToolCatalog,
     AgentToolDescriptor,
+    AgentToolRuntimeContext,
 )
 
 _OWNER_PARAMETER_NAMES = ("self", "cls")
+_RUNTIME_CONTEXT_PARAMETER_NAME = "runtime_context"
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,6 +38,7 @@ class AgentToolDispatcher:
     # target: any agent instance owning the catalog tools — no common base type.
     target: object
     catalog: AgentToolCatalog
+    runtime_context: AgentToolRuntimeContext | None = None
 
     def descriptor_for(self, call: ModelToolCall) -> AgentToolDescriptor:
         """Resolve the catalog descriptor a model tool call targets."""
@@ -51,7 +54,7 @@ class AgentToolDispatcher:
         descriptor = self.descriptor_for(call)
         invocation = descriptor.bind_invocation(call.arguments)
         callable_ = descriptor.callable
-        positional = self._with_owner_prefix(callable_, invocation.args)
+        positional = self._with_injected_prefix(callable_, invocation.args)
         if iscoroutinefunction(callable_):
             awaitable: Awaitable[object] = callable_(
                 *positional,
@@ -60,12 +63,20 @@ class AgentToolDispatcher:
             return await awaitable
         return callable_(*positional, **invocation.kwargs)
 
-    def _with_owner_prefix(
+    def _with_injected_prefix(
         self,
         callable_: AgentToolCallable,
         args: tuple[object, ...],
     ) -> tuple[object, ...]:
         parameters = tuple(signature(callable_).parameters.values())
+        injected: list[object] = []
         if parameters and parameters[0].name in _OWNER_PARAMETER_NAMES:
-            return (self.target, *args)
-        return args
+            injected.append(self.target)
+            parameters = parameters[1:]
+        if parameters and parameters[0].name == _RUNTIME_CONTEXT_PARAMETER_NAME:
+            if self.runtime_context is None:
+                raise AgentToolDispatchError(
+                    "Agent tool requires runtime context but none was provided"
+                )
+            injected.append(self.runtime_context)
+        return (*injected, *args)

--- a/core/spakky-agent/src/spakky/agent/execution.py
+++ b/core/spakky-agent/src/spakky/agent/execution.py
@@ -9,6 +9,7 @@ from typing import get_args, get_origin, get_type_hints
 from urllib.parse import urlsplit
 
 from spakky.agent.compaction import ICompactionStrategy
+from spakky.agent.delegation import build_teammate_tool_descriptors
 from spakky.agent.error import AgentDefinitionError
 from spakky.agent.hooks import AgentSignalHookCatalog, discover_agent_signal_hooks
 from spakky.agent.signal import AgentSignalKind
@@ -169,7 +170,14 @@ class Agent(Pod):
             raise AgentDefinitionError("Agent Pod metadata is invalid") from e
         self._ensure_execute_provided(agent_class)
         self._validate_execute_contract(agent_class)
-        self.tool_catalog = discover_agent_tools(agent_class)
+        discovered_tools = discover_agent_tools(agent_class)
+        teammate_tools = build_teammate_tool_descriptors(
+            agent_class,
+            self.spec.teammates,
+        )
+        self.tool_catalog = AgentToolCatalog(
+            descriptors=(*discovered_tools.descriptors, *teammate_tools),
+        )
         self.signal_hook_catalog = discover_agent_signal_hooks(agent_class)
 
     def validate_bootstrap(self) -> None:

--- a/core/spakky-agent/src/spakky/agent/inbound.py
+++ b/core/spakky-agent/src/spakky/agent/inbound.py
@@ -33,6 +33,7 @@ class RunAgentInput:
     state_id: str
     instruction: str
     conversation_id: str | None = None
+    parent_run_id: str | None = None
     resume: bool = False
     message_history: tuple[ModelMessage, ...] = ()
     metadata: JsonObject = field(default_factory=dict)
@@ -47,6 +48,8 @@ class RunAgentInput:
             raise AgentDefinitionError(
                 "Run agent input conversation id cannot be blank"
             )
+        if self.parent_run_id is not None and not self.parent_run_id.strip():
+            raise AgentDefinitionError("Run agent input parent run id cannot be blank")
 
     @property
     def effective_conversation_id(self) -> str:

--- a/core/spakky-agent/src/spakky/agent/runner.py
+++ b/core/spakky-agent/src/spakky/agent/runner.py
@@ -38,6 +38,7 @@ from spakky.agent.cancellation import (
     complete_agent_cancellation,
     run_agent_cancellation_cleanup,
 )
+from spakky.agent.delegation import DelegationToolResult
 from spakky.agent.dispatcher import AgentToolDispatcher
 from spakky.agent.error import (
     AgentModelConfigurationError,
@@ -99,7 +100,11 @@ from spakky.agent.state import (
     AgentStateTransition,
     AgentStatus,
 )
-from spakky.agent.tooling import AgentToolDescriptor, Idempotency
+from spakky.agent.tooling import (
+    AgentToolDescriptor,
+    AgentToolRuntimeContext,
+    Idempotency,
+)
 from spakky.agent.types import JsonValue
 from spakky.agent.yield_ import (
     AgentYield,
@@ -338,7 +343,11 @@ class AgentRunner:
             if not cleared:
                 return
             self._append_boundary(state.id, _before_tool(descriptor, call))
-        result = await self._dispatch(call)
+        result_object = await self._dispatch(call, attribution)
+        if isinstance(result_object, DelegationToolResult):
+            for child_event in result_object.events:
+                yield child_event
+        result = _tool_result_json(result_object)
         if state is not None:
             self._append_boundary(state.id, _after_tool(descriptor, call))
             self._append_tool_evidence(state.id, descriptor, result)
@@ -358,6 +367,7 @@ class AgentRunner:
             agent_id=self._agent_type(),
             run_id=run_input.state_id,
             conversation_id=run_input.effective_conversation_id,
+            parent_run_id=run_input.parent_run_id,
         )
 
     def _complete_state(self, state_id: str) -> None:
@@ -508,7 +518,15 @@ class AgentRunner:
             if not cleared:
                 return
             self._append_boundary(state.id, _before_tool(descriptor, call))
-        result = await self._dispatch(call)
+        result_object = await self._dispatch(
+            call,
+            AgentEventAttribution(
+                agent_id=self._agent_type(),
+                run_id=state.id if state is not None else _call_id(call),
+                conversation_id=state.id if state is not None else _call_id(call),
+            ),
+        )
+        result = _tool_result_json(result_object)
         if state is not None:
             self._append_boundary(state.id, _after_tool(descriptor, call))
             yield _evidence_yield(
@@ -551,12 +569,22 @@ class AgentRunner:
             self._append_boundary(state.id, _after_approval(call, descriptor))
         return approval_item, cleared
 
-    async def _dispatch(self, call: ModelToolCall) -> JsonValue:
+    async def _dispatch(
+        self,
+        call: ModelToolCall,
+        attribution: AgentEventAttribution,
+    ) -> object:
         dispatcher = AgentToolDispatcher(
             target=self.target,
             catalog=self.agent.tool_catalog,
+            runtime_context=AgentToolRuntimeContext(
+                state_id=attribution.run_id,
+                conversation_id=attribution.conversation_id,
+                call_id=_call_id(call),
+                tool_name=call.name,
+            ),
         )
-        return _tool_result_json(await dispatcher.dispatch(call))
+        return await dispatcher.dispatch(call)
 
     def _fail_on_model_error(
         self,
@@ -1158,6 +1186,12 @@ def _tool_result_json(result: object) -> JsonValue:
     """
     if result is None or isinstance(result, (bool, int, float, str)):
         return result
+    if isinstance(result, DelegationToolResult):
+        return {
+            "summary": result.summary,
+            "output": _tool_result_json(result.output),
+            "metadata": _tool_result_json(result.metadata),
+        }
     if isinstance(result, BaseModel):
         return result.model_dump(mode="json")
     if is_dataclass(result) and not isinstance(result, type):

--- a/core/spakky-agent/src/spakky/agent/tooling.py
+++ b/core/spakky-agent/src/spakky/agent/tooling.py
@@ -22,6 +22,8 @@ AGENT_TOOL_DEFINITION_KEY = "__spakky_agent_tool_definition__"
 
 AgentToolCallable = Callable[..., object]
 
+_RUNTIME_CONTEXT_PARAMETER_NAME = "runtime_context"
+
 _PRIMITIVE_SCHEMA_TYPES: dict[object, str] = {
     str: "string",
     int: "integer",
@@ -335,6 +337,23 @@ class ToolRisk:
 
 
 @dataclass(frozen=True, slots=True)
+class AgentToolRuntimeContext:
+    """Runtime correlation data injected into framework-owned tool callables."""
+
+    state_id: str
+    conversation_id: str
+    call_id: str
+    tool_name: str
+
+    def __post_init__(self) -> None:
+        """Reject runtime context that cannot link events and evidence."""
+        _require_non_blank(self.state_id, "Agent tool runtime state id")
+        _require_non_blank(self.conversation_id, "Agent tool runtime conversation id")
+        _require_non_blank(self.call_id, "Agent tool runtime call id")
+        _require_non_blank(self.tool_name, "Agent tool runtime tool name")
+
+
+@dataclass(frozen=True, slots=True)
 class AgentToolDefinition:
     """Method-level metadata attached by @agent_tool before owner discovery."""
 
@@ -515,7 +534,7 @@ def bind_agent_tool_invocation(
         raise AgentToolBindingError(
             "Agent tool callable signature cannot be inspected"
         ) from e
-    call_signature = _drop_owner_parameter(function_signature)
+    call_signature = _drop_injected_parameters(function_signature)
     try:
         bound = call_signature.bind(*invocation.args, **invocation.kwargs)
     except TypeError as e:
@@ -618,9 +637,11 @@ def _copy_string_key_mapping(value: object, label: str) -> dict[str, object]:
     return result
 
 
-def _drop_owner_parameter(function_signature: Signature) -> Signature:
+def _drop_injected_parameters(function_signature: Signature) -> Signature:
     parameters = tuple(function_signature.parameters.values())
     if parameters and parameters[0].name in ("self", "cls"):
+        parameters = parameters[1:]
+    if parameters and parameters[0].name == _RUNTIME_CONTEXT_PARAMETER_NAME:
         parameters = parameters[1:]
     return function_signature.replace(parameters=parameters)
 
@@ -650,6 +671,8 @@ def _build_input_schema(function: FunctionType, schema_name: str) -> _SchemaExtr
     sensitive_fields: list[SensitiveFieldDescriptor] = []
     for parameter in function_signature.parameters.values():
         if parameter.name in ("self", "cls"):
+            continue
+        if parameter.name == _RUNTIME_CONTEXT_PARAMETER_NAME:
             continue
         _validate_schema_parameter(parameter)
         annotation = type_hints.get(parameter.name, parameter.annotation)

--- a/core/spakky-agent/tests/unit/test_delegation.py
+++ b/core/spakky-agent/tests/unit/test_delegation.py
@@ -1,13 +1,19 @@
 """Tests for agent delegation contracts."""
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
+from typing import cast
 
 import pytest
 
 from spakky.agent import (
+    Agent,
     AgentDelegateTarget,
     AgentDefinitionError,
     AgentEvidenceKind,
+    AgentExecutionSpec,
+    AgentTeammate,
+    AgentToolDispatcher,
+    AgentToolRuntimeContext,
     AgentYield,
     AgentYieldKind,
     DelegationBudget,
@@ -16,9 +22,47 @@ from spakky.agent import (
     DelegationPacket,
     DelegationResult,
     DelegationReturnPolicy,
+    DelegationToolResult,
     Evidence,
     IAgentDelegate,
+    JsonValue,
+    ModelToolCall,
 )
+from spakky.agent.delegation import _packet_instruction, _task_payload
+from spakky.agent.error import AgentToolDispatchError
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="remote-parent",
+        teammates=(
+            AgentTeammate(
+                name="remote",
+                card_url="https://remote.example/.well-known/agent-card.json",
+            ),
+        ),
+    )
+)
+class RemoteParentAgent:
+    """Parent fixture exposing a remote teammate delegate port."""
+
+    def __init__(self, delegate: IAgentDelegate | None = None) -> None:
+        if delegate is not None:
+            self._delegate = delegate
+
+
+class LocalTeammate:
+    """Local teammate type used to exercise missing pod resolution."""
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="local-parent",
+        teammates=(AgentTeammate(name="local", pod=LocalTeammate),),
+    )
+)
+class LocalParentWithoutChild:
+    """Parent fixture declaring but not injecting a local teammate."""
 
 
 def test_delegation_packet_expect_expresses_task_context_constraints_output_budget() -> (
@@ -126,6 +170,181 @@ async def test_agent_delegate_hook_expect_streams_delegation_result_yields() -> 
     assert items[0].payload.packet_id == "delegation-1"
 
 
+async def test_delegate_tool_result_expect_collects_terminal_result() -> None:
+    """IAgentDelegate 기본 collector가 terminal result를 tool result로 변환한다."""
+    packet = DelegationPacket(
+        id="delegation-1",
+        parent_agent_state_id="run-parent",
+        target=AgentDelegateTarget(agent_type="ResearchAgent"),
+        task={"goal": "inspect"},
+    )
+    delegate = RecordingDelegate()
+
+    result = await delegate.delegate_tool_result(packet)
+
+    assert isinstance(result, DelegationToolResult)
+    assert result.summary == "done"
+    assert result.metadata["packet_id"] == "delegation-1"
+
+
+async def test_remote_teammate_tool_expect_dispatches_through_delegate_port() -> None:
+    """remote teammate synthetic tool이 IAgentDelegate port로 위임된다."""
+    delegate = RecordingDelegate()
+    dispatcher = AgentToolDispatcher(
+        target=RemoteParentAgent(delegate),
+        catalog=Agent.get(RemoteParentAgent).tool_catalog,
+        runtime_context=AgentToolRuntimeContext(
+            state_id="parent-run",
+            conversation_id="thread-1",
+            call_id="call-1",
+            tool_name="teammate.remote.delegate",
+        ),
+    )
+
+    result = await dispatcher.dispatch(
+        ModelToolCall(
+            name="teammate.remote.delegate",
+            arguments={"instruction": "inspect", "task": {"topic": "a2a"}},
+        )
+    )
+
+    assert isinstance(result, DelegationToolResult)
+    assert result.metadata["packet_id"] == "parent-run:call-1"
+    assert delegate.last_packet is not None
+    assert delegate.last_packet.parent_agent_state_id == "parent-run"
+    assert delegate.last_packet.target.metadata["card_url"] == (
+        "https://remote.example/.well-known/agent-card.json"
+    )
+
+
+async def test_remote_teammate_tool_expect_rejects_missing_delegate_port() -> None:
+    """remote teammate tool은 delegate port가 없으면 dispatch error를 낸다."""
+    dispatcher = AgentToolDispatcher(
+        target=RemoteParentAgent(),
+        catalog=Agent.get(RemoteParentAgent).tool_catalog,
+        runtime_context=AgentToolRuntimeContext(
+            state_id="parent-run",
+            conversation_id="thread-1",
+            call_id="call-1",
+            tool_name="teammate.remote.delegate",
+        ),
+    )
+
+    with pytest.raises(AgentToolDispatchError):
+        await dispatcher.dispatch(
+            ModelToolCall(
+                name="teammate.remote.delegate",
+                arguments={"instruction": "inspect"},
+            )
+        )
+
+
+async def test_remote_teammate_tool_expect_rejects_blank_instruction() -> None:
+    """teammate tool instruction은 공백일 수 없다."""
+    dispatcher = AgentToolDispatcher(
+        target=RemoteParentAgent(RecordingDelegate()),
+        catalog=Agent.get(RemoteParentAgent).tool_catalog,
+        runtime_context=AgentToolRuntimeContext(
+            state_id="parent-run",
+            conversation_id="thread-1",
+            call_id="call-1",
+            tool_name="teammate.remote.delegate",
+        ),
+    )
+
+    with pytest.raises(AgentToolDispatchError):
+        await dispatcher.dispatch(
+            ModelToolCall(
+                name="teammate.remote.delegate",
+                arguments={"instruction": " "},
+            )
+        )
+
+
+async def test_local_teammate_tool_expect_rejects_missing_child_pod() -> None:
+    """local teammate tool은 parent에 child pod가 없으면 dispatch error를 낸다."""
+    dispatcher = AgentToolDispatcher(
+        target=LocalParentWithoutChild(),
+        catalog=Agent.get(LocalParentWithoutChild).tool_catalog,
+        runtime_context=AgentToolRuntimeContext(
+            state_id="parent-run",
+            conversation_id="thread-1",
+            call_id="call-1",
+            tool_name="teammate.local.delegate",
+        ),
+    )
+
+    with pytest.raises(AgentToolDispatchError):
+        await dispatcher.dispatch(
+            ModelToolCall(
+                name="teammate.local.delegate",
+                arguments={"instruction": "inspect"},
+            )
+        )
+
+
+def test_delegation_tool_result_expect_rejects_blank_summary() -> None:
+    """DelegationToolResult summary는 model-facing 결과라 공백일 수 없다."""
+    with pytest.raises(AgentDefinitionError):
+        DelegationToolResult(summary=" ")
+
+
+async def test_delegate_tool_result_expect_rejects_delegate_without_result() -> None:
+    """delegate가 DelegationResult를 내지 않으면 custom dispatch error다."""
+    packet = DelegationPacket(
+        id="delegation-1",
+        parent_agent_state_id="run-parent",
+        target=AgentDelegateTarget(agent_type="ResearchAgent"),
+        task={"goal": "inspect"},
+    )
+
+    with pytest.raises(AgentToolDispatchError):
+        await EmptyDelegate().delegate_tool_result(packet)
+
+
+async def test_delegate_tool_result_expect_ignores_non_result_payloads() -> None:
+    """delegate stream의 non-result payload는 terminal result로 보지 않는다."""
+    packet = DelegationPacket(
+        id="delegation-1",
+        parent_agent_state_id="run-parent",
+        target=AgentDelegateTarget(agent_type="ResearchAgent"),
+        task={"goal": "inspect"},
+    )
+
+    with pytest.raises(AgentToolDispatchError):
+        await NonResultDelegate().delegate_tool_result(packet)
+
+
+def test_delegation_helpers_expect_reject_malformed_task_payloads() -> None:
+    """defensive helper가 비문자 task key와 instruction 없는 packet을 거부한다."""
+    malformed = cast(Mapping[str, JsonValue], {1: "bad"})
+    packet = DelegationPacket(
+        id="delegation-1",
+        parent_agent_state_id="run-parent",
+        target=AgentDelegateTarget(agent_type="ResearchAgent"),
+        task={},
+    )
+
+    with pytest.raises(AgentToolDispatchError):
+        _task_payload("inspect", malformed)
+    with pytest.raises(AgentToolDispatchError):
+        _packet_instruction(packet)
+
+
+def test_teammate_descriptor_expect_rejects_name_without_schema_token() -> None:
+    """teammate 이름이 schema token을 만들 수 없으면 definition error다."""
+    with pytest.raises(AgentDefinitionError):
+
+        @Agent(
+            spec=AgentExecutionSpec(
+                name="bad",
+                teammates=(AgentTeammate(name="!!!", pod=LocalTeammate),),
+            )
+        )
+        class BadSchemaAgent:
+            """Agent whose teammate name cannot become a schema token."""
+
+
 def test_delegation_contracts_expect_reject_blank_identity_and_invalid_budget() -> None:
     """Delegation 계약이 bootstrap 전에 불가능한 식별자와 budget을 거부한다."""
     with pytest.raises(AgentDefinitionError):
@@ -194,4 +413,36 @@ class RecordingDelegate(IAgentDelegate):
                 target=packet.target,
                 summary="done",
             ),
+        )
+
+
+class EmptyDelegate(IAgentDelegate):
+    """Delegate fixture that emits no terminal DelegationResult."""
+
+    async def delegate(
+        self,
+        packet: DelegationPacket,
+    ) -> AsyncGenerator[AgentYield[DelegationResult], None]:
+        if False:
+            yield AgentYield(
+                kind=AgentYieldKind.FINAL,
+                payload=DelegationResult(
+                    id="never",
+                    packet_id=packet.id,
+                    target=packet.target,
+                    summary="never",
+                ),
+            )
+
+
+class NonResultDelegate(IAgentDelegate):
+    """Delegate fixture that emits a non-DelegationResult payload."""
+
+    async def delegate(
+        self,
+        packet: DelegationPacket,
+    ) -> AsyncGenerator[AgentYield[DelegationResult], None]:
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=cast(DelegationResult, "not a delegation result"),
         )

--- a/core/spakky-agent/tests/unit/test_inbound.py
+++ b/core/spakky-agent/tests/unit/test_inbound.py
@@ -49,6 +49,12 @@ def test_run_agent_input_expect_rejects_blank_conversation_id() -> None:
         RunAgentInput(state_id="run-1", instruction="do it", conversation_id=" ")
 
 
+def test_run_agent_input_expect_rejects_blank_parent_run_id() -> None:
+    """공백 parent_run_id는 delegation parent linkage로 쓸 수 없어 거부된다."""
+    with pytest.raises(AgentDefinitionError):
+        RunAgentInput(state_id="run-1", instruction="do it", parent_run_id=" ")
+
+
 def test_run_agent_input_expect_defaults_message_history_empty() -> None:
     """클라이언트 주입 이력을 생략하면 빈 history로 단일턴 시드를 의미한다."""
     run_input = RunAgentInput(state_id="run-1", instruction="do it")

--- a/core/spakky-agent/tests/unit/test_runner.py
+++ b/core/spakky-agent/tests/unit/test_runner.py
@@ -1,6 +1,6 @@
 """Tests for the framework-owned AgentRunner execution loop."""
 
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass
 from typing import override
 
@@ -11,6 +11,7 @@ from spakky.agent import (
     Agent,
     AgentEvidenceKind,
     AgentExecutionSpec,
+    AgentTeammate,
     AgentRunner,
     AgentRunResult,
     AgentSignalKind,
@@ -161,6 +162,28 @@ class StatelessProbeAgent:
     def echo_read(self, value: str) -> EchoRecord:
         """Echo a value back as a structured result."""
         return EchoRecord(value=value)
+
+
+@Agent(spec=AgentExecutionSpec(name="researcher"))
+class ResearcherAgent:
+    """Local teammate fixture used by delegation tool wiring tests."""
+
+    def __init__(self, model: IAgentModel) -> None:
+        self._model = model
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="orchestrator",
+        teammates=(AgentTeammate(name="researcher", pod=ResearcherAgent),),
+    )
+)
+class OrchestratorAgent:
+    """Parent agent with a local teammate declared in its execution spec."""
+
+    def __init__(self, model: IAgentModel, researcher: ResearcherAgent) -> None:
+        self._model = model
+        self._researcher = researcher
 
 
 @Agent(spec=AgentExecutionSpec(name="toolless_probe"))
@@ -1231,6 +1254,58 @@ async def test_agent_runner_events_expect_tool_call_lifecycle_distinct_events() 
     assert {event.call_id for event in (start[0], args[0], end[0], result[0])} == {
         "read-1"
     }
+
+
+async def test_agent_runner_events_expect_local_teammate_events_join_parent_stream() -> (
+    None
+):
+    """teammate tool 호출이 child neutral events를 parent stream에 합류시킨다."""
+    child = ResearcherAgent(
+        RecordingModel(
+            (
+                ModelStreamEvent(
+                    kind=ModelStreamEventKind.MESSAGE_DELTA,
+                    message_delta="child-result",
+                ),
+                ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+            )
+        )
+    )
+    parent = OrchestratorAgent(
+        RecordingModel(
+            (
+                _tool_event(
+                    "teammate.researcher.delegate",
+                    {"instruction": "inspect the repo"},
+                    "delegate-1",
+                ),
+                ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+            )
+        ),
+        child,
+    )
+    runner = AgentRunner.for_agent_instance(parent)
+
+    events = await _collect_events(
+        runner.run_events(RunAgentInput(state_id="parent-run", instruction="delegate"))
+    )
+
+    child_messages = [
+        event
+        for event in events
+        if isinstance(event, MessageDeltaEvent)
+        and event.attribution.agent_id == "researcher"
+    ]
+    parent_results = [
+        event for event in events if isinstance(event, ToolCallResultEvent)
+    ]
+    assert child_messages[0].delta == "child-result"
+    assert child_messages[0].attribution.parent_run_id == "parent-run"
+    assert child_messages[0].attribution.conversation_id == "parent-run"
+    assert parent_results[0].tool_name == "teammate.researcher.delegate"
+    result_payload = parent_results[0].result
+    assert isinstance(result_payload, Mapping)
+    assert result_payload["summary"] == "teammate 'researcher' completed"
 
 
 async def test_agent_runner_events_expect_message_and_reasoning_distinguished() -> None:

--- a/core/spakky-agent/tests/unit/test_tooling.py
+++ b/core/spakky-agent/tests/unit/test_tooling.py
@@ -16,6 +16,7 @@ from spakky.agent import (
     AgentToolBoundInvocation,
     AgentToolDescriptor,
     AgentToolIdentity,
+    AgentToolRuntimeContext,
     AgentToolSchemaHandle,
     AgentYield,
     AgentYieldKind,
@@ -123,6 +124,30 @@ def test_agent_tool_expect_attaches_typed_descriptor_metadata_to_method() -> Non
     assert definition.metadata.approval == ToolApprovalRequirement.NOT_REQUIRED
     assert definition.metadata.risk == ToolRisk(axes=(ToolRiskAxis.READ,))
     assert definition.metadata.requires_approval_candidate is False
+
+
+def test_runtime_context_parameter_expect_hidden_from_schema_and_binding() -> None:
+    """runtime_context parameter는 model-facing schema와 payload binding에서 제외된다."""
+
+    class RuntimeContextToolOwner:
+        """Tool owner fixture with injected runtime context."""
+
+        @agent_tool(schema_name="ctx.echo")
+        def echo(
+            self,
+            runtime_context: AgentToolRuntimeContext,
+            value: str,
+        ) -> str:
+            return f"{runtime_context.state_id}:{value}"
+
+    catalog = discover_agent_tools(RuntimeContextToolOwner)
+    descriptor = catalog.by_schema_name("ctx.echo")
+    bound = bind_agent_tool_invocation(descriptor.callable, {"value": "hi"})
+    properties = descriptor.schema.input_schema["properties"]
+
+    assert isinstance(properties, Mapping)
+    assert "runtime_context" not in properties
+    assert bound.args == ("hi",)
 
 
 def test_agent_expect_discovers_decorated_methods_as_deterministic_catalog() -> None:

--- a/docs/guides/agent-a2a.md
+++ b/docs/guides/agent-a2a.md
@@ -1,6 +1,83 @@
 # A2A 어댑터
 
-> 선언형 Agent를 A2A(Agent-to-Agent) 프로토콜로 연동해, 다른 Agent와 협업하도록 노출하는 어댑터 가이드입니다.
+선언형 Agent를 A2A(Agent-to-Agent) 프로토콜로 노출하고, 다른 A2A Agent를
+teammate로 위임 호출하는 어댑터입니다. 서버와 클라이언트 모두 공식
+`a2a-sdk` 타입과 transport를 사용합니다.
 
-!!! note "작성 예정"
-    이 페이지는 정보구조(IA) 재설계에서 마련한 자리입니다. 선언형 Agent 어댑터 기능이 추가되면 후속 문서 태스크가 내용을 채웁니다. 지금은 [AI Agent 개발](agents.md)과 [AI Agent 심화](agents-advanced.md)를 참고하세요.
+## 서버 노출
+
+`spakky-a2a`는 `@Agent` 선언에서 AgentCard를 파생하고, JSON-RPC/REST/gRPC
+transport를 같은 executor와 TaskStore로 연결합니다. executor는 core runner의
+protocol-neutral `AgentEvent` stream을 A2A task/message/artifact update로
+투영합니다.
+
+```python
+from spakky.agent import Agent, AgentExecutionSpec
+from spakky.plugins.a2a import A2AAgentServer
+
+
+@A2AAgentServer(base_url="https://agents.example.com/a2a", version="1.0.0")
+@Agent(spec=AgentExecutionSpec(name="assistant"))
+class AssistantAgent:
+    ...
+```
+
+## Teammate 위임
+
+`AgentExecutionSpec.teammates`에 선언한 teammate는 runner가 자동으로
+model-callable delegation tool로 노출합니다. tool schema 이름은
+`teammate.<name>.delegate`입니다.
+
+로컬 teammate는 parent agent에 teammate pod 인스턴스를 주입하면 in-process로
+실행됩니다. child run의 neutral events는 parent stream에 합류하며
+`parent_run_id`가 parent run id로 설정됩니다.
+
+```python
+from spakky.agent import Agent, AgentExecutionSpec, AgentTeammate
+
+
+@Agent(spec=AgentExecutionSpec(name="researcher"))
+class ResearcherAgent:
+    ...
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="orchestrator",
+        teammates=(AgentTeammate(name="researcher", pod=ResearcherAgent),),
+    )
+)
+class OrchestratorAgent:
+    def __init__(self, researcher: ResearcherAgent) -> None:
+        self._researcher = researcher
+```
+
+원격 teammate는 AgentCard URL을 선언하고 `A2AAgentDelegate`를 parent agent에
+주입합니다. delegate는 AgentCard를 fetch한 뒤 SDK client로 `message/send`를
+수행하고, remote task/message/artifact stream을 neutral child events로
+되돌려 parent stream에 합류시킵니다.
+
+```python
+from spakky.agent import Agent, AgentExecutionSpec, AgentTeammate
+from spakky.plugins.a2a import A2AAgentDelegate
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="orchestrator",
+        teammates=(
+            AgentTeammate(
+                name="researcher",
+                card_url="https://agents.example.com/.well-known/agent-card.json",
+            ),
+        ),
+    )
+)
+class OrchestratorAgent:
+    def __init__(self, delegate: A2AAgentDelegate) -> None:
+        self._delegate = delegate
+```
+
+`auth-required` 같은 remote human-input pause의 first-class 처리는 별도
+흐름에서 다룹니다. 현재 delegate는 정상 완료/실패 task 추적과 stream 병합을
+제공합니다.

--- a/plugins/spakky-a2a/README.md
+++ b/plugins/spakky-a2a/README.md
@@ -2,6 +2,39 @@
 
 A2A (Agent2Agent) protocol server plugin for the Spakky framework.
 
+## Remote teammate delegation
+
+`A2AAgentDelegate` implements the core `IAgentDelegate` port for teammates whose
+`AgentExecutionSpec.teammates` entry points at a remote AgentCard URL. The core
+agent runner exposes each teammate as a model-callable delegation tool named
+`teammate.<name>.delegate`; local teammate pods run in-process, while remote
+teammates use the official `a2a-sdk` client.
+
+```python
+from spakky.agent import Agent, AgentExecutionSpec, AgentTeammate
+from spakky.plugins.a2a import A2AAgentDelegate
+
+
+@Agent(
+    spec=AgentExecutionSpec(
+        name="orchestrator",
+        teammates=(
+            AgentTeammate(
+                name="researcher",
+                card_url="https://agents.example.com/.well-known/agent-card.json",
+            ),
+        ),
+    )
+)
+class Orchestrator:
+    def __init__(self, delegate: A2AAgentDelegate) -> None:
+        self._delegate = delegate
+```
+
+Remote delegation sends `message/send` through the SDK client, tracks the remote
+task stream, and maps child task/message/artifact updates back into Spakky's
+protocol-neutral event stream with the parent run id preserved.
+
 ## REST HTTP+JSON transport
 
 `build_a2a_rest_app()` builds a mountable Starlette app for the official A2A

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/__init__.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/__init__.py
@@ -12,6 +12,8 @@ from spakky.plugins.a2a.config import (
     SPAKKY_A2A_CONFIG_ENV_PREFIX,
     A2AConfig,
 )
+from spakky.plugins.a2a.client import A2ARemoteAgentClient, RemoteA2AMessage
+from spakky.plugins.a2a.delegation import A2AAgentDelegate, A2AStreamEventMapper
 from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
 
 PLUGIN_NAME = Plugin(name="spakky-a2a")
@@ -21,5 +23,9 @@ __all__ = [
     "PLUGIN_NAME",
     "SPAKKY_A2A_CONFIG_ENV_PREFIX",
     "A2AConfig",
+    "A2AAgentDelegate",
+    "A2ARemoteAgentClient",
+    "A2AStreamEventMapper",
     "A2AAgentServer",
+    "RemoteA2AMessage",
 ]

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/card/derivation.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/card/derivation.py
@@ -59,6 +59,7 @@ class AgentCardFactory:
         tool_skills = [
             self._tool_skill(descriptor)
             for descriptor in agent.tool_catalog.descriptors
+            if not self._is_teammate_delegation_tool(descriptor)
         ]
         teammate_skills = [
             self._teammate_skill(teammate) for teammate in spec.teammates
@@ -103,6 +104,13 @@ class AgentCardFactory:
             description="Delegated teammate",
             tags=[TEAMMATE_DELEGATION_TAG],
         )
+
+    @staticmethod
+    def _is_teammate_delegation_tool(descriptor: AgentToolDescriptor) -> bool:
+        """Return whether a tool descriptor is the runner's synthetic teammate tool."""
+        return descriptor.schema.name.startswith(
+            "teammate."
+        ) and descriptor.schema.name.endswith(".delegate")
 
     @staticmethod
     def _skill_tags(metadata: AgentToolMetadata) -> list[str]:

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/client.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/client.py
@@ -1,0 +1,127 @@
+"""Official a2a-sdk client wrapper for remote teammate calls."""
+
+from collections.abc import AsyncGenerator
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass, field
+from uuid import uuid4
+from urllib.parse import urlsplit
+
+import httpx
+from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
+from a2a.types import (
+    AgentCard,
+    GetTaskRequest,
+    Message,
+    Part,
+    Role,
+    SendMessageConfiguration,
+    SendMessageRequest,
+    StreamResponse,
+    Task,
+)
+
+DEFAULT_AGENT_CARD_PATH = "/.well-known/agent-card.json"
+"""Default A2A well-known AgentCard route."""
+
+
+@dataclass(frozen=True, slots=True)
+class RemoteA2AMessage:
+    """Message envelope sent to a remote A2A teammate."""
+
+    text: str
+    task_id: str | None = None
+    context_id: str | None = None
+    message_id: str = field(default_factory=lambda: f"message-{uuid4()}")
+
+
+class A2ARemoteAgentClient:
+    """Small wrapper around the official a2a-sdk client and types."""
+
+    _httpx_client: httpx.AsyncClient | None
+    _config: ClientConfig
+    _factory: ClientFactory
+
+    def __init__(
+        self,
+        *,
+        httpx_client: httpx.AsyncClient | None = None,
+        config: ClientConfig | None = None,
+    ) -> None:
+        self._httpx_client = httpx_client
+        self._config = config or ClientConfig(httpx_client=httpx_client)
+        self._factory = ClientFactory(self._config)
+
+    async def resolve_card(self, card_url: str) -> AgentCard:
+        """Fetch a remote AgentCard with the SDK resolver."""
+        parts = urlsplit(card_url)
+        base_url = f"{parts.scheme}://{parts.netloc}"
+        path = parts.path or DEFAULT_AGENT_CARD_PATH
+        async with self._http_client() as client:
+            resolver = A2ACardResolver(client, base_url=base_url)
+            return await resolver.get_agent_card(path)
+
+    async def send_message(
+        self,
+        card_url: str,
+        message: RemoteA2AMessage,
+    ) -> tuple[StreamResponse, ...]:
+        """Send a message and collect the SDK response stream."""
+        return tuple([event async for event in self.stream_message(card_url, message)])
+
+    async def stream_message(
+        self,
+        card_url: str,
+        message: RemoteA2AMessage,
+    ) -> AsyncGenerator[StreamResponse, None]:
+        """Send a message and yield remote task/message updates as they arrive."""
+        card = await self.resolve_card(card_url)
+        client = self._factory.create(card)
+        request = SendMessageRequest(
+            message=Message(
+                role=Role.ROLE_USER,
+                message_id=message.message_id,
+                task_id=message.task_id or "",
+                context_id=message.context_id or "",
+                parts=[Part(text=message.text)],
+            ),
+            configuration=SendMessageConfiguration(return_immediately=False),
+        )
+        try:
+            async for event in client.send_message(request):
+                yield event
+        finally:
+            await client.close()
+
+    async def get_task(self, card_url: str, task_id: str) -> Task:
+        """Fetch a remote A2A task by id using the SDK client."""
+        card = await self.resolve_card(card_url)
+        client = self._factory.create(card)
+        try:
+            return await client.get_task(GetTaskRequest(id=task_id))
+        finally:
+            await client.close()
+
+    def _http_client(self) -> AbstractAsyncContextManager[httpx.AsyncClient]:
+        if self._httpx_client is not None:
+            return _BorrowedAsyncClient(self._httpx_client)
+        return httpx.AsyncClient()
+
+
+class _BorrowedAsyncClient:
+    """Async context manager that leaves caller-owned httpx clients open."""
+
+    _client: httpx.AsyncClient
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._client = client
+
+    async def __aenter__(self) -> httpx.AsyncClient:
+        return self._client
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc: object,
+        traceback: object,
+    ) -> None:
+        return None

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/delegation.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/delegation.py
@@ -1,0 +1,271 @@
+"""A2A-backed teammate delegation for ``@Agent`` teammate specs."""
+
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass, field
+
+from a2a.types import (
+    Message,
+    Part,
+    StreamResponse,
+    Task,
+    TaskArtifactUpdateEvent,
+    TaskState,
+    TaskStatusUpdateEvent,
+)
+from google.protobuf.json_format import MessageToDict
+from spakky.agent import (
+    AgentDelegateTarget,
+    AgentEvent,
+    AgentEventAttribution,
+    AgentYield,
+    AgentYieldKind,
+    ArtifactEvent,
+    DelegationResult,
+    DelegationToolResult,
+    IAgentDelegate,
+    MessageDeltaEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    StepFinishedEvent,
+    StepStartedEvent,
+)
+from spakky.agent.delegation import DelegationPacket
+from spakky.agent.error import AgentToolDispatchError
+from spakky.agent.types import JsonObject, JsonValue
+
+from spakky.plugins.a2a.client import A2ARemoteAgentClient, RemoteA2AMessage
+
+
+class A2AStreamEventMapper:
+    """Map remote A2A SDK stream responses into neutral child events."""
+
+    def map(
+        self,
+        response: StreamResponse,
+        packet: DelegationPacket,
+    ) -> tuple[AgentEvent, ...]:
+        """Project one SDK stream response onto neutral delegated events."""
+        payload = response.WhichOneof("payload")
+        if payload == "task":
+            return self._task_events(response.task, packet)
+        if payload == "message":
+            return self._message_events(response.message, packet)
+        if payload == "status_update":
+            return self._status_events(response.status_update, packet)
+        if payload == "artifact_update":
+            return self._artifact_events(response.artifact_update, packet)
+        return ()
+
+    def _task_events(
+        self,
+        task: Task,
+        packet: DelegationPacket,
+    ) -> tuple[AgentEvent, ...]:
+        attribution = _attribution(packet, task.id, task.context_id)
+        events: list[AgentEvent] = [RunStartedEvent(attribution)]
+        if task.status.state == TaskState.TASK_STATE_COMPLETED:
+            events.append(RunFinishedEvent(attribution))
+        if task.status.state == TaskState.TASK_STATE_FAILED:
+            events.append(
+                RunFinishedEvent(attribution, error=_state_error(task.status.state))
+            )
+        return tuple(events)
+
+    def _message_events(
+        self,
+        message: Message,
+        packet: DelegationPacket,
+    ) -> tuple[AgentEvent, ...]:
+        attribution = _attribution(
+            packet, _run_id(packet, message.task_id), message.context_id
+        )
+        text = _message_text(message)
+        if not text:
+            return ()
+        return (
+            MessageDeltaEvent(
+                attribution,
+                message_id=message.message_id or f"{attribution.run_id}:message",
+                delta=text,
+            ),
+        )
+
+    def _status_events(
+        self,
+        update: TaskStatusUpdateEvent,
+        packet: DelegationPacket,
+    ) -> tuple[AgentEvent, ...]:
+        attribution = _attribution(packet, update.task_id, update.context_id)
+        events: list[AgentEvent] = []
+        if update.status.state == TaskState.TASK_STATE_WORKING:
+            events.append(StepStartedEvent(attribution, step_name="remote-a2a"))
+            text = _message_text(update.status.message)
+            if text:
+                events.append(
+                    MessageDeltaEvent(
+                        attribution,
+                        message_id=f"{update.task_id}:status",
+                        delta=text,
+                    )
+                )
+        if update.status.state == TaskState.TASK_STATE_COMPLETED:
+            events.append(StepFinishedEvent(attribution, step_name="remote-a2a"))
+            events.append(RunFinishedEvent(attribution))
+        if update.status.state == TaskState.TASK_STATE_FAILED:
+            events.append(
+                RunFinishedEvent(attribution, error=_state_error(update.status.state))
+            )
+        return tuple(events)
+
+    def _artifact_events(
+        self,
+        update: TaskArtifactUpdateEvent,
+        packet: DelegationPacket,
+    ) -> tuple[AgentEvent, ...]:
+        attribution = _attribution(packet, update.task_id, update.context_id)
+        artifact = update.artifact
+        return (
+            ArtifactEvent(
+                attribution,
+                artifact_id=artifact.artifact_id or f"{update.task_id}:artifact",
+                name=artifact.name or None,
+                content=[_part_value(part) for part in artifact.parts],
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class A2AAgentDelegate(IAgentDelegate):
+    """Delegate remote teammate calls through the official A2A client."""
+
+    client: A2ARemoteAgentClient = field(default_factory=A2ARemoteAgentClient)
+    mapper: A2AStreamEventMapper = field(default_factory=A2AStreamEventMapper)
+
+    async def delegate(
+        self,
+        packet: DelegationPacket,
+    ) -> AsyncGenerator[AgentYield[DelegationResult], None]:
+        """Execute a remote delegation packet and yield its terminal result."""
+        tool_result = await self.delegate_tool_result(packet)
+        yield AgentYield(
+            kind=AgentYieldKind.FINAL,
+            payload=DelegationResult(
+                id=f"{packet.id}:result",
+                packet_id=packet.id,
+                target=packet.target,
+                summary=tool_result.summary,
+                output=tool_result.output,
+                metadata=tool_result.metadata,
+            ),
+        )
+
+    async def delegate_tool_result(
+        self,
+        packet: DelegationPacket,
+    ) -> DelegationToolResult:
+        """Call a remote A2A teammate and return model result plus child events."""
+        card_url = _card_url(packet.target)
+        events: list[AgentEvent] = []
+        final_task: Task | None = None
+        final_status: TaskStatusUpdateEvent | None = None
+        async for response in self.client.stream_message(
+            card_url,
+            RemoteA2AMessage(
+                text=_instruction(packet),
+                context_id=_conversation_id(packet),
+            ),
+        ):
+            events.extend(self.mapper.map(response, packet))
+            if response.WhichOneof("payload") == "task":
+                final_task = response.task
+            if response.WhichOneof("payload") == "status_update":
+                final_status = response.status_update
+        output = _task_output(final_task, final_status)
+        return DelegationToolResult(
+            summary=_summary(packet, output),
+            output=output,
+            events=tuple(events),
+            metadata={"packet_id": packet.id, "card_url": card_url},
+        )
+
+
+def _card_url(target: AgentDelegateTarget) -> str:
+    value = target.metadata.get("card_url")
+    if not isinstance(value, str) or not value.strip():
+        raise AgentToolDispatchError("Remote A2A delegation requires target card_url")
+    return value
+
+
+def _instruction(packet: DelegationPacket) -> str:
+    value = packet.task.get("instruction")
+    if not isinstance(value, str) or not value.strip():
+        raise AgentToolDispatchError("Remote A2A delegation requires instruction")
+    return value
+
+
+def _conversation_id(packet: DelegationPacket) -> str | None:
+    value = packet.metadata.get("conversation_id")
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _run_id(packet: DelegationPacket, candidate: str) -> str:
+    return candidate if candidate.strip() else packet.id
+
+
+def _attribution(
+    packet: DelegationPacket,
+    run_id: str,
+    conversation_id: str,
+) -> AgentEventAttribution:
+    return AgentEventAttribution(
+        agent_id=packet.target.agent_name or packet.target.agent_type,
+        run_id=_run_id(packet, run_id),
+        conversation_id=conversation_id if conversation_id.strip() else packet.id,
+        parent_run_id=packet.parent_agent_state_id,
+    )
+
+
+def _message_text(message: Message) -> str:
+    return "".join(
+        part.text for part in message.parts if part.HasField("text") and part.text
+    )
+
+
+def _part_value(part: Part) -> JsonValue:
+    if part.HasField("text"):
+        return part.text
+    if part.HasField("data"):
+        return MessageToDict(part.data)
+    if part.HasField("url"):
+        return {"url": part.url}
+    if part.HasField("raw"):
+        return {"raw": part.raw.hex()}
+    return {}
+
+
+def _state_error(state: TaskState) -> JsonObject:
+    return {"code": "remote_a2a_failed", "message": TaskState.Name(state)}
+
+
+def _task_output(
+    task: Task | None,
+    status_update: TaskStatusUpdateEvent | None = None,
+) -> JsonObject:
+    if status_update is not None:
+        return {
+            "task_id": status_update.task_id,
+            "context_id": status_update.context_id,
+            "state": TaskState.Name(status_update.status.state),
+        }
+    if task is None:
+        return {"task_id": None, "state": "unknown"}
+    return {
+        "task_id": task.id,
+        "context_id": task.context_id,
+        "state": TaskState.Name(task.status.state),
+    }
+
+
+def _summary(packet: DelegationPacket, output: JsonObject) -> str:
+    state = output.get("state")
+    return f"remote teammate '{packet.target.agent_name or packet.target.agent_type}' finished with {state}"

--- a/plugins/spakky-a2a/tests/integration/test_a2a_server.py
+++ b/plugins/spakky-a2a/tests/integration/test_a2a_server.py
@@ -1,12 +1,16 @@
 """End-to-end A2A transport tests over the assembled ASGI app."""
 
 import json
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 import pytest
 from spakky.agent.execution import Agent, AgentSignalKind
 from spakky.agent.interfaces.model import ModelStreamEvent
+from spakky.agent.delegation import AgentDelegateTarget, DelegationPacket
+from spakky.agent.event import MessageDeltaEvent, RunFinishedEvent
 
+from spakky.plugins.a2a.client import A2ARemoteAgentClient
+from spakky.plugins.a2a.delegation import A2AAgentDelegate
 from tests.integration.conftest import (
     AssistantAgent,
     build_app,
@@ -124,6 +128,43 @@ async def test_tasks_get_returns_persisted_task(
         fetched = await client.post(rpc_url, json=_send("tasks/get", {"id": task_id}))
 
     assert fetched.json()["result"]["id"] == task_id
+
+
+@pytest.mark.integration
+async def test_remote_delegate_calls_a2a_server_and_merges_child_events(
+    token_events: Sequence[ModelStreamEvent],
+) -> None:
+    """Remote teammate delegation calls A2A and returns attributed child events."""
+    async with make_client(build_app(token_events)) as client:
+        delegate = A2AAgentDelegate(
+            client=A2ARemoteAgentClient(httpx_client=client),
+        )
+        result = await delegate.delegate_tool_result(
+            DelegationPacket(
+                id="parent-run:delegate-1",
+                parent_agent_state_id="parent-run",
+                target=AgentDelegateTarget(
+                    agent_type="remote:assistant",
+                    agent_name="assistant",
+                    metadata={
+                        "card_url": "http://testserver/.well-known/agent-card.json"
+                    },
+                ),
+                task={"instruction": "hi"},
+                metadata={"conversation_id": "thread-1"},
+            )
+        )
+
+    assert isinstance(result.output, Mapping)
+    assert result.output["state"] == "TASK_STATE_COMPLETED"
+    messages = [
+        event for event in result.events if isinstance(event, MessageDeltaEvent)
+    ]
+    finishes = [event for event in result.events if isinstance(event, RunFinishedEvent)]
+    assert "hello " in "".join(event.delta for event in messages)
+    assert messages[0].attribution.parent_run_id == "parent-run"
+    assert messages[0].attribution.agent_id == "assistant"
+    assert finishes
 
 
 @pytest.mark.integration

--- a/plugins/spakky-a2a/tests/unit/test_delegation.py
+++ b/plugins/spakky-a2a/tests/unit/test_delegation.py
@@ -1,0 +1,366 @@
+"""Tests for A2A teammate delegation client event mapping."""
+
+from collections.abc import AsyncGenerator, Mapping
+from typing import cast
+
+import httpx
+import pytest
+from a2a.client import ClientFactory
+from a2a.types import (
+    AgentCard,
+    Artifact,
+    Message,
+    Part,
+    Role,
+    StreamResponse,
+    Task,
+    TaskArtifactUpdateEvent,
+    TaskState,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+)
+from google.protobuf.json_format import ParseDict
+from google.protobuf.struct_pb2 import Value
+from spakky.agent import (
+    AgentDelegateTarget,
+    ArtifactEvent,
+    AgentYieldKind,
+    MessageDeltaEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    StepStartedEvent,
+)
+from spakky.agent.delegation import DelegationPacket
+from spakky.agent.error import AgentToolDispatchError
+
+from spakky.plugins.a2a.client import A2ARemoteAgentClient, RemoteA2AMessage
+from spakky.plugins.a2a.delegation import A2AAgentDelegate, A2AStreamEventMapper
+
+
+def _packet() -> DelegationPacket:
+    return DelegationPacket(
+        id="parent-run:delegate-1",
+        parent_agent_state_id="parent-run",
+        target=AgentDelegateTarget(
+            agent_type="remote:researcher",
+            agent_name="researcher",
+            metadata={"card_url": "https://agents.example.com/card.json"},
+        ),
+        task={"instruction": "inspect"},
+        metadata={"conversation_id": "thread-1"},
+    )
+
+
+def test_stream_mapper_expect_status_updates_keep_parent_attribution() -> None:
+    """A2A status update가 parent linkage를 가진 neutral event로 매핑된다."""
+    response = StreamResponse(
+        status_update=TaskStatusUpdateEvent(
+            task_id="child-task",
+            context_id="thread-1",
+            status=TaskStatus(
+                state=TaskState.TASK_STATE_WORKING,
+                message=Message(
+                    role=Role.ROLE_AGENT,
+                    message_id="m1",
+                    parts=[Part(text="working")],
+                ),
+            ),
+        )
+    )
+
+    events = A2AStreamEventMapper().map(response, _packet())
+
+    assert isinstance(events[0], StepStartedEvent)
+    assert isinstance(events[1], MessageDeltaEvent)
+    assert events[1].delta == "working"
+    assert events[1].attribution.agent_id == "researcher"
+    assert events[1].attribution.run_id == "child-task"
+    assert events[1].attribution.parent_run_id == "parent-run"
+    assert events[1].attribution.conversation_id == "thread-1"
+
+
+def test_stream_mapper_expect_maps_terminal_and_artifact_events() -> None:
+    """A2A task/artifact update가 neutral terminal/artifact event로 매핑된다."""
+    value = Value()
+    ParseDict({"answer": 42}, value)
+    mapper = A2AStreamEventMapper()
+    packet = _packet()
+
+    completed = mapper.map(
+        StreamResponse(
+            task=Task(
+                id="child-task",
+                context_id="thread-1",
+                status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+            )
+        ),
+        packet,
+    )
+    failed = mapper.map(
+        StreamResponse(
+            status_update=TaskStatusUpdateEvent(
+                task_id="child-task",
+                context_id="thread-1",
+                status=TaskStatus(state=TaskState.TASK_STATE_FAILED),
+            )
+        ),
+        packet,
+    )
+    artifact = mapper.map(
+        StreamResponse(
+            artifact_update=TaskArtifactUpdateEvent(
+                task_id="child-task",
+                context_id="thread-1",
+                artifact=Artifact(
+                    artifact_id="artifact-1",
+                    name="report",
+                    parts=[
+                        Part(text="text"),
+                        Part(data=value),
+                        Part(url="https://example.com/report"),
+                        Part(raw=b"raw"),
+                        Part(),
+                    ],
+                ),
+            )
+        ),
+        packet,
+    )
+
+    assert isinstance(completed[0], RunStartedEvent)
+    assert isinstance(completed[1], RunFinishedEvent)
+    assert isinstance(failed[0], RunFinishedEvent)
+    assert failed[0].error == {
+        "code": "remote_a2a_failed",
+        "message": "TASK_STATE_FAILED",
+    }
+    assert isinstance(artifact[0], ArtifactEvent)
+    assert artifact[0].content == [
+        "text",
+        {"answer": 42.0},
+        {"url": "https://example.com/report"},
+        {"raw": "726177"},
+        {},
+    ]
+
+
+def test_stream_mapper_expect_ignores_empty_message_and_unknown_response() -> None:
+    """본문 없는 message와 payload 없는 response는 이벤트를 만들지 않는다."""
+    mapper = A2AStreamEventMapper()
+
+    empty_message = mapper.map(
+        StreamResponse(
+            message=Message(
+                role=Role.ROLE_AGENT,
+                message_id="m1",
+                task_id="child-task",
+                context_id="thread-1",
+            )
+        ),
+        _packet(),
+    )
+
+    assert empty_message == ()
+    assert mapper.map(StreamResponse(), _packet()) == ()
+
+
+async def test_a2a_delegate_expect_streams_remote_message_and_final_task() -> None:
+    """A2A delegate가 remote stream을 DelegationToolResult로 수집한다."""
+    fake_client = _FakeRemoteClient(
+        (
+            StreamResponse(
+                message=Message(
+                    role=Role.ROLE_AGENT,
+                    message_id="m1",
+                    task_id="child-task",
+                    context_id="thread-1",
+                    parts=[Part(text="done")],
+                )
+            ),
+            StreamResponse(
+                task=Task(
+                    id="child-task",
+                    context_id="thread-1",
+                    status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+                )
+            ),
+        )
+    )
+
+    result = await A2AAgentDelegate(
+        client=cast(A2ARemoteAgentClient, fake_client)
+    ).delegate_tool_result(_packet())
+
+    assert (
+        result.summary
+        == "remote teammate 'researcher' finished with TASK_STATE_COMPLETED"
+    )
+    assert isinstance(result.output, Mapping)
+    assert result.output["task_id"] == "child-task"
+    assert any(isinstance(event, MessageDeltaEvent) for event in result.events)
+    assert any(isinstance(event, RunFinishedEvent) for event in result.events)
+    assert fake_client.last_message is not None
+    assert fake_client.last_message.text == "inspect"
+
+
+async def test_a2a_delegate_expect_delegate_yields_terminal_result() -> None:
+    """delegate() 호환 경로가 AgentYield terminal result를 방출한다."""
+    fake_client = _FakeRemoteClient(
+        (
+            StreamResponse(
+                task=Task(
+                    id="child-task",
+                    context_id="thread-1",
+                    status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+                )
+            ),
+        )
+    )
+
+    items = [
+        item
+        async for item in A2AAgentDelegate(
+            client=cast(A2ARemoteAgentClient, fake_client)
+        ).delegate(_packet())
+    ]
+
+    assert len(items) == 1
+    assert items[0].kind == AgentYieldKind.FINAL
+    assert items[0].payload.packet_id == "parent-run:delegate-1"
+
+
+async def test_a2a_delegate_expect_unknown_output_when_remote_returns_no_task() -> None:
+    """remote stream에 task/status가 없으면 unknown output으로 수렴한다."""
+    result = await A2AAgentDelegate(
+        client=cast(A2ARemoteAgentClient, _FakeRemoteClient((StreamResponse(),)))
+    ).delegate_tool_result(_packet())
+
+    assert result.output == {"task_id": None, "state": "unknown"}
+
+
+async def test_a2a_delegate_expect_rejects_missing_card_url_and_instruction() -> None:
+    """remote delegate 입력에 card_url과 instruction이 없으면 custom error다."""
+    delegate = A2AAgentDelegate(
+        client=cast(A2ARemoteAgentClient, _FakeRemoteClient(()))
+    )
+
+    bad_target = DelegationPacket(
+        id="parent-run:delegate-1",
+        parent_agent_state_id="parent-run",
+        target=AgentDelegateTarget(agent_type="remote:researcher"),
+        task={"instruction": "inspect"},
+    )
+    bad_instruction = DelegationPacket(
+        id="parent-run:delegate-1",
+        parent_agent_state_id="parent-run",
+        target=_packet().target,
+        task={},
+    )
+
+    with pytest.raises(AgentToolDispatchError):
+        await delegate.delegate_tool_result(bad_target)
+    with pytest.raises(AgentToolDispatchError):
+        await delegate.delegate_tool_result(bad_instruction)
+
+
+async def test_remote_client_collects_stream_and_fetches_task() -> None:
+    """A2A client wrapper가 stream 수집과 task fetch에 SDK client를 사용한다."""
+    sdk_client = _FakeSdkClient()
+    client = _FakeFactoryClient(sdk_client)
+
+    sent = await client.send_message(
+        "https://agents.example.com/card.json",
+        RemoteA2AMessage(text="hi"),
+    )
+    task = await client.get_task("https://agents.example.com/card.json", "task-1")
+
+    assert len(sent) == 1
+    assert task.id == "task-1"
+    assert sdk_client.closed_count == 2
+
+
+async def test_remote_client_http_client_expect_supports_owned_and_borrowed() -> None:
+    """httpx client context manager가 borrowed와 owned 모드를 모두 지원한다."""
+    borrowed = httpx.AsyncClient()
+    try:
+        async with A2ARemoteAgentClient(httpx_client=borrowed)._http_client() as client:
+            assert client is borrowed
+    finally:
+        await borrowed.aclose()
+
+    async with A2ARemoteAgentClient()._http_client() as owned:
+        assert isinstance(owned, httpx.AsyncClient)
+
+
+class _FakeRemoteClient:
+    """Network-free A2A client test double."""
+
+    _events: tuple[StreamResponse, ...]
+    last_message: RemoteA2AMessage | None
+
+    def __init__(self, events: tuple[StreamResponse, ...]) -> None:
+        self._events = events
+        self.last_message = None
+
+    async def stream_message(
+        self,
+        card_url: str,
+        message: RemoteA2AMessage,
+    ) -> AsyncGenerator[StreamResponse, None]:
+        self.last_message = message
+        for event in self._events:
+            yield event
+
+
+class _FakeSdkClient:
+    """SDK client fake returned by the ClientFactory test double."""
+
+    closed_count: int
+
+    def __init__(self) -> None:
+        self.closed_count = 0
+
+    async def send_message(
+        self,
+        request: object,
+    ) -> AsyncGenerator[StreamResponse, None]:
+        yield StreamResponse(
+            task=Task(
+                id="task-1",
+                context_id="thread-1",
+                status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+            )
+        )
+
+    async def get_task(self, request: object) -> Task:
+        return Task(
+            id="task-1",
+            context_id="thread-1",
+            status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+        )
+
+    async def close(self) -> None:
+        self.closed_count += 1
+
+
+class _FakeFactory:
+    """ClientFactory fake that returns a prebuilt SDK client."""
+
+    _client: _FakeSdkClient
+
+    def __init__(self, client: _FakeSdkClient) -> None:
+        self._client = client
+
+    def create(self, card: AgentCard) -> _FakeSdkClient:
+        return self._client
+
+
+class _FakeFactoryClient(A2ARemoteAgentClient):
+    """A2A client wrapper test double avoiding network AgentCard resolution."""
+
+    def __init__(self, sdk_client: _FakeSdkClient) -> None:
+        super().__init__()
+        self._factory = cast(ClientFactory, _FakeFactory(sdk_client))
+
+    async def resolve_card(self, card_url: str) -> AgentCard:
+        return AgentCard(name="remote", description="remote", version="1.0.0")


### PR DESCRIPTION
## Summary
- add an official a2a-python-backed remote client for message streaming, send collection, and task tracking
- synthesize teammate delegation tools from @Agent spec teammates for local in-process pods and remote AgentCard URLs
- merge delegated child neutral events into parent runner streams with attribution and parent linkage
- document remote teammate delegation and keep AgentCard tool projection de-duplicated

## Acceptance Criteria (자가 grep)
acceptance_check: missing
reason: Issue #423 defines SC-1 in prose but provides no executable grep lines.

## Verification
- core/spakky-agent: `uv run --project ../.. ruff format .`
- core/spakky-agent: `uv run --project ../.. ruff check .`
- core/spakky-agent: `uv run --project ../.. pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text`
- core/spakky-agent: `uv run pytest` (344 passed, 100% coverage)
- core/spakky-agent: `uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- plugins/spakky-a2a: `uv run --project ../.. ruff format .`
- plugins/spakky-a2a: `uv run --project ../.. ruff check .`
- plugins/spakky-a2a: `uv run --project ../.. pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text`
- plugins/spakky-a2a: `uv run pytest` (117 passed, 100% coverage)
- plugins/spakky-a2a: `uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- repo docs: `uv run --project . mkdocs build --strict`

Closes #423