### PR TITLE
fix(agent): persist run_events conversation turns (#467)

### DIFF
--- a/core/spakky-agent/src/spakky/agent/runner.py
+++ b/core/spakky-agent/src/spakky/agent/runner.py
@@ -237,6 +237,7 @@ class AgentRunner:
         )
         cursor = _MessageCursor(state_id=run_input.state_id)
         history = await self._resolved_history(run_input)
+        assistant_text: list[str] = []
         yield RunStartedEvent(attribution)
         if state is not None:
             cancel = await self._consume_cancel(state)
@@ -255,6 +256,7 @@ class AgentRunner:
                 event, state, attribution, cursor
             ):
                 yield item
+            self._accumulate_assistant_text(event, assistant_text)
             if event.kind is ModelStreamEventKind.ERROR and event.error is not None:
                 yield StepFinishedEvent(attribution, step_name="model-call")
                 yield RunFinishedEvent(
@@ -293,6 +295,7 @@ class AgentRunner:
                 return
             yield RunFinishedEvent(attribution, error=_state_error(current))
             return
+        self._persist_turns(run_input, assistant_text)
         yield RunFinishedEvent(attribution)
 
     async def _consume_stream_event_as_events(
@@ -353,6 +356,20 @@ class AgentRunner:
                     state, event.tool_call, attribution, cursor
                 ):
                     yield item
+            case _:
+                return
+
+    def _accumulate_assistant_text(
+        self,
+        event: ModelStreamEvent,
+        assistant_text: list[str],
+    ) -> None:
+        """Collect assistant-visible deltas for persisted transcripts."""
+        match event.kind:
+            case ModelStreamEventKind.TOKEN_DELTA:
+                assistant_text.append(event.token_delta or "")
+            case ModelStreamEventKind.MESSAGE_DELTA:
+                assistant_text.append(event.message_delta or "")
             case _:
                 return
 

--- a/core/spakky-agent/tests/unit/test_runner.py
+++ b/core/spakky-agent/tests/unit/test_runner.py
@@ -1206,6 +1206,208 @@ class DurableSessionAgent:
         self._evidence = evidence
         self._task_store = task_store
 
+    @agent_tool(
+        schema_name="echo.write",
+        description="Write echo requiring approval.",
+        effects=ToolEffects.write_state(),
+        idempotency=Idempotency.CONDITIONALLY_IDEMPOTENT,
+        evidence=EvidenceCapture.STRUCTURED,
+        approval=ToolApprovalRequirement.REQUIRED,
+    )
+    def echo_write(self, value: str) -> EchoRecord:
+        """Echo a value back after approval."""
+        return EchoRecord(value=value)
+
+
+async def _run_session_events(
+    model: IAgentModel,
+    store: ITaskStore,
+    command: RunAgentInput,
+) -> tuple[AgentEvent, ...]:
+    runner = AgentRunner.for_agent_instance(SessionProbeAgent(model, store))
+    return await _collect_events(runner.run_events(command))
+
+
+async def test_agent_runner_events_expect_session_history_persisted_like_run() -> None:
+    """run_events 정상 완료도 run처럼 user·assistant turn을 영속한다."""
+    store = FakeTaskStore()
+    model = RecordingModel(
+        (
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.MESSAGE_DELTA,
+                message_delta="a physicist",
+            ),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+
+    await _run_session_events(
+        model,
+        store,
+        RunAgentInput(
+            state_id="turn-1",
+            instruction="who was Einstein?",
+            conversation_id="thread-7",
+        ),
+    )
+
+    assert store.load_history("thread-7") == (
+        ConversationTurn(ModelMessageRole.USER, "who was Einstein?"),
+        ConversationTurn(ModelMessageRole.ASSISTANT, "a physicist"),
+    )
+
+
+async def test_agent_runner_events_expect_reasoning_not_persisted_as_assistant_turn() -> (
+    None
+):
+    """run_events는 reasoning-only content를 assistant turn으로 영속하지 않는다."""
+    store = FakeTaskStore()
+    model = _ReasoningModel(
+        (
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.REASONING_DELTA,
+                reasoning_delta="thinking",
+            ),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+
+    await _run_session_events(
+        model,
+        store,
+        RunAgentInput(
+            state_id="turn-1",
+            instruction="reason privately",
+            conversation_id="thread-7",
+        ),
+    )
+
+    assert store.load_history("thread-7") == (
+        ConversationTurn(ModelMessageRole.USER, "reason privately"),
+    )
+
+
+async def test_agent_runner_events_expect_error_run_does_not_persist_session() -> None:
+    """run_events 모델 ERROR 경로는 대화 turn을 영속하지 않는다."""
+    store = FakeTaskStore()
+    model = RecordingModel(
+        (
+            ModelStreamEvent(
+                kind=ModelStreamEventKind.ERROR,
+                error=ModelError(code="boom", message="provider failed"),
+            ),
+        )
+    )
+
+    await _run_session_events(
+        model,
+        store,
+        RunAgentInput(
+            state_id="turn-1",
+            instruction="fail",
+            conversation_id="thread-7",
+        ),
+    )
+
+    assert store.load_history("thread-7") == ()
+
+
+async def test_agent_runner_events_expect_client_history_session_not_persisted() -> (
+    None
+):
+    """client-injected message_history run은 task store에 다시 쓰지 않는다."""
+    store = FakeTaskStore()
+
+    await _run_session_events(
+        RecordingModel(
+            (
+                ModelStreamEvent(
+                    kind=ModelStreamEventKind.MESSAGE_DELTA,
+                    message_delta="server reply",
+                ),
+                ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+            )
+        ),
+        store,
+        RunAgentInput(
+            state_id="turn-1",
+            instruction="latest",
+            conversation_id="thread-7",
+            message_history=(ModelMessage(ModelMessageRole.USER, "client prior turn"),),
+        ),
+    )
+
+    assert store.load_history("thread-7") == ()
+
+
+async def test_agent_runner_events_expect_cancelled_session_not_persisted() -> None:
+    """run_events CANCEL 경로는 대화 turn을 영속하지 않는다."""
+    from spakky.agent import AgentSignal
+
+    store = FakeTaskStore()
+    signals = FakeSignalRepository(
+        (
+            AgentSignal(
+                id="cancel:run-1",
+                agent_state_id="run-1",
+                kind=AgentSignalKind.CANCEL,
+                payload={"reason": "stop"},
+            ),
+        )
+    )
+    runner = AgentRunner.for_agent_instance(
+        DurableSessionAgent(
+            RecordingModel((ModelStreamEvent(kind=ModelStreamEventKind.DONE),)),
+            FakeStateRepository(),
+            signals,
+            FakeEvidenceRepository(),
+            store,
+        )
+    )
+
+    await _collect_events(
+        runner.run_events(
+            RunAgentInput(
+                state_id="run-1",
+                instruction="cancel",
+                conversation_id="thread-7",
+            )
+        )
+    )
+
+    assert store.load_history("thread-7") == ()
+
+
+async def test_agent_runner_events_expect_paused_session_not_persisted() -> None:
+    """run_events approval pause 경로는 대화 turn을 영속하지 않는다."""
+    store = FakeTaskStore()
+    runner = AgentRunner.for_agent_instance(
+        DurableSessionAgent(
+            RecordingModel(
+                (
+                    _tool_event("echo.write", {"value": "draft"}, "write-1"),
+                    ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+                )
+            ),
+            FakeStateRepository(),
+            FakeSignalRepository(()),
+            FakeEvidenceRepository(),
+            store,
+        )
+    )
+
+    await _collect_events(
+        runner.run_events(
+            RunAgentInput(
+                state_id="run-1",
+                instruction="write",
+                conversation_id="thread-7",
+            )
+        )
+    )
+
+    assert store.load_history("thread-7") == ()
+
 
 # --- Neutral AgentEvent emission (issue #441 SC-1/SC-2/SC-3) ---
 


### PR DESCRIPTION
## Summary
- Persist successful `run_events()` user/assistant turns through the existing task-store session path.
- Keep reasoning-only content, error/cancel/pause paths, and client-injected `message_history` sessions out of persisted history.
- Add focused runner tests for the #467 reproducer and exclusion paths.

Closes #467

## Acceptance Criteria (자가 grep)
acceptance_check: missing

Issue #467 contains scenario and test commands, but no grep acceptance lines.

## Verification
- `cd core/spakky-agent && uv run ruff format .`
- `cd core/spakky-agent && uv run --with pytest --with pytest-asyncio --with pytest-cov --with pytest-spec --with pytest-xdist pytest tests/unit/test_runner.py::test_agent_runner_events_expect_session_history_persisted_like_run tests/unit/test_runner.py::test_agent_runner_events_expect_reasoning_not_persisted_as_assistant_turn tests/unit/test_runner.py::test_agent_runner_events_expect_error_run_does_not_persist_session tests/unit/test_runner.py::test_agent_runner_events_expect_client_history_session_not_persisted tests/unit/test_runner.py::test_agent_runner_events_expect_cancelled_session_not_persisted tests/unit/test_runner.py::test_agent_runner_events_expect_paused_session_not_persisted -x -v --no-cov`
- `cd core/spakky-agent && uv run --with pytest --with pytest-asyncio --with pytest-cov --with pytest-spec --with pytest-xdist pytest tests/unit/test_runner.py -x -v --no-cov`
- `cd core/spakky-agent && uv run --with ruff ruff check .`
- `cd core/spakky-agent && uv run --with pyrefly --with pytest --with pytest-asyncio --with pytest-cov --with pytest-spec --with pytest-xdist pyrefly check --min-severity warn --no-progress-bar --output-format min-text src/spakky/agent/runner.py tests/unit/test_runner.py`
- `cd core/spakky-agent && uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`