### PR TITLE
fix(agent): surface lazy mcp approval target

### DIFF
--- a/core/spakky-agent/src/spakky/agent/__init__.py
+++ b/core/spakky-agent/src/spakky/agent/__init__.py
@@ -185,6 +185,7 @@ from spakky.agent.state import (
 )
 from spakky.agent.tooling import (
     AgentToolCatalog,
+    AgentToolApprovalContext,
     AgentToolBoundInvocation,
     AgentToolDefinition,
     AgentToolDescriptor,
@@ -301,6 +302,7 @@ __all__ = [
     "AgentSignalPollPoint",
     "AgentTeammate",
     "AgentToolBindingError",
+    "AgentToolApprovalContext",
     "AgentToolBoundInvocation",
     "AgentToolCatalog",
     "AgentToolDefinition",

--- a/core/spakky-agent/src/spakky/agent/approval.py
+++ b/core/spakky-agent/src/spakky/agent/approval.py
@@ -68,6 +68,7 @@ class AgentApprovalRequest:
         agent_state_id: str,
         descriptor: AgentToolDescriptor,
         prompt: str | None = None,
+        action_ref: str | None = None,
         call_id: str | None = None,
         metadata: JsonObject | None = None,
     ) -> "AgentApprovalRequest":
@@ -79,7 +80,7 @@ class AgentApprovalRequest:
             boundary=AgentApprovalBoundaryKind.TOOL_INVOCATION,
             prompt=prompt or f"Approve tool invocation: {descriptor.name}",
             risk=descriptor.metadata.risk,
-            action_ref=descriptor.identity.key,
+            action_ref=action_ref or descriptor.identity.key,
             metadata=request_metadata,
         )
 
@@ -158,6 +159,7 @@ def plan_agent_tool_approval(
     agent_state_id: str,
     agent_type: str,
     prompt: str | None = None,
+    action_ref: str | None = None,
     call_id: str | None = None,
     metadata: JsonObject | None = None,
 ) -> AgentApprovalPlan:
@@ -170,6 +172,7 @@ def plan_agent_tool_approval(
         agent_state_id=agent_state_id,
         descriptor=descriptor,
         prompt=prompt,
+        action_ref=action_ref,
         call_id=call_id,
         metadata=metadata,
     )

--- a/core/spakky-agent/src/spakky/agent/runner.py
+++ b/core/spakky-agent/src/spakky/agent/runner.py
@@ -606,12 +606,16 @@ class AgentRunner:
         the durable approval decision polled from the signal queue, the
         non-blocking resume the ADR-0013 §5 flow uses.
         """
+        approval_context = descriptor.approval_context(call.arguments)
         plan = plan_agent_tool_approval(
             descriptor=descriptor,
             approval_id=self._approval_id(state.id, call),
             agent_state_id=state.id,
             agent_type=self._agent_type(),
+            prompt=approval_context.prompt,
+            action_ref=approval_context.action_ref,
             call_id=call.call_id,
+            metadata=approval_context.metadata,
         )
         if not (plan.requires_approval and plan.yield_item is not None):
             return None, None, True

--- a/core/spakky-agent/src/spakky/agent/tooling.py
+++ b/core/spakky-agent/src/spakky/agent/tooling.py
@@ -291,6 +291,22 @@ class AgentToolMetadata:
 
 
 @dataclass(frozen=True, slots=True)
+class AgentToolApprovalContext:
+    """Invocation-specific approval display and correlation metadata."""
+
+    prompt: str | None = None
+    action_ref: str | None = None
+    metadata: JsonObject = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Reject blank override strings before they enter approval state."""
+        if self.prompt is not None:
+            _require_non_blank(self.prompt, "Agent tool approval prompt")
+        if self.action_ref is not None:
+            _require_non_blank(self.action_ref, "Agent tool approval action ref")
+
+
+@dataclass(frozen=True, slots=True)
 class ToolRisk:
     """Derived typed risk axes for policy and evidence annotations."""
 
@@ -389,6 +405,11 @@ class AgentToolDescriptor:
     def bind_invocation(self, payload: JsonObject) -> "AgentToolBoundInvocation":
         """Bind a decoded model payload before the tool callable is invoked."""
         return bind_agent_tool_invocation(self.callable, payload)
+
+    def approval_context(self, payload: JsonObject) -> AgentToolApprovalContext:
+        """Return invocation-specific approval context for this payload."""
+        _ = payload
+        return AgentToolApprovalContext()
 
 
 @dataclass(frozen=True, slots=True)

--- a/core/spakky-agent/tests/unit/test_approval.py
+++ b/core/spakky-agent/tests/unit/test_approval.py
@@ -281,6 +281,15 @@ def test_plan_agent_tool_approval_expect_preserves_prompt_and_optional_metadata(
         agent_type="ApprovalFixtureAgent",
         call_id="tool-call-1",
     )
+    plan_with_action_ref = plan_agent_tool_approval(
+        descriptor=descriptor,
+        approval_id="approval-3",
+        agent_state_id="run-1",
+        agent_type="ApprovalFixtureAgent",
+        prompt="Approve external target?",
+        action_ref="external.tool:target",
+        metadata={"target": "external"},
+    )
 
     assert plan_without_call_id.request is not None
     assert plan_without_call_id.request.prompt == "Run deployment?"
@@ -288,6 +297,10 @@ def test_plan_agent_tool_approval_expect_preserves_prompt_and_optional_metadata(
     assert plan_without_call_id.request.metadata["metadata"] == {"source": "test"}
     assert plan_with_call_id.request is not None
     assert plan_with_call_id.request.metadata["call_id"] == "tool-call-1"
+    assert plan_with_action_ref.request is not None
+    assert plan_with_action_ref.request.prompt == "Approve external target?"
+    assert plan_with_action_ref.request.action_ref == "external.tool:target"
+    assert plan_with_action_ref.request.metadata["metadata"] == {"target": "external"}
 
 
 def test_plan_agent_tool_approval_expect_rejects_invalid_state_metadata() -> None:

--- a/core/spakky-agent/tests/unit/test_public_api.py
+++ b/core/spakky-agent/tests/unit/test_public_api.py
@@ -23,6 +23,7 @@ from spakky.agent import (
     AgentCancellationRequest,
     AgentCancellationTargetKind,
     AgentToolCatalog,
+    AgentToolApprovalContext,
     AgentToolBindingError,
     AgentToolBoundInvocation,
     AgentToolDescriptor,
@@ -289,6 +290,7 @@ def test_public_api_expect_exports_required_agent_surface() -> None:
     assert AgentToolBindingError is agent_api.AgentToolBindingError
     assert AgentToolBoundInvocation is agent_api.AgentToolBoundInvocation
     assert AgentToolCatalog is agent_api.AgentToolCatalog
+    assert AgentToolApprovalContext is agent_api.AgentToolApprovalContext
     assert AgentToolDescriptor is agent_api.AgentToolDescriptor
     assert AgentToolIdentity is agent_api.AgentToolIdentity
     assert begin_agent_cancellation is agent_api.begin_agent_cancellation

--- a/core/spakky-agent/tests/unit/test_runner.py
+++ b/core/spakky-agent/tests/unit/test_runner.py
@@ -2,7 +2,7 @@
 
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass
-from typing import override
+from typing import cast, override
 
 import pytest
 from pydantic import BaseModel
@@ -19,6 +19,8 @@ from spakky.agent import (
     AgentStateReason,
     AgentStateTransition,
     AgentStatus,
+    AgentToolApprovalContext,
+    AgentToolDescriptor,
     AgentYield,
     AgentYieldKind,
     Approval,
@@ -30,6 +32,7 @@ from spakky.agent import (
     IAgentModel,
     Idempotency,
     ITaskStore,
+    JsonObject,
     JsonValue,
     AgentCompactionPolicy,
     KeepRecentMessagesCompactionStrategy,
@@ -435,6 +438,50 @@ async def test_agent_runner_expect_no_pending_decision_pauses_without_dispatch()
     assert any(isinstance(item.payload, Approval) for item in items)
     assert not any(isinstance(item.payload, Tool) for item in items)
     assert states.get("run-1").status is AgentStatus.INTERRUPTED
+
+
+async def test_agent_runner_expect_approval_context_overrides_pause_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """runner approval pause는 descriptor의 호출별 approval context를 보존한다."""
+
+    def fake_approval_context(
+        self: AgentToolDescriptor, payload: JsonObject
+    ) -> AgentToolApprovalContext:
+        assert self.schema.name == "echo.write"
+        return AgentToolApprovalContext(
+            prompt=f"Approve external target: {payload['value']}",
+            action_ref=f"external.echo:{payload['value']}",
+            metadata={"target": payload["value"]},
+        )
+
+    monkeypatch.setattr(AgentToolDescriptor, "approval_context", fake_approval_context)
+    model = RecordingModel(
+        (
+            _tool_event("echo.write", {"value": "draft"}, "write-1"),
+            ModelStreamEvent(kind=ModelStreamEventKind.DONE),
+        )
+    )
+    states = FakeStateRepository()
+
+    items = await _run_durable(
+        model,
+        RunAgentInput(state_id="run-1", instruction="write"),
+        states,
+        FakeSignalRepository(()),
+        FakeEvidenceRepository(),
+    )
+
+    approval_payloads = [
+        item.payload for item in items if isinstance(item.payload, Approval)
+    ]
+    assert len(approval_payloads) == 1
+    approval = approval_payloads[0]
+    assert approval.prompt == "Approve external target: draft"
+    assert approval.metadata["action_ref"] == "external.echo:draft"
+    approval_tool_metadata = cast(JsonObject, approval.metadata["metadata"])
+    assert approval_tool_metadata["metadata"] == {"target": "draft"}
+    assert states.get("run-1").metadata["approval"] == approval.metadata
 
 
 async def test_agent_runner_expect_model_error_fails_state_and_yields_error() -> None:

--- a/core/spakky-agent/tests/unit/test_tooling.py
+++ b/core/spakky-agent/tests/unit/test_tooling.py
@@ -12,6 +12,7 @@ from spakky.agent import (
     Agent,
     AgentDefinitionError,
     AgentToolCatalog,
+    AgentToolApprovalContext,
     AgentToolBindingError,
     AgentToolBoundInvocation,
     AgentToolDescriptor,
@@ -875,6 +876,15 @@ def test_tool_catalog_expect_preserves_owner_callable_schema_and_metadata() -> N
         )
     )
     assert descriptor.metadata.requires_approval_candidate is True
+    assert descriptor.approval_context({"command": "ls"}) == AgentToolApprovalContext()
+
+
+def test_agent_tool_approval_context_expect_rejects_blank_overrides() -> None:
+    """approval context override 문자열은 approval state에 들어가기 전 검증된다."""
+    with pytest.raises(AgentDefinitionError):
+        AgentToolApprovalContext(prompt=" ")
+    with pytest.raises(AgentDefinitionError):
+        AgentToolApprovalContext(action_ref=" ")
 
 
 def test_tool_catalog_expect_lookup_by_identity_and_schema_name() -> None:

--- a/docs/api/plugins/spakky-mcp.md
+++ b/docs/api/plugins/spakky-mcp.md
@@ -34,7 +34,7 @@
 
 ## Descriptor
 
-`descriptor` 모듈은 `McpClient`가 발견한 외부 MCP tools를 lazy `mcp_search_tools` / `mcp_call_tool` 표면 뒤에 보관하기 위한 내부 정규화 계층입니다. 애플리케이션 코드는 일반적으로 `McpClient`, `McpConfig`, `IMcpRuntimeServerResolver`만 사용합니다.
+`descriptor` 모듈은 `McpClient`가 발견한 외부 MCP tools를 lazy `mcp_search_tools` / `mcp_call_tool` 표면 뒤에 보관하기 위한 내부 정규화 계층입니다. 애플리케이션 코드는 일반적으로 `McpClient`, `McpConfig`, `IMcpRuntimeServerResolver`만 사용합니다. `mcp_call_tool` approval request는 meta-tool이 아니라 선택된 외부 MCP tool 이름과 arguments를 노출합니다.
 
 ::: spakky.plugins.mcp.descriptor
     options:

--- a/docs/guides/agent-mcp.md
+++ b/docs/guides/agent-mcp.md
@@ -244,6 +244,7 @@ MCP 서버는 도구가 많을 수 있습니다. 모든 MCP tool schema를 모�
 ```
 
 이 구조 때문에 서버가 100개 tool을 제공해도 최초 model request에는 `mcp_search_tools`, `mcp_call_tool`만 들어갑니다. 필요한 tool schema는 검색 결과로만 좁혀서 들어갑니다.
+`mcp_call_tool`이 HITL approval 후보가 되면 approval prompt와 `action_ref`는 meta-tool 이름이 아니라 선택된 외부 tool 이름을 기준으로 만들어지고, approval metadata에는 `mcp_tool_name`과 `mcp_arguments`가 포함됩니다.
 
 ## 동작 원리
 
@@ -253,7 +254,7 @@ MCP 서버는 도구가 많을 수 있습니다. 모든 MCP tool schema를 모�
 2. 각 서버 transport session을 열고 MCP `initialize`와 `list_tools()`를 수행합니다.
 3. 발견된 tool을 세션 내부 descriptor registry에 보관합니다.
 4. Agent catalog에는 `mcp_search_tools`, `mcp_call_tool`만 병합합니다.
-5. `mcp_call_tool`이 호출되면 registry에서 실제 descriptor를 찾아 MCP `call_tool`로 전달합니다.
+5. `mcp_call_tool`이 호출되면 registry에서 실제 descriptor를 찾아 MCP `call_tool`로 전달합니다. approval이 필요하면 선택된 외부 tool 이름과 arguments를 approval request에 싣습니다.
 6. runner context가 닫히면 모든 MCP session을 닫습니다.
 
 외부 tool 결과는 `structuredContent`가 있으면 그대로, 없으면 텍스트 콘텐츠를 모아 JSON 값으로 정규화합니다. 서버가 오류 결과(`isError`)를 반환하거나 연결·디스커버리·호출이 실패하면 `McpTransportError`, `McpToolDiscoveryError`, `McpToolInvocationError` 등 타입화된 오류로 표면화됩니다.

--- a/plugins/spakky-mcp/README.md
+++ b/plugins/spakky-mcp/README.md
@@ -125,6 +125,7 @@ MCP servers can expose many tools. `spakky-mcp` does not push every external too
 External tool names are returned by search as `<server_name>__<tool_name>`. For example, `weather` server tool `forecast` becomes `weather__forecast`.
 
 This keeps large MCP toolsets from polluting the model context while still letting the model discover and invoke the tools it needs.
+When `mcp_call_tool` requires human approval, the approval request names the selected external MCP tool and includes the selected arguments in metadata.
 
 ## Development checks
 

--- a/plugins/spakky-mcp/src/spakky/plugins/mcp/descriptor.py
+++ b/plugins/spakky-mcp/src/spakky/plugins/mcp/descriptor.py
@@ -17,6 +17,7 @@ from typing import cast, override
 from mcp.types import CallToolResult, TextContent, Tool
 from spakky.agent import (
     AgentRunner,
+    AgentToolApprovalContext,
     AgentToolBoundInvocation,
     AgentToolCatalog,
     AgentToolDescriptor,
@@ -80,6 +81,30 @@ class ExternalMcpToolDescriptor(AgentToolDescriptor):
     def bind_invocation(self, payload: JsonObject) -> AgentToolBoundInvocation:
         """Forward the MCP argument object as keyword arguments verbatim."""
         return AgentToolBoundInvocation(args=(), kwargs=dict(payload))
+
+
+class LazyMcpCallToolDescriptor(AgentToolDescriptor):
+    """Lazy call descriptor that surfaces the selected external tool to HITL."""
+
+    @override
+    def approval_context(self, payload: JsonObject) -> AgentToolApprovalContext:
+        """Expose the target MCP tool name and arguments to approval requests."""
+        tool_name = payload.get("tool_name")
+        if not isinstance(tool_name, str) or not tool_name.strip():
+            return AgentToolApprovalContext()
+        arguments = payload.get("arguments")
+        safe_arguments = (
+            cast(JsonObject, dict(arguments)) if isinstance(arguments, dict) else {}
+        )
+        return AgentToolApprovalContext(
+            prompt=f"Approve MCP tool invocation: {tool_name.strip()}",
+            action_ref=_external_tool_action_ref(tool_name.strip()),
+            metadata={
+                "mcp_meta_tool": MCP_CALL_TOOL_NAME,
+                "mcp_tool_name": tool_name.strip(),
+                "mcp_arguments": safe_arguments,
+            },
+        )
 
 
 def prefixed_tool_name(server_name: str, raw_tool_name: str) -> str:
@@ -232,6 +257,7 @@ def build_lazy_mcp_descriptors(
             },
             effects=ToolEffects.external_side_effect(),
             approval=ToolApprovalRequirement.DERIVED,
+            descriptor_type=LazyMcpCallToolDescriptor,
         ),
     )
 
@@ -293,6 +319,7 @@ def _lazy_descriptor(
     input_schema: JsonObject,
     effects: ToolEffects,
     approval: ToolApprovalRequirement,
+    descriptor_type: type[AgentToolDescriptor] = AgentToolDescriptor,
 ) -> AgentToolDescriptor:
     identity = AgentToolIdentity(
         owner_module=MCP_EXTERNAL_TOOL_OWNER_MODULE,
@@ -306,7 +333,7 @@ def _lazy_descriptor(
         input_schema=input_schema,
         output_schema={"type": "object", "additionalProperties": True},
     )
-    return AgentToolDescriptor(
+    return descriptor_type(
         identity=identity,
         owner=LazyMcpToolset,
         callable=callable_,
@@ -318,6 +345,14 @@ def _lazy_descriptor(
             externality=effects.externality,
             approval=approval,
         ),
+    )
+
+
+def _external_tool_action_ref(prefixed_name: str) -> str:
+    server_name = prefixed_name.split(MCP_TOOL_NAME_SEPARATOR, 1)[0]
+    return (
+        f"{MCP_EXTERNAL_TOOL_OWNER_MODULE}."
+        f"{ExternalMcpTool.__qualname__}.{server_name}:{prefixed_name}"
     )
 
 

--- a/plugins/spakky-mcp/tests/unit/test_catalog_merge.py
+++ b/plugins/spakky-mcp/tests/unit/test_catalog_merge.py
@@ -154,6 +154,37 @@ def test_lazy_mcp_search_is_not_an_approval_candidate() -> None:
     assert call.metadata.requires_approval_candidate is True
 
 
+def test_lazy_call_approval_context_names_selected_external_tool() -> None:
+    """Approval requests show the MCP tool selected through the lazy call surface."""
+    _search, call = build_lazy_mcp_descriptors([_external_descriptor()])
+
+    context = call.approval_context(
+        {"tool_name": "weather__get_data", "arguments": {"city": "seoul"}}
+    )
+
+    assert context.prompt == "Approve MCP tool invocation: weather__get_data"
+    assert (
+        context.action_ref
+        == "spakky.plugins.mcp.ExternalMcpTool.weather:weather__get_data"
+    )
+    assert context.metadata == {
+        "mcp_meta_tool": MCP_CALL_TOOL_NAME,
+        "mcp_tool_name": "weather__get_data",
+        "mcp_arguments": {"city": "seoul"},
+    }
+
+
+def test_lazy_call_approval_context_falls_back_for_invalid_tool_name() -> None:
+    """Invalid lazy-call payloads keep the default meta-tool approval context."""
+    _search, call = build_lazy_mcp_descriptors([_external_descriptor()])
+
+    context = call.approval_context({"tool_name": " "})
+
+    assert context.prompt is None
+    assert context.action_ref is None
+    assert context.metadata == {}
+
+
 async def test_lazy_search_returns_matching_external_tool_summaries() -> None:
     """The search meta-tool returns MCP tool schemas without listing all upfront."""
     search, _call = build_lazy_mcp_descriptors(


### PR DESCRIPTION
## Summary
- add invocation-specific tool approval context so lazy meta-tools can name the actual target action
- make spakky-mcp mcp_call_tool approval requests expose the selected external tool name and arguments
- document the lazy MCP approval metadata contract

## Verification
- cd core/spakky-agent && uv run ruff format . && uv run ruff check .
- cd core/spakky-agent && uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .
- cd core/spakky-agent && uv run --project ../.. pyrefly check --disable-project-excludes-heuristics --min-severity warn --no-progress-bar --output-format min-text
- cd core/spakky-agent && uv run --project ../.. pytest
- cd plugins/spakky-mcp && uv run ruff format . && uv run ruff check .
- cd plugins/spakky-mcp && uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .
- cd plugins/spakky-mcp && uv run --project ../.. pyrefly check --disable-project-excludes-heuristics --min-severity warn --no-progress-bar --output-format min-text
- cd plugins/spakky-mcp && uv run --project ../.. pytest
- uv run mkdocs build --strict
- git diff --check