### PR TITLE
feat: add ai-review auto approve workflow (#449)

### DIFF
--- a/.github/scripts/ai_review_auto_approve.sh
+++ b/.github/scripts/ai_review_auto_approve.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+set_output() {
+  local name="$1"
+  local value="$2"
+
+  if [ -n "${GITHUB_STEP_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$name" "$value" >> "$GITHUB_STEP_OUTPUT"
+  fi
+}
+
+no_approve() {
+  local reason="$1"
+
+  log "ai-review auto-approve: no-op reason=$reason"
+  set_output "approved" "false"
+  set_output "reason" "$reason"
+  exit 0
+}
+
+require_env() {
+  local name="$1"
+
+  if [ -z "${!name:-}" ]; then
+    log "ai-review auto-approve: missing required env $name"
+    exit 2
+  fi
+}
+
+require_env "REPO"
+require_env "STATUS_SHA"
+require_env "STATUS_CONTEXT"
+require_env "STATUS_STATE"
+
+if [ "$STATUS_CONTEXT" != "ai-review" ]; then
+  no_approve "context-not-ai-review"
+fi
+
+if [ "$STATUS_STATE" != "success" ]; then
+  no_approve "state-not-success"
+fi
+
+pulls_json=$(gh api \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$REPO/commits/$STATUS_SHA/pulls")
+
+matching_pr_count=$(jq --arg sha "$STATUS_SHA" '
+  [.[] | select(.state == "open" and .head.sha == $sha)] | length
+' <<<"$pulls_json")
+
+if [ "$matching_pr_count" -eq 0 ]; then
+  no_approve "no-open-pr-for-status-sha"
+fi
+
+if [ "$matching_pr_count" -gt 1 ]; then
+  no_approve "ambiguous-open-prs-for-status-sha"
+fi
+
+pr_number=$(jq -r --arg sha "$STATUS_SHA" '
+  [.[] | select(.state == "open" and .head.sha == $sha)] | first | .number
+' <<<"$pulls_json")
+
+pull_json=$(gh api "repos/$REPO/pulls/$pr_number")
+head_sha=$(jq -r '.head.sha // ""' <<<"$pull_json")
+head_repo=$(jq -r '.head.repo.full_name // ""' <<<"$pull_json")
+base_repo=$(jq -r '.base.repo.full_name // ""' <<<"$pull_json")
+
+if [ "$head_sha" != "$STATUS_SHA" ]; then
+  no_approve "stale-status"
+fi
+
+if [ "$head_repo" != "$base_repo" ]; then
+  no_approve "fork-pr"
+fi
+
+statuses_json=$(gh api "repos/$REPO/commits/$STATUS_SHA/statuses")
+latest_status=$(jq -c --arg context "$STATUS_CONTEXT" '
+  [.[] | select(.context == $context)] | sort_by(.created_at) | last // empty
+' <<<"$statuses_json")
+
+if [ -z "$latest_status" ]; then
+  no_approve "ai-review-status-not-found"
+fi
+
+latest_state=$(jq -r '.state // ""' <<<"$latest_status")
+creator_login=$(jq -r '.creator.login // ""' <<<"$latest_status")
+
+if [ "$latest_state" != "success" ]; then
+  no_approve "latest-ai-review-status-not-success"
+fi
+
+if [ -z "$creator_login" ]; then
+  no_approve "ai-review-status-creator-missing"
+fi
+
+if ! permission_json=$(gh api "repos/$REPO/collaborators/$creator_login/permission"); then
+  no_approve "creator-permission-unavailable"
+fi
+
+creator_role=$(jq -r '.role_name // ""' <<<"$permission_json")
+
+case "$creator_role" in
+  admin | maintain) ;;
+  *) no_approve "creator-role-not-admin-or-maintain" ;;
+esac
+
+reviews_json=$(gh api "repos/$REPO/pulls/$pr_number/reviews")
+already_approved_count=$(jq --arg sha "$STATUS_SHA" '
+  [
+    .[]
+    | select(.user.login == "github-actions[bot]")
+    | select(.state == "APPROVED")
+    | select((.commit_id // "") == $sha)
+  ]
+  | length
+' <<<"$reviews_json")
+
+if [ "$already_approved_count" -gt 0 ]; then
+  no_approve "already-approved-by-bot"
+fi
+
+review_body=$(cat <<EOF_REVIEW_BODY
+ai-review status success verified for ${STATUS_SHA}.
+
+- status creator: @${creator_login}
+- creator role: ${creator_role}
+- provenance: same repository
+- staleness: PR head SHA matches status SHA
+EOF_REVIEW_BODY
+)
+
+if [ "${AI_REVIEW_DRY_RUN:-false}" = "true" ]; then
+  log "ai-review auto-approve: dry-run pr=$pr_number sha=$STATUS_SHA creator=$creator_login role=$creator_role"
+  set_output "dry_run" "true"
+else
+  gh pr review "$pr_number" \
+    --repo "$REPO" \
+    --approve \
+    --body "$review_body"
+fi
+
+log "ai-review auto-approve: approved pr=$pr_number sha=$STATUS_SHA creator=$creator_login role=$creator_role"
+set_output "approved" "true"
+set_output "reason" "approved"
+set_output "pr_number" "$pr_number"
+set_output "creator" "$creator_login"
+set_output "creator_role" "$creator_role"

--- a/.github/scripts/test_ai_review_auto_approve.sh
+++ b/.github/scripts/test_ai_review_auto_approve.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/ai_review_auto_approve.sh"
+
+if [ ! -f "$SCRIPT_UNDER_TEST" ]; then
+  echo "FATAL: script not found at $SCRIPT_UNDER_TEST" >&2
+  exit 1
+fi
+
+make_gh_mock() {
+  local bin_dir="$1"
+  local fixture_dir="$2"
+
+  cat > "$bin_dir/gh" <<'EOF_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case_name="${AI_REVIEW_TEST_CASE:?AI_REVIEW_TEST_CASE is required}"
+case_dir="${AI_REVIEW_FIXTURE_DIR:?AI_REVIEW_FIXTURE_DIR is required}/$case_name"
+
+if [ "${1:-}" = "api" ]; then
+  shift
+  while [ "${1:-}" = "-H" ]; do
+    shift 2
+  done
+  endpoint="${1:-}"
+
+  case "$endpoint" in
+    repos/*/commits/*/pulls)
+      cat "$case_dir/pulls.json"
+      ;;
+    repos/*/pulls/*/reviews)
+      cat "$case_dir/reviews.json"
+      ;;
+    repos/*/pulls/*)
+      cat "$case_dir/pull.json"
+      ;;
+    repos/*/commits/*/statuses)
+      cat "$case_dir/statuses.json"
+      ;;
+    repos/*/collaborators/*/permission)
+      cat "$case_dir/permission.json"
+      ;;
+    *)
+      echo "unhandled gh api endpoint: $endpoint" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "review" ]; then
+  printf '%s\n' "$*" >> "$case_dir/approve.log"
+  exit 0
+fi
+
+echo "unhandled gh command: $*" >&2
+exit 1
+EOF_GH
+
+  chmod +x "$bin_dir/gh"
+  export AI_REVIEW_FIXTURE_DIR="$fixture_dir"
+}
+
+write_common_case() {
+  local case_dir="$1"
+  local sha="${2:-abc123}"
+  local head_repo="${3:-E5presso/spakky-framework}"
+  local base_repo="${4:-E5presso/spakky-framework}"
+  local role="${5:-admin}"
+  local status_state="${6:-success}"
+  local creator="${7:-E5presso}"
+  local pull_head_sha="${8:-$sha}"
+
+  mkdir -p "$case_dir"
+
+  cat > "$case_dir/pulls.json" <<EOF_JSON
+[
+  {
+    "number": 999,
+    "state": "open",
+    "head": {
+      "sha": "$sha"
+    }
+  }
+]
+EOF_JSON
+
+  cat > "$case_dir/pull.json" <<EOF_JSON
+{
+  "number": 999,
+  "head": {
+    "sha": "$pull_head_sha",
+    "repo": {
+      "full_name": "$head_repo"
+    }
+  },
+  "base": {
+    "repo": {
+      "full_name": "$base_repo"
+    }
+  }
+}
+EOF_JSON
+
+  cat > "$case_dir/statuses.json" <<EOF_JSON
+[
+  {
+    "context": "ai-review",
+    "state": "$status_state",
+    "created_at": "2026-01-01T00:01:00Z",
+    "creator": {
+      "login": "$creator"
+    }
+  }
+]
+EOF_JSON
+
+  cat > "$case_dir/permission.json" <<EOF_JSON
+{
+  "role_name": "$role"
+}
+EOF_JSON
+
+  echo "[]" > "$case_dir/reviews.json"
+}
+
+run_case() {
+  local case_name="$1"
+  local expected_approval="$2"
+  local expected_reason="$3"
+  local tmpdir="$4"
+
+  local output_file="$tmpdir/$case_name.step-output"
+  rm -f "$tmpdir/$case_name/approve.log" "$output_file"
+
+  PATH="$tmpdir/bin:/usr/bin:/bin" \
+    AI_REVIEW_TEST_CASE="$case_name" \
+    REPO="E5presso/spakky-framework" \
+    STATUS_SHA="abc123" \
+    STATUS_CONTEXT="ai-review" \
+    STATUS_STATE="success" \
+    GITHUB_STEP_OUTPUT="$output_file" \
+    bash "$SCRIPT_UNDER_TEST" > "$tmpdir/$case_name.stdout" 2> "$tmpdir/$case_name.stderr"
+
+  local approval_seen="false"
+  if [ -f "$tmpdir/$case_name/approve.log" ]; then
+    approval_seen="true"
+  fi
+
+  if [ "$approval_seen" != "$expected_approval" ]; then
+    echo "FAIL [$case_name]: expected approval=$expected_approval actual=$approval_seen" >&2
+    cat "$tmpdir/$case_name.stderr" >&2
+    return 1
+  fi
+
+  if ! grep -q "^reason=$expected_reason$" "$output_file"; then
+    echo "FAIL [$case_name]: expected reason=$expected_reason" >&2
+    cat "$output_file" >&2
+    cat "$tmpdir/$case_name.stderr" >&2
+    return 1
+  fi
+
+  echo "OK [$case_name]"
+}
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+mkdir -p "$tmpdir/bin"
+make_gh_mock "$tmpdir/bin" "$tmpdir"
+
+write_common_case "$tmpdir/approve"
+write_common_case "$tmpdir/fork" "abc123" "contributor/spakky-framework" "E5presso/spakky-framework"
+write_common_case "$tmpdir/low-role" "abc123" "E5presso/spakky-framework" "E5presso/spakky-framework" "write"
+write_common_case "$tmpdir/stale" "abc123" "E5presso/spakky-framework" "E5presso/spakky-framework" "admin" "success" "E5presso" "def456"
+write_common_case "$tmpdir/latest-failure" "abc123" "E5presso/spakky-framework" "E5presso/spakky-framework" "admin" "failure"
+write_common_case "$tmpdir/already-approved"
+
+cat > "$tmpdir/already-approved/reviews.json" <<'EOF_JSON'
+[
+  {
+    "user": {
+      "login": "github-actions[bot]"
+    },
+    "state": "APPROVED",
+    "commit_id": "abc123"
+  }
+]
+EOF_JSON
+
+fail=0
+run_case "approve" "true" "approved" "$tmpdir" || fail=1
+run_case "fork" "false" "fork-pr" "$tmpdir" || fail=1
+run_case "low-role" "false" "creator-role-not-admin-or-maintain" "$tmpdir" || fail=1
+run_case "stale" "false" "stale-status" "$tmpdir" || fail=1
+run_case "latest-failure" "false" "latest-ai-review-status-not-success" "$tmpdir" || fail=1
+run_case "already-approved" "false" "already-approved-by-bot" "$tmpdir" || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  echo "test_ai_review_auto_approve.sh: FAIL" >&2
+  exit 1
+fi
+
+echo "test_ai_review_auto_approve.sh: OK"

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,32 @@
+name: AI Review Auto Approve
+
+on:
+  status:
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: read
+
+jobs:
+  approve:
+    name: Approve verified ai-review status
+    if: ${{ github.event.context == 'ai-review' && github.event.state == 'success' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      STATUS_CONTEXT: ${{ github.event.context }}
+      STATUS_STATE: ${{ github.event.state }}
+      STATUS_SHA: ${{ github.event.sha }}
+    steps:
+      - name: Checkout workflow scripts
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Approve PR when ai-review status is trusted
+        id: approve
+        shell: bash
+        run: .github/scripts/ai_review_auto_approve.sh


### PR DESCRIPTION
Closes #449

## Summary
- add status-event workflow for verified `ai-review` success statuses
- gate approval on open PR head SHA, same-repo provenance, latest status creator role, and duplicate bot approval checks
- add fixture-based shell regression coverage for approve/no-op paths

## Verification
- repo setting `can_approve_pull_request_reviews=true` confirmed via `gh api`
- `.github/scripts/test_ai_review_auto_approve.sh`
- `bash -n .github/scripts/ai_review_auto_approve.sh .github/scripts/test_ai_review_auto_approve.sh`
- `uv run python` YAML load for `.github/workflows/ai-review.yml`
- `git diff --cached --check`

## Notes
- This PR bootstraps the default-branch workflow, so it cannot approve itself until merged.