### PR TITLE
fix(agui): preserve parent run id at endpoint (#465)

### DIFF
--- a/plugins/spakky-agui/src/spakky/plugins/agui/endpoint.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/endpoint.py
@@ -70,13 +70,14 @@ def _to_core_input(ag_ui_input: AgUiRunAgentInput) -> RunAgentInput:
     ``runId`` is the durable run/state id, ``threadId`` the conversation, and the
     last user message seeds the instruction. ``resume`` is set when the input
     carries an approval decision so the runner replays its paused boundary.
-    ``parentRunId`` is not forwarded: ``run_events`` does not set a parent run on
-    its attribution, so a delegation parent has no neutral channel to flow through.
+    ``parentRunId`` preserves delegated run ancestry through the neutral core
+    attribution path.
     """
     return RunAgentInput(
         state_id=ag_ui_input.run_id,
         instruction=_last_user_text(ag_ui_input),
         conversation_id=ag_ui_input.thread_id,
+        parent_run_id=ag_ui_input.parent_run_id,
         resume=carries_approval_decision(ag_ui_input),
     )
 

--- a/plugins/spakky-agui/tests/unit/test_endpoint_mapping.py
+++ b/plugins/spakky-agui/tests/unit/test_endpoint_mapping.py
@@ -55,13 +55,20 @@ def test_to_core_input_maps_ids_and_last_user_message() -> None:
     assert core.resume is False
 
 
-def test_to_core_input_does_not_forward_parent_run_id() -> None:
-    """parentRunId는 코어로 전달되지 않는다(run_events가 parent run을 세팅하지 않음)."""
+def test_to_core_input_forwards_parent_run_id() -> None:
+    """parentRunId가 코어 parent_run_id로 전달된다."""
     core = _to_core_input(
         _ag_ui_input([{"id": "u1", "role": "user", "content": "hi"}], parent="parent-9")
     )
 
-    assert core.metadata == {}
+    assert core.parent_run_id == "parent-9"
+
+
+def test_to_core_input_without_parent_run_id_sets_none() -> None:
+    """parentRunId가 없으면 코어 parent_run_id가 None이다."""
+    core = _to_core_input(_ag_ui_input([{"id": "u1", "role": "user", "content": "hi"}]))
+
+    assert core.parent_run_id is None
 
 
 def test_to_core_input_skips_non_text_user_message() -> None:


### PR DESCRIPTION
## Summary
- `_to_core_input()` now maps AG-UI `parentRunId` into core `RunAgentInput.parent_run_id`.
- Replaced the old drop-locking test with propagation/no-parent regression coverage.

## Verification
- [x] Failing regression observed before endpoint fix: `uv run pytest tests/unit/test_endpoint_mapping.py::test_to_core_input_forwards_parent_run_id -x -v --no-cov` -> failed with `None == 'parent-9'`
- [x] `cd plugins/spakky-agui && uv run pytest tests/unit/test_endpoint_mapping.py -x -v --no-cov`
- [x] `cd plugins/spakky-agui && uv run ruff format .`
- [x] `cd plugins/spakky-agui && uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- [x] `cd plugins/spakky-agui && uv run ruff check .`
- [x] `cd plugins/spakky-agui && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text`
- [x] `rg -n "parent_run_id=ag_ui_input.parent_run_id" plugins/spakky-agui/src/spakky/plugins/agui/endpoint.py`

## Acceptance Criteria (자가 grep)
- [x] `cd plugins/spakky-agui && uv run pytest tests/unit/test_endpoint_mapping.py -x -v --no-cov` -> 6 passed
- [x] `rg -n "parent_run_id=ag_ui_input.parent_run_id" plugins/spakky-agui/src/spakky/plugins/agui/endpoint.py` -> line 80

Closes #465
