### PR TITLE
feat: add acronym-compatible agent plugin APIs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -538,8 +538,8 @@ spakky-data = "spakky.data.main:initialize"
 | `spakky-vllm` | `VllmConfig`, `HttpxVllmChatClient`, `VllmAgentModel` |
 | `spakky-agent` | `AgentBootstrapValidationPostProcessor` |
 | `spakky-agui` | `AgUiConfig` |
-| `spakky-a2a` | `A2AConfig`, `A2AAgentRegistry`, `A2AAgentServerSpec`, `RegisterA2AAgentServersPostProcessor` |
-| `spakky-mcp` | `McpConfig`, `McpClient`, `McpToolServer` |
+| `spakky-a2a` | `A2AConfig`, `A2AAgentRegistry`, `A2AAgentServerSpec`, `RegisterA2AAgentServersPostProcessor`, `MountA2AASGIPostProcessor`, `RegisterA2AGRPCPostProcessor` |
+| `spakky-mcp` | `MCPConfig`, `MCPClient`, `MCPToolServer` |
 
 ### Agentic workflow layer
 
@@ -1294,8 +1294,8 @@ flowchart TD
 | 플러그인 | 등록/공개 컴포넌트 | 외부 의존성 |
 |---------|------------------|-----------|
 | `spakky-agui` | `AgUiConfig`, `AgUiProjector`, `AgUiRunDriver`, `add_agui_endpoint`, `add_agui_http_stream_endpoint`, `add_agui_websocket_endpoint`, `AgUiStdioCommand`, deferred-tool HITL decision ingestion | `ag-ui-protocol`, `fastapi[standard]`, `pydantic-settings`, `spakky-agent` |
-| `spakky-a2a` | `A2AConfig`, `A2AAgentRegistry`, `A2AAgentServerSpec`, `RegisterA2AAgentServersPostProcessor`, `@A2AAgentServer`, `build_a2a_app`, `build_a2a_rest_app`, `build_a2a_grpc_handler`, `A2AAgentDelegate`, in-memory `IA2ATaskRepository` fallback | `a2a-sdk[http-server]`, `grpcio`, `pydantic`, `pydantic-settings`, `spakky-agent` |
-| `spakky-mcp` | `McpConfig`, `McpClient.open_runner`, external `AgentToolDescriptor` merge, `McpToolServer`, stdio/streamable-HTTP tool server exposure | `mcp`, `pydantic-settings`, `spakky-agent` |
+| `spakky-a2a` | `A2AConfig`, `A2AAgentRegistry`, `A2AAgentServerSpec`, `RegisterA2AAgentServersPostProcessor`, `MountA2AASGIPostProcessor`, `RegisterA2AGRPCPostProcessor`, `@A2ACompatible`, `A2AAgentDelegate`, in-memory `IA2ATaskRepository` fallback | `a2a-sdk[http-server]`, `grpcio`, `pydantic`, `pydantic-settings`, `spakky-agent` |
+| `spakky-mcp` | `MCPConfig`, `MCPClient.open_runner`, external `AgentToolDescriptor` merge, `MCPToolServer`, stdio/streamable-HTTP tool server exposure | `mcp`, `pydantic-settings`, `spakky-agent` |
 
 ### 트랜스포트 플러그인
 

--- a/docs/api/plugins/spakky-a2a.md
+++ b/docs/api/plugins/spakky-a2a.md
@@ -2,7 +2,7 @@
 
 > `spakky-a2a`는 `@Agent`를 A2A AgentCard와 task transport로 노출하고, 원격 A2A teammate를 `spakky-agent` delegation stream으로 합류시키는 어댑터입니다.
 
-서버 경로는 공식 `a2a-sdk` request handler와 task store를 사용하며, 실행은 `IAgentRunnerFactory`가 여는 runner의 `AgentEvent` stream을 A2A task/message/artifact update로 투영합니다. `@A2AAgentServer @Agent`는 registry에 등록되고 ASGI host Pod가 있으면 자동 mount됩니다.
+서버 경로는 공식 `a2a-sdk` request handler와 task store를 사용하며, 실행은 `IAgentRunnerFactory`가 여는 runner의 `AgentEvent` stream을 A2A task/message/artifact update로 투영합니다. `@A2ACompatible @Agent`는 registry에 등록되고 ASGI host Pod가 있으면 JSON-RPC/REST endpoint가 자동 mount됩니다. `spakky-grpc`의 `GrpcServerSpec`가 있으면 gRPC handler도 선언형으로 등록됩니다.
 
 ## Public API
 
@@ -24,7 +24,7 @@
 
 ## 서버 등록
 
-::: spakky.plugins.a2a.stereotypes.a2a_agent_server
+::: spakky.plugins.a2a.stereotypes.a2a_compatible
     options:
       show_root_heading: false
 
@@ -99,6 +99,10 @@
       show_root_heading: false
 
 ::: spakky.plugins.a2a.post_processors.mount_asgi
+    options:
+      show_root_heading: false
+
+::: spakky.plugins.a2a.post_processors.register_grpc
     options:
       show_root_heading: false
 

--- a/docs/api/plugins/spakky-agui.md
+++ b/docs/api/plugins/spakky-agui.md
@@ -2,7 +2,7 @@
 
 > `spakky-agui`는 `spakky-agent`의 protocol-neutral `AgentEvent` stream을 AG-UI 이벤트로 투영하고 FastAPI SSE, HTTP streaming, WebSocket, stdio 경계로 노출합니다.
 
-FastAPI SSE/HTTP streaming/WebSocket endpoint는 `@AgUiAgent @Agent` 선언을 `AgUiAgentRegistry`에 등록한 뒤 post-processor가 host FastAPI Pod에 자동 mount합니다. `add_agui_endpoint` 계열 helper는 lower-level 호환 API입니다.
+FastAPI SSE/HTTP streaming/WebSocket endpoint는 `@AGUICompatible @Agent` 선언을 `AgUiAgentRegistry`에 등록한 뒤 post-processor가 host FastAPI Pod에 자동 mount합니다. `add_agui_endpoint` 계열 helper는 lower-level 호환 API입니다.
 
 ## Public API
 
@@ -18,7 +18,7 @@ FastAPI SSE/HTTP streaming/WebSocket endpoint는 `@AgUiAgent @Agent` 선언을 `
 
 ## Endpoint
 
-::: spakky.plugins.agui.stereotypes.agui_agent
+::: spakky.plugins.agui.stereotypes.agui_compatible
     options:
       show_root_heading: false
 

--- a/docs/api/plugins/spakky-mcp.md
+++ b/docs/api/plugins/spakky-mcp.md
@@ -2,7 +2,7 @@
 
 > `spakky-mcp`는 외부 MCP server tool을 `AgentToolCatalog`에 병합하고, 반대로 `@agent_tool` 카탈로그를 MCP server로 노출하는 양방향 어댑터입니다.
 
-client 방향은 `McpClient`가 `IAgentRunnerFactory` 구현체로 외부 서버 연결 수명주기를 소유하고, server 방향은 `@McpToolServerAgent @Agent`를 registry에 등록한 뒤 `McpToolServer`가 agent name으로 tool catalog를 MCP `Server`로 변환합니다. agent instance를 직접 받는 helper들은 lower-level API입니다.
+client 방향은 `MCPClient`가 `IAgentRunnerFactory` 구현체로 외부 서버 연결 수명주기를 소유하고, server 방향은 `@MCPServer @Agent`를 registry에 등록한 뒤 `MCPToolServer`가 agent name으로 tool catalog를 MCP `Server`로 변환합니다. agent instance를 직접 받는 helper들은 lower-level API입니다.
 
 ## Public API
 
@@ -34,7 +34,7 @@ client 방향은 `McpClient`가 `IAgentRunnerFactory` 구현체로 외부 서버
 
 ## Server
 
-::: spakky.plugins.mcp.stereotypes.mcp_tool_server_agent
+::: spakky.plugins.mcp.stereotypes.mcp_server
     options:
       show_root_heading: false
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -326,17 +326,18 @@ event가 없으므로 `RunPausedEvent`는 `hitl_approval` deferred tool call로 
 
 ### A2A Adapter
 
-`spakky-a2a`가 제공하는 Agent-to-Agent protocol adapter입니다. `@A2AAgentServer` marker와
-server builder는 `@Agent` spec/tool/teammate에서 AgentCard를 파생하고, JSON-RPC,
-HTTP+JSON REST, gRPC transport로 노출합니다. `A2AAgentDelegate`는 원격 AgentCard를
+`spakky-a2a`가 제공하는 Agent-to-Agent protocol adapter입니다. `@A2ACompatible` marker와
+post-processors는 `@Agent` spec/tool/teammate에서 AgentCard를 파생하고, JSON-RPC,
+HTTP+JSON REST, gRPC transport에 선언형으로 연결합니다. `A2AAgentDelegate`는 원격 AgentCard를
 사용해 teammate call을 보내고 remote stream을 child `AgentEvent`로 parent run에 합류시킵니다.
 
 ### MCP Adapter
 
 `spakky-mcp`가 제공하는 Model Context Protocol 양방향 adapter입니다. client 방향의
-`McpClient.open_runner()`는 외부 MCP server tool을 `AgentToolCatalog`에 병합한
-`AgentRunner`를 열고, server 방향의 `McpToolServer`와 `build_agent_tool_server()`는
-기존 `@agent_tool` 카탈로그를 MCP `Server`로 노출합니다.
+`MCPClient.open_runner()`는 외부 MCP server tool을 `AgentToolCatalog`에 병합한
+`AgentRunner`를 열고, server 방향의 `MCPToolServer`와 `build_agent_tool_server()`는
+기존 `@agent_tool` 카탈로그를 MCP `Server`로 노출합니다. MCP server는 agent가 아니라
+도구 카탈로그를 표준 MCP 프로토콜로 제공하는 protocol host입니다.
 
 ### @Repository
 

--- a/docs/guides/agent-a2a.md
+++ b/docs/guides/agent-a2a.md
@@ -14,30 +14,34 @@ pip install spakky-a2a
 
 ## 서버로 노출
 
-`@A2AAgentServer`는 `@Agent` class에 붙는 marker입니다. `@Agent`가 Pod 등록을 담당하고, A2A marker는 AgentCard에 광고할 base URL/version과 optional ASGI mount path를 기록합니다.
+`@A2ACompatible`는 `@Agent` class에 붙는 marker입니다. `@Agent`가 Pod 등록을 담당하고, A2A marker는 AgentCard에 광고할 public transport URL/version과 optional ASGI/gRPC exposure metadata를 기록합니다.
 
 ```python
 from spakky.agent import Agent, AgentExecutionSpec
-from spakky.plugins.a2a import A2AAgentServer
+from spakky.plugins.a2a import A2ACompatible
 
 
-@A2AAgentServer(
+@A2ACompatible(
     base_url="https://agents.example.com/a2a/assistant",
     version="1.0.0",
     mount_path="/a2a/assistant",
+    rest_mount_path="/a2a-rest/assistant",
+    rest_base_url="https://agents.example.com/a2a-rest/assistant",
+    grpc_enabled=True,
+    grpc_base_url="grpc://agents.example.com:443",
 )
 @Agent(spec=AgentExecutionSpec(name="assistant", objective="answer with tools"))
 class AssistantAgent:
     ...
 ```
 
-plugin 초기화는 `A2AConfig`, `A2AAgentRegistry`, `A2AAgentServerSpec`, `RegisterA2AAgentServersPostProcessor`, ASGI mount post-processor, remote delegate Pod를 등록합니다. 부트스트랩 후 `@A2AAgentServer`와 `@Agent`가 모두 붙은 Pod는 registry에 agent name 기준으로 들어가고, Starlette/FastAPI host Pod가 있으면 자동으로 mount됩니다.
+plugin 초기화는 `A2AConfig`, `A2AAgentRegistry`, `A2AAgentServerSpec`, `RegisterA2AAgentServersPostProcessor`, ASGI mount post-processor, gRPC registration post-processor, remote delegate Pod를 등록합니다. 부트스트랩 후 `@A2ACompatible`와 `@Agent`가 모두 붙은 Pod는 registry에 agent name 기준으로 들어가고, Starlette/FastAPI host Pod가 있으면 자동으로 mount됩니다. `spakky-grpc`가 함께 로드되어 `GrpcServerSpec`가 있으면 `grpc_enabled=True` entry의 gRPC handler도 자동 등록됩니다.
 
-`A2AConfig`는 `SPAKKY_A2A_` 접두사의 환경변수를 읽습니다. 이 값은 `@A2AAgentServer`가 `base_url` 또는 `version`을 직접 지정하지 않을 때 derived AgentCard 기본값으로 사용됩니다.
+`A2AConfig`는 `SPAKKY_A2A_` 접두사의 환경변수를 읽습니다. `default_base_url`은 marker가 `base_url`을 생략할 때 실제 mount path와 결합되어 AgentCard interface URL을 유도합니다.
 
 | 환경변수 | 의미 | 기본값 |
 | --- | --- | --- |
-| `SPAKKY_A2A_DEFAULT_BASE_URL` | AgentCard transport interface에 광고할 base URL | `http://localhost:8000` |
+| `SPAKKY_A2A_DEFAULT_BASE_URL` | mount path와 결합할 public host URL | `http://localhost:8000` |
 | `SPAKKY_A2A_DEFAULT_VERSION` | AgentCard에 광고할 semantic version | `1.0.0` |
 | `SPAKKY_A2A_DEFAULT_MOUNT_PATH_PREFIX` | 자동 mount path prefix | `/a2a` |
 
@@ -53,54 +57,22 @@ def asgi_host() -> Starlette:
 
 `mount_path`를 생략하면 `{default_mount_path_prefix}/{agent_name}`을 사용합니다. Bootstrap 후
 `/a2a/assistant/.well-known/agent-card.json`과 `/a2a/assistant/` JSON-RPC route가 host app에
-존재합니다. Registry에 등록된 app을 직접 얻어야 하는 특수 host에서는 `A2AAgentServerSpec`을
-lower-level API로 사용할 수 있습니다.
-
-```python
-from spakky.plugins.a2a.server.builder import A2AAgentServerSpec
-
-spec = application.container.get(A2AAgentServerSpec)
-a2a_app = spec.build_app_for("assistant")
-```
-
-agent instance를 직접 들고 있는 테스트/어댑터 경계에서는 builder를 호출할 수 있습니다.
-
-```python
-from spakky.plugins.a2a.server.builder import build_a2a_app
-
-a2a_app = build_a2a_app(
-    assistant,
-    base_url="https://agents.example.com/a2a",
-    version="1.0.0",
-)
-```
+존재합니다. `rest_mount_path`를 지정하면 `/a2a-rest/assistant/.well-known/agent-card.json`과
+REST operation route가 같은 host app에 추가됩니다.
 
 ## Transport 선택
 
-`build_a2a_app()`은 AgentCard route와 JSON-RPC route를 함께 가진 mountable Starlette app을 만듭니다. HTTP+JSON REST 또는 gRPC가 필요하면 transport별 builder를 사용합니다.
+일반 애플리케이션은 transport별 builder 함수를 호출하지 않습니다. 노출할 transport를 `@A2ACompatible` metadata로 선언하고, plugin post-processor가 host에 연결합니다.
 
-| transport | builder | 설명 |
-|-----------|---------|------|
-| JSON-RPC + AgentCard | `build_a2a_app()` | `a2a-sdk` JSON-RPC route와 AgentCard route를 노출합니다. |
-| HTTP+JSON REST + AgentCard | `build_a2a_rest_app()` | REST operation route와 AgentCard route를 노출합니다. |
-| gRPC | `build_a2a_grpc_handler()` | 공식 `lf.a2a.v1.A2AService` generic gRPC handler를 만듭니다. |
+| transport | 선언 | 결과 |
+|-----------|------|------|
+| JSON-RPC + AgentCard | `mount_path` 또는 기본 prefix | Starlette/FastAPI host에 mount |
+| HTTP+JSON REST + AgentCard | `rest_mount_path` | Starlette/FastAPI host에 별도 mount |
+| gRPC | `grpc_enabled=True`, 선택적 `grpc_base_url` | `spakky-grpc` `GrpcServerSpec`에 handler 등록 |
 
-```python
-from spakky.plugins.a2a.rest_transport.builder import build_a2a_rest_app
-from spakky.plugins.a2a.grpc_transport import build_a2a_grpc_handler
+`base_url`, `rest_base_url`, `grpc_base_url`은 AgentCard에 광고되는 public operation endpoint입니다. ASGI mount path나 reverse proxy prefix가 외부 URL에 보이면 포함해야 합니다. AgentCard discovery path인 `/.well-known/agent-card.json` 자체는 포함하지 않습니다. 값을 생략하면 JSON-RPC는 `default_base_url + mount_path`, REST는 `default_base_url + rest_mount_path`를 사용합니다. gRPC는 HTTP path 기반 mount가 아니므로 실제 listener/scheme이 다르면 `grpc_base_url`을 명시합니다.
 
-rest_app = build_a2a_rest_app(
-    assistant,
-    base_url="https://agents.example.com/a2a",
-    version="1.0.0",
-    path_prefix="/v1",
-)
-grpc_handler = build_a2a_grpc_handler(
-    assistant,
-    base_url="https://agents.example.com/a2a-grpc",
-    version="1.0.0",
-)
-```
+`A2AAgentServerSpec.build_app_for()`, `build_rest_app_for()`, `build_grpc_handler_for()`와 transport builder 함수들은 custom host와 테스트를 위한 lower-level API입니다.
 
 ## AgentCard derivation
 
@@ -116,19 +88,28 @@ grpc_handler = build_a2a_grpc_handler(
 
 ## Task 저장소
 
-서버 builder의 `repository` 인자는 optional `IA2ATaskRepository`입니다. 지정하지 않으면 `InMemoryA2ATaskRepository`가 사용됩니다. 운영에서 durable task state가 필요하면 `IA2ATaskRepository` 구현을 Pod나 builder 인자로 제공합니다.
+서버 transport는 container에서 optional `IA2ATaskRepository` Pod를 찾습니다. 등록된 repository가 없으면 `InMemoryA2ATaskRepository`가 사용됩니다. 운영에서 durable task state가 필요하면 repository 구현을 Pod로 등록합니다.
 
 ```python
+from collections.abc import Sequence
+from a2a.types import Task
+from spakky.core.pod.annotations.pod import Pod
 from spakky.plugins.a2a.store.interfaces import IA2ATaskRepository
-from spakky.plugins.a2a.server.builder import build_a2a_app
 
-repository = application.container.get(IA2ATaskRepository)
-a2a_app = build_a2a_app(
-    assistant,
-    base_url="https://agents.example.com/a2a",
-    version="1.0.0",
-    repository=repository,
-)
+
+@Pod()
+class PostgresA2ATaskRepository(IA2ATaskRepository):
+    def get_or_none(self, task_id: str) -> Task | None:
+        ...
+
+    def save(self, task: Task) -> None:
+        ...
+
+    def delete(self, task_id: str) -> None:
+        ...
+
+    def list_all(self) -> Sequence[Task]:
+        ...
 ```
 
 `SpakkyA2ATaskStore`는 synchronous repository를 `a2a-sdk`의 async `TaskStore`로 감싸는 bridge입니다.

--- a/docs/guides/agent-ag-ui.md
+++ b/docs/guides/agent-ag-ui.md
@@ -60,7 +60,7 @@ class Assistant:
 
 ## 2. endpoint 마운트
 
-AG-UI 노출은 `@Agent` 위에 `@AgUiAgent` tag를 쌓아 선언합니다. plugin은
+AG-UI 노출은 `@Agent` 위에 `@AGUICompatible` tag를 쌓아 선언합니다. plugin은
 `AgUiConfig`, `AgUiAgentRegistry`, FastAPI mount post-processor를 등록하고, post-processor가
 marked Agent와 FastAPI Pod를 발견해 SSE/HTTP streaming/WebSocket route를 자동으로 붙입니다.
 애플리케이션 코드는 `run_driver_factory`나 `add_agui_endpoint()`를 호출하지 않습니다.
@@ -71,7 +71,7 @@ from spakky.agent import Agent, AgentExecutionSpec, IAgentModel
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
 from spakky.core.pod.annotations.pod import Pod
-from spakky.plugins.agui import AgUiAgent
+from spakky.plugins.agui import AGUICompatible
 
 
 @Pod(name="fastapi_app")
@@ -79,7 +79,7 @@ def fastapi_app() -> FastAPI:
     return FastAPI()
 
 
-@AgUiAgent()
+@AGUICompatible()
 @Agent(spec=AgentExecutionSpec(name="assistant", objective="answer with tools"))
 class Assistant:
     def __init__(self, model: IAgentModel) -> None:
@@ -94,7 +94,7 @@ app = application.container.get(FastAPI)
 여러 Agent를 노출할 때는 path 충돌을 피하도록 각 Agent에 경로를 선언합니다.
 
 ```python
-@AgUiAgent(
+@AGUICompatible(
     sse_path="/agents/researcher/agui",
     http_stream_path="/agents/researcher/agui/stream",
     websocket_path="/agents/researcher/agui/ws",
@@ -104,7 +104,7 @@ class Researcher:
     ...
 ```
 
-`@AgUiAgent(server_names=("weather",))`를 지정하면 `spakky-mcp`가 제공하는
+`@AGUICompatible(server_names=("weather",))`를 지정하면 `spakky-mcp`가 제공하는
 `IAgentRunnerFactory`가 해당 external MCP server tool만 이 Agent run에 결합합니다. 비워두면
 configured MCP server 전체를 사용합니다.
 
@@ -119,7 +119,7 @@ CLI나 MCP-style local bridge가 AG-UI payload를 stdio로 주고받아야 하�
 `AgUiStdioCommand`를 사용합니다. 입력은 AG-UI `RunAgentInput` JSON 한 건이고, 출력은
 AG-UI encoded event payload를 한 줄에 하나씩 씁니다.
 stdio 전용 host는 lower-level `RunDriverFactory`를 `AgUiStdioCommand`에 전달합니다. 일반
-FastAPI SSE/HTTP/WebSocket 노출은 `@AgUiAgent` 선언만 사용합니다.
+FastAPI SSE/HTTP/WebSocket 노출은 `@AGUICompatible` 선언만 사용합니다.
 
 ### 설정
 

--- a/docs/guides/agent-mcp.md
+++ b/docs/guides/agent-mcp.md
@@ -22,11 +22,11 @@ pip install spakky-mcp
 pip install "spakky[agent]"
 ```
 
-plugin 초기화는 `McpConfig`, `McpClient`, `McpToolServerRegistry`, `McpToolServer`, MCP post-processor를 등록합니다. 또한 `IAgentRunnerFactory`를 `McpClient`로 바인딩하므로 AG-UI/A2A 같은 inbound adapter가 runner factory를 통해 실행할 때 외부 도구가 자동으로 합류합니다.
+plugin 초기화는 `MCPConfig`, `MCPClient`, `MCPToolServerRegistry`, `MCPToolServer`, MCP post-processor를 등록합니다. 또한 `IAgentRunnerFactory`를 `MCPClient`로 바인딩하므로 AG-UI/A2A 같은 inbound adapter가 runner factory를 통해 실행할 때 외부 도구가 자동으로 합류합니다.
 
 ## 외부 서버 선언
 
-외부 서버는 `SPAKKY_MCP__` 접두사 환경변수 또는 `McpConfig`로 선언합니다. `transport`는 `stdio`(하위 프로세스로 서버 구동)와 `streamable_http`(원격 HTTP 서버)를 지원합니다.
+외부 서버는 `SPAKKY_MCP__` 접두사 환경변수 또는 `MCPConfig`로 선언합니다. `transport`는 `stdio`(하위 프로세스로 서버 구동)와 `streamable_http`(원격 HTTP 서버)를 지원합니다.
 
 ```bash
 # stdio 서버 1개를 JSON 배열로 선언
@@ -55,7 +55,7 @@ export SPAKKY_MCP__SERVERS='[{"name": "weather", "command": "weather-mcp-server"
 ## 에이전트에 합류시키기
 
 외부 MCP tool은 `IAgentRunnerFactory` 경로로 합류합니다. `spakky-mcp`가 로드되면 이 port가
-`McpClient`에 바인딩되고, inbound adapter가 agent run마다 factory context를 열 때 외부 서버에
+`MCPClient`에 바인딩되고, inbound adapter가 agent run마다 factory context를 열 때 외부 서버에
 연결해 도구를 발견합니다. 외부 서버 세션은 runner context 동안 유지되며 context를 벗어나면
 정리됩니다.
 
@@ -92,14 +92,16 @@ async def custom_inbound_boundary(
 
 ### 서버 만들기
 
-MCP server로 노출할 Agent는 `@Agent` 위에 `@McpToolServerAgent` marker를 쌓습니다.
+MCP server는 agent가 아니라 MCP protocol host입니다. `@MCPServer`는 `@Agent` 자체를
+서버라고 부르는 annotation이 아니라, 그 Agent의 `@agent_tool` 카탈로그를 MCP server에
+연결하겠다는 marker입니다.
 
 ```python
 from spakky.agent import Agent, AgentExecutionSpec, agent_tool
-from spakky.plugins.mcp import McpToolServerAgent
+from spakky.plugins.mcp import MCPServer
 
 
-@McpToolServerAgent(server_name="weather-agent")
+@MCPServer(server_name="weather-agent")
 @Agent(spec=AgentExecutionSpec(name="weather"))
 class WeatherAgent:
     @agent_tool(schema_name="forecast", description="Return a forecast.")
@@ -107,13 +109,13 @@ class WeatherAgent:
         return f"sunny:{city}"
 ```
 
-`McpToolServer` Pod는 registry에서 agent를 resolve하므로 host entrypoint는 agent instance를 직접 넘기지 않습니다.
+`MCPToolServer` Pod는 registry에서 agent를 resolve하므로 host entrypoint는 agent instance를 직접 넘기지 않습니다.
 
 ```python
-from spakky.plugins.mcp import McpToolServer
+from spakky.plugins.mcp import MCPToolServer
 
 
-async def expose(server: McpToolServer) -> None:
+async def expose(server: MCPToolServer) -> None:
     await server.serve_stdio_for("weather")
 ```
 
@@ -121,8 +123,8 @@ async def expose(server: McpToolServer) -> None:
 
 | 전송 | 진입점 | 용도 |
 |------|--------|------|
-| `stdio` | `McpToolServer.serve_stdio_for(agent_name)` | 클라이언트가 하위 프로세스로 서버를 구동 |
-| `streamable_http` | `McpToolServer.streamable_http_session_manager_for(agent_name)` | 원격 HTTP 노출 — 반환된 세션 매니저를 호스트 애플리케이션의 lifespan에서 구동하고 인바운드 요청을 `handle_request`로 라우팅 |
+| `stdio` | `MCPToolServer.serve_stdio_for(agent_name)` | 클라이언트가 하위 프로세스로 서버를 구동 |
+| `streamable_http` | `MCPToolServer.streamable_http_session_manager_for(agent_name)` | 원격 HTTP 노출 — 반환된 세션 매니저를 호스트 애플리케이션의 lifespan에서 구동하고 인바운드 요청을 `handle_request`로 라우팅 |
 
 `streamable_http` 세션 매니저는 자신의 `run()` 컨텍스트 동안 단일 task group을 소유하며 컨텍스트를 벗어나면 재사용할 수 없습니다 — 호스트 애플리케이션 lifespan에서 1회 구동합니다.
 

--- a/plugins/spakky-a2a/README.md
+++ b/plugins/spakky-a2a/README.md
@@ -17,25 +17,29 @@ pip install spakky-a2a
 
 | 환경변수 | 기본값 | 목적 |
 |----------------------|---------|---------|
-| `SPAKKY_A2A_DEFAULT_BASE_URL` | `http://localhost:8000` | 기본 config를 쓰는 derived AgentCard interface에 광고할 base URL |
+| `SPAKKY_A2A_DEFAULT_BASE_URL` | `http://localhost:8000` | marker가 `base_url`을 생략할 때 mount path와 결합할 public host URL |
 | `SPAKKY_A2A_DEFAULT_VERSION` | `1.0.0` | derived AgentCard에 광고할 semantic version |
 | `SPAKKY_A2A_DEFAULT_MOUNT_PATH_PREFIX` | `/a2a` | 자동 mount되는 A2A agent app의 path prefix |
 
-Plugin 초기화는 `A2AConfig`, `A2AAgentRegistry`, `A2AAgentServerSpec`, A2A remote delegate Pod, 그리고 `@Agent`와 `@A2AAgentServer`가 함께 붙은 class를 발견해 ASGI host에 mount하는 post-processor를 등록합니다.
+Plugin 초기화는 `A2AConfig`, `A2AAgentRegistry`, `A2AAgentServerSpec`, A2A remote delegate Pod, 그리고 `@Agent`와 `@A2ACompatible`가 함께 붙은 class를 발견해 ASGI/gRPC host에 연결하는 post-processor를 등록합니다.
 
 ## Agent 노출
 
-`@A2AAgentServer`는 `@Agent`와 같은 class에 쌓는 tag입니다. `@Agent`가 Pod를 등록하고, tag는 A2A transport metadata와 optional mount path를 기록합니다.
+`@A2ACompatible`는 `@Agent`와 같은 class에 쌓는 tag입니다. `@Agent`가 Pod를 등록하고, tag는 A2A transport metadata와 optional mount path를 기록합니다.
 
 ```python
 from spakky.agent import Agent, AgentExecutionSpec, IAgentModel
-from spakky.plugins.a2a import A2AAgentServer
+from spakky.plugins.a2a import A2ACompatible
 
 
-@A2AAgentServer(
+@A2ACompatible(
     base_url="https://agents.example.com/a2a/planner",
     version="1.0.0",
     mount_path="/a2a/planner",
+    rest_mount_path="/a2a-rest/planner",
+    rest_base_url="https://agents.example.com/a2a-rest/planner",
+    grpc_enabled=True,
+    grpc_base_url="grpc://agents.example.com:443",
 )
 @Agent(spec=AgentExecutionSpec(name="planner", objective="Plan work"))
 class PlannerAgent:
@@ -44,9 +48,19 @@ class PlannerAgent:
 ```
 
 애플리케이션이 Starlette/FastAPI host Pod를 제공하면 plugin post-processor가 bootstrap 중
-`mount_path`에 A2A JSON-RPC + AgentCard app을 자동 mount합니다. `mount_path`를 생략하면
-`{default_mount_path_prefix}/{agent_name}`을 사용합니다. `base_url`과 `version`을 생략하면
-`A2AConfig.default_base_url`, `A2AConfig.default_version`을 사용합니다.
+`mount_path`에 A2A JSON-RPC + AgentCard app을 자동 mount합니다. `rest_mount_path`를 지정하면
+HTTP+JSON REST + AgentCard app도 그 path에 별도로 mount합니다. `mount_path`를 생략하면
+`{default_mount_path_prefix}/{agent_name}`을 사용합니다. `version`을 생략하면
+`A2AConfig.default_version`을 사용합니다.
+
+`base_url`은 AgentCard `supported_interfaces[].url`에 광고되는 **public transport endpoint**입니다.
+클라이언트가 reverse proxy나 ASGI mount path를 통해 호출한다면 그 외부 path를 포함해야 하며,
+`/.well-known/agent-card.json` 자체는 포함하지 않습니다. 예를 들어 위 선언에서 card URL은
+`https://agents.example.com/a2a/planner/.well-known/agent-card.json`이고, JSON-RPC operation endpoint는
+`https://agents.example.com/a2a/planner/`입니다. `base_url`을 생략하면 framework가
+`A2AConfig.default_base_url.rstrip("/") + mount_path`로 유도하므로 기본 설정에서는
+`http://localhost:8000/a2a/planner`가 광고됩니다. REST도 `rest_base_url`을 생략하면
+`default_base_url + rest_mount_path`를 광고합니다.
 
 ```python
 from starlette.applications import Starlette
@@ -58,25 +72,14 @@ def asgi_host() -> Starlette:
     return Starlette()
 ```
 
-애플리케이션 bootstrap 이후 `A2AAgentServerSpec.build_app_for("planner")`는 등록된 agent를
-resolve하는 lower-level API로 사용할 수 있습니다. Container에 `IA2ATaskRepository`가 등록되어
-있으면 이를 사용하고, 없으면 `InMemoryA2ATaskRepository`를 사용합니다.
+gRPC 노출은 `grpc_enabled=True`인 entry를 `spakky-grpc`의 `GrpcServerSpec`에 자동 등록합니다.
+따라서 애플리케이션은 `spakky-a2a`와 `spakky-grpc` plugin을 함께 로드하고
+`SPAKKY_GRPC_BIND_ADDRESSES`를 설정하면 됩니다. `spakky-grpc`가 로드되지 않은 애플리케이션에서는
+gRPC 선언은 no-op입니다.
 
-직접 조립해야 하는 host 환경에서는 transport별 builder를 lower-level API로 사용할 수 있습니다.
-
-```python
-from spakky.plugins.a2a.server.builder import build_a2a_app
-from spakky.plugins.a2a.rest_transport import build_a2a_rest_app
-from spakky.plugins.a2a.grpc_transport import build_a2a_grpc_handler
-
-jsonrpc_app = build_a2a_app(agent, base_url="https://agents.example.com/a2a", version="1.0.0")
-rest_app = build_a2a_rest_app(agent, base_url="https://agents.example.com/a2a", version="1.0.0")
-grpc_handler = build_a2a_grpc_handler(agent, base_url="https://agents.example.com/a2a", version="1.0.0")
-```
-
-- `build_a2a_app()`은 AgentCard route와 `a2a-sdk` JSON-RPC route(v0.3 method compatibility 포함)를 가진 Starlette app을 만듭니다.
-- `build_a2a_rest_app()`은 HTTP+JSON REST binding을 만들고 optional `path_prefix`를 받습니다.
-- `build_a2a_grpc_handler()`는 `lf.a2a.v1.A2AService`용 `grpc.GenericRpcHandler`를 만듭니다.
+애플리케이션 bootstrap 이후 `A2AAgentServerSpec.build_app_for("planner")`,
+`build_rest_app_for("planner")`, `build_grpc_handler_for("planner")`는 특수 host나 테스트에서 쓰는
+lower-level escape hatch입니다. 일반 애플리케이션은 `@A2ACompatible` 선언과 host Pod만 사용합니다.
 
 ## AgentCard 유도
 

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/__init__.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/__init__.py
@@ -16,6 +16,7 @@ from spakky.plugins.a2a.client import A2ARemoteAgentClient, RemoteA2AMessage
 from spakky.plugins.a2a.delegation import A2AAgentDelegate, A2AStreamEventMapper
 from spakky.plugins.a2a.error import A2AEndpointConflictError
 from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
 
 PLUGIN_NAME = Plugin(name="spakky-a2a")
 """Plugin identifier for the A2A integration."""
@@ -27,6 +28,7 @@ __all__ = [
     "A2AAgentDelegate",
     "A2ARemoteAgentClient",
     "A2AStreamEventMapper",
+    "A2ACompatible",
     "A2AAgentServer",
     "A2AEndpointConflictError",
     "RemoteA2AMessage",

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/config.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/config.py
@@ -9,7 +9,7 @@ SPAKKY_A2A_CONFIG_ENV_PREFIX = "SPAKKY_A2A_"
 """Environment prefix for A2A plugin settings."""
 
 DEFAULT_A2A_BASE_URL = "http://localhost:8000"
-"""Fallback base URL advertised on a derived AgentCard interface."""
+"""Fallback public host URL used to derive AgentCard transport endpoints."""
 
 DEFAULT_A2A_VERSION = "1.0.0"
 """Fallback semantic version advertised on a derived AgentCard."""
@@ -29,7 +29,7 @@ class A2AConfig(BaseSettings):
     )
 
     default_base_url: str = DEFAULT_A2A_BASE_URL
-    """Base URL advertised on a derived AgentCard transport interface."""
+    """Public host URL combined with the mount path when a marker omits base_url."""
 
     default_version: str = DEFAULT_A2A_VERSION
     """Semantic version advertised on a derived AgentCard."""

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/main.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/main.py
@@ -1,7 +1,7 @@
 """Plugin initialization for the A2A protocol server integration.
 
 Registers the plugin configuration, the agent-server registry, the container-aware
-app-builder spec, and the post-processor that discovers @A2AAgentServer-marked
+app-builder spec, and the post-processor that discovers @A2ACompatible-marked
 @Agent Pods. This function is called automatically during plugin loading.
 """
 
@@ -11,6 +11,9 @@ from spakky.agent import AgentRunnerFactory, IAgentDelegate, IAgentRunnerFactory
 from spakky.plugins.a2a.config import A2AConfig
 from spakky.plugins.a2a.delegation import A2AAgentDelegate
 from spakky.plugins.a2a.post_processors.mount_asgi import MountA2AASGIPostProcessor
+from spakky.plugins.a2a.post_processors.register_grpc import (
+    RegisterA2AGRPCPostProcessor,
+)
 from spakky.plugins.a2a.post_processors.register_agent_servers import (
     RegisterA2AAgentServersPostProcessor,
 )
@@ -33,3 +36,4 @@ def initialize(app: SpakkyApplication) -> None:
     app.add(A2AAgentServerSpec)
     app.add(RegisterA2AAgentServersPostProcessor)
     app.add(MountA2AASGIPostProcessor)
+    app.add(RegisterA2AGRPCPostProcessor)

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/post_processors/mount_asgi.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/post_processors/mount_asgi.py
@@ -1,5 +1,6 @@
 """Post-processor that mounts discovered A2A agents on ASGI host Pods."""
 
+from collections.abc import Callable
 from logging import getLogger
 from typing import cast, override
 
@@ -19,7 +20,7 @@ from starlette.applications import Starlette
 from spakky.plugins.a2a.error import A2AEndpointConflictError
 from spakky.plugins.a2a.server.builder import A2AAgentServerSpec
 from spakky.plugins.a2a.server.registry import A2AAgentRegistry, A2AAgentServerEntry
-from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
 
 logger = getLogger(__name__)
 
@@ -34,7 +35,7 @@ class MountA2AASGIPostProcessor(
     _container: IContainer
     _application_context: IApplicationContext
     _claimed_paths: dict[tuple[int, str], str]
-    _mounted: set[tuple[int, str]]
+    _mounted: set[tuple[int, str, str]]
 
     def __init__(self) -> None:
         self._claimed_paths = {}
@@ -62,7 +63,7 @@ class MountA2AASGIPostProcessor(
             self._mount_registered_agents(pod)
             return pod
         agent_type = self._unwrap_proxy_type(type(pod))
-        if not (A2AAgentServer.exists(agent_type) and Agent.exists(agent_type)):
+        if not (A2ACompatible.exists(agent_type) and Agent.exists(agent_type)):
             return pod
         entry = self._container.get(A2AAgentRegistry).get(self._agent_name(agent_type))
         for app in self._asgi_hosts():
@@ -86,17 +87,44 @@ class MountA2AASGIPostProcessor(
 
     def _mount_entry(self, app: Starlette, entry: A2AAgentServerEntry) -> None:
         spec = self._container.get(A2AAgentServerSpec)
-        path = spec.mount_path_for(entry.agent_name)
+        self._mount_app(
+            app,
+            entry,
+            transport="jsonrpc",
+            path=spec.mount_path_for(entry.agent_name),
+            app_factory=lambda: spec.build_app_for(entry.agent_name),
+        )
+        rest_path = spec.rest_mount_path_for(entry.agent_name)
+        if rest_path is None:
+            return
+        self._mount_app(
+            app,
+            entry,
+            transport="rest",
+            path=rest_path,
+            app_factory=lambda: spec.build_rest_app_for(entry.agent_name),
+        )
+
+    def _mount_app(
+        self,
+        app: Starlette,
+        entry: A2AAgentServerEntry,
+        *,
+        transport: str,
+        path: str,
+        app_factory: Callable[[], Starlette],
+    ) -> None:
         app_id = id(app)
         claim_key = (app_id, path)
-        current_agent = self._claimed_paths.get(claim_key)
-        if current_agent is not None and current_agent != entry.agent_name:
+        label = f"{entry.agent_name}:{transport}"
+        current_label = self._claimed_paths.get(claim_key)
+        if current_label is not None and current_label != label:
             raise A2AEndpointConflictError
-        self._claimed_paths[claim_key] = entry.agent_name
-        mount_key = (app_id, entry.agent_name)
+        self._claimed_paths[claim_key] = label
+        mount_key = (app_id, entry.agent_name, transport)
         if mount_key in self._mounted:
             return
-        app.mount(path, spec.build_app_for(entry.agent_name))
+        app.mount(path, app_factory())
         self._mounted.add(mount_key)
 
     @staticmethod

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/post_processors/register_agent_servers.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/post_processors/register_agent_servers.py
@@ -1,4 +1,4 @@
-"""Post-processor registering @A2AAgentServer-marked @Agent Pods."""
+"""Post-processor registering @A2ACompatible-marked @Agent Pods."""
 
 from logging import getLogger
 from typing import override
@@ -12,7 +12,7 @@ from spakky.core.pod.interfaces.container import IContainer
 from spakky.core.pod.interfaces.post_processor import IPostProcessor
 
 from spakky.plugins.a2a.server.registry import A2AAgentRegistry
-from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
 
 logger = getLogger(__name__)
 
@@ -20,7 +20,7 @@ logger = getLogger(__name__)
 @Order(0)
 @Pod()
 class RegisterA2AAgentServersPostProcessor(IPostProcessor, IContainerAware):
-    """Registers Pods carrying both @Agent and @A2AAgentServer in the registry."""
+    """Registers Pods carrying both @Agent and @A2ACompatible in the registry."""
 
     _container: IContainer
 
@@ -42,14 +42,14 @@ class RegisterA2AAgentServersPostProcessor(IPostProcessor, IContainerAware):
 
     @override
     def post_process(self, pod: object) -> object:
-        """Register *pod* when it is an @A2AAgentServer-marked @Agent.
+        """Register *pod* when it is an @A2ACompatible-marked @Agent.
 
         Pods missing either marker are returned unchanged.
         """
         pod_type = self._unwrap_proxy_type(type(pod))
-        if not (A2AAgentServer.exists(pod_type) and Agent.exists(pod_type)):
+        if not (A2ACompatible.exists(pod_type) and Agent.exists(pod_type)):
             return pod
         registry = self._container.get(A2AAgentRegistry)
-        registry.register(pod, pod_type, A2AAgentServer.get(pod_type))
+        registry.register(pod, pod_type, A2ACompatible.get(pod_type))
         logger.info("Registered A2A agent server from %s", pod_type.__qualname__)
         return pod

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/post_processors/register_grpc.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/post_processors/register_grpc.py
@@ -1,0 +1,97 @@
+"""Post-processor registering A2A gRPC handlers with spakky-grpc."""
+
+from typing import cast, override
+
+from spakky.agent.execution import Agent
+from spakky.core.common.constants import DYNAMIC_PROXY_CLASS_NAME_SUFFIX
+from spakky.core.pod.annotations.order import Order
+from spakky.core.pod.annotations.pod import Pod
+from spakky.core.pod.interfaces.aware.container_aware import IContainerAware
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.core.pod.interfaces.post_processor import IPostProcessor
+
+from spakky.plugins.a2a.server.builder import A2AAgentServerSpec
+from spakky.plugins.a2a.server.registry import A2AAgentRegistry
+from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
+
+GRPC_SERVER_SPEC_MODULE = "spakky.plugins.grpc.server_spec"
+"""Module path used to identify spakky-grpc's GrpcServerSpec without importing it."""
+
+GRPC_SERVER_SPEC_NAME = "GrpcServerSpec"
+"""Class name used to identify spakky-grpc's GrpcServerSpec without importing it."""
+
+
+class _GrpcServerSpecLike:
+    """Nominal local type for the GrpcServerSpec method this adapter needs."""
+
+    def add_handler(self, handler: object) -> None:
+        """Register a generic RPC handler."""
+        ...
+
+
+@Order(2)
+@Pod()
+class RegisterA2AGRPCPostProcessor(IPostProcessor, IContainerAware):
+    """Register @A2ACompatible gRPC handlers when spakky-grpc is active."""
+
+    _container: IContainer
+    _registered: set[str]
+    _grpc_specs: list[_GrpcServerSpecLike]
+
+    def __init__(self) -> None:
+        self._registered = set()
+        self._grpc_specs = []
+
+    @override
+    def set_container(self, container: IContainer) -> None:
+        self._container = container
+
+    @staticmethod
+    def _unwrap_proxy_type(pod_type: type[object]) -> type[object]:
+        """Return the original class when *pod_type* is an AOP dynamic proxy."""
+        if pod_type.__name__.endswith(DYNAMIC_PROXY_CLASS_NAME_SUFFIX):
+            return pod_type.__bases__[0]
+        return pod_type
+
+    @staticmethod
+    def _is_grpc_spec(pod: object) -> bool:
+        pod_type = type(pod)
+        return (
+            pod_type.__module__ == GRPC_SERVER_SPEC_MODULE
+            and pod_type.__name__ == GRPC_SERVER_SPEC_NAME
+        )
+
+    @override
+    def post_process(self, pod: object) -> object:
+        """Register enabled A2A gRPC handlers when a spec or agent appears."""
+        if self._is_grpc_spec(pod):
+            grpc_spec = cast(_GrpcServerSpecLike, pod)
+            self._grpc_specs.append(grpc_spec)
+            for entry in self._container.get(A2AAgentRegistry).list_entries():
+                self._register_entry(grpc_spec, entry.agent_name)
+            return pod
+        if self._is_marked_agent(pod):
+            agent_type = self._unwrap_proxy_type(type(pod))
+            agent_name = self._agent_name(agent_type)
+            for grpc_spec in self._grpc_specs:
+                self._register_entry(grpc_spec, agent_name)
+        return pod
+
+    def _is_marked_agent(self, pod: object) -> bool:
+        agent_type = self._unwrap_proxy_type(type(pod))
+        return A2ACompatible.exists(agent_type) and Agent.exists(agent_type)
+
+    def _register_entry(self, grpc_spec: _GrpcServerSpecLike, agent_name: str) -> None:
+        entry = self._container.get(A2AAgentRegistry).get(agent_name)
+        if not entry.metadata.grpc_enabled:
+            return
+        if entry.agent_name in self._registered:
+            return
+        a2a_spec = self._container.get(A2AAgentServerSpec)
+        grpc_spec.add_handler(a2a_spec.build_grpc_handler_for(entry.agent_name))
+        self._registered.add(entry.agent_name)
+
+    @staticmethod
+    def _agent_name(agent_type: type[object]) -> str:
+        agent = Agent.get(agent_type)
+        return agent.spec.name or agent_type.__name__

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/server/builder.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/server/builder.py
@@ -19,6 +19,9 @@ from starlette.applications import Starlette
 
 from spakky.plugins.a2a.card.derivation import AgentCardFactory
 from spakky.plugins.a2a.config import A2AConfig
+from spakky.plugins.a2a.grpc_transport.builder import build_a2a_grpc_handler
+from spakky.plugins.a2a.grpc_transport.handler import A2AGrpcHandler
+from spakky.plugins.a2a.rest_transport.builder import build_a2a_rest_app
 from spakky.plugins.a2a.server.request_handler import build_a2a_request_handler
 from spakky.plugins.a2a.server.registry import A2AAgentServerEntry
 from spakky.plugins.a2a.server.registry import A2AAgentRegistry
@@ -102,6 +105,34 @@ class A2AAgentServerSpec(IContainerAware):
             runner_factory=runner_factory,
         )
 
+    def build_rest_app_for(self, agent_name: str) -> Starlette:
+        """Build a mountable A2A REST app for a registered agent name."""
+        entry = self._container.get(A2AAgentRegistry).get(agent_name)
+        repository = self._container.get_or_none(IA2ATaskRepository)
+        runner_factory = self._container.get(IAgentRunnerFactory)
+        return build_a2a_rest_app(
+            entry.instance,
+            base_url=self._rest_base_url(entry),
+            version=self._version(entry),
+            repository=repository,
+            agent_type=entry.agent_type,
+            runner_factory=runner_factory,
+        )
+
+    def build_grpc_handler_for(self, agent_name: str) -> A2AGrpcHandler:
+        """Build an A2A gRPC handler for a registered agent name."""
+        entry = self._container.get(A2AAgentRegistry).get(agent_name)
+        repository = self._container.get_or_none(IA2ATaskRepository)
+        runner_factory = self._container.get(IAgentRunnerFactory)
+        return build_a2a_grpc_handler(
+            entry.instance,
+            base_url=self._grpc_base_url(entry),
+            version=self._version(entry),
+            repository=repository,
+            agent_type=entry.agent_type,
+            runner_factory=runner_factory,
+        )
+
     def mount_path_for(self, agent_name: str) -> str:
         """Return the ASGI mount path for a registered agent."""
         entry = self._container.get(A2AAgentRegistry).get(agent_name)
@@ -110,8 +141,29 @@ class A2AAgentServerSpec(IContainerAware):
         prefix = self._config().default_mount_path_prefix.rstrip("/")
         return f"{prefix}/{agent_name}"
 
+    def rest_mount_path_for(self, agent_name: str) -> str | None:
+        """Return the optional REST ASGI mount path for a registered agent."""
+        entry = self._container.get(A2AAgentRegistry).get(agent_name)
+        return entry.metadata.rest_mount_path
+
     def _base_url(self, entry: A2AAgentServerEntry) -> str:
-        return entry.metadata.base_url or self._config().default_base_url
+        if entry.metadata.base_url is not None:
+            return entry.metadata.base_url
+        default_host = self._config().default_base_url.rstrip("/")
+        return f"{default_host}{self.mount_path_for(entry.agent_name)}"
+
+    def _rest_base_url(self, entry: A2AAgentServerEntry) -> str:
+        if entry.metadata.rest_base_url is not None:
+            return entry.metadata.rest_base_url
+        rest_mount_path = entry.metadata.rest_mount_path
+        if rest_mount_path is not None:
+            return f"{self._config().default_base_url.rstrip('/')}{rest_mount_path}"
+        return self._base_url(entry)
+
+    def _grpc_base_url(self, entry: A2AAgentServerEntry) -> str:
+        if entry.metadata.grpc_base_url is not None:
+            return entry.metadata.grpc_base_url
+        return self._base_url(entry)
 
     def _version(self, entry: A2AAgentServerEntry) -> str:
         return entry.metadata.version or self._config().default_version

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/server/registry.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/server/registry.py
@@ -6,7 +6,7 @@ from spakky.agent.execution import Agent
 from spakky.core.pod.annotations.pod import Pod
 
 from spakky.plugins.a2a.error import A2AAgentServerNotRegisteredError
-from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
 
 
 @dataclass(frozen=True, slots=True)
@@ -16,7 +16,7 @@ class A2AAgentServerEntry:
     agent_name: str
     instance: object
     agent_type: type[object]
-    metadata: A2AAgentServer
+    metadata: A2ACompatible
 
 
 @Pod()
@@ -32,7 +32,7 @@ class A2AAgentRegistry:
         self,
         instance: object,
         agent_type: type[object],
-        metadata: A2AAgentServer,
+        metadata: A2ACompatible,
     ) -> None:
         """Register an @Agent instance under its resolved agent name.
 

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/stereotypes/a2a_agent_server.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/stereotypes/a2a_agent_server.py
@@ -1,31 +1,8 @@
-"""@A2AAgentServer marker for exposing an @Agent over the A2A protocol.
+"""Backward-compatible import for the legacy @A2AAgentServer marker name."""
 
-Unlike ``@GrpcController`` (which subclasses ``Controller`` and registers its own
-Pod), this marker subclasses :class:`~spakky.core.pod.annotations.tag.Tag`: the
-``@Agent`` decorator already registers the Pod, so this tag only records the A2A
-transport metadata and stacks above ``@Agent`` on the same class.
-"""
+from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
 
-from dataclasses import dataclass
+A2AAgentServer = A2ACompatible
+"""Deprecated alias for :class:`A2ACompatible`."""
 
-from spakky.core.pod.annotations.tag import Tag
-
-
-@dataclass(eq=False)
-class A2AAgentServer(Tag):
-    """Marks an @Agent class to be served as an A2A protocol endpoint.
-
-    Attributes:
-        base_url: Transport endpoint advertised on the derived AgentCard.
-        version: Semantic version advertised on the derived AgentCard.
-        mount_path: Starlette/FastAPI mount path for automatic ASGI exposure.
-    """
-
-    base_url: str | None = None
-    """Transport endpoint advertised on the derived AgentCard interface."""
-
-    version: str | None = None
-    """Semantic version advertised on the derived AgentCard."""
-
-    mount_path: str | None = None
-    """ASGI host mount path. None uses ``A2AConfig.default_mount_path_prefix``."""
+__all__ = ["A2AAgentServer"]

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/stereotypes/a2a_compatible.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/stereotypes/a2a_compatible.py
@@ -1,0 +1,43 @@
+"""@A2ACompatible marker for exposing an @Agent over the A2A protocol.
+
+Unlike ``@GrpcController`` (which subclasses ``Controller`` and registers its own
+Pod), this marker subclasses :class:`~spakky.core.pod.annotations.tag.Tag`: the
+``@Agent`` decorator already registers the Pod, so this tag only records the A2A
+transport metadata and stacks above ``@Agent`` on the same class.
+"""
+
+from dataclasses import dataclass
+
+from spakky.core.pod.annotations.tag import Tag
+
+
+@dataclass(eq=False)
+class A2ACompatible(Tag):
+    """Marks an @Agent class to be served through an A2A protocol endpoint.
+
+    Attributes:
+        base_url: Public transport endpoint advertised on the derived AgentCard.
+        version: Semantic version advertised on the derived AgentCard.
+        mount_path: Starlette/FastAPI mount path for automatic ASGI exposure.
+    """
+
+    base_url: str | None = None
+    """Public endpoint advertised on the derived AgentCard interface."""
+
+    version: str | None = None
+    """Semantic version advertised on the derived AgentCard."""
+
+    mount_path: str | None = None
+    """ASGI host mount path. None uses ``A2AConfig.default_mount_path_prefix``."""
+
+    rest_mount_path: str | None = None
+    """Optional ASGI mount path for the HTTP+JSON REST transport."""
+
+    rest_base_url: str | None = None
+    """Public REST transport endpoint. None derives from default_base_url + path."""
+
+    grpc_enabled: bool = False
+    """Whether to register the official A2A gRPC handler when spakky-grpc is active."""
+
+    grpc_base_url: str | None = None
+    """Public gRPC transport endpoint advertised by the gRPC handler."""

--- a/plugins/spakky-a2a/tests/integration/conftest.py
+++ b/plugins/spakky-a2a/tests/integration/conftest.py
@@ -36,7 +36,7 @@ from spakky.agent.tooling import (
 from starlette.applications import Starlette
 
 from spakky.plugins.a2a.server.builder import build_a2a_app
-from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
 from tests.unit.conftest import (
     FakeEvidenceRepository,
     FakeSignalRepository,
@@ -87,7 +87,7 @@ def _tool(name: str) -> ModelStreamEvent:
     )
 
 
-@A2AAgentServer(base_url="http://assistant.local", version="1.0.0")
+@A2ACompatible(base_url="http://assistant.local", version="1.0.0")
 @Agent(spec=DURABLE_SPEC)
 class AssistantAgent:
     """Durable served agent exercised through the A2A transport."""

--- a/plugins/spakky-a2a/tests/integration/test_auto_mount.py
+++ b/plugins/spakky-a2a/tests/integration/test_auto_mount.py
@@ -1,4 +1,4 @@
-"""Integration: @A2AAgentServer agents mount on ASGI hosts through DI."""
+"""Integration: @A2ACompatible agents mount on ASGI hosts through DI."""
 
 from collections.abc import AsyncIterator
 
@@ -21,7 +21,7 @@ from starlette.applications import Starlette
 from typing import override
 
 from spakky.plugins.a2a.main import initialize as initialize_a2a
-from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
 
 type JsonObject = dict[str, object]
 
@@ -48,7 +48,7 @@ class AutoMountModel(IAgentModel):
         yield ModelStreamEvent(kind=ModelStreamEventKind.DONE)
 
 
-@A2AAgentServer(base_url="http://auto.local", version="1.0.0")
+@A2ACompatible(base_url="http://auto.local", version="1.0.0")
 @Agent(spec=AgentExecutionSpec(name="auto_a2a", objective="answer"))
 class AutoMountedA2AAgent:
     """Agent exposed as A2A solely by declaration."""
@@ -88,7 +88,7 @@ def _build_app() -> Starlette:
 
 
 async def test_a2a_agent_mounts_jsonrpc_app_without_manual_builder() -> None:
-    """@A2AAgentServer @Agent가 수동 builder 없이 ASGI host에 mount된다."""
+    """@A2ACompatible @Agent가 수동 builder 없이 ASGI host에 mount된다."""
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=_build_app()),
         base_url="http://testserver",

--- a/plugins/spakky-a2a/tests/unit/_sample_agents.py
+++ b/plugins/spakky-a2a/tests/unit/_sample_agents.py
@@ -17,7 +17,7 @@ from spakky.agent.tooling import (
     agent_tool,
 )
 
-from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
 
 
 class StubModel(IAgentModel):
@@ -38,7 +38,7 @@ class StubModel(IAgentModel):
         yield  # pragma: no cover - empty async generator body
 
 
-@A2AAgentServer(base_url="http://planner.local", version="1.2.3")
+@A2ACompatible(base_url="http://planner.local", version="1.2.3")
 @Agent(spec=AgentExecutionSpec(name="planner", objective="Plan things."))
 class ServedPlannerAgent:
     """Agent marked for A2A serving, used by registry and builder tests."""

--- a/plugins/spakky-a2a/tests/unit/test_a2a_agent_server_stereotype.py
+++ b/plugins/spakky-a2a/tests/unit/test_a2a_agent_server_stereotype.py
@@ -1,43 +1,57 @@
-"""Tests for the @A2AAgentServer marker."""
+"""Tests for the @A2ACompatible marker."""
 
 from spakky.agent.execution import Agent, AgentExecutionSpec
 from spakky.agent.interfaces.model import IAgentModel
 from spakky.core.pod.annotations.pod import Pod
+import spakky.plugins.a2a as a2a_api
+from spakky.plugins.a2a import A2ACompatible as PublicA2ACompatible
 
+from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
 from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
 
 
 def test_marker_does_not_register_its_own_pod() -> None:
-    """@A2AAgentServer alone records metadata without registering a Pod."""
+    """@A2ACompatible alone records metadata without registering a Pod."""
 
-    @A2AAgentServer(base_url="http://x", version="1.0.0")
+    @A2ACompatible(base_url="http://x", version="1.0.0")
     class PlainClass:
         pass
 
     assert not Pod.exists(PlainClass)
-    assert A2AAgentServer.exists(PlainClass)
+    assert A2ACompatible.exists(PlainClass)
 
 
 def test_marker_stacks_above_agent_preserving_agent_pod() -> None:
     """Stacked above @Agent, the marker coexists with the agent's Pod."""
 
-    @A2AAgentServer(base_url="http://x", version="2.0.0")
+    @A2ACompatible(base_url="http://x", version="2.0.0")
     @Agent(spec=AgentExecutionSpec(name="stacked"))
     class StackedAgent:
         def __init__(self, model: IAgentModel) -> None:
             self._model = model
 
     assert Agent.exists(StackedAgent)
-    assert A2AAgentServer.exists(StackedAgent)
+    assert A2ACompatible.exists(StackedAgent)
 
 
 def test_marker_stores_base_url_and_version() -> None:
     """The marker preserves the declared base url and version."""
 
-    @A2AAgentServer(base_url="http://host:9000", version="3.1.4")
+    @A2ACompatible(base_url="http://host:9000", version="3.1.4")
     class Marked:
         pass
 
-    marker = A2AAgentServer.get(Marked)
+    marker = A2ACompatible.get(Marked)
     assert marker.base_url == "http://host:9000"
     assert marker.version == "3.1.4"
+
+
+def test_legacy_agent_server_name_aliases_compatible_marker() -> None:
+    """The old @A2AAgentServer import remains a compatibility alias."""
+    assert A2AAgentServer is A2ACompatible
+
+
+def test_public_api_exports_compatible_marker() -> None:
+    """The canonical public import exports @A2ACompatible."""
+    assert PublicA2ACompatible is A2ACompatible
+    assert a2a_api.A2ACompatible is A2ACompatible

--- a/plugins/spakky-a2a/tests/unit/test_builder.py
+++ b/plugins/spakky-a2a/tests/unit/test_builder.py
@@ -7,6 +7,7 @@ from spakky.core.pod.interfaces.container import IContainer
 from starlette.applications import Starlette
 
 from spakky.plugins.a2a.error import A2AAgentServerNotRegisteredError
+from spakky.plugins.a2a.config import A2AConfig
 from spakky.plugins.a2a.server.builder import A2AAgentServerSpec, build_a2a_app
 from spakky.plugins.a2a.server.registry import A2AAgentRegistry
 from spakky.plugins.a2a.store.interfaces import IA2ATaskRepository
@@ -89,8 +90,46 @@ def test_server_spec_uses_container_repository_when_present() -> None:
     container.get_or_none.assert_called_once_with(IA2ATaskRepository)
 
 
+def test_server_spec_builds_rest_app_for_registered_agent() -> None:
+    """The spec can build the declared REST transport from the registry."""
+    registry = A2AAgentRegistry()
+    registry.register(
+        ServedPlannerAgent(StubModel()),
+        ServedPlannerAgent,
+        _planner_marker(rest_mount_path="/rest/planner"),
+    )
+    config = A2AConfig()
+    config.default_base_url = "https://agents.example.com"
+    container = MagicMock(spec=IContainer)
+    container.get = MagicMock(
+        side_effect=lambda key: config if key is A2AConfig else registry
+    )
+    container.get_or_none = MagicMock(return_value=None)
+
+    app = _spec_with_container(container).build_rest_app_for("planner")
+
+    assert isinstance(app, Starlette)
+
+
+def test_server_spec_builds_grpc_handler_for_registered_agent() -> None:
+    """The spec can build the declared gRPC handler from the registry."""
+    registry = A2AAgentRegistry()
+    registry.register(
+        ServedPlannerAgent(StubModel()),
+        ServedPlannerAgent,
+        _planner_marker(grpc_base_url="grpc://planner.local"),
+    )
+    container = MagicMock(spec=IContainer)
+    container.get = MagicMock(return_value=registry)
+    container.get_or_none = MagicMock(return_value=None)
+
+    handler = _spec_with_container(container).build_grpc_handler_for("planner")
+
+    assert handler is not None
+
+
 def test_server_spec_mount_path_uses_marker_override() -> None:
-    """@A2AAgentServer mount_path가 있으면 config prefix 대신 그 값을 쓴다."""
+    """@A2ACompatible mount_path가 있으면 config prefix 대신 그 값을 쓴다."""
     registry = A2AAgentRegistry()
     registry.register(
         ServedPlannerAgent(StubModel()),
@@ -105,11 +144,101 @@ def test_server_spec_mount_path_uses_marker_override() -> None:
     )
 
 
-def _planner_marker(mount_path: str | None = None):
-    from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+def test_server_spec_derives_default_base_url_from_mount_path() -> None:
+    """base_url 생략 시 default_base_url과 실제 mount path를 합쳐 광고한다."""
+    registry = A2AAgentRegistry()
+    registry.register(
+        ServedPlannerAgent(StubModel()),
+        ServedPlannerAgent,
+        _planner_marker(base_url=None, mount_path="/custom/planner"),
+    )
+    config = A2AConfig()
+    config.default_base_url = "https://agents.example.com/root/"
+    container = MagicMock(spec=IContainer)
+    container.get = MagicMock(
+        side_effect=lambda key: config if key is A2AConfig else registry
+    )
 
-    return A2AAgentServer(
-        base_url="http://planner.local",
+    entry = registry.get("planner")
+
+    assert (
+        _spec_with_container(container)._base_url(entry)
+        == "https://agents.example.com/root/custom/planner"
+    )
+
+
+def test_server_spec_rest_base_url_uses_explicit_value() -> None:
+    """rest_base_url이 있으면 REST mount path에서 유도하지 않는다."""
+    registry = A2AAgentRegistry()
+    registry.register(
+        ServedPlannerAgent(StubModel()),
+        ServedPlannerAgent,
+        _planner_marker(
+            base_url=None,
+            rest_mount_path="/rest/planner",
+            rest_base_url="https://rest.example/planner",
+        ),
+    )
+    container = MagicMock(spec=IContainer)
+    container.get = MagicMock(return_value=registry)
+    entry = registry.get("planner")
+
+    assert (
+        _spec_with_container(container)._rest_base_url(entry)
+        == "https://rest.example/planner"
+    )
+
+
+def test_server_spec_rest_base_url_falls_back_to_agent_base_url() -> None:
+    """REST 전용 endpoint가 없으면 AgentCard base_url을 재사용한다."""
+    registry = A2AAgentRegistry()
+    registry.register(
+        ServedPlannerAgent(StubModel()),
+        ServedPlannerAgent,
+        _planner_marker(base_url="https://agents.example.com/a2a/planner"),
+    )
+    container = MagicMock(spec=IContainer)
+    container.get = MagicMock(return_value=registry)
+    entry = registry.get("planner")
+
+    assert (
+        _spec_with_container(container)._rest_base_url(entry)
+        == "https://agents.example.com/a2a/planner"
+    )
+
+
+def test_server_spec_grpc_base_url_falls_back_to_agent_base_url() -> None:
+    """grpc_base_url을 생략하면 AgentCard base_url을 재사용한다."""
+    registry = A2AAgentRegistry()
+    registry.register(
+        ServedPlannerAgent(StubModel()),
+        ServedPlannerAgent,
+        _planner_marker(base_url="https://agents.example.com/a2a/planner"),
+    )
+    container = MagicMock(spec=IContainer)
+    container.get = MagicMock(return_value=registry)
+    entry = registry.get("planner")
+
+    assert (
+        _spec_with_container(container)._grpc_base_url(entry)
+        == "https://agents.example.com/a2a/planner"
+    )
+
+
+def _planner_marker(
+    base_url: str | None = "http://planner.local",
+    mount_path: str | None = None,
+    rest_mount_path: str | None = None,
+    rest_base_url: str | None = None,
+    grpc_base_url: str | None = None,
+):
+    from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
+
+    return A2ACompatible(
+        base_url=base_url,
         version="1.2.3",
         mount_path=mount_path,
+        rest_mount_path=rest_mount_path,
+        rest_base_url=rest_base_url,
+        grpc_base_url=grpc_base_url,
     )

--- a/plugins/spakky-a2a/tests/unit/test_main.py
+++ b/plugins/spakky-a2a/tests/unit/test_main.py
@@ -9,6 +9,9 @@ from spakky.plugins.a2a.config import A2AConfig
 from spakky.plugins.a2a.delegation import A2AAgentDelegate
 from spakky.plugins.a2a.main import initialize
 from spakky.plugins.a2a.post_processors.mount_asgi import MountA2AASGIPostProcessor
+from spakky.plugins.a2a.post_processors.register_grpc import (
+    RegisterA2AGRPCPostProcessor,
+)
 from spakky.plugins.a2a.post_processors.register_agent_servers import (
     RegisterA2AAgentServersPostProcessor,
 )
@@ -32,12 +35,13 @@ def test_initialize_registers_plugin_pods() -> None:
             call(A2AAgentServerSpec),
             call(RegisterA2AAgentServersPostProcessor),
             call(MountA2AASGIPostProcessor),
+            call(RegisterA2AGRPCPostProcessor),
         ],
         any_order=False,
     )
     app.container.contains.assert_called_once_with(IAgentRunnerFactory)
     app.container.bind_to_type.assert_called_once_with(IAgentDelegate, A2AAgentDelegate)
-    assert app.add.call_count == 7
+    assert app.add.call_count == 8
 
 
 def test_initialize_reuses_existing_runner_factory_binding() -> None:

--- a/plugins/spakky-a2a/tests/unit/test_mount_asgi.py
+++ b/plugins/spakky-a2a/tests/unit/test_mount_asgi.py
@@ -47,15 +47,28 @@ class _Container:
 
 
 class _ServerSpec:
-    def __init__(self, mount_path: str = "/a2a/planner") -> None:
+    def __init__(
+        self,
+        mount_path: str = "/a2a/planner",
+        rest_mount_path: str | None = None,
+    ) -> None:
         self.builds: list[str] = []
+        self.rest_builds: list[str] = []
         self.mount_path = mount_path
+        self.rest_mount_path = rest_mount_path
 
     def mount_path_for(self, agent_name: str) -> str:
         return self.mount_path
 
+    def rest_mount_path_for(self, agent_name: str) -> str | None:
+        return self.rest_mount_path
+
     def build_app_for(self, agent_name: str) -> Starlette:
         self.builds.append(agent_name)
+        return Starlette()
+
+    def build_rest_app_for(self, agent_name: str) -> Starlette:
+        self.rest_builds.append(agent_name)
         return Starlette()
 
 
@@ -105,6 +118,41 @@ def test_agent_post_process_mounts_on_existing_asgi_hosts() -> None:
 
     assert processed is agent
     assert spec.builds == ["planner"]
+
+
+def test_declared_rest_mount_path_mounts_rest_app() -> None:
+    """rest_mount_path 선언이 있으면 REST app도 별도 path에 mount된다."""
+    registry = A2AAgentRegistry()
+    registry.register(
+        ServedPlannerAgent(StubModel()),
+        ServedPlannerAgent,
+        _planner_marker(rest_mount_path="/a2a-rest/planner"),
+    )
+    spec = _ServerSpec(rest_mount_path="/a2a-rest/planner")
+    host = Starlette()
+
+    _processor(registry, spec).post_process(host)
+
+    paths = {getattr(route, "path", None) for route in host.routes}
+    assert "/a2a/planner" in paths
+    assert "/a2a-rest/planner" in paths
+    assert spec.builds == ["planner"]
+    assert spec.rest_builds == ["planner"]
+
+
+def test_rest_and_jsonrpc_cannot_claim_same_path() -> None:
+    """REST와 JSON-RPC transport가 같은 path를 공유하면 route 충돌로 거부한다."""
+    registry = A2AAgentRegistry()
+    registry.register(
+        ServedPlannerAgent(StubModel()),
+        ServedPlannerAgent,
+        _planner_marker(rest_mount_path="/a2a/planner"),
+    )
+
+    with pytest.raises(A2AEndpointConflictError):
+        _processor(registry, _ServerSpec(rest_mount_path="/a2a/planner")).post_process(
+            Starlette()
+        )
 
 
 def test_unmarked_agent_is_returned_without_mounting() -> None:
@@ -160,9 +208,9 @@ def test_path_conflict_between_agents_is_rejected() -> None:
     """서로 다른 A2A agent가 같은 mount path를 claim하면 실패한다."""
 
     from spakky.agent import Agent, AgentExecutionSpec
-    from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+    from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
 
-    @A2AAgentServer()
+    @A2ACompatible()
     @Agent(spec=AgentExecutionSpec(name="writer", objective="write"))
     class WriterAgent:
         def __init__(self) -> None:
@@ -172,13 +220,17 @@ def test_path_conflict_between_agents_is_rejected() -> None:
     registry.register(
         ServedPlannerAgent(StubModel()), ServedPlannerAgent, _planner_marker()
     )
-    registry.register(WriterAgent(), WriterAgent, A2AAgentServer())
+    registry.register(WriterAgent(), WriterAgent, A2ACompatible())
 
     with pytest.raises(A2AEndpointConflictError):
         _processor(registry, _ServerSpec()).post_process(Starlette())
 
 
-def _planner_marker():
-    from spakky.plugins.a2a.stereotypes.a2a_agent_server import A2AAgentServer
+def _planner_marker(rest_mount_path: str | None = None):
+    from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
 
-    return A2AAgentServer(base_url="http://planner.local", version="1.2.3")
+    return A2ACompatible(
+        base_url="http://planner.local",
+        version="1.2.3",
+        rest_mount_path=rest_mount_path,
+    )

--- a/plugins/spakky-a2a/tests/unit/test_register_agent_servers.py
+++ b/plugins/spakky-a2a/tests/unit/test_register_agent_servers.py
@@ -1,4 +1,4 @@
-"""Tests for the @A2AAgentServer registration post-processor."""
+"""Tests for the @A2ACompatible registration post-processor."""
 
 from unittest.mock import MagicMock
 
@@ -38,7 +38,7 @@ def test_registers_marked_agent_pod(
     processor: RegisterA2AAgentServersPostProcessor,
     registry: A2AAgentRegistry,
 ) -> None:
-    """A Pod with both @Agent and @A2AAgentServer is registered by name."""
+    """A Pod with both @Agent and @A2ACompatible is registered by name."""
     pod = ServedPlannerAgent(StubModel())
 
     result = processor.post_process(pod)

--- a/plugins/spakky-a2a/tests/unit/test_register_grpc.py
+++ b/plugins/spakky-a2a/tests/unit/test_register_grpc.py
@@ -1,0 +1,133 @@
+"""Tests for declarative A2A gRPC handler registration."""
+
+from unittest.mock import MagicMock
+
+from grpc import GenericRpcHandler
+from spakky.core.common.constants import DYNAMIC_PROXY_CLASS_NAME_SUFFIX
+from spakky.core.pod.interfaces.container import IContainer
+from spakky.plugins.grpc.server_spec import GrpcServerSpec
+
+from spakky.plugins.a2a.post_processors.register_grpc import (
+    RegisterA2AGRPCPostProcessor,
+)
+from spakky.plugins.a2a.server.builder import A2AAgentServerSpec
+from spakky.plugins.a2a.server.registry import A2AAgentRegistry
+from spakky.plugins.a2a.stereotypes.a2a_compatible import A2ACompatible
+from tests.unit._sample_agents import ServedPlannerAgent, StubModel
+
+
+class _A2ASpec:
+    def __init__(self, handler: GenericRpcHandler) -> None:
+        self.handler = handler
+        self.calls: list[str] = []
+
+    def build_grpc_handler_for(self, agent_name: str) -> GenericRpcHandler:
+        self.calls.append(agent_name)
+        return self.handler
+
+
+def _processor(
+    registry: A2AAgentRegistry,
+    grpc_spec: GrpcServerSpec,
+    a2a_spec: _A2ASpec,
+) -> RegisterA2AGRPCPostProcessor:
+    container = MagicMock(spec=IContainer)
+    container.get = MagicMock(
+        side_effect=lambda key: {
+            A2AAgentRegistry: registry,
+            A2AAgentServerSpec: a2a_spec,
+            GrpcServerSpec: grpc_spec,
+        }[key]
+    )
+    container.get_or_none = MagicMock(
+        side_effect=lambda key: grpc_spec if key is GrpcServerSpec else None
+    )
+    processor = RegisterA2AGRPCPostProcessor()
+    processor.set_container(container)
+    return processor
+
+
+def test_grpc_spec_post_process_registers_enabled_entries() -> None:
+    """grpc_enabled=True인 A2A entry를 GrpcServerSpec에 등록한다."""
+    registry = A2AAgentRegistry()
+    registry.register(
+        ServedPlannerAgent(StubModel()),
+        ServedPlannerAgent,
+        A2ACompatible(grpc_enabled=True, grpc_base_url="grpc://planner.local"),
+    )
+    grpc_spec = GrpcServerSpec()
+    handler = MagicMock(spec=GenericRpcHandler)
+    a2a_spec = _A2ASpec(handler)
+
+    result = _processor(registry, grpc_spec, a2a_spec).post_process(grpc_spec)
+
+    assert result is grpc_spec
+    assert a2a_spec.calls == ["planner"]
+    assert grpc_spec.handlers == [handler]
+
+
+def test_grpc_registration_is_idempotent() -> None:
+    """동일 agent gRPC handler는 한 번만 등록된다."""
+    registry = A2AAgentRegistry()
+    agent = ServedPlannerAgent(StubModel())
+    registry.register(
+        agent,
+        ServedPlannerAgent,
+        A2ACompatible(grpc_enabled=True, grpc_base_url="grpc://planner.local"),
+    )
+    grpc_spec = GrpcServerSpec()
+    handler = MagicMock(spec=GenericRpcHandler)
+    a2a_spec = _A2ASpec(handler)
+    processor = _processor(registry, grpc_spec, a2a_spec)
+
+    processor.post_process(grpc_spec)
+    processor.post_process(agent)
+
+    assert a2a_spec.calls == ["planner"]
+    assert grpc_spec.handlers == [handler]
+
+
+def test_grpc_registration_unwraps_dynamic_proxy_agent() -> None:
+    """AOP dynamic proxy subclass도 원본 @A2ACompatible marker로 등록된다."""
+
+    class ServedPlannerAgentDynamicProxy(ServedPlannerAgent):
+        pass
+
+    ServedPlannerAgentDynamicProxy.__name__ = (
+        f"ServedPlannerAgent{DYNAMIC_PROXY_CLASS_NAME_SUFFIX}"
+    )
+    proxy = ServedPlannerAgentDynamicProxy(StubModel())
+    registry = A2AAgentRegistry()
+    grpc_spec = GrpcServerSpec()
+    handler = MagicMock(spec=GenericRpcHandler)
+    a2a_spec = _A2ASpec(handler)
+    processor = _processor(registry, grpc_spec, a2a_spec)
+
+    processor.post_process(grpc_spec)
+    registry.register(
+        proxy,
+        ServedPlannerAgent,
+        A2ACompatible(grpc_enabled=True, grpc_base_url="grpc://planner.local"),
+    )
+    processor.post_process(proxy)
+
+    assert a2a_spec.calls == ["planner"]
+    assert grpc_spec.handlers == [handler]
+
+
+def test_grpc_disabled_entries_are_ignored() -> None:
+    """grpc_enabled가 꺼진 entry는 GrpcServerSpec에 추가하지 않는다."""
+    registry = A2AAgentRegistry()
+    registry.register(
+        ServedPlannerAgent(StubModel()),
+        ServedPlannerAgent,
+        A2ACompatible(grpc_enabled=False),
+    )
+    grpc_spec = GrpcServerSpec()
+    handler = MagicMock(spec=GenericRpcHandler)
+    a2a_spec = _A2ASpec(handler)
+
+    _processor(registry, grpc_spec, a2a_spec).post_process(grpc_spec)
+
+    assert a2a_spec.calls == []
+    assert grpc_spec.handlers == []

--- a/plugins/spakky-agui/README.md
+++ b/plugins/spakky-agui/README.md
@@ -75,7 +75,7 @@ AG-UI BaseEvent  ──(EventEncoder)──▶  "data: {...}\n\n" SSE 프레임
 
 ## 사용법
 
-`@Agent` 위에 `@AgUiAgent`를 쌓고 FastAPI host를 Pod으로 등록합니다. plugin
+`@Agent` 위에 `@AGUICompatible`를 쌓고 FastAPI host를 Pod으로 등록합니다. plugin
 `initialize()`는 `AgUiConfig`, `AgUiAgentRegistry`, FastAPI mount post-processor를 등록하므로
 애플리케이션 코드는 `run_driver_factory`나 `add_agui_endpoint()`를 호출하지 않습니다.
 
@@ -85,7 +85,7 @@ from spakky.agent import Agent, AgentExecutionSpec, IAgentModel
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
 from spakky.core.pod.annotations.pod import Pod
-from spakky.plugins.agui import AgUiAgent
+from spakky.plugins.agui import AGUICompatible
 
 
 @Pod(name="fastapi_app")
@@ -93,7 +93,7 @@ def fastapi_app() -> FastAPI:
     return FastAPI()
 
 
-@AgUiAgent()
+@AGUICompatible()
 @Agent(spec=AgentExecutionSpec(name="assistant", objective="answer with tools"))
 class Assistant:
     def __init__(self, model: IAgentModel) -> None:
@@ -108,7 +108,7 @@ app = application.container.get(FastAPI)
 여러 Agent를 AG-UI로 노출한다면 각 Agent가 서로 다른 path를 선언해야 합니다.
 
 ```python
-@AgUiAgent(
+@AGUICompatible(
     sse_path="/agents/researcher/agui",
     http_stream_path="/agents/researcher/agui/stream",
     websocket_path="/agents/researcher/agui/ws",
@@ -118,7 +118,7 @@ class Researcher:
     ...
 ```
 
-`@AgUiAgent(server_names=("weather",))`를 지정하면 `spakky-mcp`가 제공하는
+`@AGUICompatible(server_names=("weather",))`를 지정하면 `spakky-mcp`가 제공하는
 `IAgentRunnerFactory`가 해당 external MCP server tool만 이 Agent run에 결합합니다. 비워두면
 configured MCP server 전체를 사용합니다.
 
@@ -139,7 +139,7 @@ CLI stdio 경계는 아직 host command가 필요하므로 lower-level `AgUiStdi
 한 줄에 하나씩 출력합니다. Typer 같은 CLI plugin은 이 callable을 command로 등록하면 됩니다.
 
 stdio 전용 host는 `AgUiStdioCommand`에 lower-level `RunDriverFactory`를 전달합니다. 일반
-FastAPI SSE/HTTP/WebSocket 노출은 위의 `@AgUiAgent` 선언만 사용합니다.
+FastAPI SSE/HTTP/WebSocket 노출은 위의 `@AGUICompatible` 선언만 사용합니다.
 
 ## HITL — deferred-tool 승인 흐름
 

--- a/plugins/spakky-agui/src/spakky/plugins/agui/__init__.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/__init__.py
@@ -27,6 +27,7 @@ from spakky.plugins.agui.stdio import (
     run_agui_stdio,
 )
 from spakky.plugins.agui.stereotypes.agui_agent import AgUiAgent
+from spakky.plugins.agui.stereotypes.agui_compatible import AGUICompatible
 from spakky.plugins.agui.transport import AgUiManagedRunDriver, AgUiRunDriver
 from spakky.plugins.agui.websocket import add_agui_websocket_endpoint
 
@@ -38,6 +39,7 @@ __all__ = [
     "AgUiApprovalDecodeError",
     "AgUiConfig",
     "AgUiEndpointConflictError",
+    "AGUICompatible",
     "AgUiAgent",
     "AgUiAgentEntry",
     "AgUiAgentRegistry",

--- a/plugins/spakky-agui/src/spakky/plugins/agui/post_processors/mount_fastapi.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/post_processors/mount_fastapi.py
@@ -25,7 +25,7 @@ from spakky.plugins.agui.endpoint_input import AgUiInboundRun
 from spakky.plugins.agui.error import AgUiEndpointConflictError
 from spakky.plugins.agui.http_stream import add_agui_http_stream_endpoint
 from spakky.plugins.agui.server.registry import AgUiAgentEntry, AgUiAgentRegistry
-from spakky.plugins.agui.stereotypes.agui_agent import AgUiAgent
+from spakky.plugins.agui.stereotypes.agui_compatible import AGUICompatible
 from spakky.plugins.agui.transport import AgUiManagedRunDriver
 from spakky.plugins.agui.websocket import add_agui_websocket_endpoint
 
@@ -39,7 +39,7 @@ type _EndpointRegistrar = Callable[..., None]
 class MountAgUiFastAPIPostProcessor(
     IPostProcessor, IContainerAware, IApplicationContextAware
 ):
-    """Discover @AgUiAgent @Agent Pods and mount their AG-UI FastAPI routes."""
+    """Discover @AGUICompatible @Agent Pods and mount their AG-UI FastAPI routes."""
 
     _container: IContainer
     _application_context: IApplicationContext
@@ -72,10 +72,10 @@ class MountAgUiFastAPIPostProcessor(
             self._mount_registered_agents(pod)
             return pod
         agent_type = self._unwrap_proxy_type(type(pod))
-        if not (AgUiAgent.exists(agent_type) and Agent.exists(agent_type)):
+        if not (AGUICompatible.exists(agent_type) and Agent.exists(agent_type)):
             return pod
         registry = self._container.get(AgUiAgentRegistry)
-        entry = registry.register(pod, agent_type, AgUiAgent.get(agent_type))
+        entry = registry.register(pod, agent_type, AGUICompatible.get(agent_type))
         for app in self._fastapi_apps():
             self._mount_entry(app, entry)
         logger.info("Registered AG-UI agent from %s", agent_type.__qualname__)

--- a/plugins/spakky-agui/src/spakky/plugins/agui/server/registry.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/server/registry.py
@@ -6,7 +6,7 @@ from spakky.agent import Agent
 from spakky.core.pod.annotations.pod import Pod
 
 from spakky.plugins.agui.error import AgUiRunResolutionError
-from spakky.plugins.agui.stereotypes.agui_agent import AgUiAgent
+from spakky.plugins.agui.stereotypes.agui_compatible import AGUICompatible
 
 
 @dataclass(frozen=True, slots=True)
@@ -15,7 +15,7 @@ class AgUiAgentEntry:
 
     instance: object
     agent_type: type[object]
-    metadata: AgUiAgent
+    metadata: AGUICompatible
 
     @property
     def agent_name(self) -> str:
@@ -37,7 +37,7 @@ class AgUiAgentRegistry:
         self,
         instance: object,
         agent_type: type[object],
-        metadata: AgUiAgent,
+        metadata: AGUICompatible,
     ) -> AgUiAgentEntry:
         """Register one exposed @Agent instance and return the entry."""
         entry = AgUiAgentEntry(

--- a/plugins/spakky-agui/src/spakky/plugins/agui/stereotypes/agui_agent.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/stereotypes/agui_agent.py
@@ -1,27 +1,8 @@
-"""@AgUiAgent marker for exposing an @Agent over AG-UI transports."""
+"""Backward-compatible import for the legacy @AgUiAgent marker name."""
 
-from dataclasses import dataclass
+from spakky.plugins.agui.stereotypes.agui_compatible import AGUICompatible
 
-from spakky.core.pod.annotations.tag import Tag
+AgUiAgent = AGUICompatible
+"""Deprecated alias for :class:`AGUICompatible`."""
 
-
-@dataclass(eq=False)
-class AgUiAgent(Tag):
-    """Marks an @Agent class to be served through the AG-UI adapter.
-
-    Paths default to :class:`AgUiConfig` so a single declaration can use the
-    plugin defaults, while multi-agent applications can assign distinct paths
-    declaratively on each marked agent.
-    """
-
-    sse_path: str | None = None
-    """SSE endpoint path for this agent. None uses ``AgUiConfig.sse_path``."""
-
-    http_stream_path: str | None = None
-    """HTTP streaming endpoint path. None uses ``AgUiConfig.http_stream_path``."""
-
-    websocket_path: str | None = None
-    """WebSocket endpoint path. None uses ``AgUiConfig.websocket_path``."""
-
-    server_names: tuple[str, ...] = ()
-    """External MCP server names to join for this agent. Empty means all configured."""
+__all__ = ["AgUiAgent"]

--- a/plugins/spakky-agui/src/spakky/plugins/agui/stereotypes/agui_compatible.py
+++ b/plugins/spakky-agui/src/spakky/plugins/agui/stereotypes/agui_compatible.py
@@ -1,0 +1,27 @@
+"""@AGUICompatible marker for exposing an @Agent over AG-UI transports."""
+
+from dataclasses import dataclass
+
+from spakky.core.pod.annotations.tag import Tag
+
+
+@dataclass(eq=False)
+class AGUICompatible(Tag):
+    """Marks an @Agent class to be served through the AG-UI adapter.
+
+    Paths default to :class:`AgUiConfig` so a single declaration can use the
+    plugin defaults, while multi-agent applications can assign distinct paths
+    declaratively on each marked agent.
+    """
+
+    sse_path: str | None = None
+    """SSE endpoint path for this agent. None uses ``AgUiConfig.sse_path``."""
+
+    http_stream_path: str | None = None
+    """HTTP streaming endpoint path. None uses ``AgUiConfig.http_stream_path``."""
+
+    websocket_path: str | None = None
+    """WebSocket endpoint path. None uses ``AgUiConfig.websocket_path``."""
+
+    server_names: tuple[str, ...] = ()
+    """External MCP server names to join for this agent. Empty means all configured."""

--- a/plugins/spakky-agui/tests/integration/test_fastapi_auto_mount.py
+++ b/plugins/spakky-agui/tests/integration/test_fastapi_auto_mount.py
@@ -1,4 +1,4 @@
-"""Integration: @AgUiAgent is mounted on FastAPI through DI post-processing."""
+"""Integration: @AGUICompatible is mounted on FastAPI through DI post-processing."""
 
 from collections.abc import AsyncIterator
 from json import loads
@@ -22,7 +22,7 @@ from spakky.core.application.application_context import ApplicationContext
 from spakky.core.pod.annotations.pod import Pod
 
 from spakky.plugins.agui.main import initialize as initialize_agui
-from spakky.plugins.agui.stereotypes.agui_agent import AgUiAgent
+from spakky.plugins.agui.stereotypes.agui_compatible import AGUICompatible
 
 
 @Pod()
@@ -47,7 +47,7 @@ class AutoMountModel(IAgentModel):
         yield ModelStreamEvent(kind=ModelStreamEventKind.DONE)
 
 
-@AgUiAgent()
+@AGUICompatible()
 @Agent(spec=AgentExecutionSpec(name="auto_agui", objective="answer"))
 class AutoMountedAssistant:
     """Agent exposed through AG-UI solely by declaration."""
@@ -86,7 +86,7 @@ def _build_app() -> FastAPI:
 
 
 def test_agui_agent_mounts_sse_endpoint_without_manual_factory() -> None:
-    """@AgUiAgent @Agent가 수동 endpoint helper 없이 /agui SSE를 노출한다."""
+    """@AGUICompatible @Agent가 수동 endpoint helper 없이 /agui SSE를 노출한다."""
     client = TestClient(_build_app())
 
     response = client.post("/agui", json=_run_agent_input())

--- a/plugins/spakky-agui/tests/unit/test_auto_mount.py
+++ b/plugins/spakky-agui/tests/unit/test_auto_mount.py
@@ -21,16 +21,16 @@ from spakky.plugins.agui.post_processors.mount_fastapi import (
     MountAgUiFastAPIPostProcessor,
 )
 from spakky.plugins.agui.server.registry import AgUiAgentRegistry
-from spakky.plugins.agui.stereotypes.agui_agent import AgUiAgent
+from spakky.plugins.agui.stereotypes.agui_compatible import AGUICompatible
 
 
-@AgUiAgent()
+@AGUICompatible()
 @Agent(spec=AgentExecutionSpec(name="assistant", objective="answer"))
 class _MountedAssistant:
     """Agent fixture exposed through the AG-UI auto-mount path."""
 
 
-@AgUiAgent()
+@AGUICompatible()
 @Agent(spec=AgentExecutionSpec(name="researcher", objective="research"))
 class _MountedResearcher:
     """Second fixture used to prove path conflict detection."""
@@ -130,7 +130,7 @@ def test_app_post_process_mounts_registered_agent_routes() -> None:
     """FastAPI Pod가 나중에 처리되어도 registry의 AG-UI agent routes가 붙는다."""
     registry = AgUiAgentRegistry()
     registry.register(
-        _MountedAssistant(), _MountedAssistant, AgUiAgent.get(_MountedAssistant)
+        _MountedAssistant(), _MountedAssistant, AGUICompatible.get(_MountedAssistant)
     )
     app = FastAPI()
 
@@ -175,7 +175,7 @@ def test_mounting_same_agent_twice_is_idempotent() -> None:
 
 
 def test_dynamic_proxy_type_is_unwrapped_before_mounting() -> None:
-    """AOP dynamic proxy subclass도 원본 @AgUiAgent marker로 등록된다."""
+    """AOP dynamic proxy subclass도 원본 @AGUICompatible marker로 등록된다."""
 
     class MountedAssistantDynamicProxy(_MountedAssistant):
         marker = "proxy"
@@ -198,10 +198,10 @@ def test_auto_mount_detects_path_conflicts_between_agents() -> None:
     """서로 다른 AG-UI agent가 같은 path를 claim하면 conflict로 실패한다."""
     registry = AgUiAgentRegistry()
     registry.register(
-        _MountedAssistant(), _MountedAssistant, AgUiAgent.get(_MountedAssistant)
+        _MountedAssistant(), _MountedAssistant, AGUICompatible.get(_MountedAssistant)
     )
     registry.register(
-        _MountedResearcher(), _MountedResearcher, AgUiAgent.get(_MountedResearcher)
+        _MountedResearcher(), _MountedResearcher, AGUICompatible.get(_MountedResearcher)
     )
 
     try:
@@ -226,10 +226,10 @@ def test_registry_lists_entries_by_agent_name() -> None:
     """registry list는 agent 이름 기준 stable order를 보존한다."""
     registry = AgUiAgentRegistry()
     registry.register(
-        _MountedResearcher(), _MountedResearcher, AgUiAgent.get(_MountedResearcher)
+        _MountedResearcher(), _MountedResearcher, AGUICompatible.get(_MountedResearcher)
     )
     registry.register(
-        _MountedAssistant(), _MountedAssistant, AgUiAgent.get(_MountedAssistant)
+        _MountedAssistant(), _MountedAssistant, AGUICompatible.get(_MountedAssistant)
     )
 
     assert [entry.agent_name for entry in registry.list_entries()] == [

--- a/plugins/spakky-agui/tests/unit/test_public_api.py
+++ b/plugins/spakky-agui/tests/unit/test_public_api.py
@@ -3,6 +3,7 @@
 import spakky.plugins.agui as agui_api
 from spakky.plugins.agui import (
     AbstractAgUiError,
+    AGUICompatible,
     AgUiAgent,
     AgUiAgentEntry,
     AgUiAgentRegistry,
@@ -34,7 +35,8 @@ def test_public_api_exports_agui_surface() -> None:
     """public API가 plugin id, config, adapter 구성요소, 에러, hook을 노출한다."""
     assert PLUGIN_NAME.name == "spakky-agui"
     assert AgUiConfig is agui_api.AgUiConfig
-    assert AgUiAgent is agui_api.AgUiAgent
+    assert AGUICompatible is agui_api.AGUICompatible
+    assert AgUiAgent is AGUICompatible
     assert AgUiAgentEntry is agui_api.AgUiAgentEntry
     assert AgUiAgentRegistry is agui_api.AgUiAgentRegistry
     assert AgUiProjector is agui_api.AgUiProjector

--- a/plugins/spakky-mcp/README.md
+++ b/plugins/spakky-mcp/README.md
@@ -21,7 +21,7 @@ uv add "spakky[agent]"
 
 ## 설정
 
-외부 서버는 `SPAKKY_MCP__` 접두사 환경변수 또는 `McpConfig`로 선언합니다.
+외부 서버는 `SPAKKY_MCP__` 접두사 환경변수 또는 `MCPConfig`로 선언합니다.
 
 | 환경변수 | 의미 | 기본값 |
 |----------|------|--------|
@@ -32,14 +32,14 @@ uv add "spakky[agent]"
 
 도구를 MCP 서버로 노출할 때의 기본 식별자는 `SPAKKY_MCP__TOOL_SERVER__NAME`(기본 `spakky-agent`)으로 선언합니다. `SPAKKY_MCP__TOOL_SERVER__TRANSPORT`는 설정 모델에 보존되는 전송 의도 값이며, 현재 host entrypoint는 `serve_stdio_for()` 또는 `streamable_http_session_manager_for()` 중 하나를 명시적으로 호출해 실제 전송을 선택합니다.
 
-`initialize()`는 `McpConfig`, `McpClient`, `McpToolServerRegistry`, `McpToolServer`, MCP post-processor를 application container에 등록합니다. 또한 `IAgentRunnerFactory`를 `McpClient`에 바인딩하므로 AG-UI/A2A 같은 inbound adapter가 runner factory를 주입받아 실행할 때 외부 MCP tool이 자동으로 합류합니다.
+`initialize()`는 `MCPConfig`, `MCPClient`, `MCPToolServerRegistry`, `MCPToolServer`, MCP post-processor를 application container에 등록합니다. 또한 `IAgentRunnerFactory`를 `MCPClient`에 바인딩하므로 AG-UI/A2A 같은 inbound adapter가 runner factory를 주입받아 실행할 때 외부 MCP tool이 자동으로 합류합니다.
 
 ## 사용
 
 ### 클라이언트: 외부 도구 끌어오기
 
-애플리케이션 코드가 `McpClient.open_runner(agent)`를 직접 호출할 필요는 없습니다. `spakky-mcp`
-plugin이 로드되면 `IAgentRunnerFactory`가 `McpClient`로 바인딩되고, AG-UI/A2A 같은 inbound
+애플리케이션 코드가 `MCPClient.open_runner(agent)`를 직접 호출할 필요는 없습니다. `spakky-mcp`
+plugin이 로드되면 `IAgentRunnerFactory`가 `MCPClient`로 바인딩되고, AG-UI/A2A 같은 inbound
 adapter가 그 factory로 runner를 열 때 선언된 MCP server tools가 runner catalog에 합류합니다.
 
 ```python
@@ -54,18 +54,20 @@ async def custom_inbound_boundary(factory: IAgentRunnerFactory, agent: object) -
 
 모델이 보는 외부 도구 이름은 `<서버이름>__<도구이름>` 형태로 접두사가 붙어 서버 간 이름 충돌을 막습니다.
 
-`McpClient.open_runner()`는 지정된 서버들의 transport session을 열고 `list_tools()` 결과를 `AgentToolDescriptor`로 정규화한 뒤, native catalog와 external catalog를 합친 runner를 yield합니다. 이 runner는 context manager가 살아 있는 동안만 외부 도구 callable이 유효합니다. `ExternalMcpToolDescriptor`는 MCP argument object를 그대로 keyword argument로 전달하므로 MCP schema가 `args` 또는 `kwargs`라는 필드를 선언해도 Spakky의 structured-call binding heuristic에 의해 손실되지 않습니다.
+`MCPClient.open_runner()`는 지정된 서버들의 transport session을 열고 `list_tools()` 결과를 `AgentToolDescriptor`로 정규화한 뒤, native catalog와 external catalog를 합친 runner를 yield합니다. 이 runner는 context manager가 살아 있는 동안만 외부 도구 callable이 유효합니다. `ExternalMcpToolDescriptor`는 MCP argument object를 그대로 keyword argument로 전달하므로 MCP schema가 `args` 또는 `kwargs`라는 필드를 선언해도 Spakky의 structured-call binding heuristic에 의해 손실되지 않습니다.
 
 ### 서버: 자신의 도구 내보내기
 
-Agent 도구를 MCP server로 노출하려면 `@Agent` 위에 `@McpToolServerAgent`를 쌓습니다.
+MCP server는 agent가 아니라 MCP protocol host입니다. `@MCPServer`는 `@Agent` 자체를
+서버라고 부르는 annotation이 아니라, 그 Agent의 `@agent_tool` 카탈로그를 MCP server에
+연결하겠다는 marker입니다.
 
 ```python
 from spakky.agent import Agent, AgentExecutionSpec, agent_tool
-from spakky.plugins.mcp import McpToolServerAgent
+from spakky.plugins.mcp import MCPServer
 
 
-@McpToolServerAgent(server_name="weather-agent")
+@MCPServer(server_name="weather-agent")
 @Agent(spec=AgentExecutionSpec(name="weather"))
 class WeatherAgent:
     @agent_tool(schema_name="forecast", description="Return a forecast.")
@@ -73,18 +75,18 @@ class WeatherAgent:
         return f"sunny:{city}"
 ```
 
-Bootstrap 후 `McpToolServer`는 registry에서 agent를 resolve합니다. Host entrypoint는 agent instance를
+Bootstrap 후 `MCPToolServer`는 registry에서 agent를 resolve합니다. Host entrypoint는 agent instance를
 넘기지 않고 agent name만 지정합니다.
 
 ```python
-from spakky.plugins.mcp import McpToolServer
+from spakky.plugins.mcp import MCPToolServer
 
 
-async def expose_tools(server: McpToolServer) -> None:
+async def expose_tools(server: MCPToolServer) -> None:
     await server.serve_stdio_for("weather")
 ```
 
-원격 노출에는 `McpToolServer.streamable_http_session_manager_for("weather")`가 돌려주는 세션 매니저를 호스트 애플리케이션 lifespan에서 구동합니다. `build_agent_tool_server(agent_instance, server_name)`와 `serve_stdio(server)`는 특수 host나 테스트에서 쓰는 lower-level API입니다.
+원격 노출에는 `MCPToolServer.streamable_http_session_manager_for("weather")`가 돌려주는 세션 매니저를 호스트 애플리케이션 lifespan에서 구동합니다. `build_agent_tool_server(agent_instance, server_name)`와 `serve_stdio(server)`는 특수 host나 테스트에서 쓰는 lower-level API입니다.
 
 서버 방향은 agent의 `AgentToolCatalog`를 `mcp.types.Tool` 목록으로 변환하고, inbound `call_tool`을 `AgentToolDispatcher`로 실행합니다. 반환값은 MCP `content`와 `structuredContent`로 정규화됩니다. mapping 결과는 structured payload 그대로 노출하고, scalar 결과는 `{"result": ...}`로 감싸서 항상 JSON object structured content를 제공합니다.
 

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/__init__.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/__init__.py
@@ -44,6 +44,7 @@ from spakky.plugins.mcp.server_registry import (
     McpToolServerRegistry,
 )
 from spakky.plugins.mcp.stereotypes.mcp_tool_server_agent import McpToolServerAgent
+from spakky.plugins.mcp.stereotypes.mcp_server import MCPServer
 from spakky.plugins.mcp.server import (
     McpToolServer,
     build_agent_tool_server,
@@ -56,26 +57,63 @@ from spakky.plugins.mcp.server import (
 PLUGIN_NAME = Plugin(name="spakky-mcp")
 """Plugin identifier for the MCP adapter package."""
 
+MCPClient = McpClient
+"""Uppercase-acronym alias for :class:`McpClient`."""
+
+MCPConfig = McpConfig
+"""Uppercase-acronym alias for :class:`McpConfig`."""
+
+MCPServerConfig = McpServerConfig
+"""Uppercase-acronym alias for :class:`McpServerConfig`."""
+
+MCPToolServer = McpToolServer
+"""Uppercase-acronym alias for :class:`McpToolServer`."""
+
+MCPToolServerEntry = McpToolServerEntry
+"""Uppercase-acronym alias for :class:`McpToolServerEntry`."""
+
+MCPToolServerConfig = McpToolServerConfig
+"""Uppercase-acronym alias for :class:`McpToolServerConfig`."""
+
+MCPToolServerNotRegisteredError = McpToolServerNotRegisteredError
+"""Uppercase-acronym alias for :class:`McpToolServerNotRegisteredError`."""
+
+MCPToolServerRegistry = McpToolServerRegistry
+"""Uppercase-acronym alias for :class:`McpToolServerRegistry`."""
+
+MCPTransport = McpTransport
+"""Uppercase-acronym alias for :class:`McpTransport`."""
+
 __all__ = [
     "PLUGIN_NAME",
     "AbstractMcpError",
     "ExternalMcpTool",
     "ExternalMcpToolDescriptor",
     "McpCatalogMergeError",
+    "MCPClient",
     "McpClient",
+    "MCPConfig",
     "McpConfig",
     "McpResponseError",
+    "MCPServerConfig",
     "McpServerConfig",
     "McpServerConfigurationError",
     "McpToolDiscoveryError",
     "McpToolExposureError",
     "McpToolInvocationError",
+    "MCPServer",
+    "MCPToolServer",
     "McpToolServer",
     "McpToolServerAgent",
+    "MCPToolServerEntry",
+    "MCPToolServerConfig",
     "McpToolServerConfig",
     "McpToolServerEntry",
+    "MCPToolServerNotRegisteredError",
     "McpToolServerNotRegisteredError",
+    "MCPToolServerRegistry",
     "McpToolServerRegistry",
+    "MCPTransport",
     "McpTransport",
     "McpTransportError",
     "build_agent_tool_server",

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/post_processors/register_tool_server_agents.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/post_processors/register_tool_server_agents.py
@@ -1,4 +1,4 @@
-"""Post-processor registering @McpToolServerAgent-marked @Agent Pods."""
+"""Post-processor registering @MCPServer-marked @Agent Pods."""
 
 from logging import getLogger
 from typing import override
@@ -12,7 +12,7 @@ from spakky.core.pod.interfaces.container import IContainer
 from spakky.core.pod.interfaces.post_processor import IPostProcessor
 
 from spakky.plugins.mcp.server_registry import McpToolServerRegistry
-from spakky.plugins.mcp.stereotypes.mcp_tool_server_agent import McpToolServerAgent
+from spakky.plugins.mcp.stereotypes.mcp_server import MCPServer
 
 logger = getLogger(__name__)
 
@@ -20,7 +20,7 @@ logger = getLogger(__name__)
 @Order(0)
 @Pod()
 class RegisterMcpToolServerAgentsPostProcessor(IPostProcessor, IContainerAware):
-    """Registers Pods carrying both @Agent and @McpToolServerAgent."""
+    """Registers Pods carrying both @Agent and @MCPServer."""
 
     _container: IContainer
 
@@ -37,11 +37,11 @@ class RegisterMcpToolServerAgentsPostProcessor(IPostProcessor, IContainerAware):
 
     @override
     def post_process(self, pod: object) -> object:
-        """Register *pod* when it is an MCP tool-server agent."""
+        """Register *pod* when it is an @MCPServer-compatible @Agent."""
         pod_type = self._unwrap_proxy_type(type(pod))
-        if not (McpToolServerAgent.exists(pod_type) and Agent.exists(pod_type)):
+        if not (MCPServer.exists(pod_type) and Agent.exists(pod_type)):
             return pod
         registry = self._container.get(McpToolServerRegistry)
-        registry.register(pod, pod_type, McpToolServerAgent.get(pod_type))
-        logger.info("Registered MCP tool-server agent from %s", pod_type.__qualname__)
+        registry.register(pod, pod_type, MCPServer.get(pod_type))
+        logger.info("Registered MCP server from %s", pod_type.__qualname__)
         return pod

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/server.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/server.py
@@ -142,7 +142,7 @@ class McpToolServer:
         return build_agent_tool_server(agent_instance, self.config.tool_server.name)
 
     def build_server_for(self, agent_name: str) -> Server:
-        """Build an MCP server for a registered @McpToolServerAgent name."""
+        """Build an MCP server for a registered @MCPServer-compatible agent name."""
         entry = self._entry(agent_name)
         return build_agent_tool_server(entry.instance, self._server_name(entry))
 

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/server_registry.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/server_registry.py
@@ -6,7 +6,7 @@ from spakky.agent import Agent
 from spakky.core.pod.annotations.pod import Pod
 
 from spakky.plugins.mcp.error import McpToolServerNotRegisteredError
-from spakky.plugins.mcp.stereotypes.mcp_tool_server_agent import McpToolServerAgent
+from spakky.plugins.mcp.stereotypes.mcp_server import MCPServer
 
 
 @dataclass(frozen=True, slots=True)
@@ -15,7 +15,7 @@ class McpToolServerEntry:
 
     instance: object
     agent_type: type[object]
-    metadata: McpToolServerAgent
+    metadata: MCPServer
 
     @property
     def agent_name(self) -> str:
@@ -37,9 +37,9 @@ class McpToolServerRegistry:
         self,
         instance: object,
         agent_type: type[object],
-        metadata: McpToolServerAgent,
+        metadata: MCPServer,
     ) -> McpToolServerEntry:
-        """Register one MCP tool-server agent and return the entry."""
+        """Register one MCP server entry and return it."""
         entry = McpToolServerEntry(
             instance=instance,
             agent_type=agent_type,

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/stereotypes/mcp_server.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/stereotypes/mcp_server.py
@@ -1,0 +1,13 @@
+"""@MCPServer marker for exposing an @Agent's tools over MCP."""
+
+from dataclasses import dataclass
+
+from spakky.core.pod.annotations.tag import Tag
+
+
+@dataclass(eq=False)
+class MCPServer(Tag):
+    """Marks an @Agent class whose native tools are exposed through an MCP server."""
+
+    server_name: str | None = None
+    """MCP server identity. None uses ``McpConfig.tool_server.name``."""

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/stereotypes/mcp_tool_server_agent.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/stereotypes/mcp_tool_server_agent.py
@@ -1,13 +1,8 @@
-"""@McpToolServerAgent marker for exposing an @Agent's tools over MCP."""
+"""Backward-compatible import for the legacy @McpToolServerAgent marker name."""
 
-from dataclasses import dataclass
+from spakky.plugins.mcp.stereotypes.mcp_server import MCPServer
 
-from spakky.core.pod.annotations.tag import Tag
+McpToolServerAgent = MCPServer
+"""Deprecated alias for :class:`MCPServer`."""
 
-
-@dataclass(eq=False)
-class McpToolServerAgent(Tag):
-    """Marks an @Agent class whose native tools are exposed through MCP."""
-
-    server_name: str | None = None
-    """MCP server identity. None uses ``McpConfig.tool_server.name``."""
+__all__ = ["McpToolServerAgent"]

--- a/plugins/spakky-mcp/tests/unit/test_public_api.py
+++ b/plugins/spakky-mcp/tests/unit/test_public_api.py
@@ -7,20 +7,30 @@ from spakky.plugins.mcp import (
     ExternalMcpTool,
     ExternalMcpToolDescriptor,
     McpCatalogMergeError,
+    MCPClient,
     McpClient,
+    MCPConfig,
     McpConfig,
     McpResponseError,
+    MCPServerConfig,
     McpServerConfig,
     McpServerConfigurationError,
     McpToolDiscoveryError,
     McpToolExposureError,
     McpToolInvocationError,
     McpToolServer,
+    MCPServer,
+    MCPToolServer,
+    MCPToolServerEntry,
     McpToolServerAgent,
+    MCPToolServerConfig,
     McpToolServerConfig,
     McpToolServerEntry,
+    MCPToolServerNotRegisteredError,
     McpToolServerNotRegisteredError,
+    MCPToolServerRegistry,
     McpToolServerRegistry,
+    MCPTransport,
     McpTransport,
     McpTransportError,
     build_agent_tool_server,
@@ -42,17 +52,25 @@ from spakky.plugins.mcp import (
 def test_public_api_exposes_plugin_identity() -> None:
     """The public API exposes the plugin id and its config surface."""
     assert PLUGIN_NAME.name == "spakky-mcp"
+    assert MCPConfig is McpConfig
     assert McpConfig is mcp_api.McpConfig
+    assert MCPServerConfig is McpServerConfig
     assert McpServerConfig is mcp_api.McpServerConfig
+    assert MCPToolServerConfig is McpToolServerConfig
     assert McpToolServerConfig is mcp_api.McpToolServerConfig
+    assert MCPTransport is McpTransport
     assert McpTransport is mcp_api.McpTransport
 
 
 def test_public_api_exposes_tool_server_surface() -> None:
     """The public API exposes the server-side exposure functions and Pod."""
+    assert MCPToolServer is McpToolServer
     assert McpToolServer is mcp_api.McpToolServer
-    assert McpToolServerAgent is mcp_api.McpToolServerAgent
+    assert MCPServer is mcp_api.MCPServer
+    assert McpToolServerAgent is MCPServer
+    assert MCPToolServerEntry is McpToolServerEntry
     assert McpToolServerEntry is mcp_api.McpToolServerEntry
+    assert MCPToolServerRegistry is McpToolServerRegistry
     assert McpToolServerRegistry is mcp_api.McpToolServerRegistry
     assert build_agent_tool_server is mcp_api.build_agent_tool_server
     assert build_agent_tools is mcp_api.build_agent_tools
@@ -64,6 +82,7 @@ def test_public_api_exposes_tool_server_surface() -> None:
 
 def test_public_api_exposes_client_and_catalog_surface() -> None:
     """The public API exposes the client and catalog-integration functions."""
+    assert MCPClient is McpClient
     assert McpClient is mcp_api.McpClient
     assert connect_server is mcp_api.connect_server
     assert make_mcp_tool_callable is mcp_api.make_mcp_tool_callable
@@ -86,4 +105,5 @@ def test_public_api_exposes_error_surface() -> None:
     assert McpToolInvocationError is mcp_api.McpToolInvocationError
     assert McpResponseError is mcp_api.McpResponseError
     assert McpCatalogMergeError is mcp_api.McpCatalogMergeError
+    assert MCPToolServerNotRegisteredError is McpToolServerNotRegisteredError
     assert McpToolServerNotRegisteredError is mcp_api.McpToolServerNotRegisteredError

--- a/plugins/spakky-mcp/tests/unit/test_register_tool_server_agents.py
+++ b/plugins/spakky-mcp/tests/unit/test_register_tool_server_agents.py
@@ -1,4 +1,4 @@
-"""Tests for registering @McpToolServerAgent Pods."""
+"""Tests for registering @MCPServer Pods."""
 
 from unittest.mock import MagicMock
 
@@ -45,7 +45,7 @@ def test_registers_marked_agent_pod(
     processor: RegisterMcpToolServerAgentsPostProcessor,
     registry: McpToolServerRegistry,
 ) -> None:
-    """@McpToolServerAgent @Agent Pod가 registry에 등록된다."""
+    """@MCPServer @Agent Pod가 registry에 등록된다."""
     pod = ToolAgent()
 
     result = processor.post_process(pod)

--- a/plugins/spakky-mcp/tests/unit/test_server.py
+++ b/plugins/spakky-mcp/tests/unit/test_server.py
@@ -37,10 +37,10 @@ from spakky.plugins.mcp.server import (
     serve_stdio,
     streamable_http_session_manager,
 )
-from spakky.plugins.mcp.stereotypes.mcp_tool_server_agent import McpToolServerAgent
+from spakky.plugins.mcp.stereotypes.mcp_server import MCPServer
 
 
-@McpToolServerAgent(server_name="marked-agent")
+@MCPServer(server_name="marked-agent")
 @Agent(spec=AgentExecutionSpec(name="unit", objective="serve tools"))
 class ToolAgent:
     """Agent fixture with one native tool used across server unit tests."""
@@ -167,9 +167,7 @@ def test_tool_server_build_server_uses_configured_name(
 def test_tool_server_build_server_for_registered_agent_uses_marker_name() -> None:
     """The Pod builds a server for a declaratively registered MCP agent."""
     registry = McpToolServerRegistry()
-    registry.register(
-        ToolAgent(), ToolAgent, McpToolServerAgent(server_name="marked-agent")
-    )
+    registry.register(ToolAgent(), ToolAgent, MCPServer(server_name="marked-agent"))
     server = McpToolServer(McpConfig(), registry).build_server_for("unit")
 
     assert isinstance(server, Server)
@@ -179,7 +177,7 @@ def test_tool_server_build_server_for_registered_agent_uses_marker_name() -> Non
 def test_tool_server_build_server_for_uses_config_name_when_marker_omits_name() -> None:
     """Marker server_name 생략 시 tool_server config name을 사용한다."""
     registry = McpToolServerRegistry()
-    registry.register(ToolAgent(), ToolAgent, McpToolServerAgent())
+    registry.register(ToolAgent(), ToolAgent, MCPServer())
     config = McpConfig()
     config.tool_server = McpToolServerConfig(name="fallback-agent")
 
@@ -216,9 +214,7 @@ def test_tool_server_streamable_http_session_manager_wraps_built_server(
 def test_tool_server_streamable_http_session_manager_for_registered_agent() -> None:
     """agent-name 기반 streamable HTTP manager가 registry에서 server를 만든다."""
     registry = McpToolServerRegistry()
-    registry.register(
-        ToolAgent(), ToolAgent, McpToolServerAgent(server_name="marked-agent")
-    )
+    registry.register(ToolAgent(), ToolAgent, MCPServer(server_name="marked-agent"))
 
     manager = McpToolServer(McpConfig(), registry).streamable_http_session_manager_for(
         "unit"
@@ -253,9 +249,7 @@ async def test_tool_server_serve_stdio_for_delegates_to_registered_agent(
         served.append(server)
 
     registry = McpToolServerRegistry()
-    registry.register(
-        ToolAgent(), ToolAgent, McpToolServerAgent(server_name="marked-agent")
-    )
+    registry.register(ToolAgent(), ToolAgent, MCPServer(server_name="marked-agent"))
     monkeypatch.setattr("spakky.plugins.mcp.server.serve_stdio", _serve)
 
     await McpToolServer(McpConfig(), registry).serve_stdio_for("unit")


### PR DESCRIPTION
## Summary
- add canonical `@A2ACompatible`, `@AGUICompatible`, and `@MCPServer` public markers while keeping legacy aliases compatible
- wire A2A REST/gRPC exposure through declarative metadata and post-processors, including separate REST mount handling and optional gRPC registration
- refresh A2A, AG-UI, and MCP docs/API references so developers can follow declarative usage without relying on lower-level builders

## Verification
- `plugins/spakky-a2a`: `uv run ruff format . && uv run ruff check . && uv run pyrefly check src tests --min-severity warn --progress-bar no --output-format min-text && uv run pytest` (139 passed, 100% coverage)
- `plugins/spakky-agui`: `uv run ruff check . && uv run pyrefly check src tests --min-severity warn --progress-bar no --output-format min-text && uv run pytest` (102 passed, 11 skipped, 100% coverage)
- `plugins/spakky-mcp`: `uv run ruff check . && uv run pyrefly check src tests --min-severity warn --progress-bar no --output-format min-text && uv run pytest` (77 passed, 100% coverage)
- harness: `validate_python_harness.py .` passed for spakky-a2a, spakky-agui, spakky-mcp
- docs: `uv run mkdocs build --strict`
- clean-slate docs/API evaluator: SATISFIED for accuracy, sufficiency, and readability across spakky-a2a, spakky-agui, spakky-mcp

## Acceptance Criteria (자가 grep)
acceptance_check: user-requested direct cleanup; no issue acceptance file
