### PR TITLE
docs: sync package documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -499,37 +499,47 @@ spakky-data = "spakky.data.main:initialize"
 
 `SpakkyApplication.load_plugins()`는 `importlib.metadata.entry_points(group="spakky.plugins")`로 등록된 base 플러그인을 발견하고, 각 플러그인의 `initialize(app: SpakkyApplication)` 함수를 호출합니다. 그 뒤 active core feature마다 `spakky.contributions.<feature>` group을 조회해 feature contribution을 base plugin 이후, `scan()`/`start()` 이전에 호출합니다. Feature plugin 이름의 `-`는 entry point group에서 `.`로 정규화되므로 `spakky-outbox`의 group은 `spakky.contributions.spakky.outbox`입니다. 복수 구현체 DI resolution은 이 자동 활성화 모델을 유지합니다. 여러 플러그인이 같은 port 후보를 등록해도 플러그인은 그대로 초기화되고, 단수 주입 지점에서만 Qualifier/name/binding/`@Primary`/legacy parameter name 순서로 하나를 선택합니다.
 
-### 플러그인 등록 요약
+### 플러그인 자동 등록 요약
 
-| 플러그인 | 등록하는 컴포넌트 |
-|---------|-------------------|
+아래 표는 각 base plugin `initialize()` 또는 contribution `initialize()`가 `app.add(...)`로 등록하는 구성요소를 요약합니다. 공개 helper/API는 각 패키지 README와 API Reference에서 설명합니다.
+
+| Entry point | 자동 등록 구성요소 |
+|-------------|--------------------|
 | `spakky-logging` | `LoggingConfig`, `LoggingSetupPostProcessor`, `LoggingAspect`, `AsyncLoggingAspect`, `LogContextBinder` |
 | `spakky-domain` | (없음 — 모델만 제공) |
-| `spakky-auth` | Provider-neutral auth model, ABC port, `AuthCapability`, auth contribution contract, AOP enforcement, capability startup validation |
-| `spakky-cryptography` | Cryptographic utility surface; `CryptographyAuthProvider` contribution for snapshot sign/verify and password hash/verify |
-| `spakky-policy` | YAML/TOML/JSON policy document evaluator for RBAC/PBAC/ABAC authorization |
-| `spakky-oidc` | OIDC/OAuth bearer credential verification provider for `AuthCapability.AUTHENTICATION` |
-| `spakky-openfga` | OpenFGA relation/policy authorization provider contribution |
+| `spakky-auth` | `auth_snapshot_propagation_config`, `AuthCapabilityStartupValidationService`, `AuthorizationAspect`, `AsyncAuthorizationAspect` |
+| `spakky-cryptography` | `CryptographyAuthProviderConfig`, `CryptographyAuthProvider` |
+| `spakky-cryptography` contribution for `spakky-auth` | `cryptography_auth_provider_contribution` |
+| `spakky-policy` | `SpakkyPolicyConfig`, `spakky_policy_document`, `SpakkyPolicyAuthProvider` |
+| `spakky-policy` contribution for `spakky-auth` | `policy_auth_provider_contribution` |
+| `spakky-oidc` | `OidcProviderConfig`, `OidcAuthenticationProvider` |
+| `spakky-oidc` contribution for `spakky-auth` | `oidc_auth_provider_contribution` |
+| `spakky-openfga` | `OpenFgaConfig`, `OpenFgaSdkCheckClient`, `OpenFgaAuthProvider` |
+| `spakky-openfga` contribution for `spakky-auth` | `openfga_auth_provider_contribution` |
 | `spakky-data` | `AsyncTransactionalAspect`, `TransactionalAspect`, `AggregateCollector` |
-| `spakky-event` | `EventMediator`, `EventPublisher` (sync+async), `DirectEventBus` (sync+async), `TransactionalEventPublishingAspect` (sync+async), `EventHandlerRegistrationPostProcessor` |
-| `spakky-fastapi` | `FastAPIActuatorConfig`, `BindLifespanPostProcessor`, `AddBuiltInMiddlewaresPostProcessor`, `RegisterActuatorPostProcessor`, `RegisterRoutesPostProcessor` |
-| `spakky-typer` | `ActuatorTyperConfig`, `ActuatorTyperCommandPostProcessor`, `TyperCLIPostProcessor` |
-| `spakky-rabbitmq` | `RabbitMQConnectionConfig`, Consumer/`RabbitMQEventTransport` (sync+async), `RabbitMQPostProcessor` |
-| `spakky-kafka` | `KafkaConnectionConfig`, Consumer/`KafkaEventTransport` (sync+async), `KafkaPostProcessor` |
-| `spakky-sqlalchemy` | `SQLAlchemyConnectionConfig`, `SchemaRegistry`, Session/ConnectionManager, Transaction |
-| `spakky-sqlalchemy` contribution for `spakky-outbox` | `SqlAlchemyOutboxStorage` (sync+async), `OutboxMessageTable` |
-| `spakky-sqlalchemy` contribution for `spakky-agent` | `SqlAlchemyAgentStateRepository`, `SqlAlchemyAgentSignalRepository`, `SqlAlchemyAgentEvidenceRepository`, `AgentStateTable`, `AgentSignalTable`, `AgentEvidenceTable` |
-| `spakky-outbox` | `OutboxConfig`, `OutboxEventBus` (sync+async), `OutboxRelayBackgroundService` (sync+async) |
-| `spakky-task` | `TaskRegistrationPostProcessor` |
-| `spakky-actuator` | `ActuatorConfig`, `ActuatorExtensionRegistry`, `ActuatorExtensionPostProcessor`, `ActuatorAggregationService` |
+| `spakky-event` | `AsyncTransactionalEventPublishingAspect`, `TransactionalEventPublishingAspect`, `EventMediator`, `AsyncEventMediator`, `EventPublisher`, `AsyncEventPublisher`, `AuthContextSnapshotHeaderInjector`, `DirectEventBus`, `AsyncDirectEventBus`, `EventHandlerRegistrationPostProcessor` |
+| `spakky-fastapi` | `FastAPIConfig`, `fastapi_app`(기존 FastAPI Pod가 없을 때), `FastAPIActuatorConfig`, `BindLifespanPostProcessor`, `AddBuiltInMiddlewaresPostProcessor`, `RegisterActuatorPostProcessor`, `RegisterRoutesPostProcessor` |
+| `spakky-typer` | `typer_app`(기존 Typer Pod가 없을 때), `ActuatorTyperConfig`, `ActuatorTyperCommandPostProcessor`, `TyperCLIPostProcessor` |
+| `spakky-rabbitmq` | `RabbitMQConnectionConfig`, `RabbitMQPostProcessor`, `RabbitMQEventConsumer`, `RabbitMQEventTransport`, `AsyncRabbitMQEventConsumer`, `AsyncRabbitMQEventTransport` |
+| `spakky-kafka` | `KafkaConnectionConfig`, `KafkaEventConsumer`, `KafkaEventTransport`, `AsyncKafkaEventConsumer`, `AsyncKafkaEventTransport`, `KafkaPostProcessor` |
+| `spakky-sqlalchemy` | `SQLAlchemyConnectionConfig`, `SchemaRegistry`, `ConnectionManager`, `SessionManager`, `Transaction`; async mode 활성화 시 `AsyncConnectionManager`, `AsyncSessionManager`, `AsyncTransaction` |
+| `spakky-sqlalchemy` contribution for `spakky-outbox` | `OutboxMessageTable`, `SqlAlchemyOutboxStorage`; async mode 활성화 시 `AsyncSqlAlchemyOutboxStorage` |
+| `spakky-sqlalchemy` contribution for `spakky-agent` | `AgentStateTable`, `AgentSignalTable`, `AgentEvidenceTable`, `SqlAlchemyAgentStateRepository`, `SqlAlchemyAgentSignalRepository`, `SqlAlchemyAgentEvidenceRepository` |
+| `spakky-outbox` | `OutboxConfig`, `OutboxEventBus`, `AsyncOutboxEventBus`, `OutboxRelayBackgroundService`, `AsyncOutboxRelayBackgroundService` |
+| `spakky-task` | `DirectTaskExecutor`, `TaskRegistrationPostProcessor` |
+| `spakky-actuator` | `ActuatorConfig`, `ActuatorExtensionRegistry`, `_startup_report_info_contributor(app)`, `ActuatorExtensionPostProcessor`, `ActuatorAggregationService` |
 | `spakky-cache` | `CacheAspect`, `AsyncCacheAspect` |
-| `spakky-celery` | `CeleryConfig`, `CeleryPostProcessor`, `CeleryTaskDispatchAspect` (sync+async) |
+| `spakky-celery` | `CeleryConfig`, `celery_app`(기존 Celery Pod가 없을 때), `CeleryPostProcessor`, `CeleryTaskDispatchAspect`, `AsyncCeleryTaskDispatchAspect` |
 | `spakky-tracing` | `W3CTracePropagator` |
 | `spakky-opentelemetry` | `OpenTelemetryConfig`, `OTelSetupPostProcessor`, `LogContextBridge` |
 | `spakky-saga` | (없음 — `@Saga`가 `@Pod` 기반이므로 Pod 스캔만으로 DI 컨테이너가 관리) |
-| `spakky-grpc` | `RegisterServicesPostProcessor`, `AddInterceptorsPostProcessor`, `BindServerPostProcessor` |
-| `spakky-redis` | `RedisCacheConfig`, `RedisCache`, `RedisCacheHealthProbe`, `RedisCacheMetricsInfoContributor` |
+| `spakky-grpc` | `GrpcConfig`, `descriptor_registry`, `grpc_server_spec`, `RegisterServicesPostProcessor`, `AddInterceptorsPostProcessor`, `BindServerPostProcessor` |
+| `spakky-redis` | `RedisCacheConfig`, `RedisCache`, `redis_cache_health_probe`, `redis_cache_metrics_info_contributor` |
 | `spakky-vllm` | `VllmConfig`, `HttpxVllmChatClient`, `VllmAgentModel` |
+| `spakky-agent` | `AgentBootstrapValidationPostProcessor` |
+| `spakky-agui` | `AgUiConfig` |
+| `spakky-a2a` | `A2AConfig`, `A2AAgentRegistry`, `A2AAgentServerSpec`, `RegisterA2AAgentServersPostProcessor` |
+| `spakky-mcp` | `McpConfig`, `McpClient`, `McpToolServer` |
 
 ### Agentic workflow layer
 

--- a/core/spakky-actuator/README.md
+++ b/core/spakky-actuator/README.md
@@ -107,6 +107,19 @@ class BuildInfo(IInfoContributor):
 
 Backend plugin은 자신이 소유한 외부 의존 상태를 first-party probe/contributor로 등록합니다. 예를 들어 `spakky-redis`는 Redis 연결 상태와 cache metrics를 actuator health/info에 연결합니다. 애플리케이션은 transport adapter를 바꾸지 않고 같은 계약으로 자체 check를 추가할 수 있습니다.
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/core/spakky-agent/README.md
+++ b/core/spakky-agent/README.md
@@ -312,3 +312,20 @@ Optimization 실행 전후 기록은 기존 `AgentYieldKind.EVIDENCE` stream과 
 Evidence와 model output/stream boundary도 같은 descriptor를 재사용합니다. `AgentEvidenceCandidate.tool_result(..., sensitive_fields=...)`, `ModelResponse.guarded(...)`, `ModelStreamEvent.guarded(...)`는 raw PII/secret 값을 append-only evidence나 downstream stream payload에 넣기 전에 deterministic replacement로 바꿉니다.
 
 Streaming output은 `StreamingRedactionSession`으로 bounded buffering을 적용할 수 있습니다. Adapter나 agent orchestration은 `StreamingSensitivePattern`을 제공하고 `StreamingRedactionPolicy(buffer_size=..., emit_chunk_size=...)`로 redaction correctness와 latency tradeoff를 조절합니다. Session은 `push()`에서 안전하게 확정된 prefix만 반환하고 `finish()`에서 aggregate final audit을 항상 실행합니다. Audit이 raw 후보를 발견하면 기본값은 `AgentOutputGuardError` raise이며, `StreamingGuardFailureMode.EMIT_ERROR`를 선택한 경우에는 stream consumer가 `StreamingRedactionAudit.to_evidence_payload()`와 error payload를 append-only evidence / `AgentYieldKind.ERROR`로 남길 수 있습니다. Core는 heuristic PII detector를 내장하지 않으며, detector나 concrete pattern selection은 extension/adapter가 담당합니다.
+
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
+## 라이선스
+
+MIT License

--- a/core/spakky-auth/README.md
+++ b/core/spakky-auth/README.md
@@ -28,7 +28,7 @@ pip install spakky-auth
 - `AuthCapabilityStartupValidationService`: plugin load/scan 이후 service start 이전에 protected metadata와 snapshot propagation config가 요구하는 `AuthCapability` 제공자 count를 검증하는 startup service
 - `AbstractSpakkyAuthError` 기반 auth 오류 hierarchy
 
-Provider implementation과 boundary integration은 후속 이슈에서 추가됩니다. Decorator가 없는 boundary는 allow all이며, protected/decorated boundary는 request-scope `AuthContext`와 provider-neutral checker port를 통해 fail closed로 처리됩니다.
+Provider implementation과 boundary integration은 현재 별도 패키지와 adapter에 분산되어 있습니다. `spakky-cryptography`는 snapshot sign/verify와 password hash/verify를, `spakky-oidc`는 inbound bearer credential 인증을, `spakky-policy`는 policy/permission/role/scope 평가를, `spakky-openfga`는 relation/policy check를 `spakky.contributions.spakky.auth` contribution으로 제공합니다. FastAPI, Typer, gRPC, Kafka, RabbitMQ, Celery 같은 boundary adapter는 credential 또는 signed snapshot을 읽어 request/context scope에 `AuthContext`를 seed하거나 보호된 handler 앞에서 provider-neutral checker port를 호출합니다. Decorator가 없는 boundary는 allow all이며, protected/decorated boundary는 request-scope `AuthContext`와 provider-neutral checker port를 통해 fail closed로 처리됩니다.
 
 ## Decorator Metadata & AOP Enforcement
 
@@ -89,7 +89,7 @@ missing, invalid, expired snapshot은 기본적으로 `CHALLENGE` decision이며
 spakky-auth = "spakky.auth.main:initialize"
 ```
 
-현재 `initialize()`는 `AuthCapabilityStartupValidationService`, `AuthorizationAspect`, `AsyncAuthorizationAspect`를 등록합니다. 후속 이슈에서 boundary integration이 추가되면 같은 entry point를 통해 feature-local component를 등록합니다.
+현재 `initialize()`는 `AuthCapabilityStartupValidationService`, `AuthorizationAspect`, `AsyncAuthorizationAspect`를 등록합니다. Provider plugin은 각자의 base entry point와 `spakky.contributions.spakky.auth` contribution entry point를 함께 제공하며, inbound/transport adapter는 이 core entry point를 수정하지 않고 같은 provider-neutral contract를 사용합니다.
 
 ## 개발 검증
 

--- a/core/spakky-cache/README.md
+++ b/core/spakky-cache/README.md
@@ -115,6 +115,19 @@ class AnswerService:
 
 `spakky-cache`는 애플리케이션 데이터 캐시 추상화입니다. `ApplicationContext` 내부의 타입 캐시, 싱글톤 캐시, 컨텍스트 캐시와는 별개입니다. Tag 기반 무효화, stampede 보호, write-through/write-behind, metrics는 core capability contract로 정의되며, `spakky-redis`가 Redis backend 구현을 제공합니다.
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/core/spakky-data/README.md
+++ b/core/spakky-data/README.md
@@ -202,6 +202,19 @@ class PaymentServiceProxy(IPaymentProxy):
 | `spakky-domain` | DDD building block(Entity, AggregateRoot, ValueObject) |
 | `spakky-event` | Event publisher/consumer interface |
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/core/spakky-domain/README.md
+++ b/core/spakky-domain/README.md
@@ -198,6 +198,19 @@ class GetUserUseCase(IAsyncQueryUseCase[GetUserQuery, User | None]):
 | `spakky-data` | Repository와 transaction 추상화 |
 | `spakky-event` | Event publisher/consumer interface와 `@EventHandler` stereotype |
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/core/spakky-event/README.md
+++ b/core/spakky-event/README.md
@@ -213,6 +213,19 @@ flowchart TD
     mediator --> handler
 ```
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/core/spakky-outbox/README.md
+++ b/core/spakky-outbox/README.md
@@ -118,6 +118,19 @@ class MyCustomStorage(IAsyncOutboxStorage):
         ...
 ```
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/core/spakky-saga/README.md
+++ b/core/spakky-saga/README.md
@@ -195,6 +195,19 @@ flow = saga_flow(
 - [ADR-0007](../../docs/adr/0007-spakky-saga-plan.md) — architecture decision record
 - `spakky-domain` — `AbstractSagaData`의 부모인 `AbstractDomainModel` 제공
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/core/spakky-task/README.md
+++ b/core/spakky-task/README.md
@@ -165,6 +165,19 @@ result = executor.execute(
 
 - **`spakky-celery`**: AOP 기반 task dispatch와 schedule 등록을 위한 Celery backend
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/core/spakky-tracing/README.md
+++ b/core/spakky-tracing/README.md
@@ -63,6 +63,19 @@ propagator.inject(carrier)
 ctx = propagator.extract(carrier)
 ```
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/core/spakky/README.md
+++ b/core/spakky/README.md
@@ -15,6 +15,9 @@ pip install spakky
 pip install "spakky[recommended]"              # FastAPI + SQLAlchemy + 운영 기본기
 pip install "spakky[web]"                      # FastAPI 중심 HTTP 서비스
 pip install "spakky[events-kafka]"             # Kafka 이벤트 서비스
+pip install "spakky[agent]"                    # Agent core + vLLM + AG-UI/A2A/MCP + SQLAlchemy persistence
+pip install "spakky[security]"                 # Auth core + cryptography/OIDC/policy/OpenFGA providers
+pip install "spakky[cache-app]"                # Cache core + Redis backend
 pip install "spakky[full]"                     # 모든 공식 통합
 ```
 
@@ -433,6 +436,9 @@ count와 skip reason이 기록됩니다.
 | [`spakky-policy`](https://pypi.org/project/spakky-policy/) | Policy document 기반 AuthZ evaluator |
 | [`spakky-opentelemetry`](https://pypi.org/project/spakky-opentelemetry/) | OpenTelemetry SDK bridge |
 | [`spakky-vllm`](https://pypi.org/project/spakky-vllm/) | vLLM OpenAI-compatible Agent model adapter |
+| [`spakky-agui`](https://pypi.org/project/spakky-agui/) | AG-UI protocol adapter |
+| [`spakky-a2a`](https://pypi.org/project/spakky-a2a/) | A2A AgentCard/server transport와 remote teammate delegation adapter |
+| [`spakky-mcp`](https://pypi.org/project/spakky-mcp/) | MCP client/server adapter |
 
 ## 코어 모듈
 
@@ -461,6 +467,19 @@ count와 skip reason이 기록됩니다.
 | [`spakky-tracing`](https://pypi.org/project/spakky-tracing/) | 분산 트레이싱 추상화(TraceContext, Propagator) |
 | [`spakky-outbox`](https://pypi.org/project/spakky-outbox/) | Transactional Outbox 패턴(OutboxEventBus, Relay) |
 | [`spakky-saga`](https://pypi.org/project/spakky-saga/) | 분산 트랜잭션 사가 오케스트레이션 |
+
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
 
 ## 라이선스
 

--- a/docs/api/core/spakky-data.md
+++ b/docs/api/core/spakky-data.md
@@ -14,45 +14,45 @@ Repository, Transaction 추상화 — 데이터 접근 계층
 ## 플러그인 진입점
 
 ::: spakky.data.main
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 스테레오타입
 
 ::: spakky.data.stereotype.repository
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 영속성
 
 ::: spakky.data.persistency.repository
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.data.persistency.transaction
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.data.persistency.aggregate_collector
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.data.persistency.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 외부 Proxy
 
 ::: spakky.data.external.proxy
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.data.external.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Aspect
 
 ::: spakky.data.aspects.transactional
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false

--- a/docs/api/core/spakky-domain.md
+++ b/docs/api/core/spakky-domain.md
@@ -7,43 +7,43 @@ DDD 빌딩 블록 — Aggregate Root, Entity, Value Object, Domain Event, CQRS
 ## 플러그인 진입점
 
 ::: spakky.domain.main
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 모델
 
 ::: spakky.domain.models.base
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.domain.models.aggregate_root
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.domain.models.entity
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.domain.models.value_object
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.domain.models.event
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 애플리케이션 (CQRS)
 
 ::: spakky.domain.application.command
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.domain.application.query
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 에러
 
 ::: spakky.domain.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false

--- a/docs/api/core/spakky-event.md
+++ b/docs/api/core/spakky-event.md
@@ -7,71 +7,71 @@
 ## 플러그인 진입점
 
 ::: spakky.event.main
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Publisher 인터페이스
 
 ::: spakky.event.event_publisher
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Consumer 인터페이스
 
 ::: spakky.event.event_consumer
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Dispatcher 인터페이스
 
 ::: spakky.event.event_dispatcher
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## EventBus
 
 ::: spakky.event.bus.transport_event_bus
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Auth Propagation
 
 ::: spakky.event.auth_propagation
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Mediator
 
 ::: spakky.event.mediator.domain_event_mediator
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Publisher
 
 ::: spakky.event.publisher.domain_event_publisher
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Aspect
 
 ::: spakky.event.aspects.transactional_event_publishing
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 스테레오타입
 
 ::: spakky.event.stereotype.event_handler
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 후처리기
 
 ::: spakky.event.post_processor
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 에러
 
 ::: spakky.event.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false

--- a/docs/api/core/spakky-outbox.md
+++ b/docs/api/core/spakky-outbox.md
@@ -7,53 +7,43 @@ Outbox 패턴 — 이벤트 발행 보장
 ## 플러그인 진입점
 
 ::: spakky.outbox.main
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## EventBus
 
 ::: spakky.outbox.bus.outbox_event_bus
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 포트
 
 ::: spakky.outbox.ports.storage
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Relay
 
 ::: spakky.outbox.relay
-options:
-show_root_heading: false
-
-::: spakky.outbox.relay.relay
-options:
-show_root_heading: false
-
-## 공통
-
-::: spakky.outbox.common.config
-options:
-show_root_heading: false
-
-::: spakky.outbox.common.message
-options:
-show_root_heading: false
-
-## 에러
-
-::: spakky.outbox.error
-options:
-show_root_heading: false
-
-## 추가 모듈
+    options:
+      show_root_heading: false
 
 ::: spakky.outbox.relay.relay
     options:
       show_root_heading: false
 
-::: spakky.outbox.main
+## 공통
+
+::: spakky.outbox.common.config
+    options:
+      show_root_heading: false
+
+::: spakky.outbox.common.message
+    options:
+      show_root_heading: false
+
+## 에러
+
+::: spakky.outbox.error
     options:
       show_root_heading: false

--- a/docs/api/core/spakky-saga.md
+++ b/docs/api/core/spakky-saga.md
@@ -69,13 +69,3 @@
 ::: spakky.saga.error
     options:
       show_root_heading: false
-
-## 추가 모듈
-
-::: spakky.saga.auth
-    options:
-      show_root_heading: false
-
-::: spakky.saga.main
-    options:
-      show_root_heading: false

--- a/docs/api/core/spakky-task.md
+++ b/docs/api/core/spakky-task.md
@@ -7,49 +7,43 @@
 ## 플러그인 진입점
 
 ::: spakky.task.main
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 스테레오타입
 
 ::: spakky.task.stereotype.task_handler
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.task.stereotype.schedule
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.task.stereotype.crontab
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 인터페이스
 
 ::: spakky.task.interfaces.task_result
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 직접 실행
 
 ::: spakky.task.direct
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 후처리기
 
 ::: spakky.task.post_processor
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 에러
 
 ::: spakky.task.error
-options:
-show_root_heading: false
-
-## 추가 모듈
-
-::: spakky.task.main
     options:
       show_root_heading: false

--- a/docs/api/core/spakky-tracing.md
+++ b/docs/api/core/spakky-tracing.md
@@ -7,35 +7,29 @@
 ## 플러그인 진입점
 
 ::: spakky.tracing.main
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 컨텍스트
 
 ::: spakky.tracing.context
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Propagator 인터페이스
 
 ::: spakky.tracing.propagator
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## W3C Propagator
 
 ::: spakky.tracing.w3c_propagator
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 에러
 
 ::: spakky.tracing.error
-options:
-show_root_heading: false
-
-## 추가 모듈
-
-::: spakky.tracing.main
     options:
       show_root_heading: false

--- a/docs/api/core/spakky.md
+++ b/docs/api/core/spakky.md
@@ -7,251 +7,251 @@ DI 컨테이너, AOP, 부트스트랩 — Spakky Framework의 핵심 패키지
 ## Application
 
 ::: spakky.core.application.application
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.application.application_context
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.application.plugin
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.application.discovery_manifest
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.application.startup_diagnostics
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.application.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## AOP
 
 ::: spakky.core.aop.aspect
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.aop.advisor
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.aop.pointcut
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.aop.interfaces
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.aop.interfaces.aspect
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.aop.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Pod
 
 ::: spakky.core.pod.annotations
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.annotations.pod
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.annotations.lazy
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.annotations.order
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.annotations.primary
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.annotations.qualifier
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.annotations.tag
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.binding
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.diagnostics
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.inject
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.interfaces.container
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.interfaces.application_context
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.interfaces.post_processor
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.interfaces.tag_registry
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.interfaces.aware
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.interfaces.aware.aware
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.interfaces.aware.application_context_aware
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.interfaces.aware.container_aware
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.interfaces.aware.tag_registry_aware
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.post_processors.aware_post_processor
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.pod.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Service
 
 ::: spakky.core.service.interfaces
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.service.interfaces.service
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.service.background
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.service.post_processor
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 스테레오타입
 
 ::: spakky.core.stereotype.configuration
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.stereotype.controller
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.stereotype.usecase
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 공통
 
 ::: spakky.core.common.annotation
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.constants
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.interfaces
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.interfaces.cloneable
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.interfaces.comparable
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.interfaces.disposable
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.interfaces.equatable
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.interfaces.representable
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.metadata
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.mro
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.mutability
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.proxy
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.common.types
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 로깅 인터페이스
 
 ::: spakky.core.logging.interfaces.log_context_binder
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 유틸리티
 
 ::: spakky.core.utils.casing
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.utils.inspection
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.utils.naming
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.core.utils.uuid
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false

--- a/docs/api/plugins/spakky-celery.md
+++ b/docs/api/plugins/spakky-celery.md
@@ -5,44 +5,44 @@ Celery 통합 — 태스크 디스패치, 스케줄링
 ## 메인
 
 ::: spakky.plugins.celery.main
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Aspect
 
 ::: spakky.plugins.celery.aspects.task_dispatch
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Auth
 
 ::: spakky.plugins.celery.auth
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 설정
 
 ::: spakky.plugins.celery.common.config
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 태스크 결과
 
 ::: spakky.plugins.celery.common.task_result
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 후처리기
 
 ::: spakky.plugins.celery.post_processor
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 에러
 
 ::: spakky.plugins.celery.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 추가 모듈
 

--- a/docs/api/plugins/spakky-fastapi.md
+++ b/docs/api/plugins/spakky-fastapi.md
@@ -13,98 +13,98 @@ connection close로 처리됩니다.
 ## 스테레오타입
 
 ::: spakky.plugins.fastapi.stereotypes.api_controller
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 라우트
 
 ::: spakky.plugins.fastapi.routes.route
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.fastapi.routes.get
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.fastapi.routes.post
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.fastapi.routes.put
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.fastapi.routes.patch
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.fastapi.routes.delete
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.fastapi.routes.head
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.fastapi.routes.options
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.fastapi.routes.websocket
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 미들웨어
 
 ::: spakky.plugins.fastapi.middlewares.error_handling
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.fastapi.middlewares.tracing
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 설정
 
 ::: spakky.plugins.fastapi.config
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 후처리기
 
 ::: spakky.plugins.fastapi.post_processors.bind_lifespan
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.fastapi.post_processors.add_builtin_middlewares
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.fastapi.post_processors.register_routes
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.fastapi.post_processors.register_actuator
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Actuator
 
 ::: spakky.plugins.fastapi.actuator
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 에러
 
 ::: spakky.plugins.fastapi.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 플러그인 진입점
 
 ::: spakky.plugins.fastapi.main
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 추가 모듈
 

--- a/docs/api/plugins/spakky-kafka.md
+++ b/docs/api/plugins/spakky-kafka.md
@@ -5,38 +5,38 @@ Kafka 통합 — 이벤트 전송/수신
 ## 메인
 
 ::: spakky.plugins.kafka.main
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 이벤트 Transport
 
 ::: spakky.plugins.kafka.event.transport
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 이벤트 Consumer
 
 ::: spakky.plugins.kafka.event.consumer
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Auth Boundary
 
 ::: spakky.plugins.kafka.auth
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 설정
 
 ::: spakky.plugins.kafka.common.config
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 후처리기
 
 ::: spakky.plugins.kafka.post_processor
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 추가 모듈
 

--- a/docs/api/plugins/spakky-logging.md
+++ b/docs/api/plugins/spakky-logging.md
@@ -5,44 +5,44 @@
 ## Aspect
 
 ::: spakky.plugins.logging.aspects.logging_aspect
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 어노테이션
 
 ::: spakky.plugins.logging.annotation
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 설정
 
 ::: spakky.plugins.logging.config
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 컨텍스트
 
 ::: spakky.plugins.logging.context
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Filters
 
 ::: spakky.plugins.logging.filters
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Formatters
 
 ::: spakky.plugins.logging.formatters
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 후처리기
 
 ::: spakky.plugins.logging.post_processor
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 추가 모듈
 

--- a/docs/api/plugins/spakky-opentelemetry.md
+++ b/docs/api/plugins/spakky-opentelemetry.md
@@ -5,32 +5,32 @@ OpenTelemetry SDK 브릿지 — Spakky 트레이싱을 OpenTelemetry로 연결
 ## 브릿지
 
 ::: spakky.plugins.opentelemetry.bridge
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Propagator
 
 ::: spakky.plugins.opentelemetry.propagator
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 후처리기
 
 ::: spakky.plugins.opentelemetry.post_processor
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 설정
 
 ::: spakky.plugins.opentelemetry.config
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 에러
 
 ::: spakky.plugins.opentelemetry.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 추가 모듈
 

--- a/docs/api/plugins/spakky-rabbitmq.md
+++ b/docs/api/plugins/spakky-rabbitmq.md
@@ -5,38 +5,38 @@ RabbitMQ 통합 — 이벤트 전송/수신
 ## 메인
 
 ::: spakky.plugins.rabbitmq.main
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 이벤트 Transport
 
 ::: spakky.plugins.rabbitmq.event.transport
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 이벤트 Consumer
 
 ::: spakky.plugins.rabbitmq.event.consumer
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 인증 Boundary
 
 ::: spakky.plugins.rabbitmq.auth
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 설정
 
 ::: spakky.plugins.rabbitmq.common.config
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 후처리기
 
 ::: spakky.plugins.rabbitmq.post_processor
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 추가 모듈
 

--- a/docs/api/plugins/spakky-sqlalchemy.md
+++ b/docs/api/plugins/spakky-sqlalchemy.md
@@ -24,84 +24,84 @@ execution을 운영에서 사용하려면 `spakky-agent`와 `spakky-sqlalchemy[a
 ## 메인
 
 ::: spakky.plugins.sqlalchemy.main
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 설정
 
 ::: spakky.plugins.sqlalchemy.common.config
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## ORM
 
 ::: spakky.plugins.sqlalchemy.orm.table
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.sqlalchemy.orm.schema_registry
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.sqlalchemy.orm.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 영속성
 
 ::: spakky.plugins.sqlalchemy.persistency.repository
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.sqlalchemy.persistency.transaction
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.sqlalchemy.persistency.session_manager
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.sqlalchemy.persistency.connection_manager
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.sqlalchemy.persistency.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Outbox
 
 ::: spakky.plugins.sqlalchemy.contributions.outbox
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.sqlalchemy.outbox.storage
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.sqlalchemy.outbox.table
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## Agent Persistence
 
 ::: spakky.plugins.sqlalchemy.contributions.agent
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.sqlalchemy.agent.repository
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.sqlalchemy.agent.table
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 에러
 
 ::: spakky.plugins.sqlalchemy.error
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 추가 모듈
 

--- a/docs/api/plugins/spakky-typer.md
+++ b/docs/api/plugins/spakky-typer.md
@@ -5,31 +5,31 @@ Typer CLI 통합 — CLI 컨트롤러 자동 등록
 ## 메인
 
 ::: spakky.plugins.typer.main
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 스테레오타입
 
 ::: spakky.plugins.typer.stereotypes.cli_controller
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 후처리기
 
 ::: spakky.plugins.typer.post_processor
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.typer.actuator
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ## 유틸리티
 
 ::: spakky.plugins.typer.utils.asyncio
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false
 
 ::: spakky.plugins.typer.utils.casing
-options:
-show_root_heading: false
+    options:
+      show_root_heading: false

--- a/docs/error-hierarchy.md
+++ b/docs/error-hierarchy.md
@@ -42,7 +42,7 @@ flowchart TD
   AbstractSpakkyFrameworkError --> AbstractVllmError
   AbstractSpakkyFrameworkError --> CryptographyErrors[spakky-cryptography concrete errors]
   AbstractSpakkyFrameworkError --> CommonErrors[common concrete errors]
-  Exception --> PolicyDocumentError
+  AbstractSpakkyFrameworkError --> PolicyDocumentError
 
   AbstractSpakkyDomainError --> AbstractDomainValidationError
   AbstractSpakkyDomainError --> EntityNotFoundError
@@ -630,7 +630,7 @@ from spakky.plugins.oidc.error import (
 
 ### spakky-policy
 
-Policy document loader/evaluator 내부의 provider-local 입력 검증 예외입니다. 이 예외들은 `AbstractSpakkyFrameworkError`를 상속하지 않는 plain `Exception` 계층이며, auth provider 경계에서는 `AuthorizationDecision.ERROR`로 매핑됩니다.
+Policy document loader/evaluator 내부의 provider-local 입력 검증 예외입니다. 이 예외들은 `AbstractSpakkyFrameworkError`를 상속하는 `PolicyDocumentError` 계층이며, auth provider 경계에서는 `AuthorizationDecision.ERROR`로 매핑됩니다.
 
 ```python
 from spakky.plugins.policy.error import (
@@ -756,6 +756,8 @@ from spakky.plugins.grpc.error import (
     UnsupportedResponseTypeError,
     DescriptorAlreadyRegisteredError,
     ProtoFieldNumberConflictError,
+    InvalidProtoFieldNumberError,
+    DuplicateProtoFieldNumberError,
 )
 ```
 
@@ -781,6 +783,8 @@ from spakky.plugins.grpc.error import (
 | `UnsupportedResponseTypeError`        | protobuf `Message`나 Pydantic `BaseModel`이 아닌 응답 |
 | `DescriptorAlreadyRegisteredError`    | 이미 등록된 descriptor 재등록 시도     |
 | `ProtoFieldNumberConflictError`       | 명시 `ProtoField` 번호가 자동 부여 필드의 번호와 충돌 |
+| `InvalidProtoFieldNumberError`        | 명시 `ProtoField(number=...)`가 protobuf 유효 범위 밖이거나 reserved band에 있음 |
+| `DuplicateProtoFieldNumberError`      | 같은 message 안에서 두 필드가 같은 명시 `ProtoField` 번호를 사용 |
 
 ### spakky-openfga
 

--- a/docs/guides/agent-a2a.md
+++ b/docs/guides/agent-a2a.md
@@ -29,6 +29,13 @@ class AssistantAgent:
 
 plugin 초기화는 `A2AConfig`, `A2AAgentRegistry`, `A2AAgentServerSpec`, `RegisterA2AAgentServersPostProcessor`를 등록합니다. 부트스트랩 후 `@A2AAgentServer`와 `@Agent`가 모두 붙은 Pod는 registry에 agent name 기준으로 들어갑니다.
 
+`A2AConfig`는 `SPAKKY_A2A_` 접두사의 환경변수를 읽습니다. 이 값은 `@A2AAgentServer`가 `base_url` 또는 `version`을 직접 지정하지 않을 때 derived AgentCard 기본값으로 사용됩니다.
+
+| 환경변수 | 의미 | 기본값 |
+| --- | --- | --- |
+| `SPAKKY_A2A_DEFAULT_BASE_URL` | AgentCard transport interface에 광고할 base URL | `http://localhost:8000` |
+| `SPAKKY_A2A_DEFAULT_VERSION` | AgentCard에 광고할 semantic version | `1.0.0` |
+
 ```python
 from spakky.plugins.a2a.server.builder import A2AAgentServerSpec
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -223,6 +223,19 @@ app = (
 model = app.container.get(type_=IAgentModel)
 ```
 
+`spakky-vllm`은 `SPAKKY_VLLM__` 접두사의 환경변수를 읽습니다.
+
+| 환경변수 | 의미 | 기본값 |
+| --- | --- | --- |
+| `SPAKKY_VLLM__ENDPOINT_URL` | OpenAI-compatible vLLM base URL | `http://127.0.0.1:8000/v1` |
+| `SPAKKY_VLLM__MODEL` | chat completions 요청에 넘길 model id | `default` |
+| `SPAKKY_VLLM__REQUEST_TIMEOUT_SECONDS` | non-streaming 요청 timeout | `30.0` |
+| `SPAKKY_VLLM__STREAM_TIMEOUT_SECONDS` | streaming 요청 timeout | `300.0` |
+| `SPAKKY_VLLM__STREAM_ENABLED` | streaming surface 사용 가능 여부 | `true` |
+| `SPAKKY_VLLM__CONTEXT_WINDOW_TOKENS` | 운영자가 선언한 context window token 수 | 미설정 |
+| `SPAKKY_VLLM__SUPPORTS_REASONING` | reasoning delta를 surface할지 여부 | `false` |
+| `SPAKKY_VLLM__CHAT_TEMPLATE_KWARGS` | vLLM chat template kwargs JSON/object | `{}` |
+
 `spakky-vllm` 플러그인은 `VllmConfig`, `HttpxVllmChatClient`, `VllmAgentModel`을 등록하고 `IAgentModel -> VllmAgentModel` binding을 설정합니다.
 테스트에서는 network가 없는 scripted `IAgentModel` fake를 만들어 token이나 tool event를 원하는 순서로 내보내면 됩니다.
 

--- a/docs/guides/celery.md
+++ b/docs/guides/celery.md
@@ -40,6 +40,19 @@ export SPAKKY_CELERY__BROKER_URL=amqp://guest:guest@localhost:5672//
 export SPAKKY_CELERY__APP_NAME=myapp
 ```
 
+주요 설정은 다음과 같습니다. 값은 `CeleryConfig`에서 읽으며 serializer는 `json`, `pickle`, `yaml`, `msgpack` 중 하나입니다.
+
+| 환경변수 | 의미 | 기본값 |
+| --- | --- | --- |
+| `SPAKKY_CELERY__APP_NAME` | Celery application name | `spakky-celery` |
+| `SPAKKY_CELERY__BROKER_URL` | Celery broker URL | 필수 |
+| `SPAKKY_CELERY__RESULT_BACKEND` | result backend URL, 미설정 시 result 저장 안 함 | 미설정 |
+| `SPAKKY_CELERY__TASK_SERIALIZER` | task message serializer | `json` |
+| `SPAKKY_CELERY__RESULT_SERIALIZER` | task result serializer | `json` |
+| `SPAKKY_CELERY__ACCEPT_CONTENT` | deserialize 허용 content 목록 | `json` |
+| `SPAKKY_CELERY__TIMEZONE` | schedule timezone, IANA 이름 | `UTC` |
+| `SPAKKY_CELERY__ENABLE_UTC` | 내부 datetime UTC 처리 | `true` |
+
 ---
 
 ## 태스크 정의

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -130,6 +130,23 @@ api = app.container.get(FastAPI)
 OIDC provider는 discovery document와 JWKS를 읽고, `kid` key selection, RS256 signature, issuer, audience, `azp`, `exp`, `nbf`, `iat`, clock skew를 검증합니다. `sub`, display name, tenant, roles, scopes, selected safe claims만 `AuthContext`에 남기며 raw bearer token은 claims, metadata, credential carrier에 보존하지 않습니다.
 FastAPI/gRPC/Typer 같은 inbound adapter가 boundary에서 bearer credential을 읽고 provider-neutral auth port를 호출한 뒤 `AuthContext`를 저장하므로, 애플리케이션 코드는 provider를 직접 호출하지 않고 decorator로 요구사항을 선언합니다.
 
+`spakky-oidc`는 `SPAKKY_OIDC_` 접두사의 환경변수를 읽습니다.
+
+| 환경변수 | 의미 | 기본값 |
+| --- | --- | --- |
+| `SPAKKY_OIDC_ISSUER` | expected issuer이자 discovery URL 기본 base | `https://issuer.example.test` |
+| `SPAKKY_OIDC_AUDIENCE` | 허용 audience 문자열 또는 문자열 목록 | `spakky` |
+| `SPAKKY_OIDC_CLIENT_ID` | token의 `azp`가 있을 때 기대하는 client id | 미설정 |
+| `SPAKKY_OIDC_DISCOVERY_URL` | 명시 discovery URL | `<issuer>/.well-known/openid-configuration` |
+| `SPAKKY_OIDC_ALGORITHM` | 기대 JWT signing algorithm | `RS256` |
+| `SPAKKY_OIDC_CLOCK_SKEW` | `exp`/`nbf`/`iat` clock skew 허용치 | `60s` |
+| `SPAKKY_OIDC_RETAINED_CLAIM_NAMES` | `AuthContext.claims`에 보존할 safe claim 목록 | provider 기본값 |
+| `SPAKKY_OIDC_ROLES_CLAIM` | role refs claim 이름 | `roles` |
+| `SPAKKY_OIDC_SCOPES_CLAIM` | scope refs claim 이름 | `scope` |
+| `SPAKKY_OIDC_TENANT_CLAIM` | tenant ref claim 이름 | `tenant` |
+| `SPAKKY_OIDC_DISPLAY_NAME_CLAIM` | subject display name claim 이름 | `name` |
+| `SPAKKY_OIDC_PROVIDER_AVAILABLE` | provider dependency 가용성 테스트/운영 토글 | `true` |
+
 실패는 다음 decision으로 정규화됩니다.
 
 | 실패 | Decision |

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -139,7 +139,7 @@ FastAPI/gRPC/Typer 같은 inbound adapter가 boundary에서 bearer credential을
 | `SPAKKY_OIDC_CLIENT_ID` | token의 `azp`가 있을 때 기대하는 client id | 미설정 |
 | `SPAKKY_OIDC_DISCOVERY_URL` | 명시 discovery URL | `<issuer>/.well-known/openid-configuration` |
 | `SPAKKY_OIDC_ALGORITHM` | 기대 JWT signing algorithm | `RS256` |
-| `SPAKKY_OIDC_CLOCK_SKEW` | `exp`/`nbf`/`iat` clock skew 허용치 | `60s` |
+| `SPAKKY_OIDC_CLOCK_SKEW` | `exp`/`nbf`/`iat` clock skew 허용치. 환경변수로 지정할 때는 초 단위 숫자 또는 Pydantic duration 형식을 사용 | `60` |
 | `SPAKKY_OIDC_RETAINED_CLAIM_NAMES` | `AuthContext.claims`에 보존할 safe claim 목록 | provider 기본값 |
 | `SPAKKY_OIDC_ROLES_CLAIM` | role refs claim 이름 | `roles` |
 | `SPAKKY_OIDC_SCOPES_CLAIM` | scope refs claim 이름 | `scope` |

--- a/docs/guides/sqlalchemy.md
+++ b/docs/guides/sqlalchemy.md
@@ -49,6 +49,23 @@ export SPAKKY_SQLALCHEMY__AUTOCOMMIT="true"
 export SPAKKY_SQLALCHEMY__SUPPORT_ASYNC_MODE="true"
 ```
 
+주요 설정은 다음과 같습니다. 전체 field는 [`spakky-sqlalchemy` API Reference](../api/plugins/spakky-sqlalchemy.md)의 `SQLAlchemyConnectionConfig`를 기준으로 확인합니다.
+
+| 환경변수 | 의미 | 기본값 |
+| --- | --- | --- |
+| `SPAKKY_SQLALCHEMY__CONNECTION_STRING` | SQLAlchemy database URL | 필수 |
+| `SPAKKY_SQLALCHEMY__ECHO` | SQL statement logging | `false` |
+| `SPAKKY_SQLALCHEMY__ECHO_POOL` | pool checkout/checkin logging | `false` |
+| `SPAKKY_SQLALCHEMY__POOL_SIZE` | persistent pool connection 수 | `5` |
+| `SPAKKY_SQLALCHEMY__POOL_MAX_OVERFLOW` | pool size 초과 허용 connection 수 | `10` |
+| `SPAKKY_SQLALCHEMY__POOL_TIMEOUT` | pool 고갈 시 대기 시간(초) | `30.0` |
+| `SPAKKY_SQLALCHEMY__POOL_RECYCLE` | connection recycle 초, `-1`은 비활성 | `-1` |
+| `SPAKKY_SQLALCHEMY__POOL_PRE_PING` | checkout 전 liveness check | `false` |
+| `SPAKKY_SQLALCHEMY__SESSION_AUTOFLUSH` | query 전 pending change flush | `true` |
+| `SPAKKY_SQLALCHEMY__SESSION_EXPIRE_ON_COMMIT` | commit 후 ORM object expire | `true` |
+| `SPAKKY_SQLALCHEMY__AUTOCOMMIT` | transaction context 종료 시 자동 commit | `true` |
+| `SPAKKY_SQLALCHEMY__SUPPORT_ASYNC_MODE` | async session/transaction Pod 등록 여부 | `true` |
+
 `postgresql+psycopg://` URL은 `psycopg` driver가 필요합니다. `spakky[database]`와
 `spakky[sqlalchemy]`는 특정 DB driver를 강제로 설치하지 않습니다. PostgreSQL을 쓴다면
 `spakky[database-postgres]`를 선택하거나 프로젝트 의존성에 `psycopg[binary]`를 직접 추가하세요.

--- a/plugins/spakky-a2a/README.md
+++ b/plugins/spakky-a2a/README.md
@@ -1,37 +1,30 @@
 # spakky-a2a
 
-A2A (Agent2Agent) protocol server and delegation plugin for `spakky-agent`.
-It exposes a Spakky `@Agent` as an A2A server, derives an AgentCard from the
-agent spec/tool catalog/teammates, and implements the core `IAgentDelegate` port
-for remote teammate calls over the official `a2a-sdk` client.
+> `spakky-a2a`는 `spakky-agent`를 A2A (Agent2Agent) protocol server와 원격 teammate delegation으로 노출하는 adapter plugin입니다.
+> Spakky `@Agent`를 A2A server로 공개하고, agent spec/tool catalog/teammates에서 AgentCard를 유도하며, 공식 `a2a-sdk` client 위에 core `IAgentDelegate` port를 구현합니다.
 
-## Installation
+## 설치
 
 ```bash
 pip install spakky-a2a
 ```
 
-An executable agent still needs an `IAgentModel` provider and, for durable runs
-or HITL resume, the `spakky-agent` persistence repositories supplied by a
-provider such as `spakky-sqlalchemy[agent]`.
+실행 가능한 agent에는 별도 `IAgentModel` provider가 필요합니다. Durable run 또는 HITL resume을 사용하면 `spakky-sqlalchemy[agent]` 같은 provider가 공급하는 `spakky-agent` persistence repository도 필요합니다.
 
-## Configuration
+## 설정
 
-`A2AConfig` reads `SPAKKY_A2A_` environment variables.
+`A2AConfig`는 `SPAKKY_A2A_` 접두사의 환경변수를 읽습니다.
 
-| Environment variable | Default | Purpose |
+| 환경변수 | 기본값 | 목적 |
 |----------------------|---------|---------|
-| `SPAKKY_A2A_DEFAULT_BASE_URL` | `http://localhost:8000` | Base URL advertised on derived AgentCard interfaces when an app uses the default config |
-| `SPAKKY_A2A_DEFAULT_VERSION` | `1.0.0` | Semantic version advertised on derived AgentCards |
+| `SPAKKY_A2A_DEFAULT_BASE_URL` | `http://localhost:8000` | 기본 config를 쓰는 derived AgentCard interface에 광고할 base URL |
+| `SPAKKY_A2A_DEFAULT_VERSION` | `1.0.0` | derived AgentCard에 광고할 semantic version |
 
-Plugin initialization registers `A2AConfig`, `A2AAgentRegistry`,
-`A2AAgentServerSpec`, and the post-processor that discovers classes carrying both
-`@Agent` and `@A2AAgentServer`.
+Plugin 초기화는 `A2AConfig`, `A2AAgentRegistry`, `A2AAgentServerSpec`, 그리고 `@Agent`와 `@A2AAgentServer`가 함께 붙은 class를 발견하는 post-processor를 등록합니다.
 
-## Exposing an Agent
+## Agent 노출
 
-`@A2AAgentServer` is a tag stacked on the same class as `@Agent`; `@Agent`
-registers the Pod, while the tag records A2A transport metadata.
+`@A2AAgentServer`는 `@Agent`와 같은 class에 쌓는 tag입니다. `@Agent`가 Pod를 등록하고, tag는 A2A transport metadata를 기록합니다.
 
 ```python
 from spakky.agent import Agent, AgentExecutionSpec, IAgentModel
@@ -45,11 +38,9 @@ class PlannerAgent:
         self.model = model
 ```
 
-After application bootstrap, `A2AAgentServerSpec.build_app_for("planner")`
-resolves the registered agent, uses a container-provided `IA2ATaskRepository`
-when one is registered, and falls back to an in-memory task repository otherwise.
+애플리케이션 bootstrap 이후 `A2AAgentServerSpec.build_app_for("planner")`는 등록된 agent를 resolve합니다. Container에 `IA2ATaskRepository`가 등록되어 있으면 이를 사용하고, 없으면 `InMemoryA2ATaskRepository`를 사용합니다.
 
-For direct assembly, use the transport-specific builders:
+직접 조립할 때는 transport별 builder를 사용합니다.
 
 ```python
 from spakky.plugins.a2a.server.builder import build_a2a_app
@@ -61,30 +52,22 @@ rest_app = build_a2a_rest_app(agent, base_url="https://agents.example.com/a2a", 
 grpc_handler = build_a2a_grpc_handler(agent, base_url="https://agents.example.com/a2a", version="1.0.0")
 ```
 
-- `build_a2a_app()` builds a Starlette app with the AgentCard route plus
-  JSON-RPC routes from `a2a-sdk` with v0.3 method compatibility.
-- `build_a2a_rest_app()` builds the HTTP+JSON REST binding and accepts an
-  optional `path_prefix`.
-- `build_a2a_grpc_handler()` builds a `grpc.GenericRpcHandler` for
-  `lf.a2a.v1.A2AService`.
+- `build_a2a_app()`은 AgentCard route와 `a2a-sdk` JSON-RPC route(v0.3 method compatibility 포함)를 가진 Starlette app을 만듭니다.
+- `build_a2a_rest_app()`은 HTTP+JSON REST binding을 만들고 optional `path_prefix`를 받습니다.
+- `build_a2a_grpc_handler()`는 `lf.a2a.v1.A2AService`용 `grpc.GenericRpcHandler`를 만듭니다.
 
-## AgentCard Derivation
+## AgentCard 유도
 
-`AgentCardFactory` derives the card from:
+`AgentCardFactory`는 다음 입력에서 card를 유도합니다.
 
-- `AgentExecutionSpec.name`, `objective`, or `instructions` for name/description.
-- `streaming_exposure_mode`; `NO_STREAM_UNTIL_FINAL_GUARDED` disables streaming
-  capability exposure.
-- native `@agent_tool` descriptors, excluding synthetic teammate delegation tools.
-- declared `AgentTeammate` entries, projected as delegation skills.
+- name/description: `AgentExecutionSpec.name`, `objective`, 또는 `instructions`
+- streaming capability: `streaming_exposure_mode`; `NO_STREAM_UNTIL_FINAL_GUARDED`는 streaming capability 노출을 끕니다.
+- tool: synthetic teammate delegation tool을 제외한 native `@agent_tool` descriptor
+- delegation skill: 선언된 `AgentTeammate` entry
 
-## Remote Teammate Delegation
+## 원격 Teammate 위임
 
-`A2AAgentDelegate` implements the core `IAgentDelegate` port for teammates whose
-`AgentExecutionSpec.teammates` entry points at a remote AgentCard URL. The core
-agent runner exposes each teammate as a model-callable delegation tool named
-`teammate.<name>.delegate`; local teammate pods run in-process, while remote
-teammates use the official `a2a-sdk` client.
+`A2AAgentDelegate`는 `AgentExecutionSpec.teammates` entry가 원격 AgentCard URL을 가리키는 teammate를 위해 core `IAgentDelegate` port를 구현합니다. Core agent runner는 각 teammate를 `teammate.<name>.delegate`라는 model-callable delegation tool로 노출합니다. Local teammate Pod는 in-process로 실행하고, remote teammate는 공식 `a2a-sdk` client를 사용합니다.
 
 ```python
 from spakky.agent import Agent, AgentExecutionSpec, AgentTeammate
@@ -107,13 +90,11 @@ class Orchestrator:
         self.delegate = delegate
 ```
 
-Remote delegation sends `message/send` through the SDK client, tracks the remote
-task stream, and maps child task/message/artifact updates back into Spakky's
-protocol-neutral event stream with the parent run id preserved.
+원격 delegation은 SDK client로 `message/send`를 보내고 remote task stream을 추적한 뒤, child task/message/artifact update를 parent run id를 보존한 Spakky protocol-neutral event stream으로 되돌립니다.
 
 ## REST HTTP+JSON Transport
 
-The SDK route names differ from JSON-RPC method strings:
+SDK route 이름은 JSON-RPC method 문자열과 다릅니다.
 
 | A2A operation | REST route |
 |---------------|------------|
@@ -123,30 +104,31 @@ The SDK route names differ from JSON-RPC method strings:
 | `tasks/cancel` | `POST /tasks/{id}:cancel` |
 | `tasks/subscribe` | `GET /tasks/{id}:subscribe` or `POST /tasks/{id}:subscribe` |
 
-REST request and response bodies use the A2A SDK protobuf JSON encoding. For
-example, send a user message with `{"message":{"role":"ROLE_USER","messageId":"m1","parts":[{"text":"hi"}]}}`.
+REST request/response body는 A2A SDK protobuf JSON encoding을 사용합니다. 예를 들어 user message는 `{"message":{"role":"ROLE_USER","messageId":"m1","parts":[{"text":"hi"}]}}` 형태로 보냅니다.
 
-## HITL and Auth Interrupts
+## HITL와 Auth Interrupt
 
-`SpakkyAgentExecutor` consumes the core `AgentRunner.run_events()` stream. Approval
-and auth pauses arrive as protocol-neutral `RunPausedEvent` items rather than as
-successful `RunFinishedEvent` terminals. The A2A projector maps
-`reason=approval_required` to `TASK_STATE_INPUT_REQUIRED` and includes the
-approval id plus allowed decisions in a data part. It maps `reason=auth_required`
-to `TASK_STATE_AUTH_REQUIRED`, so auth-required is reachable without inspecting
-durable `state.reason` after the run stream drains.
+`SpakkyAgentExecutor`는 core `AgentRunner.run_events()` stream을 소비합니다. Approval/auth pause는 successful terminal `RunFinishedEvent`가 아니라 protocol-neutral `RunPausedEvent`로 들어옵니다. A2A projector는 `reason=approval_required`를 `TASK_STATE_INPUT_REQUIRED`로 매핑하고 approval id와 allowed decisions를 data part에 포함합니다. `reason=auth_required`는 `TASK_STATE_AUTH_REQUIRED`로 매핑하므로, run stream이 끝난 뒤 durable `state.reason`을 다시 조회하지 않아도 auth-required 상태를 표현할 수 있습니다.
 
-Approval resume is carried as an inbound A2A data part with `approval_id` and
-`decision`; the executor appends an `APPROVAL_DECISION` signal and reruns the
-same task id with `RunAgentInput(resume=True)`.
+Approval resume은 `approval_id`와 `decision`을 가진 inbound A2A data part로 전달됩니다. Executor는 `APPROVAL_DECISION` signal을 append하고 같은 task id로 `RunAgentInput(resume=True)`를 다시 실행합니다.
 
 ## Task Store
 
-Server transports use `SpakkyA2ATaskStore`, an async `a2a-sdk` `TaskStore` bridge
-over the synchronous `IA2ATaskRepository` port. If no repository is supplied to a
-builder and no repository Pod is present in the container, the plugin uses
-`InMemoryA2ATaskRepository`.
+Server transport는 synchronous `IA2ATaskRepository` port 위에 async `a2a-sdk` `TaskStore`를 얹는 bridge인 `SpakkyA2ATaskStore`를 사용합니다. Builder 인자로 repository를 주지 않고 container에도 repository Pod가 없으면 plugin은 `InMemoryA2ATaskRepository`를 사용합니다.
 
-## License
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
+## 라이선스
 
 MIT License

--- a/plugins/spakky-agui/README.md
+++ b/plugins/spakky-agui/README.md
@@ -186,3 +186,20 @@ approval id, tool call id, allowed decisions를 담고 있으므로 어댑터가
 생략하며(graceful degrade), 현재 모델 루프가 생성하지 않는 `STATE_SNAPSHOT`/`STATE_DELTA`/
 `ARTIFACT`는 live 런에서 방출되지 않습니다. projector는 taxonomy 완전성을 위해 이들 종류도
 계속 처리합니다.
+
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
+## 라이선스
+
+MIT License

--- a/plugins/spakky-celery/README.md
+++ b/plugins/spakky-celery/README.md
@@ -155,6 +155,19 @@ Raw bearer token은 task/broker header로 전파하지 않습니다. 같은 work
 - **`spakky-rabbitmq`**: RabbitMQ event transport(Celery broker로도 사용 가능)
 - **`spakky-tracing`**: 분산 트레이싱 추상화(필수, context propagation 활성화)
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/plugins/spakky-cryptography/README.md
+++ b/plugins/spakky-cryptography/README.md
@@ -12,6 +12,32 @@
 
 JWT/OIDC token 검증은 이 패키지의 범위 밖이며 `spakky-oidc`가 담당합니다.
 
+## 설치
+
+```bash
+pip install spakky-cryptography
+```
+
+Auth snapshot propagation이나 password provider로 쓰려면 `spakky-auth`와 함께 로드합니다.
+
+```bash
+pip install spakky-auth spakky-cryptography
+```
+
+## 설정
+
+`CryptographyAuthProviderConfig`는 `SPAKKY_CRYPTOGRAPHY_` 접두사의 환경변수를 읽습니다.
+
+| 환경변수 | 의미 | 기본값 |
+| --- | --- | --- |
+| `SPAKKY_CRYPTOGRAPHY_SNAPSHOT_KEY` | snapshot HMAC key, URL-safe base64 문자열 | 런타임 생성 32-byte key |
+| `SPAKKY_CRYPTOGRAPHY_SNAPSHOT_KEY_ID` | signed snapshot envelope에 들어갈 key id | `spakky-cryptography:default` |
+| `SPAKKY_CRYPTOGRAPHY_SNAPSHOT_TTL` | 새 snapshot 유효 기간 | `5m` |
+| `SPAKKY_CRYPTOGRAPHY_VERIFICATION_AVAILABLE` | snapshot verification provider 가용성 | `true` |
+| `SPAKKY_CRYPTOGRAPHY_PASSWORD_AVAILABLE` | password hash/verify provider 가용성 | `true` |
+
+운영에서는 모든 프로세스가 같은 snapshot을 검증할 수 있도록 `SNAPSHOT_KEY`를 명시적으로 고정하세요. 기본 key는 프로세스 시작마다 생성되므로 단일 프로세스 개발용입니다.
+
 ## Auth Provider Capability
 
 플러그인은 다음 capability를 구현하는 `CryptographyAuthProvider`를 등록합니다.
@@ -23,3 +49,51 @@ JWT/OIDC token 검증은 이 패키지의 범위 밖이며 `spakky-oidc`가 담�
 
 Snapshot verification은 누락, invalid, expired envelope을 `CHALLENGE` decision으로
 매핑합니다. Provider를 사용할 수 없는 상태는 `ERROR`로 매핑합니다.
+
+## 플러그인 등록
+
+Base plugin entry point는 `CryptographyAuthProviderConfig`, `CryptographyAuthProvider`를 등록하고 다음 port를 같은 provider 구현체에 binding합니다.
+
+- `IAuthContextSnapshotSigner`
+- `IAuthContextSnapshotVerifier`
+- `IPasswordHasher`
+- `IPasswordVerifier`
+
+Auth feature contribution entry point는 `spakky.contributions.spakky.auth` group에 `AuthProviderContribution` capability metadata를 등록합니다. `spakky-auth`의 startup validation은 이 metadata로 snapshot/password capability provider count를 검증합니다.
+
+## 사용 예
+
+```python
+import spakky.auth
+import spakky.plugins.cryptography
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+
+app = (
+    SpakkyApplication(ApplicationContext())
+    .load_plugins(
+        include={
+            spakky.auth.PLUGIN_NAME,
+            spakky.plugins.cryptography.PLUGIN_NAME,
+        }
+    )
+    .start()
+)
+```
+
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
+## 라이선스
+
+MIT License

--- a/plugins/spakky-cryptography/README.md
+++ b/plugins/spakky-cryptography/README.md
@@ -32,7 +32,7 @@ pip install spakky-auth spakky-cryptography
 | --- | --- | --- |
 | `SPAKKY_CRYPTOGRAPHY_SNAPSHOT_KEY` | snapshot HMAC key, URL-safe base64 문자열 | 런타임 생성 32-byte key |
 | `SPAKKY_CRYPTOGRAPHY_SNAPSHOT_KEY_ID` | signed snapshot envelope에 들어갈 key id | `spakky-cryptography:default` |
-| `SPAKKY_CRYPTOGRAPHY_SNAPSHOT_TTL` | 새 snapshot 유효 기간 | `5m` |
+| `SPAKKY_CRYPTOGRAPHY_SNAPSHOT_TTL` | 새 snapshot 유효 기간. 환경변수로 지정할 때는 초 단위 숫자 또는 Pydantic duration 형식을 사용 | `300` |
 | `SPAKKY_CRYPTOGRAPHY_VERIFICATION_AVAILABLE` | snapshot verification provider 가용성 | `true` |
 | `SPAKKY_CRYPTOGRAPHY_PASSWORD_AVAILABLE` | password hash/verify provider 가용성 | `true` |
 

--- a/plugins/spakky-fastapi/README.md
+++ b/plugins/spakky-fastapi/README.md
@@ -226,6 +226,19 @@ application = (
 )
 ```
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT

--- a/plugins/spakky-grpc/README.md
+++ b/plugins/spakky-grpc/README.md
@@ -176,6 +176,19 @@ app.load_plugins(include={
 | 1 | `AddInterceptorsPostProcessor` | 에러/트레이싱 인터셉터를 `GrpcServerSpec`에 추가 |
 | 2 | `BindServerPostProcessor` | `GrpcServerService`를 `ApplicationContext`에 등록 (start_async에서 `spec.build()`) |
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License입니다. [Spakky Framework repository](https://github.com/E5presso/spakky-framework)를 참고하세요.

--- a/plugins/spakky-kafka/README.md
+++ b/plugins/spakky-kafka/README.md
@@ -150,6 +150,19 @@ signed `AuthContextSnapshot`을 `IAuthContextSnapshotVerifier`로 검증하고,
 | `KafkaConnectionConfig` | 환경변수 기반 설정 |
 | `KafkaAuthBoundary` | signed `AuthContextSnapshot` 검증 및 `AuthContext` seeding |
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/plugins/spakky-logging/README.md
+++ b/plugins/spakky-logging/README.md
@@ -74,6 +74,19 @@ with LogContext.scope(trace_id="t-789"):
 | 느린 호출 감지         | method 실행 시간이 threshold를 넘으면 warning 출력 |
 | 결과 truncation           | 긴 return value를 log output에서 잘라냄 |
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/plugins/spakky-mcp/README.md
+++ b/plugins/spakky-mcp/README.md
@@ -70,6 +70,19 @@ async def expose_tools(server: McpToolServer, agent: object) -> None:
 
 자세한 내용은 [MCP 어댑터 가이드](../../docs/guides/agent-mcp.md)를 참고하세요.
 
-## License
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
+## 라이선스
 
 MIT License

--- a/plugins/spakky-oidc/README.md
+++ b/plugins/spakky-oidc/README.md
@@ -72,6 +72,19 @@ Inbound adapter는 boundary에서 bearer credential을 관찰하고 provider-neu
 호출해 `AuthContext`를 저장합니다. 애플리케이션 코드는 provider를 직접 호출하지 않고
 `spakky-auth` decorator로 요구사항을 선언합니다.
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT

--- a/plugins/spakky-openfga/README.md
+++ b/plugins/spakky-openfga/README.md
@@ -14,6 +14,12 @@
 매핑됩니다. `AuthContext.subject.id`는 OpenFGA user로 매핑되고, resource/tenant canonical
 ref는 OpenFGA object 문자열로 매핑됩니다.
 
+## 설치
+
+```bash
+pip install spakky-auth spakky-openfga
+```
+
 ## 설정
 
 `OpenFgaConfig`는 settings Pod로 등록되며 `SPAKKY_OPENFGA_*` 환경변수를 읽습니다.
@@ -24,11 +30,37 @@ tenant/object 매핑 설정을 담습니다. 기본적으로 type prefix가 없�
 
 주요 설정:
 
-- `SPAKKY_OPENFGA_API_URL`
-- `SPAKKY_OPENFGA_STORE_ID`
-- `SPAKKY_OPENFGA_AUTHORIZATION_MODEL_ID`
-- `SPAKKY_OPENFGA_PRINCIPAL_TYPE`
-- `SPAKKY_OPENFGA_INCLUDE_TENANT_IN_OBJECT`
+| 환경변수 | 의미 | 기본값 |
+| --- | --- | --- |
+| `SPAKKY_OPENFGA_API_URL` | OpenFGA API URL | `http://localhost:8080` |
+| `SPAKKY_OPENFGA_STORE_ID` | check request에 사용할 store id | `""` |
+| `SPAKKY_OPENFGA_AUTHORIZATION_MODEL_ID` | optional authorization model id | 미설정 |
+| `SPAKKY_OPENFGA_PRINCIPAL_TYPE` | type prefix 없는 subject id에 붙일 user type | `user` |
+| `SPAKKY_OPENFGA_TENANT_SEPARATOR` | tenant ref와 resource ref를 결합할 separator | `/` |
+| `SPAKKY_OPENFGA_INCLUDE_TENANT_IN_OBJECT` | tenant ref를 object string 앞에 붙일지 여부 | `true` |
+| `SPAKKY_OPENFGA_RELATION_CHECK_AVAILABLE` | relation check provider 가용성 | `true` |
+
+## 사용법
+
+```python
+import spakky.auth
+import spakky.plugins.openfga
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+
+app = (
+    SpakkyApplication(ApplicationContext())
+    .load_plugins(
+        include={
+            spakky.auth.PLUGIN_NAME,
+            spakky.plugins.openfga.PLUGIN_NAME,
+        }
+    )
+    .start()
+)
+```
+
+Base plugin entry point는 `OpenFgaConfig`, `OpenFgaSdkCheckClient`, `OpenFgaAuthProvider`를 등록하고 `IRelationChecker`, `IAuthorizationPolicyEvaluator`를 provider에 binding합니다. Auth feature contribution entry point는 `spakky.contributions.spakky.auth` group에 `RELATION_CHECK`, `POLICY_EVALUATION` capability metadata를 등록합니다.
 
 ## 범위 밖
 
@@ -37,3 +69,20 @@ data/query filtering, tuple/model management surface를 제공하지 않습니�
 
 Provider를 사용할 수 없는 상태는 `AuthorizationReasonCode.VERIFICATION_PROVIDER_UNAVAILABLE`
 reason code를 가진 `ERROR` authorization decision으로 매핑됩니다.
+
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
+## 라이선스
+
+MIT License

--- a/plugins/spakky-opentelemetry/README.md
+++ b/plugins/spakky-opentelemetry/README.md
@@ -76,6 +76,19 @@ bridge = app.container.get(type_=LogContextBridge)
 bridge.sync()  # LogContext에 trace_id, span_id 바인딩
 ```
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/plugins/spakky-policy/README.md
+++ b/plugins/spakky-policy/README.md
@@ -62,6 +62,70 @@ api = app.container.get(FastAPI)
 - named policy가 OR/ANY 사용자 표면입니다. MCP/tool authorization, generic policy API,
   policy UI, authorized data filtering은 이 패키지 범위 밖입니다.
 
+## Policy 문서 구조
+
+정책 문서는 YAML, TOML, JSON을 지원하며 다음 top-level collection을 typed canonical model로 변환합니다.
+
+| 필드 | 의미 |
+| --- | --- |
+| `version` | policy document schema version 문자열 |
+| `metadata` | `name`, optional `description`, `labels` |
+| `subjects` | subject ref와 역할, scope, permission, claim, tenant binding |
+| `resources` | resource ref와 optional tenant |
+| `actions` | action ref |
+| `permissions` | resource/action 묶음을 가진 named permission |
+| `roles` | permission 묶음을 가진 named role |
+| `scopes` | permission 묶음을 가진 named scope |
+| `policies` | statement 목록을 가진 named policy |
+| `conditions` | 재사용 가능한 atomic/composite condition |
+
+최소 YAML 예:
+
+```yaml
+version: "1"
+metadata:
+  name: article-policy
+subjects:
+  - ref: user:alice
+    roles: [role:editor]
+resources:
+  - ref: article:1
+actions:
+  - ref: article:read
+permissions:
+  - ref: permission:article-read
+    resources: [article:1]
+    actions: [article:read]
+roles:
+  - ref: role:editor
+    permissions: [permission:article-read]
+policies:
+  - ref: policy:read-article
+    statements:
+      - ref: allow-editor
+        effect: allow
+        roles: [role:editor]
+        resources: [article:1]
+        actions: [article:read]
+```
+
+## 플러그인 등록
+
+Base plugin entry point는 `SpakkyPolicyConfig`, `spakky_policy_document`, `SpakkyPolicyAuthProvider`를 등록하고 `IAuthorizationPolicyEvaluator`, `IPermissionChecker`, `IRoleChecker`, `IScopeChecker`를 provider에 binding합니다. Auth feature contribution entry point는 `spakky.contributions.spakky.auth` group에 policy/permission/role/scope capability metadata를 등록합니다.
+
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT

--- a/plugins/spakky-rabbitmq/README.md
+++ b/plugins/spakky-rabbitmq/README.md
@@ -148,6 +148,19 @@ class AsyncUserService:
 - **`InvalidMessageError`**: 필수 metadata(`consumer_tag` 또는 `delivery_tag`)가 없는 message에서 발생
 - 보호된 handler 인증/인가 실패는 handler를 호출하지 않고 ack/nack 정책으로 fail-closed 처리됩니다
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/plugins/spakky-redis/README.md
+++ b/plugins/spakky-redis/README.md
@@ -96,6 +96,19 @@ class AnswerService:
 
 `set_with_tags()` / `evict_tags()`는 Redis set 기반 tag index로 그룹 무효화를 처리합니다. `get_or_set()`은 Redis lock으로 동일 key miss population을 직렬화합니다. `write_through()`는 origin writer 성공 후 cache를 갱신하고, `write_behind()`는 cache 갱신 후 origin writer를 호출합니다. `metrics()`는 hit/miss/write/delete/clear/tag eviction/stampede wait counter를 반환하며, actuator가 로드되면 `RedisCacheHealthProbe`와 `RedisCacheMetricsInfoContributor`가 등록됩니다.
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/plugins/spakky-sqlalchemy/README.md
+++ b/plugins/spakky-sqlalchemy/README.md
@@ -334,6 +334,19 @@ spakky-sqlalchemy = "spakky.plugins.sqlalchemy.contributions.agent:initialize"
 | `delete(aggregate)` | aggregate 삭제 |
 | `delete_all(aggregates)` | 여러 aggregate 삭제 |
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT License

--- a/plugins/spakky-typer/README.md
+++ b/plugins/spakky-typer/README.md
@@ -244,6 +244,19 @@ if __name__ == "__main__":
 | `add_help_option` | `bool` | --help option 추가 여부 |
 | `rich_help_panel` | `str` | Rich console help panel 이름 |
 
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
 ## 라이선스
 
 MIT

--- a/plugins/spakky-vllm/README.md
+++ b/plugins/spakky-vllm/README.md
@@ -96,3 +96,42 @@ background request를 남기지 않습니다.
 - server-sent event chunk를 `ModelStreamEvent`로 변환하는 streaming adapter 동작
 - timeout, transport, provider error, refusal, unsupported constrained decoding mode,
   non-success finish reason의 typed error mapping
+
+## 사용 예
+
+```python
+import spakky.agent
+import spakky.plugins.vllm
+from spakky.agent import IAgentModel
+from spakky.core.application.application import SpakkyApplication
+from spakky.core.application.application_context import ApplicationContext
+
+app = (
+    SpakkyApplication(ApplicationContext())
+    .load_plugins(
+        include={
+            spakky.agent.PLUGIN_NAME,
+            spakky.plugins.vllm.PLUGIN_NAME,
+        }
+    )
+    .start()
+)
+model = app.container.get(type_=IAgentModel)
+```
+
+## 개발 검증
+
+패키지 단위 검증은 해당 패키지 디렉토리에서 실행합니다.
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run pyrefly check
+uv run pytest
+```
+
+`pytest`는 각 패키지 `pyproject.toml`의 coverage 설정을 사용합니다.
+
+## 라이선스
+
+MIT License


### PR DESCRIPTION
## Summary
- Sync all workspace package READMEs with development verification/license coverage and fill missing AG-UI/A2A/MCP/agent/security provider documentation.
- Update architecture, API reference pages, error hierarchy, and user guides from current code facts.
- Normalize API mkdocstrings directives and remove duplicate API module directives.

## Verification
- uv run mkdocs build --strict --site-dir /tmp/spakky-docs-build-final-3
- git diff --check
- pre-commit: python-harness-rules, monorepo-pre-commit
- pre-push: monorepo-pre-push-tests across affected projects
- clean-slate DEV documentation auditor: PASS
- clean-slate META documentation evaluator: PASS

## Acceptance Criteria (자가 grep)
- package README coverage: 30/30
- package README development verification blocks: 30/30
- package README license blocks: 30/30
- docs-only change; no framework code patch required