### PR TITLE
docs: sync user docs with package behavior

### DIFF
--- a/docs/error-hierarchy.md
+++ b/docs/error-hierarchy.md
@@ -59,9 +59,12 @@ flowchart TD
   AbstractAgUiError --> AgUiApprovalDecodeError
   AbstractAgUiError --> AgUiPendingApprovalError
   AbstractAgUiError --> AgUiRunResolutionError
+  AbstractAgUiError --> AgUiEndpointConflictError
 
   AbstractSpakkyA2AError --> A2AAgentServerNotRegisteredError
   AbstractSpakkyA2AError --> A2AAgentCardDerivationError
+  AbstractSpakkyA2AError --> A2AEndpointConflictError
+  AbstractSpakkyA2AError --> A2ARunResolutionError
   AbstractSpakkyA2AError --> UnsupportedAgentEventError
   AbstractSpakkyA2AError --> InvalidApprovalDecisionError
 
@@ -119,6 +122,7 @@ flowchart TD
   AbstractVllmError --> VllmConstrainedDecodingUnsupportedError
   AbstractVllmError --> VllmStreamingDisabledError
   AbstractVllmError --> VllmModelRefusalError
+  AbstractVllmError --> VllmModelSelectionError
   AbstractVllmError --> VllmStreamingNotImplementedError
   PolicyDocumentError --> PolicyDocumentLoadError
   PolicyDocumentError --> PolicyDocumentValidationError
@@ -814,6 +818,7 @@ from spakky.plugins.vllm.error import (
     AbstractVllmError,
     VllmConstrainedDecodingUnsupportedError,
     VllmModelRefusalError,
+    VllmModelSelectionError,
     VllmResponseError,
     VllmStreamingDisabledError,
     VllmStreamingNotImplementedError,
@@ -831,6 +836,7 @@ from spakky.plugins.vllm.error import (
 | `VllmConstrainedDecodingUnsupportedError` | 요청된 tool constraint를 vLLM이 강제할 수 없음 |
 | `VllmStreamingDisabledError` | plugin 설정에서 streaming이 비활성화됨 |
 | `VllmModelRefusalError` | 모델이 정상 completion 생성을 거부함 |
+| `VllmModelSelectionError` | run이 vLLM adapter 범위 밖의 model을 선택함 |
 | `VllmStreamingNotImplementedError` | pre-streaming adapter 실패 호환 alias |
 
 ### spakky-agui
@@ -841,6 +847,7 @@ AG-UI protocol adapter 관련 에러입니다. AG-UI request를 core `RunAgentIn
 from spakky.plugins.agui.error import (
     AbstractAgUiError,
     AgUiApprovalDecodeError,
+    AgUiEndpointConflictError,
     AgUiPendingApprovalError,
     AgUiRunResolutionError,
 )
@@ -850,6 +857,7 @@ from spakky.plugins.agui.error import (
 | ---- | ---- | ---- |
 | `AbstractAgUiError` | AG-UI adapter 에러 기반 클래스 | `AbstractSpakkyFrameworkError` |
 | `AgUiApprovalDecodeError` | resume input의 approval decision payload가 없거나 유효하지 않음 | `AbstractAgUiError` |
+| `AgUiEndpointConflictError` | 여러 AG-UI agent가 같은 transport path를 claim함 | `AbstractAgUiError` |
 | `AgUiPendingApprovalError` | paused approval state 또는 `RunPausedEvent`가 approval id, prompt, decision 목록을 제공하지 못함 | `AbstractAgUiError` |
 | `AgUiRunResolutionError` | AG-UI run request를 실행 가능한 agent run으로 해석할 수 없음 | `AbstractAgUiError` |
 
@@ -860,8 +868,10 @@ A2A AgentCard, task event projection, gRPC wrapper, approval resume 관련 에�
 ```python
 from spakky.plugins.a2a.error import (
     AbstractSpakkyA2AError,
+    A2AEndpointConflictError,
     A2AAgentCardDerivationError,
     A2AAgentServerNotRegisteredError,
+    A2ARunResolutionError,
     InvalidApprovalDecisionError,
     UnsupportedA2AGrpcEventError,
     UnsupportedA2AGrpcResultError,
@@ -875,6 +885,8 @@ from spakky.plugins.a2a.error import (
 | `AbstractSpakkyA2AError` | A2A plugin 에러 기반 클래스 | `AbstractSpakkyFrameworkError` |
 | `A2AAgentServerNotRegisteredError` | 요청한 agent name으로 등록된 A2A server가 없음 | `AbstractSpakkyA2AError` |
 | `A2AAgentCardDerivationError` | `@Agent` 선언에서 AgentCard를 파생할 수 없음 | `AbstractSpakkyA2AError` |
+| `A2AEndpointConflictError` | 여러 A2A agent가 같은 ASGI mount path를 claim함 | `AbstractSpakkyA2AError` |
+| `A2ARunResolutionError` | inbound A2A request의 run 설정을 실행 가능한 agent run으로 해석할 수 없음 | `AbstractSpakkyA2AError` |
 | `UnsupportedAgentEventError` | `AgentEvent` kind를 A2A task event로 투영할 수 없음 | `AbstractSpakkyA2AError` |
 | `UnsupportedFinalOutputError` | final output을 A2A part로 투영할 수 없음 | `AbstractSpakkyA2AError` |
 | `InvalidApprovalDecisionError` | inbound approval-decision data part가 알려진 `ApprovalDecision` 값이 아님 | `AbstractSpakkyA2AError` |

--- a/docs/event-system.md
+++ b/docs/event-system.md
@@ -69,7 +69,7 @@ class OrderPlacedEvent(AbstractIntegrationEvent):
 
 ## AggregateRoot에서 이벤트 발생
 
-AggregateRoot는 도메인 이벤트를 수집하고, 트랜잭션 커밋 시 발행합니다.
+AggregateRoot는 도메인 이벤트를 수집만 합니다. 트랜잭션 커밋 후 발행은 저장된 Aggregate를 추적하는 `AggregateCollector`와 `TransactionalEventPublishingAspect`의 책임입니다.
 
 ```python
 from spakky.domain.models.aggregate_root import AbstractAggregateRoot
@@ -107,6 +107,8 @@ class Order(AbstractAggregateRoot[UUID]):
 - `remove_event(event)` — 이벤트 제거
 - `clear_events()` — 모든 이벤트 제거
 - `events` — 현재 이벤트 목록 (읽기 전용)
+
+Repository 저장 경로에서 `AggregateCollector.collect()`가 AggregateRoot 참조를 모으고, 트랜잭션 커밋 후 `TransactionalEventPublishingAspect`가 수집된 AggregateRoot의 `events`를 읽어 `IEventPublisher`로 발행합니다.
 
 ---
 
@@ -222,7 +224,7 @@ class UserEventHandler:
 
 ### 핸들러 자동 등록
 
-`@EventHandler` Pod가 등록되면, `@on_event`로 표시된 메서드가 자동으로 Consumer에 등록됩니다.
+`@EventHandler` Pod가 등록되면, `AbstractDomainEvent`를 받는 `@on_event` 메서드가 in-process Consumer에 자동 등록됩니다. `AbstractIntegrationEvent`는 이 자동 등록 대상이 아니라 RabbitMQ/Kafka 같은 transport consumer 경로에서 처리합니다.
 
 ---
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -444,7 +444,7 @@ class Email(AbstractValueObject):
 
 ### AggregateRoot
 
-일관성 경계를 관리하는 엔터티의 진입점. 도메인 이벤트를 수집하고 발행합니다. `AbstractAggregateRoot`를 상속합니다.
+일관성 경계를 관리하는 엔터티의 진입점. 도메인 이벤트를 수집하며, 발행은 `AggregateCollector`와 `TransactionalEventPublishingAspect`가 트랜잭션 커밋 후 수행합니다. `AbstractAggregateRoot`를 상속합니다.
 
 ```python
 from spakky.domain.models.aggregate_root import AbstractAggregateRoot
@@ -528,7 +528,7 @@ class OrderPlacedEvent(AbstractIntegrationEvent):
 - **Consumer** — 핸들러를 **등록**하는 인터페이스 (`register(event_type, callback)`)
 - **EventHandler** — 이벤트를 **처리**하는 클래스 스테레오타입 (`@EventHandler` + `@on_event`)
 
-`EventHandlerRegistrationPostProcessor`가 `@EventHandler` Pod를 스캔하여 `@on_event` 메서드를 Consumer에 자동 등록합니다.
+`EventHandlerRegistrationPostProcessor`가 `@EventHandler` Pod를 스캔하여 `AbstractDomainEvent`를 받는 `@on_event` 메서드를 in-process Consumer에 자동 등록합니다. `AbstractIntegrationEvent`는 broker transport consumer 경로에서 처리합니다.
 
 ### EventPublisher
 
@@ -660,7 +660,7 @@ app.load_plugins(include={FASTAPI_PLUGIN})
 
 ### AggregateCollector
 
-AggregateRoot에서 발생한 도메인 이벤트를 수집하여 트랜잭션 커밋 시 발행하는 컴포넌트.
+Repository 저장 경로에서 AggregateRoot 참조를 수집하는 컴포넌트. 트랜잭션 커밋 후 `TransactionalEventPublishingAspect`가 collector에 모인 AggregateRoot의 이벤트를 발행합니다.
 
 ---
 
@@ -903,6 +903,8 @@ flow = saga_flow(
 |------|---------|------|
 | step | `step(..., timeout=timedelta(...))` | 초과 시 `SagaStepTimeoutError`가 `on_error` 전략을 거침 |
 | saga | `SagaFlow.timeout(duration)` | 초과 시 `SagaStatus.TIMED_OUT`으로 종료하고 commit된 step을 역순 보상 |
+
+v1 제약상 전체 timeout이 `parallel()` 그룹 실행 도중 만료되면, 이미 성공했지만 compensable 등록 전인 side effect는 보상되지 않을 수 있습니다. 순차 step이나 이미 완료된 parallel 그룹의 commit된 step은 정상 보상됩니다.
 
 ### run_saga_flow
 

--- a/docs/guides/events.md
+++ b/docs/guides/events.md
@@ -92,7 +92,7 @@ class AsyncOrderEventHandler:
 
 #### 같은 이벤트, 여러 핸들러
 
-하나의 이벤트에 여러 핸들러를 등록할 수 있습니다. 도메인 이벤트와 통합 이벤트 모두 동일합니다.
+하나의 Domain Event에 여러 핸들러를 등록할 수 있습니다. `@EventHandler` 자동 등록은 `AbstractDomainEvent` 서브클래스만 대상으로 하며, Integration Event는 bus/transport consumer 경로로 처리합니다.
 
 ```python
 @EventHandler()
@@ -173,7 +173,7 @@ app = (
 ```
 
 !!! info "자동 등록"
-    `app.start()` 시점에 `EventHandlerRegistrationPostProcessor`가 `@EventHandler` 클래스를 스캔하여 `@on_event` 메서드를 이벤트 타입별로 자동 등록합니다.
+    `app.start()` 시점에 `EventHandlerRegistrationPostProcessor`가 `@EventHandler` 클래스를 스캔하여 `@on_event` 메서드를 Domain Event 타입별로 자동 등록합니다. `AbstractIntegrationEvent`는 자동 등록 대상이 아니라 broker consumer 경로에서 처리됩니다.
 
 ---
 

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -27,18 +27,22 @@ Spakky의 트레이싱 아키텍처는 두 계층으로 나뉩니다:
 ```python
 from spakky.core.application.application import SpakkyApplication
 from spakky.core.application.application_context import ApplicationContext
+import spakky.tracing
 import spakky.plugins.opentelemetry
 import apps
 
 app = (
     SpakkyApplication(ApplicationContext())
-    .load_plugins(include={spakky.plugins.opentelemetry.PLUGIN_NAME})
+    .load_plugins(include={
+        spakky.tracing.PLUGIN_NAME,
+        spakky.plugins.opentelemetry.PLUGIN_NAME,
+    })
     .scan(apps)
     .start()
 )
 ```
 
-`load_plugins()`가 `spakky-opentelemetry`의 엔트리포인트(`spakky.plugins.opentelemetry.main:initialize`)를 호출하면, 다음 Pod가 컨테이너에 등록됩니다:
+선택적 `include`를 사용할 때 propagator 교체까지 활성화하려면 `spakky.tracing.PLUGIN_NAME`도 함께 포함해야 합니다. `spakky-tracing`이 기본 `W3CTracePropagator`를 등록하고, `spakky-opentelemetry`의 엔트리포인트(`spakky.plugins.opentelemetry.main:initialize`)가 다음 Pod를 등록합니다:
 
 1. **`OpenTelemetryConfig`** --- 환경변수 기반 설정 (`@Configuration`)
 2. **`OTelSetupPostProcessor`** --- `TracerProvider` 초기화 및 propagator 교체 (`IPostProcessor`)

--- a/docs/guides/rabbitmq.md
+++ b/docs/guides/rabbitmq.md
@@ -58,7 +58,7 @@ export SPAKKY_RABBITMQ__MALFORMED_PAYLOAD_ACTION=ack
 | `port` | `SPAKKY_RABBITMQ__PORT` | (필수) | RabbitMQ 포트 |
 | `user` | `SPAKKY_RABBITMQ__USER` | (필수) | 인증 사용자명 |
 | `password` | `SPAKKY_RABBITMQ__PASSWORD` | (필수) | 인증 비밀번호 |
-| `exchange_name` | `SPAKKY_RABBITMQ__EXCHANGE_NAME` | `None` | Exchange 이름 (pub/sub 라우팅) |
+| `exchange_name` | `SPAKKY_RABBITMQ__EXCHANGE_NAME` | `None` | Exchange 이름 (event_name routing key 라우팅) |
 | `auth_challenge_action` | `SPAKKY_RABBITMQ__AUTH_CHALLENGE_ACTION` | `ack` | missing/invalid/expired snapshot 처리 |
 | `auth_deny_action` | `SPAKKY_RABBITMQ__AUTH_DENY_ACTION` | `ack` | protected handler DENY 처리 |
 | `auth_error_action` | `SPAKKY_RABBITMQ__AUTH_ERROR_ACTION` | `nack_requeue` | verifier/provider ERROR 처리 |
@@ -158,10 +158,10 @@ sequenceDiagram
 
 ## Exchange 라우팅
 
-`exchange_name`을 설정하면 pub/sub 패턴으로 동작합니다.
+`exchange_name`을 설정하면 configured exchange에 이벤트 이름을 routing key로 사용합니다.
 
-- Transport가 exchange를 선언하고 큐를 바인딩
-- 같은 exchange에 여러 큐가 바인딩되면 메시지가 팬아웃
+- Transport가 exchange를 선언하고 이벤트 이름과 같은 durable queue를 바인딩
+- 발행 시 `event_name` routing key로 publish하므로 소비 queue도 같은 routing key 계약을 사용
 
 `exchange_name`이 `None`이면 기본 exchange(direct)를 사용합니다.
 

--- a/docs/guides/saga-advanced.md
+++ b/docs/guides/saga-advanced.md
@@ -99,7 +99,7 @@ from datetime import timedelta
 step(saga.call_external_api, timeout=timedelta(seconds=3)) | Retry(max_attempts=2)
 ```
 
-`SagaFlow.timeout(duration)`으로 Saga 전체 타임아웃을 설정합니다. 초과 시 `SagaStatus.TIMED_OUT`으로 종료되며, 그 시점까지 commit된 step은 역순으로 보상됩니다.
+`SagaFlow.timeout(duration)`으로 Saga 전체 타임아웃을 설정합니다. 초과 시 `SagaStatus.TIMED_OUT`으로 종료되며, 그 시점까지 commit된 step은 역순으로 보상됩니다. v1 제약상 timeout이 `parallel()` 그룹 실행 도중 만료되면, 이미 성공했지만 compensable 등록 전인 side effect는 보상되지 않을 수 있습니다.
 
 ```python
 from datetime import timedelta

--- a/docs/guides/saga.md
+++ b/docs/guides/saga.md
@@ -291,7 +291,7 @@ action이 새 `AbstractSagaData` 인스턴스를 반환하면 엔진이 이후 s
 
 ### Controller에서 Saga 호출
 
-Controller는 Saga를 다른 Pod와 동일하게 DI로 주입받아 `execute()`를 호출하고, `SagaResult.status`로 응답을 분기합니다. 예외는 발생하지 않으므로 `try/except`가 아니라 **상태 분기**로 제어 흐름을 짭니다.
+Controller는 Saga를 다른 Pod와 동일하게 DI로 주입받아 `execute()`를 호출하고, `SagaResult.status`로 응답을 분기합니다. 일반 step 실패는 예외로 던지지 않고 `SagaResult.status`로 반환되므로 **상태 분기**로 제어 흐름을 짭니다. 다만 보상 실행 자체가 실패하면 `SagaCompensationFailedError`가 raise될 수 있습니다.
 
 `spakky-fastapi`를 사용하는 예시입니다 (`@ApiController(prefix)` + `@post(path)`).
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -387,30 +387,41 @@ spakky-fastapi = "spakky.plugins.fastapi.main:initialize"
 # plugins/spakky-fastapi/src/spakky/plugins/fastapi/main.py
 def initialize(app: SpakkyApplication) -> None:
     """FastAPI 플러그인 초기화"""
+    app.add(FastAPIConfig)
+    if not _has_fastapi_pod(app):
+        app.add(fastapi_app)
+    app.add(FastAPIActuatorConfig)
     app.add(BindLifespanPostProcessor)
     app.add(AddBuiltInMiddlewaresPostProcessor)
+    app.add(RegisterActuatorPostProcessor)
     app.add(RegisterRoutesPostProcessor)
 ```
+
+사용자가 이미 `FastAPI` Pod를 등록했다면 플러그인은 기본 `fastapi_app`을 추가하지 않습니다.
 
 ### PostProcessor 구현
 
 ```python
 @Pod()
-class RegisterRoutesPostProcessor(IPostProcessor):
-    """Controller의 라우트를 FastAPI에 등록"""
+class RegisterRoutesPostProcessor(
+    IPostProcessor, IContainerAware, IApplicationContextAware
+):
+    """Controller의 라우트를 등록된 모든 FastAPI Pod에 등록"""
 
-    def __init__(self, fast_api: FastAPI) -> None:
-        self.fast_api = fast_api
+    def set_container(self, container: IContainer) -> None: ...
+
+    def set_application_context(
+        self,
+        application_context: IApplicationContext,
+    ) -> None: ...
 
     def post_process(self, pod: object) -> object:
-        if Controller.exists(type(pod)):
-            self._register_routes(pod)
-        return pod
-
-    def _register_routes(self, controller: object) -> None:
-        # 라우트 등록 로직
+        # @ApiController Pod에서 APIRouter를 만들고,
+        # application_context에 등록된 모든 FastAPI Pod에 include_router()
         ...
 ```
+
+`RegisterRoutesPostProcessor`는 `FastAPI` 단일 인스턴스를 생성자에서 주입받지 않습니다. 컨테이너와 `ApplicationContext`를 통해 `FastAPI` 타입 Pod를 찾아, 각 앱에 같은 controller router를 포함합니다.
 
 ---
 


### PR DESCRIPTION
## Summary

- Sync user docs with verified package behavior across FastAPI, Event, Saga, RabbitMQ, OpenTelemetry, and agent protocol error docs.
- Add missing vLLM, AG-UI, and A2A error classes to the public error hierarchy.
- Clarify DomainEvent-only EventHandler auto-registration, AggregateRoot event collection vs publishing, RabbitMQ exchange routing, OpenTelemetry selective plugin loading, and Saga timeout/compensation behavior.

## Verification

- 6 delegated package-documentation verification tracks completed.
- Follow-up verifier rechecked the 9 changed docs against implementation and reported `status: clean`.
- `uv run mkdocs build --strict --site-dir /tmp/spakky-docs-audit-fixes-final-site`
