### PR TITLE
fix(kafka): propagate async producer security config (#484)

### DIFF
--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/event/transport.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/event/transport.py
@@ -111,6 +111,21 @@ class AsyncKafkaEventTransport(IAsyncEventTransport):
             ]
         )
 
+    def _producer_config(self) -> dict[str, str]:
+        config = {
+            "bootstrap_servers": self.config.bootstrap_servers,
+            "client_id": self.config.client_id,
+        }
+        if self.config.security_protocol:
+            config["security_protocol"] = self.config.security_protocol
+        if self.config.sasl_mechanism:
+            config["sasl_mechanism"] = self.config.sasl_mechanism
+        if self.config.sasl_username:
+            config["sasl_plain_username"] = self.config.sasl_username
+        if self.config.sasl_password:
+            config["sasl_plain_password"] = self.config.sasl_password
+        return config
+
     @override
     async def send(
         self,
@@ -126,9 +141,7 @@ class AsyncKafkaEventTransport(IAsyncEventTransport):
             headers: Metadata headers for trace propagation.
         """
         self._create_topic(topic=event_name)
-        producer = AIOKafkaProducer(
-            bootstrap_servers=self.config.bootstrap_servers,
-        )
+        producer = AIOKafkaProducer(**self._producer_config())
         await producer.start()
         try:
             await producer.send_and_wait(

--- a/plugins/spakky-kafka/tests/unit/test_transport.py
+++ b/plugins/spakky-kafka/tests/unit/test_transport.py
@@ -175,6 +175,7 @@ async def test_async_transport_send_expect_produce_and_flush(
 
     mock_aio_producer_cls.assert_called_once_with(
         bootstrap_servers=config.bootstrap_servers,
+        client_id=config.client_id,
     )
     mock_producer.start.assert_awaited_once()
     mock_producer.send_and_wait.assert_awaited_once_with(
@@ -183,3 +184,44 @@ async def test_async_transport_send_expect_produce_and_flush(
         headers=[("traceparent", b"00-abc-def-01")],
     )
     mock_producer.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_send_with_sasl_config_expect_security_kwargs(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """비동기 producer 생성 시 SASL/security 설정을 aiokafka kwargs로 전달한다."""
+    from spakky.plugins.kafka.common.constants import SPAKKY_KAFKA_CONFIG_ENV_PREFIX
+
+    monkeypatch.setenv(f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID", "test-group")
+    monkeypatch.setenv(f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID", "secure-client")
+    monkeypatch.setenv(
+        f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS", "secure:9093"
+    )
+    monkeypatch.setenv(f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SECURITY_PROTOCOL", "SASL_SSL")
+    monkeypatch.setenv(f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SASL_MECHANISM", "PLAIN")
+    monkeypatch.setenv(f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SASL_USERNAME", "api-key")
+    monkeypatch.setenv(f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SASL_PASSWORD", "api-secret")
+
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = set()
+    mock_admin_cls.return_value = mock_admin
+    mock_producer = AsyncMock()
+    mock_aio_producer_cls.return_value = mock_producer
+
+    config = KafkaConnectionConfig()
+    transport = AsyncKafkaEventTransport(config)
+    await transport.send("SecureEvent", b"{}", {})
+
+    mock_aio_producer_cls.assert_called_once_with(
+        bootstrap_servers="secure:9093",
+        client_id="secure-client",
+        security_protocol="SASL_SSL",
+        sasl_mechanism="PLAIN",
+        sasl_plain_username="api-key",
+        sasl_plain_password="api-secret",
+    )


### PR DESCRIPTION
## Summary

- Map async Kafka producer connection settings to aiokafka kwargs.
- Pass `client_id`, `security_protocol`, `sasl_mechanism`, `sasl_plain_username`, and `sasl_plain_password` when configured.
- Add a regression test for SASL/security propagation while preserving existing async send semantics.

## Investigation

`AsyncKafkaEventTransport.send()` constructed `AIOKafkaProducer` with only `bootstrap_servers`, so documented production Kafka SASL/security settings were ignored on the async publish path. `AIOKafkaProducer` expects Python kwargs such as `sasl_plain_username`, so the confluent-style dotted `configuration_dict` cannot be passed through unchanged.

## Acceptance Criteria (자가 grep)

- [x] `rg -n "sasl_plain_username|sasl_plain_password" plugins/spakky-kafka/src plugins/spakky-kafka/tests` -> expected at least 2 hits, actual 4
- [x] `rg -n "test_async_transport_send_with_sasl_config_expect_security_kwargs" plugins/spakky-kafka/tests/unit/test_transport.py` -> expected at least 1 hit, actual 1

## Verification

- `uv run ruff format . --check`
- `uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`
- `uv run ruff check .`
- `uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text`
- `uv run pytest --no-cov tests/unit/test_transport.py::test_async_transport_send_with_sasl_config_expect_security_kwargs -x -v`
- `uv run pytest --no-cov tests/unit/test_transport.py::test_async_transport_send_expect_produce_and_flush -x -v`
- `uv run pytest`

Closes #484
