### PR TITLE
docs(mcp): document v7 migration path

### DIFF
--- a/docs/api/plugins/spakky-mcp.md
+++ b/docs/api/plugins/spakky-mcp.md
@@ -4,6 +4,12 @@
 
 `McpClient`가 `IAgentRunnerFactory` 구현체로 외부 서버 연결 수명주기를 소유합니다. `McpRuntimeServerResolver`는 configured server 이름과 run-time inline server 선언을 해석하고, descriptor 계층은 발견된 MCP tools를 lazy search/call meta-tools 뒤에 보관합니다.
 
+## v7 Breaking Change
+
+v7에서 `spakky-mcp`는 Agent의 자체 도구를 MCP server로 노출하던 공개 API를 제거했습니다. 삭제된 표면은 `MCPServer`, `MCPToolServer`, `McpToolServerConfig`, `build_agent_tool_server`, `serve_stdio`, `McpConfig.tool_server`, server registry 모듈입니다.
+
+새 계약은 단방향입니다. MCP server는 FastMCP나 공식 MCP SDK 등으로 별도 구현하고, Spakky Agent run에는 `McpConfig.servers` 또는 `RunAgentInput.metadata["mcp"]["servers"]`로 연결합니다. Agent class에는 MCP 노출 annotation을 붙이지 않습니다.
+
 ## Public API
 
 ::: spakky.plugins.mcp

--- a/docs/guides/agent-mcp.md
+++ b/docs/guides/agent-mcp.md
@@ -38,6 +38,24 @@ pip install "spakky[agent]"
 
 plugin 초기화는 `McpConfig`, HTTP client provider, runtime resolver, `McpClient`를 등록하고 `IAgentRunnerFactory`를 `McpClient`로 바인딩합니다. 그래서 AG-UI/A2A 같은 inbound adapter가 runner factory를 통해 실행하면 MCP 서버가 자동으로 합류합니다.
 
+## v7 마이그레이션
+
+`spakky-mcp` v7은 Agent 도구를 MCP 서버로 노출하던 역방향 API를 제거합니다.
+
+제거된 공개 표면:
+
+- `MCPServer`, `MCPToolServer`, `McpToolServerConfig`
+- `build_agent_tool_server`, `serve_stdio`
+- `McpConfig.tool_server`
+- Agent class에 붙여 MCP 서버 노출을 선언하던 annotation과 registry 모듈
+
+마이그레이션 경로:
+
+1. MCP 서버는 FastMCP, 공식 MCP SDK, 사내 서버 프레임워크 등으로 별도 구현합니다.
+2. Agent 서비스는 허용된 서버를 `McpConfig.servers`에 저장하거나, 사용자 설정에서 per-run inline declaration을 구성합니다.
+3. 실행 시 `RunAgentInput.metadata["mcp"]["servers"]`에 선택된 서버를 넣습니다.
+4. Agent class에는 MCP annotation을 붙이지 않습니다. `spakky-mcp`가 runner factory에서 외부 서버를 lazy tool로 붙입니다.
+
 ## 서버 선언
 
 `McpConfig.servers`에는 서비스가 미리 허용한 서버를 선언합니다. `SPAKKY_MCP__` 환경변수로도 같은 값을 넣을 수 있습니다.

--- a/plugins/spakky-mcp/README.md
+++ b/plugins/spakky-mcp/README.md
@@ -25,6 +25,26 @@ uv add "spakky[agent]"
 
 Loading the plugin registers `McpClient` as `IAgentRunnerFactory`. Inbound adapters such as AG-UI and A2A can keep using the runner factory; MCP servers join the run through `RunAgentInput.metadata`.
 
+## v7 breaking change
+
+`spakky-mcp` v7 removes the reverse "Agent tools as an MCP server" surface:
+
+- removed `MCPServer`, `MCPToolServer`, `McpToolServerConfig`,
+  `build_agent_tool_server`, `serve_stdio`, and the server registry modules,
+- removed `McpConfig.tool_server`,
+- removed Agent annotations whose only purpose was exposing local Agent tools
+  as an MCP server.
+
+The replacement path is intentionally one-way:
+
+1. Build MCP servers with FastMCP, the official MCP SDK, or another MCP server
+   framework.
+2. Register allowed servers in `McpConfig.servers` or accept per-run inline
+   declarations from user/service settings.
+3. Pass selected servers through `RunAgentInput.metadata["mcp"]["servers"]`.
+4. Let `spakky-mcp` attach those external tools lazily through
+   `mcp_search_tools` and `mcp_call_tool`.
+
 ## Configure servers
 
 Configured servers use the `SPAKKY_MCP__` settings prefix.


### PR DESCRIPTION
## Summary
- document the v7 removal of reverse Agent-tool MCP server exposure APIs
- add the supported migration path: build MCP servers separately and attach them at run time through McpConfig or RunAgentInput metadata
- clarify that Agent classes should not use MCP annotations for external server attachment

## Verification
- uv run mkdocs build --strict
- git diff --check