### PR TITLE
feat(domain): validate events after initialization (#488)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -592,6 +592,8 @@ classDiagram
     }
     class AbstractEvent {
         @immutable
+        validate()
+        __post_init__()
     }
     class AbstractDomainEvent {
         Bounded Context 내부 이벤트
@@ -609,7 +611,8 @@ classDiagram
 - `uid`, `version` (UUID v7), `created_at`, `updated_at` 필드
 - 동등성: `uid` 기반 (identity equality)
 - `__setattr__` 오버라이드: 유효성 검사 + `updated_at`/`version` 자동 갱신
-- 추상 메서드: `next_id()`, `validate()`
+- 추상 메서드: `next_id()`
+- `validate()`는 기본 no-op virtual hook이며, 필요 시 재정의한다. `__post_init__()`에서 생성 직후 호출하고 변경 시에도 재검증
 
 ### AggregateRoot
 
@@ -622,11 +625,13 @@ classDiagram
 - 동등성: `astuple(self)` 기반 (structural equality)
 - 모든 속성 타입이 hashable인지 `__init_subclass__`에서 검증
 - `clone()` → `self` 반환 (불변이므로 안전)
+- `validate()`는 기본 no-op virtual hook이며, 필요 시 재정의한다. `__post_init__()`에서 생성 직후 호출
 
 ### Event
 
 - `event_id: UUID`, `timestamp: datetime`
 - `event_name` → 클래스명
+- `validate()`는 기본 no-op virtual hook이며, 필요 시 재정의한다. `__post_init__()`에서 생성 직후 호출
 - `IComparable` 구현: `timestamp` 기반 비교
 
 ### CQRS

--- a/core/spakky-domain/src/spakky/domain/models/entity.py
+++ b/core/spakky-domain/src/spakky/domain/models/entity.py
@@ -65,14 +65,12 @@ class AbstractEntity[EquatableT](AbstractDomainModel, IEquatable, ABC):
         """
         ...
 
-    @abstractmethod
     def validate(self) -> None:
         """Validate entity state.
 
-        Raises:
-            AbstractDomainValidationError: If validation fails.
+        Subclasses may override this method to enforce entity invariants.
         """
-        ...
+        return
 
     @override
     def __eq__(self, other: object) -> bool:

--- a/core/spakky-domain/src/spakky/domain/models/event.py
+++ b/core/spakky-domain/src/spakky/domain/models/event.py
@@ -28,6 +28,13 @@ class AbstractEvent(AbstractDomainModel, IEquatable, IComparable, ICloneable, AB
     timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
     """When the event occurred."""
 
+    def validate(self) -> None:
+        """Validate event state.
+
+        Subclasses may override this method to enforce event invariants.
+        """
+        return
+
     @property
     def event_name(self) -> str:
         """Get event type name.
@@ -115,6 +122,11 @@ class AbstractEvent(AbstractDomainModel, IEquatable, IComparable, ICloneable, AB
             True if this event occurred after or at same time as the other.
         """
         return self.timestamp >= __value.timestamp
+
+    @override
+    def __post_init__(self) -> None:
+        """Validate event after initialization."""
+        self.validate()
 
 
 @immutable

--- a/core/spakky-domain/src/spakky/domain/models/value_object.py
+++ b/core/spakky-domain/src/spakky/domain/models/value_object.py
@@ -4,7 +4,7 @@ This module provides AbstractValueObject for representing immutable domain conce
 compared by their attributes rather than identity.
 """
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from dataclasses import astuple
 from typing import Self, override
 
@@ -44,14 +44,12 @@ class AbstractValueObject(AbstractDomainModel, IEquatable, ICloneable, IDataclas
         """
         return self
 
-    @abstractmethod
     def validate(self) -> None:
         """Validate value object state.
 
-        Raises:
-            AbstractDomainValidationError: If validation fails.
+        Subclasses may override this method to enforce value object invariants.
         """
-        ...
+        return
 
     @override
     def __eq__(self, __value: object) -> bool:

--- a/core/spakky-domain/tests/models/test_domain_event.py
+++ b/core/spakky-domain/tests/models/test_domain_event.py
@@ -1,9 +1,64 @@
 from datetime import datetime
+from typing import override
 from uuid import UUID
 
+import pytest
 from spakky.core.common.mutability import immutable
 
+from spakky.domain.error import AbstractDomainValidationError
 from spakky.domain.models.event import AbstractDomainEvent
+
+
+class InvalidEventError(AbstractDomainValidationError):
+    """Raised when a test event is invalid."""
+
+    message = "Test event is invalid."
+
+
+def test_domain_event_validate_called_on_initialization() -> None:
+    """도메인 이벤트 초기화 후 override된 validate가 호출됨을 검증한다."""
+    validated_codes: list[str] = []
+
+    @immutable
+    class ValidatingEvent(AbstractDomainEvent):
+        code: str
+
+        @override
+        def validate(self) -> None:
+            validated_codes.append(self.code)
+
+    event = ValidatingEvent(code="ready")
+
+    assert event.code == "ready"
+    assert validated_codes == ["ready"]
+
+
+def test_domain_event_default_validate_allows_initialization() -> None:
+    """validate를 재정의하지 않은 도메인 이벤트 생성이 허용됨을 검증한다."""
+
+    @immutable
+    class SampleEvent(AbstractDomainEvent):
+        code: str
+
+    event = SampleEvent(code="ready")
+
+    assert event.code == "ready"
+
+
+def test_domain_event_invalid_state_expect_error() -> None:
+    """검증에 실패한 도메인 이벤트 생성이 실패함을 검증한다."""
+
+    @immutable
+    class PositiveQuantityEvent(AbstractDomainEvent):
+        quantity: int
+
+        @override
+        def validate(self) -> None:
+            if self.quantity <= 0:
+                raise InvalidEventError()
+
+    with pytest.raises(InvalidEventError):
+        PositiveQuantityEvent(quantity=0)
 
 
 def test_domain_event_equals() -> None:

--- a/core/spakky-domain/tests/models/test_entity.py
+++ b/core/spakky-domain/tests/models/test_entity.py
@@ -18,9 +18,6 @@ def test_entity_equals() -> None:
     class User(AbstractEntity[UUID]):
         name: str
 
-        def validate(self) -> None:
-            return
-
         @classmethod
         def next_id(cls) -> UUID:
             return uuid4()
@@ -42,9 +39,6 @@ def test_entity_not_equals_with_wrong_type() -> None:
     class User(AbstractEntity[UUID]):
         name: str
 
-        def validate(self) -> None:
-            return
-
         @classmethod
         def next_id(cls) -> UUID:
             return uuid4()
@@ -56,9 +50,6 @@ def test_entity_not_equals_with_wrong_type() -> None:
     @mutable
     class Class(AbstractEntity[UUID]):
         name: str
-
-        def validate(self) -> None:
-            return
 
         @classmethod
         def next_id(cls) -> UUID:
@@ -81,9 +72,6 @@ def test_entity_not_equals_transient() -> None:
     class User(AbstractEntity[UUID]):
         name: str
 
-        def validate(self) -> None:
-            return
-
         @classmethod
         def next_id(cls) -> UUID:
             return uuid4()
@@ -104,9 +92,6 @@ def test_entity_not_equals() -> None:
     @mutable
     class User(AbstractEntity[UUID]):
         name: str
-
-        def validate(self) -> None:
-            return
 
         @classmethod
         def next_id(cls) -> UUID:
@@ -129,9 +114,6 @@ def test_entity_hash() -> None:
     class User(AbstractEntity[UUID]):
         name: str
 
-        def validate(self) -> None:
-            return
-
         @classmethod
         def next_id(cls) -> UUID:
             return uuid4()
@@ -150,9 +132,6 @@ def test_entity_prevent_monkey_patching() -> None:
     @mutable
     class User(AbstractEntity[UUID]):
         name: str
-
-        def validate(self) -> None:
-            return
 
         def update_name(self, name: str) -> None:
             self.name = name
@@ -276,9 +255,6 @@ def test_entity_auto_updates_timestamp_and_version_on_change() -> None:
         name: str
         email: str
 
-        def validate(self) -> None:
-            return
-
         @classmethod
         def next_id(cls) -> UUID:
             return uuid4()
@@ -313,9 +289,6 @@ def test_entity_metadata_fields_do_not_trigger_auto_update() -> None:
     @mutable
     class User(AbstractEntity[UUID]):
         name: str
-
-        def validate(self) -> None:
-            return
 
         @classmethod
         def next_id(cls) -> UUID:

--- a/core/spakky-domain/tests/models/test_value_object.py
+++ b/core/spakky-domain/tests/models/test_value_object.py
@@ -15,9 +15,6 @@ def test_value_object_equals() -> None:
         name: str
         age: int
 
-        def validate(self) -> None:
-            return
-
     value_object1: SampleValueObject = SampleValueObject(name="John", age=30)
     value_object2: SampleValueObject = SampleValueObject(name="John", age=30)
     assert value_object1 == value_object2
@@ -30,9 +27,6 @@ def test_value_object_not_equals() -> None:
     class SampleValueObject(AbstractValueObject):
         name: str
         age: int
-
-        def validate(self) -> None:
-            return
 
     value_object1: SampleValueObject = SampleValueObject(name="John", age=30)
     value_object2: SampleValueObject = SampleValueObject(name="Sarah", age=30)
@@ -47,16 +41,10 @@ def test_value_object_not_equals_with_wrong_type() -> None:
         name: str
         age: int
 
-        def validate(self) -> None:
-            return
-
     @immutable
     class AnotherValueObject(AbstractValueObject):
         name: str
         age: int
-
-        def validate(self) -> None:
-            return
 
     value_object1: SampleValueObject = SampleValueObject(name="John", age=30)
     value_object2: AnotherValueObject = AnotherValueObject(name="Sarah", age=30)
@@ -71,9 +59,6 @@ def test_value_object_clone() -> None:
         name: str
         age: int
 
-        def validate(self) -> None:
-            return
-
     value_object1: SampleValueObject = SampleValueObject(name="John", age=30)
     value_object2: SampleValueObject = value_object1.clone()
     assert value_object1 == value_object2
@@ -86,9 +71,6 @@ def test_value_object_hash() -> None:
     class SampleValueObject(AbstractValueObject):
         name: str
         age: int
-
-        def validate(self) -> None:
-            return
 
     value_object1: SampleValueObject = SampleValueObject(name="John", age=30)
     value_object2: SampleValueObject = SampleValueObject(name="John", age=30)
@@ -104,9 +86,6 @@ def test_value_object_can_only_composed_by_hashable_objects_expect_success() -> 
         age: int
         jobs: frozenset[str]
 
-        def validate(self) -> None:
-            return
-
 
 def test_value_object_can_only_composed_by_hashable_objects_expect_error() -> None:
     """해시 불가능한 타입을 포함한 값 객체 생성 시 UnhashableFieldTypeError가 발생함을 검증한다."""
@@ -120,9 +99,6 @@ def test_value_object_can_only_composed_by_hashable_objects_expect_error() -> No
             age: int
             jobs: list
 
-            def validate(self) -> None:
-                return
-
     assert exc_info.value.field_name == "jobs"
 
 
@@ -133,9 +109,6 @@ def test_value_object_hash_order_sensitive() -> None:
     class Pair(AbstractValueObject):
         first: int
         second: int
-
-        def validate(self) -> None:
-            return
 
     # Different order should produce different hashes
     pair1 = Pair(first=1, second=2)
@@ -152,9 +125,6 @@ def test_value_object_hash_in_set() -> None:
     class Point(AbstractValueObject):
         x: int
         y: int
-
-        def validate(self) -> None:
-            return
 
     point1 = Point(x=1, y=2)
     point2 = Point(x=1, y=2)


### PR DESCRIPTION
## Summary

- Add `AbstractEvent.validate()` as a shared virtual hook with a default no-op implementation, and call it from `AbstractEvent.__post_init__()`.
- Make `AbstractEntity.validate()` and `AbstractValueObject.validate()` match the same virtual-hook policy: subclasses may override, but no empty override is required.
- Remove no-op validation overrides from domain tests and cover overridden/default validation behavior.

Closes #488

## Acceptance Criteria (자가 grep)

```bash
$ rg "def __post_init__" core/spakky-domain/src/spakky/domain/models/event.py
127:    def __post_init__(self) -> None:

$ rg "def validate" core/spakky-domain/src/spakky/domain/models/event.py core/spakky-domain/src/spakky/domain/models/entity.py core/spakky-domain/src/spakky/domain/models/value_object.py
core/spakky-domain/src/spakky/domain/models/event.py
31:    def validate(self) -> None:

core/spakky-domain/src/spakky/domain/models/entity.py
68:    def validate(self) -> None:

core/spakky-domain/src/spakky/domain/models/value_object.py
47:    def validate(self) -> None:
```

acceptance_check: PASS

## Verification

- `core/spakky-domain`: `uv run ruff format .`; `uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .`; layer dependency grep; `uv run ruff check .`; `uv run pyrefly check 'src/spakky/domain/**/*.py' 'tests/**/*.py' --min-severity warn --no-progress-bar --output-format min-text`; `uv run pytest` (43 passed, 100% coverage)
- Earlier cross-package verification after the event hook change: `core/spakky-event` (59 passed, 12 skipped, 100% coverage), `core/spakky-outbox` (23 passed, 100% coverage), `plugins/spakky-kafka` (82 passed, 4 skipped, 100% coverage), `plugins/spakky-rabbitmq` (81 passed, 5 skipped, 100% coverage)
- `git diff --check`: passed
- pre-commit hook: passed
- pre-push hook: passed