### PR TITLE
fix(kafka): route failed messages to a dead-letter topic (#494)

### DIFF
--- a/docs/guides/kafka.md
+++ b/docs/guides/kafka.md
@@ -59,6 +59,9 @@ export SPAKKY_KAFKA__POLL_TIMEOUT=1.0
 | `replication_factor` | `SPAKKY_KAFKA__REPLICATION_FACTOR` | `1` | 토픽 복제 팩터 |
 | `auto_offset_reset` | `SPAKKY_KAFKA__AUTO_OFFSET_RESET` | `earliest` | 오프셋 리셋 정책 |
 | `poll_timeout` | `SPAKKY_KAFKA__POLL_TIMEOUT` | `1.0` | 폴링 타임아웃 (초) |
+| `dead_letter_topic_suffix` | `SPAKKY_KAFKA__DEAD_LETTER_TOPIC_SUFFIX` | `.dlt` | 원본 토픽에 붙여 dead-letter 토픽 이름을 만드는 접미사 |
+| `max_handler_retries` | `SPAKKY_KAFKA__MAX_HANDLER_RETRIES` | `0` | dead-letter로 보내기 전 핸들러를 다시 호출하는 횟수 |
+| `dead_letter_delivery_timeout` | `SPAKKY_KAFKA__DEAD_LETTER_DELIVERY_TIMEOUT` | `10.0` | dead-letter 레코드 배달을 기다리는 최대 시간 (초) |
 
 ---
 
@@ -143,10 +146,37 @@ sequenceDiagram
 | payload | Pydantic `TypeAdapter`가 만든 JSON bytes |
 | headers | `ITracePropagator.inject()`가 넣은 trace header |
 | consumer group | `SPAKKY_KAFKA__GROUP_ID` |
-| topic 생성 | 없으면 `number_of_partitions`, `replication_factor`로 생성 |
+| topic 생성 | 없으면 `number_of_partitions`, `replication_factor`로 생성 (dead-letter 토픽 포함) |
 | offset reset | `SPAKKY_KAFKA__AUTO_OFFSET_RESET` (`earliest`/`latest`/`none`) |
+| 처리 실패 | `<topic>` + `dead_letter_topic_suffix` 토픽으로 전달 |
 
 `spakky-outbox`를 함께 로드하면 `OutboxEventBus` / `AsyncOutboxEventBus`가 기본 bus를 대체하므로 이벤트는 Kafka에 즉시 produce되지 않고 Outbox 테이블에 저장됩니다. Relay가 재시도 가능한 방식으로 Kafka transport를 호출하므로, 주문 생성 같은 DB 변경과 Kafka 발행을 원자적으로 묶어야 할 때 기본 선택은 Outbox 조합입니다.
+
+---
+
+## 처리 실패 메시지 (dead-letter)
+
+핸들러가 실패하거나 메시지 본문이 이벤트 타입으로 역직렬화되지 않으면, Consumer는 그 메시지를 원본 토픽 이름에 `dead_letter_topic_suffix`(기본 `.dlt`)를 붙인 토픽으로 보냅니다. 예를 들어 `OrderPlacedEvent` 처리에 실패하면 `OrderPlacedEvent.dlt`로 전달됩니다. dead-letter 토픽은 `initialize` 시점에 구독 토픽과 함께 자동 생성됩니다.
+
+원본 본문과 key는 바이트 그대로 전달합니다. 원본 헤더는 consumer가 읽은 문자열 형태로 함께 실리므로, 값이 UTF-8 문자열이 아닌 헤더와 값이 없는 헤더는 옮겨지지 않습니다. 여기에 다음 헤더를 덧붙입니다. 재처리 도구는 본문을 열지 않고 이 헤더만으로 판단할 수 있습니다.
+
+| 헤더 | 값 |
+|------|-----|
+| `x-spakky-dead-letter-original-topic` | 원본 토픽 이름 |
+| `x-spakky-dead-letter-original-partition` | 원본 파티션 번호 |
+| `x-spakky-dead-letter-original-offset` | 원본 오프셋 |
+| `x-spakky-dead-letter-original-timestamp` | 원본 메시지 타임스탬프 |
+| `x-spakky-dead-letter-consumer-group` | 처리에 실패한 consumer group |
+| `x-spakky-dead-letter-exception-type` | 예외 클래스 이름 |
+| `x-spakky-dead-letter-exception-message` | 예외 메시지 |
+
+dead-letter 발행은 `dead_letter_delivery_timeout`(기본 10초)까지만 배달을 기다립니다. 레코드가 크기 제한을 넘거나 producer 큐가 가득 찼거나 브로커가 거절하면 오류 로그를 남기고 consumer는 계속 폴링합니다 — 실패가 조용히 사라지지도, 소비가 멈추지도 않습니다.
+
+비동기 consumer에서 시간 안에 배달 확인을 받지 못한 경우는 확정 실패와 구분해 "unconfirmed" 로그를 남깁니다. 이때 레코드는 producer 배치에 남아 나중에 실제로 배달될 수 있으므로, 그 로그만 근거로 수동 재발행하면 dead-letter 토픽에 중복이 생깁니다.
+
+`max_handler_retries`를 0보다 크게 설정하면 dead-letter로 보내기 전에 같은 메시지로 핸들러를 그 횟수만큼 다시 호출합니다. 재호출은 해당 이벤트에 등록된 모든 핸들러를 다시 실행하므로, 이 값을 올리려면 핸들러가 멱등해야 합니다. 역직렬화 실패는 같은 본문으로 다시 시도해도 결과가 같으므로 이 설정과 무관하게 즉시 dead-letter로 보냅니다.
+
+지연 재시도 토픽 계층은 두지 않습니다. 메시지를 다른 토픽으로 옮기는 순간 그 aggregate의 파티션 내 순서가 깨지기 때문입니다.
 
 ---
 

--- a/plugins/spakky-kafka/README.md
+++ b/plugins/spakky-kafka/README.md
@@ -45,6 +45,14 @@ export SPAKKY_KAFKA__NUMBER_OF_PARTITIONS="3"
 export SPAKKY_KAFKA__REPLICATION_FACTOR="1"
 ```
 
+### 처리 실패 메시지 설정 (선택)
+
+```bash
+export SPAKKY_KAFKA__DEAD_LETTER_TOPIC_SUFFIX=".dlt"
+export SPAKKY_KAFKA__MAX_HANDLER_RETRIES="0"
+export SPAKKY_KAFKA__DEAD_LETTER_DELIVERY_TIMEOUT="10.0"
+```
+
 ## 사용법
 
 ### 이벤트 발행
@@ -130,9 +138,35 @@ signed `AuthContextSnapshot`을 `IAuthContextSnapshotVerifier`로 검증하고,
   broker/runtime retry 정책에 맡깁니다.
 - 기존 `traceparent` header와 event payload 역직렬화 의미는 그대로 유지됩니다.
 
+## 처리 실패 메시지 (dead-letter)
+
+핸들러 실패와 역직렬화 실패 메시지는 원본 topic 이름에 `dead_letter_topic_suffix`(기본
+`.dlt`)를 붙인 topic으로 전달됩니다. 원본 본문과 key는 바이트 그대로 전달하고, 원본
+header는 consumer가 읽은 문자열 형태로 함께 싣습니다(값이 없거나 UTF-8 문자열이 아닌
+header는 제외). 재처리 도구가 본문을 열지 않고 판단할 수 있도록 원본 좌표와 예외
+정보를 header로 덧붙입니다.
+
+- `x-spakky-dead-letter-original-topic` / `-partition` / `-offset` / `-timestamp`: 원본 좌표
+- `x-spakky-dead-letter-consumer-group`: 처리에 실패한 consumer group
+- `x-spakky-dead-letter-exception-type` / `-exception-message`: 실패 원인
+
+`max_handler_retries`를 0보다 크게 두면 dead-letter 전에 핸들러를 그 횟수만큼 다시
+호출합니다. 재호출은 해당 이벤트의 모든 handler를 다시 실행하므로 handler 멱등성이
+전제입니다. 역직렬화 실패는 재시도가 해결하지 못하므로 이 설정과 무관하게 즉시
+dead-letter로 보냅니다.
+
+dead-letter 발행은 `dead_letter_delivery_timeout`(기본 10초)까지만 배달을 기다립니다.
+크기 제한 초과·producer 큐 포화·브로커 거절은 오류 로그를 남기고 consumer는 계속
+폴링합니다. 비동기 경로에서 배달 확인이 시간 안에 오지 않은 경우는 확정 실패와 구분해
+"unconfirmed"로 기록합니다 — 그 레코드는 나중에 배달될 수 있어 수동 재발행 시 중복이
+생깁니다.
+
+dead-letter topic은 consumer `initialize` 시점에 구독 topic과 함께 생성됩니다.
+
 ## 주요 기능
 
-- **자동 topic 생성**: 이벤트 타입 이름을 기준으로 topic 생성
+- **자동 topic 생성**: 이벤트 타입 이름을 기준으로 topic 생성 (dead-letter topic 포함)
+- **Dead-letter 경로**: 처리 실패 메시지를 원본 좌표·예외 header와 함께 `.dlt` topic으로 전달
 - **동기/비동기 지원**: 동기 및 비동기 publisher/consumer 모두 지원
 - **Background service 패턴**: consumer polling을 background service로 실행
 - **Pydantic 직렬화**: 이벤트를 Pydantic으로 직렬화/역직렬화
@@ -148,6 +182,7 @@ signed `AuthContextSnapshot`을 `IAuthContextSnapshotVerifier`로 검증하고,
 | `KafkaEventConsumer` | 동기 event consumer(background service) |
 | `AsyncKafkaEventConsumer` | 비동기 event consumer(background service) |
 | `KafkaConnectionConfig` | 환경변수 기반 설정 |
+| `DeadLetterHeaderKey` | dead-letter 메시지에 실리는 원본 좌표·예외 header 키 |
 | `KafkaAuthBoundary` | signed `AuthContextSnapshot` 검증 및 `AuthContext` seeding |
 
 ## 개발 검증

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/common/config.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/common/config.py
@@ -5,8 +5,9 @@ bootstrap servers, consumer group, and security settings.
 """
 
 from enum import StrEnum
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
+from pydantic import NonNegativeInt, PositiveFloat, StringConstraints
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from spakky.core.stereotype.configuration import Configuration
 
@@ -64,6 +65,28 @@ class KafkaConnectionConfig(BaseSettings):
     poll_timeout: float = 1.0
     """Consumer poll timeout in seconds."""
 
+    dead_letter_topic_suffix: Annotated[str, StringConstraints(min_length=1)] = ".dlt"
+    """Suffix appended to the original topic name to build its dead-letter topic.
+
+    An empty suffix would make the dead-letter topic the original topic itself,
+    republishing every failure back into the stream it came from, so it is rejected.
+    """
+
+    max_handler_retries: NonNegativeInt = 0
+    """How many times a failed handler dispatch is retried before dead-lettering.
+
+    Retrying re-invokes every handler registered for the event, so handlers must
+    be idempotent when this is raised above zero. Deserialization failures never
+    succeed on retry and are dead-lettered immediately regardless of this value.
+    """
+
+    dead_letter_delivery_timeout: PositiveFloat = 10.0
+    """Seconds to wait for a dead-letter record to reach the broker.
+
+    Bounds how long the consumer blocks on one failed message; without it a broker
+    outage would stall the poll loop until the client's own message timeout.
+    """
+
     def __init__(self) -> None:
         super().__init__()
 
@@ -83,4 +106,26 @@ class KafkaConnectionConfig(BaseSettings):
             config["sasl.username"] = self.sasl_username
         if self.sasl_password:
             config["sasl.password"] = self.sasl_password
+        return config
+
+    @property
+    def async_producer_configuration_dict(self) -> dict[str, str]:
+        """Same connection settings rendered as `aiokafka.AIOKafkaProducer` keywords.
+
+        `aiokafka` takes snake_case keywords instead of the dotted librdkafka
+        property names in `configuration_dict`, so every async producer in this
+        plugin reads its settings here rather than mapping them again.
+        """
+        config = {
+            "bootstrap_servers": self.bootstrap_servers,
+            "client_id": self.client_id,
+        }
+        if self.security_protocol:
+            config["security_protocol"] = self.security_protocol
+        if self.sasl_mechanism:
+            config["sasl_mechanism"] = self.sasl_mechanism
+        if self.sasl_username:
+            config["sasl_plain_username"] = self.sasl_username
+        if self.sasl_password:
+            config["sasl_plain_password"] = self.sasl_password
         return config

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/common/constants.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/common/constants.py
@@ -1,1 +1,19 @@
+from enum import StrEnum
+
 SPAKKY_KAFKA_CONFIG_ENV_PREFIX = "SPAKKY_KAFKA__"
+
+
+class DeadLetterHeaderKey(StrEnum):
+    """Kafka header keys describing where a dead-lettered message came from.
+
+    A reprocessing tool must be able to decide what to do from these headers
+    alone, without parsing the original message body.
+    """
+
+    ORIGINAL_TOPIC = "x-spakky-dead-letter-original-topic"
+    ORIGINAL_PARTITION = "x-spakky-dead-letter-original-partition"
+    ORIGINAL_OFFSET = "x-spakky-dead-letter-original-offset"
+    ORIGINAL_TIMESTAMP = "x-spakky-dead-letter-original-timestamp"
+    CONSUMER_GROUP = "x-spakky-dead-letter-consumer-group"
+    EXCEPTION_TYPE = "x-spakky-dead-letter-exception-type"
+    EXCEPTION_MESSAGE = "x-spakky-dead-letter-exception-message"

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/event/consumer.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/event/consumer.py
@@ -1,3 +1,4 @@
+from asyncio import wait_for
 from logging import getLogger
 from typing import Any, cast
 
@@ -7,10 +8,11 @@ from spakky.auth import (
     AuthRequirementProviderUnavailableError,
     AuthVerificationProviderUnavailableError,
 )
-from confluent_kafka import Consumer, Message
+from aiokafka import AIOKafkaProducer
+from confluent_kafka import Consumer, KafkaError, KafkaException, Message, Producer
 from confluent_kafka.admin import AdminClient, NewTopic
 from confluent_kafka.aio import AIOConsumer
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.service.background import (
     AbstractAsyncBackgroundService,
@@ -29,6 +31,7 @@ from typing import override
 
 from spakky.plugins.kafka.auth import KAFKA_AUTH_HEADERS_PARAMETER
 from spakky.plugins.kafka.common.config import KafkaConnectionConfig
+from spakky.plugins.kafka.common.constants import DeadLetterHeaderKey
 
 logger = getLogger(__name__)
 
@@ -51,6 +54,8 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
     handlers: dict[type[AbstractEvent], list[EventHandlerCallback[Any]]]
     admin: AdminClient
     consumer: Consumer
+    producer: Producer
+    """Dead-letter producer, bound by `initialize` for the service lifetime."""
     _propagator: ITracePropagator | None
     _auth_boundary_handlers: set[EventHandlerCallback[Any]]
 
@@ -128,6 +133,82 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
             ]
         )
 
+    @staticmethod
+    def _dead_letter_delivery_report(
+        error: KafkaError | None,
+        message: Message,
+    ) -> None:
+        """Log the broker verdict on a dead-letter record.
+
+        `Producer.produce` only enqueues, so failures the broker decides —
+        authorization refusals and delivery timeouts — surface only here.
+        """
+        if error is not None:
+            logger.error(f"Dead-letter delivery failed for {message.topic()}: {error}")
+
+    def _send_to_dead_letter(
+        self,
+        topic: str,
+        message: Message,
+        headers: dict[str, str],
+        error: Exception,
+    ) -> None:
+        """Forward a message the handlers could not process to its dead-letter topic.
+
+        The original body and key are forwarded unchanged and the decoded original
+        headers travel with them, so the record can be replayed from its own
+        coordinates.
+
+        Args:
+            topic: Topic the failed message was consumed from.
+            message: The Kafka message that could not be processed.
+            headers: Decoded headers of the original message.
+            error: Exception that ended the last processing attempt.
+        """
+        _, original_timestamp = message.timestamp()
+        dead_letter_headers: dict[str, bytes | str | None] = {
+            **headers,
+            DeadLetterHeaderKey.ORIGINAL_TOPIC.value: topic,
+            DeadLetterHeaderKey.ORIGINAL_PARTITION.value: str(message.partition()),
+            DeadLetterHeaderKey.ORIGINAL_OFFSET.value: str(message.offset()),
+            DeadLetterHeaderKey.ORIGINAL_TIMESTAMP.value: str(original_timestamp),
+            DeadLetterHeaderKey.CONSUMER_GROUP.value: self.config.group_id,
+            DeadLetterHeaderKey.EXCEPTION_TYPE.value: type(error).__name__,
+            DeadLetterHeaderKey.EXCEPTION_MESSAGE.value: str(error),
+        }
+        try:
+            self.producer.produce(
+                topic=f"{topic}{self.config.dead_letter_topic_suffix}",
+                value=message.value(),
+                key=message.key(),
+                headers=dead_letter_headers,
+                callback=self._dead_letter_delivery_report,
+            )
+        except (BufferError, KafkaException) as delivery_error:
+            # produce() rejects a record over `message.max.bytes` and a full local
+            # queue synchronously. This runs on the poll thread, so an escaping
+            # exception would kill consumption while stop() still looks clean.
+            logger.error(f"Dead-letter delivery failed for {topic}: {delivery_error}")
+            return
+        undelivered = self.producer.flush(self.config.dead_letter_delivery_timeout)
+        if undelivered:
+            logger.error(
+                f"Dead-letter record for {topic} still unsent after "
+                f"{self.config.dead_letter_delivery_timeout}s"
+            )
+
+    def _invoke_handlers(
+        self,
+        event_type: type[AbstractEvent],
+        event_data: AbstractEvent,
+        headers: dict[str, str],
+    ) -> None:
+        for handler in self.handlers[event_type]:
+            if handler in self._auth_boundary_handlers:
+                handler(event_data, **{KAFKA_AUTH_HEADERS_PARAMETER: headers})
+                continue
+            handler(event_data)
+
     def _route_event_handler(self, message: Message) -> None:
         if message.error():  # pragma: no cover - Kafka 브로커 에러 콜백
             logger.error(f"Consumer error: {message.error()}")
@@ -151,22 +232,36 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
             if event_message is None:  # pragma: no cover - Kafka 메시지 본문 누락 방어
                 logger.warning(f"Received empty message for event type: {topic}")
                 return
-            event_data = self.type_adapters[event_type].validate_json(event_message)
-            handlers = self.handlers[event_type]
-            for handler in handlers:
-                if handler in self._auth_boundary_handlers:
-                    handler(event_data, **{KAFKA_AUTH_HEADERS_PARAMETER: headers})
-                    continue
-                handler(event_data)
-        except (
-            AuthVerificationProviderUnavailableError,
-            AuthRequirementProviderUnavailableError,
-        ):
-            raise
-        except (AuthContextNotFoundError, AuthRequirementDeniedError):
-            return
-        except Exception as e:  # pragma: no cover - 핸들러 예외 방어
-            logger.error(f"Error processing message for event type {topic}: {e}")
+            try:
+                event_data = self.type_adapters[event_type].validate_json(event_message)
+            except ValidationError as error:
+                # 역직렬화 실패는 같은 본문으로 재시도해도 결과가 같으므로 즉시 보낸다.
+                logger.error(f"Cannot deserialize message from topic {topic}: {error}")
+                self._send_to_dead_letter(topic, message, headers, error)
+                return
+            remaining_retries = self.config.max_handler_retries
+            while True:
+                try:
+                    self._invoke_handlers(event_type, event_data, headers)
+                    return
+                except (
+                    AuthVerificationProviderUnavailableError,
+                    AuthRequirementProviderUnavailableError,
+                ):
+                    raise
+                except (AuthContextNotFoundError, AuthRequirementDeniedError):
+                    return
+                except Exception as error:
+                    if remaining_retries == 0:
+                        logger.error(
+                            f"Error processing message for event type {topic}: {error}"
+                        )
+                        self._send_to_dead_letter(topic, message, headers, error)
+                        return
+                    remaining_retries -= 1
+                    logger.warning(
+                        f"Retrying message for event type {topic} after error: {error}"
+                    )
         finally:
             if self._propagator is not None:
                 TraceContext.clear()
@@ -188,11 +283,15 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
 
     @override
     def initialize(self) -> None:
-        """Create Kafka topics and subscribe the consumer."""
+        """Create Kafka topics, open the dead-letter producer, and subscribe."""
         topics: list[str] = [
             _event_routing_name(event_type) for event_type in self.handlers.keys()
         ]
-        self._create_topics(topics=topics)
+        self.producer = Producer(self.config.configuration_dict, logger=logger)
+        self._create_topics(
+            topics=topics
+            + [f"{topic}{self.config.dead_letter_topic_suffix}" for topic in topics]
+        )
         self.consumer.subscribe(topics=topics)
 
     @override
@@ -208,7 +307,13 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
 
     @override
     def dispose(self) -> None:
-        """Close the Kafka consumer connection."""
+        """Flush pending dead-letter records and close the Kafka consumer.
+
+        The flush is bounded so an unreachable broker cannot block shutdown
+        forever; records still queued at that point are reported by the
+        delivery callback.
+        """
+        self.producer.flush(self.config.dead_letter_delivery_timeout)
         self.consumer.close()
 
 
@@ -222,6 +327,8 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
     handlers: dict[type[AbstractEvent], list[AsyncEventHandlerCallback[Any]]]
     admin: AdminClient
     consumer: AIOConsumer
+    producer: AIOKafkaProducer
+    """Dead-letter producer, bound by `initialize_async` for the service lifetime."""
     _propagator: ITracePropagator | None
     _auth_boundary_handlers: set[AsyncEventHandlerCallback[Any]]
 
@@ -295,9 +402,76 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
             ]
         )
 
-    async def _route_event_handler(  # pragma: no cover - 별도 asyncio 태스크로 실행
-        self, message: Message
+    async def _send_to_dead_letter(
+        self,
+        topic: str,
+        message: Message,
+        headers: dict[str, str],
+        error: Exception,
     ) -> None:
+        """Forward a message the handlers could not process to its dead-letter topic.
+
+        The original body and key are forwarded unchanged and the decoded original
+        headers travel with them, so the record can be replayed from its own
+        coordinates. Delivery is awaited so a broker rejection is logged rather
+        than lost, and it is bounded so one unreachable broker cannot stall the
+        poll loop.
+
+        Args:
+            topic: Topic the failed message was consumed from.
+            message: The Kafka message that could not be processed.
+            headers: Decoded headers of the original message.
+            error: Exception that ended the last processing attempt.
+        """
+        _, original_timestamp = message.timestamp()
+        dead_letter_headers: dict[str, str] = {
+            **headers,
+            DeadLetterHeaderKey.ORIGINAL_TOPIC.value: topic,
+            DeadLetterHeaderKey.ORIGINAL_PARTITION.value: str(message.partition()),
+            DeadLetterHeaderKey.ORIGINAL_OFFSET.value: str(message.offset()),
+            DeadLetterHeaderKey.ORIGINAL_TIMESTAMP.value: str(original_timestamp),
+            DeadLetterHeaderKey.CONSUMER_GROUP.value: self.config.group_id,
+            DeadLetterHeaderKey.EXCEPTION_TYPE.value: type(error).__name__,
+            DeadLetterHeaderKey.EXCEPTION_MESSAGE.value: str(error),
+        }
+        try:
+            await wait_for(
+                self.producer.send_and_wait(
+                    topic=f"{topic}{self.config.dead_letter_topic_suffix}",
+                    value=message.value(),
+                    key=message.key(),
+                    headers=[
+                        (key, value.encode())
+                        for key, value in dead_letter_headers.items()
+                    ],
+                ),
+                timeout=self.config.dead_letter_delivery_timeout,
+            )
+        except TimeoutError:
+            # Only the confirmation wait is abandoned here — the record stays in the
+            # producer batch and may still reach the broker, so replaying it by hand
+            # can duplicate it. Reported apart from a confirmed refusal.
+            logger.error(
+                f"Dead-letter delivery for {topic} unconfirmed after "
+                f"{self.config.dead_letter_delivery_timeout}s; "
+                "it may still be delivered"
+            )
+        except Exception as delivery_error:
+            logger.error(f"Dead-letter delivery failed for {topic}: {delivery_error}")
+
+    async def _invoke_handlers(
+        self,
+        event_type: type[AbstractEvent],
+        event_data: AbstractEvent,
+        headers: dict[str, str],
+    ) -> None:
+        for handler in self.handlers[event_type]:
+            if handler in self._auth_boundary_handlers:
+                await handler(event_data, **{KAFKA_AUTH_HEADERS_PARAMETER: headers})
+                continue
+            await handler(event_data)
+
+    async def _route_event_handler(self, message: Message) -> None:
         if message.error():  # pragma: no cover - Kafka 브로커 에러 콜백
             logger.error(f"Consumer error: {message.error()}")
             return
@@ -320,25 +494,36 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
             if event_message is None:  # pragma: no cover - Kafka 메시지 본문 누락 방어
                 logger.warning(f"Received empty message for event type: {topic}")
                 return
-            event_data = self.type_adapters[event_type].validate_json(event_message)
-            handlers = self.handlers[event_type]
-            for handler in handlers:
-                if handler in self._auth_boundary_handlers:
-                    await handler(
-                        event_data,
-                        **{KAFKA_AUTH_HEADERS_PARAMETER: headers},
+            try:
+                event_data = self.type_adapters[event_type].validate_json(event_message)
+            except ValidationError as error:
+                # 역직렬화 실패는 같은 본문으로 재시도해도 결과가 같으므로 즉시 보낸다.
+                logger.error(f"Cannot deserialize message from topic {topic}: {error}")
+                await self._send_to_dead_letter(topic, message, headers, error)
+                return
+            remaining_retries = self.config.max_handler_retries
+            while True:
+                try:
+                    await self._invoke_handlers(event_type, event_data, headers)
+                    return
+                except (
+                    AuthVerificationProviderUnavailableError,
+                    AuthRequirementProviderUnavailableError,
+                ):
+                    raise
+                except (AuthContextNotFoundError, AuthRequirementDeniedError):
+                    return
+                except Exception as error:
+                    if remaining_retries == 0:
+                        logger.error(
+                            f"Error processing message for event type {topic}: {error}"
+                        )
+                        await self._send_to_dead_letter(topic, message, headers, error)
+                        return
+                    remaining_retries -= 1
+                    logger.warning(
+                        f"Retrying message for event type {topic} after error: {error}"
                     )
-                    continue
-                await handler(event_data)
-        except (
-            AuthVerificationProviderUnavailableError,
-            AuthRequirementProviderUnavailableError,
-        ):
-            raise
-        except (AuthContextNotFoundError, AuthRequirementDeniedError):
-            return
-        except Exception as e:  # pragma: no cover - 핸들러 예외 방어
-            logger.error(f"Error processing message for event type {topic}: {e}")
         finally:
             if self._propagator is not None:
                 TraceContext.clear()
@@ -360,12 +545,19 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
 
     @override
     async def initialize_async(self) -> None:
-        """Create Kafka topics and subscribe the async consumer."""
+        """Create Kafka topics, open the dead-letter producer, and subscribe."""
         self.consumer = AIOConsumer(self.config.configuration_dict)
+        self.producer = AIOKafkaProducer(
+            **self.config.async_producer_configuration_dict
+        )
+        await self.producer.start()
         topics: list[str] = [
             _event_routing_name(event_type) for event_type in self.handlers.keys()
         ]
-        self._create_topics(topics=topics)
+        self._create_topics(
+            topics=topics
+            + [f"{topic}{self.config.dead_letter_topic_suffix}" for topic in topics]
+        )
         await self.consumer.subscribe(topics=topics)
 
     @override
@@ -381,5 +573,6 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
 
     @override
     async def dispose_async(self) -> None:
-        """Close the async Kafka consumer connection."""
+        """Flush pending dead-letter records and close the async Kafka consumer."""
+        await self.producer.stop()
         await self.consumer.close()

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/event/transport.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/event/transport.py
@@ -111,21 +111,6 @@ class AsyncKafkaEventTransport(IAsyncEventTransport):
             ]
         )
 
-    def _producer_config(self) -> dict[str, str]:
-        config = {
-            "bootstrap_servers": self.config.bootstrap_servers,
-            "client_id": self.config.client_id,
-        }
-        if self.config.security_protocol:
-            config["security_protocol"] = self.config.security_protocol
-        if self.config.sasl_mechanism:
-            config["sasl_mechanism"] = self.config.sasl_mechanism
-        if self.config.sasl_username:
-            config["sasl_plain_username"] = self.config.sasl_username
-        if self.config.sasl_password:
-            config["sasl_plain_password"] = self.config.sasl_password
-        return config
-
     @override
     async def send(
         self,
@@ -141,7 +126,7 @@ class AsyncKafkaEventTransport(IAsyncEventTransport):
             headers: Metadata headers for trace propagation.
         """
         self._create_topic(topic=event_name)
-        producer = AIOKafkaProducer(**self._producer_config())
+        producer = AIOKafkaProducer(**self.config.async_producer_configuration_dict)
         await producer.start()
         try:
             await producer.send_and_wait(

--- a/plugins/spakky-kafka/tests/apps/dummy.py
+++ b/plugins/spakky-kafka/tests/apps/dummy.py
@@ -28,6 +28,20 @@ class AsyncTestEvent(AbstractIntegrationEvent):
     message: str
 
 
+@immutable
+class FailingEvent(AbstractIntegrationEvent):
+    """Event whose synchronous handler always fails, exercising dead-letter routing."""
+
+    message: str
+
+
+@immutable
+class AsyncFailingEvent(AbstractIntegrationEvent):
+    """Event whose asynchronous handler always fails, exercising dead-letter routing."""
+
+    message: str
+
+
 @EventHandler()
 class DummyEventHandler(IApplicationContextAware):
     __application_context: IApplicationContext
@@ -84,3 +98,16 @@ class AsyncEventHandler(IApplicationContextAware):
         print(f"Async handler received event: {event}")
         self.__count += 1
         self.__context_ids.add(self.__application_context.get_context_id())
+
+
+@EventHandler()
+class FailingEventHandler:
+    """Handler that always raises, so the message must land on the dead-letter topic."""
+
+    @on_event(FailingEvent)
+    def handle_failing(self, event: FailingEvent) -> None:
+        raise RuntimeError(f"cannot process {event.message}")
+
+    @on_event(AsyncFailingEvent)
+    async def handle_async_failing(self, event: AsyncFailingEvent) -> None:
+        raise RuntimeError(f"cannot process {event.message}")

--- a/plugins/spakky-kafka/tests/integration/test_event.py
+++ b/plugins/spakky-kafka/tests/integration/test_event.py
@@ -1,7 +1,9 @@
 from asyncio import sleep as asleep
+from os import environ
 from time import sleep, time
 
 import pytest
+from confluent_kafka import Consumer, Message
 from pydantic import TypeAdapter
 from spakky.core.application.application import SpakkyApplication
 from spakky.event.event_consumer import (
@@ -13,13 +15,20 @@ from spakky.event.event_publisher import (
     IEventTransport,
 )
 
+from spakky.plugins.kafka.common.config import AutoOffsetResetType
+from spakky.plugins.kafka.common.constants import (
+    SPAKKY_KAFKA_CONFIG_ENV_PREFIX,
+    DeadLetterHeaderKey,
+)
 from spakky.plugins.kafka.event.consumer import (
     AsyncKafkaEventConsumer,
     KafkaEventConsumer,
 )
 from tests.apps.dummy import (
+    AsyncFailingEvent,
     DummyEventHandler,
     DuplicateTestEvent,
+    FailingEvent,
     SampleEvent,
 )
 
@@ -117,3 +126,79 @@ async def test_multiple_handler_registration_async(app: SpakkyApplication) -> No
     consumer.register(DuplicateTestEvent, handler2)
 
     assert len(consumer.handlers[DuplicateTestEvent]) == 2
+
+
+def decode_headers(record: Message) -> dict[str, str]:
+    """Decode the byte-valued Kafka headers of a record for assertion."""
+    return {
+        key: value.decode()
+        for key, value in (record.headers() or [])
+        if isinstance(value, bytes)
+    }
+
+
+def read_dead_letter_record(topic: str) -> Message:
+    """Consume the single record the consumer routed to `topic`, or time out."""
+    dead_letter_consumer = Consumer(
+        {
+            "group.id": f"dead-letter-reader-{topic}",
+            "client.id": f"dead-letter-reader-{topic}",
+            "bootstrap.servers": environ[
+                f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"
+            ],
+            "auto.offset.reset": AutoOffsetResetType.EARLIEST.value,
+        }
+    )
+    dead_letter_consumer.subscribe([topic])
+    try:
+        start = time()
+        while time() - start <= MAX_WAIT_TIME:
+            record = dead_letter_consumer.poll(timeout=POLL_INTERVAL)
+            if record is not None and record.error() is None:
+                return record
+        raise TimeoutError(f"No dead-letter record arrived on {topic}")
+    finally:
+        dead_letter_consumer.close()
+
+
+def test_synchronous_handler_failure_expect_dead_letter_record(
+    app: SpakkyApplication,
+) -> None:
+    """동기 핸들러가 실패한 메시지가 dead-letter 토픽에서 원본 본문·헤더와 함께 관찰된다."""
+    transport = app.container.get(IEventTransport)
+    event = FailingEvent(message="sync-poison")
+    payload = TypeAdapter(FailingEvent).dump_json(event)
+
+    transport.send("FailingEvent", payload, {})
+
+    record = read_dead_letter_record("FailingEvent.dlt")
+    assert record.value() == payload
+    headers = decode_headers(record)
+    assert headers[DeadLetterHeaderKey.ORIGINAL_TOPIC] == "FailingEvent"
+    assert headers[DeadLetterHeaderKey.CONSUMER_GROUP] == "test-group"
+    assert headers[DeadLetterHeaderKey.EXCEPTION_TYPE] == "RuntimeError"
+    assert (
+        "cannot process sync-poison" in headers[DeadLetterHeaderKey.EXCEPTION_MESSAGE]
+    )
+
+
+@pytest.mark.asyncio
+async def test_asynchronous_handler_failure_expect_dead_letter_record(
+    app: SpakkyApplication,
+) -> None:
+    """비동기 핸들러가 실패한 메시지가 dead-letter 토픽에서 원본 본문·헤더와 함께 관찰된다."""
+    transport = app.container.get(IAsyncEventTransport)
+    event = AsyncFailingEvent(message="async-poison")
+    payload = TypeAdapter(AsyncFailingEvent).dump_json(event)
+
+    await transport.send("AsyncFailingEvent", payload, {})
+
+    record = read_dead_letter_record("AsyncFailingEvent.dlt")
+    assert record.value() == payload
+    headers = decode_headers(record)
+    assert headers[DeadLetterHeaderKey.ORIGINAL_TOPIC] == "AsyncFailingEvent"
+    assert headers[DeadLetterHeaderKey.CONSUMER_GROUP] == "test-group"
+    assert headers[DeadLetterHeaderKey.EXCEPTION_TYPE] == "RuntimeError"
+    assert (
+        "cannot process async-poison" in headers[DeadLetterHeaderKey.EXCEPTION_MESSAGE]
+    )

--- a/plugins/spakky-kafka/tests/unit/test_config.py
+++ b/plugins/spakky-kafka/tests/unit/test_config.py
@@ -9,6 +9,7 @@ from typing import Any
 from collections.abc import Generator
 
 import pytest
+from pydantic import ValidationError
 
 from spakky.plugins.kafka.common.config import (
     AutoOffsetResetType,
@@ -31,6 +32,9 @@ def clean_environment_fixture() -> Generator[None, Any, None]:
         f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}NUMBER_OF_PARTITIONS",
         f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}REPLICATION_FACTOR",
         f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}AUTO_OFFSET_RESET",
+        f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}DEAD_LETTER_TOPIC_SUFFIX",
+        f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}MAX_HANDLER_RETRIES",
+        f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}DEAD_LETTER_DELIVERY_TIMEOUT",
     ]
     original_values = {}
     for key in keys_to_remove:
@@ -97,6 +101,9 @@ def test_kafka_config_default_values(clean_env: None) -> None:
     assert config.number_of_partitions == 1
     assert config.replication_factor == 1
     assert config.auto_offset_reset == AutoOffsetResetType.EARLIEST
+    assert config.dead_letter_topic_suffix == ".dlt"
+    assert config.max_handler_retries == 0
+    assert config.dead_letter_delivery_timeout == 10.0
 
 
 def test_kafka_config_configuration_dict_basic(clean_env: None) -> None:
@@ -166,6 +173,86 @@ def test_kafka_config_with_custom_partitions_and_replication(clean_env: None) ->
 
     assert config.number_of_partitions == 3
     assert config.replication_factor == 2
+
+
+def test_kafka_config_with_custom_dead_letter_settings(clean_env: None) -> None:
+    """dead-letter 접미사와 재시도 상한이 환경 변수에서 로드되는지 검증한다."""
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "test-group"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "test-client"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = "localhost:9092"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}DEAD_LETTER_TOPIC_SUFFIX"] = ".dead"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}MAX_HANDLER_RETRIES"] = "3"
+
+    config = KafkaConnectionConfig()
+
+    assert config.dead_letter_topic_suffix == ".dead"
+    assert config.max_handler_retries == 3
+
+
+def test_kafka_config_with_negative_max_handler_retries_expect_rejected(
+    clean_env: None,
+) -> None:
+    """음수 재시도 상한은 무한 재시도를 만들므로 설정 로딩에서 거부된다."""
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "test-group"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "test-client"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = "localhost:9092"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}MAX_HANDLER_RETRIES"] = "-1"
+
+    with pytest.raises(ValidationError):
+        KafkaConnectionConfig()
+
+
+def test_kafka_config_with_empty_dead_letter_topic_suffix_expect_rejected(
+    clean_env: None,
+) -> None:
+    """빈 접미사는 실패 메시지를 원본 토픽으로 되돌리므로 설정 로딩에서 거부된다."""
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "test-group"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "test-client"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = "localhost:9092"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}DEAD_LETTER_TOPIC_SUFFIX"] = ""
+
+    with pytest.raises(ValidationError):
+        KafkaConnectionConfig()
+
+
+def test_kafka_config_async_producer_configuration_dict_with_sasl(
+    clean_env: None,
+) -> None:
+    """비동기 producer 설정이 aiokafka 키워드로 SASL 자격까지 전달하는지 검증한다."""
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "test-group"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "secure-client"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = "secure:9093"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SECURITY_PROTOCOL"] = "SASL_SSL"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SASL_MECHANISM"] = "PLAIN"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SASL_USERNAME"] = "api-key"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SASL_PASSWORD"] = "api-secret"
+
+    config = KafkaConnectionConfig()
+
+    assert config.async_producer_configuration_dict == {
+        "bootstrap_servers": "secure:9093",
+        "client_id": "secure-client",
+        "security_protocol": "SASL_SSL",
+        "sasl_mechanism": "PLAIN",
+        "sasl_plain_username": "api-key",
+        "sasl_plain_password": "api-secret",
+    }
+
+
+def test_kafka_config_async_producer_configuration_dict_without_sasl(
+    clean_env: None,
+) -> None:
+    """SASL 미설정 환경에서는 연결 정보만 aiokafka 키워드로 전달한다."""
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "test-group"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "plain-client"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = "localhost:9092"
+
+    config = KafkaConnectionConfig()
+
+    assert config.async_producer_configuration_dict == {
+        "bootstrap_servers": "localhost:9092",
+        "client_id": "plain-client",
+    }
 
 
 def test_kafka_config_env_prefix_is_correct() -> None:

--- a/plugins/spakky-kafka/tests/unit/test_consumer.py
+++ b/plugins/spakky-kafka/tests/unit/test_consumer.py
@@ -4,12 +4,16 @@ Tests registration, routing, initialization, and lifecycle methods
 for both synchronous and asynchronous Kafka event consumers.
 """
 
+import logging
 import threading
+from asyncio import sleep
 from typing import Any, override
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aiokafka.errors import KafkaTimeoutError
+from confluent_kafka import KafkaError, KafkaException
 from spakky.auth import (
     AUTH_CONTEXT_SNAPSHOT_HEADER_KEY,
     AuthRequirementDeniedError,
@@ -21,6 +25,7 @@ from spakky.tracing.context import TraceContext
 from spakky.tracing.w3c_propagator import W3CTracePropagator
 
 from spakky.plugins.kafka.common.config import KafkaConnectionConfig
+from spakky.plugins.kafka.common.constants import DeadLetterHeaderKey
 from spakky.plugins.kafka.event.consumer import (
     AsyncKafkaEventConsumer,
     KafkaEventConsumer,
@@ -76,6 +81,25 @@ def config_fixture() -> Generator[KafkaConnectionConfig, Any, None]:
                 environ.pop(key, None)
             else:
                 environ[key] = value
+
+
+SAMPLE_TIMESTAMP = (1, 1700000000000)
+"""Kafka `(timestamp_type, timestamp)` pair returned by `Message.timestamp()`."""
+
+
+@pytest.fixture(name="incoming_message")
+def incoming_message_fixture() -> MagicMock:
+    """Kafka 메시지 stub — 유효한 SampleEvent 본문과 원본 좌표를 담는다."""
+    message = MagicMock()
+    message.error.return_value = None
+    message.topic.return_value = "SampleEvent"
+    message.partition.return_value = 3
+    message.offset.return_value = 42
+    message.timestamp.return_value = SAMPLE_TIMESTAMP
+    message.key.return_value = b"order-1"
+    message.value.return_value = b'{"data": "hello"}'
+    message.headers.return_value = [("traceparent", SAMPLE_TRACEPARENT.encode())]
+    return message
 
 
 @patch("spakky.plugins.kafka.event.consumer.Consumer")
@@ -171,14 +195,17 @@ def test_sync_consumer_create_topics_expect_topics_created(
     assert topic_names == {"topic1", "topic2"}
 
 
+@patch("spakky.plugins.kafka.event.consumer.Producer")
 @patch("spakky.plugins.kafka.event.consumer.Consumer")
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")
 def test_sync_consumer_initialize_expect_subscribe(
     mock_admin_cls: MagicMock,
     mock_consumer_cls: MagicMock,
+    mock_producer_cls: MagicMock,
     config: KafkaConnectionConfig,
 ) -> None:
     """동기 consumer의 initialize가 토픽 생성 및 구독을 수행하는지 검증한다."""
+    del mock_producer_cls
     mock_admin = MagicMock()
     mock_admin.list_topics.return_value.topics.keys.return_value = set()
     mock_admin_cls.return_value = mock_admin
@@ -194,14 +221,41 @@ def test_sync_consumer_initialize_expect_subscribe(
     mock_inner_consumer.subscribe.assert_called_once_with(topics=["SampleEvent"])
 
 
+@patch("spakky.plugins.kafka.event.consumer.Producer")
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_initialize_expect_dead_letter_topic_created(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    mock_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """initialize가 구독 토픽과 함께 dead-letter 토픽도 생성한다."""
+    del mock_consumer_cls, mock_producer_cls
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = set()
+    mock_admin_cls.return_value = mock_admin
+
+    consumer = KafkaEventConsumer(config)
+    consumer.register(SampleEvent, MagicMock())
+
+    consumer.initialize()
+
+    created_topics = {topic.topic for topic in mock_admin.create_topics.call_args[0][0]}
+    assert created_topics == {"SampleEvent", "SampleEvent.dlt"}
+
+
+@patch("spakky.plugins.kafka.event.consumer.Producer")
 @patch("spakky.plugins.kafka.event.consumer.Consumer")
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")
 def test_sync_consumer_initialize_custom_event_name_expect_subscribe_to_event_name(
     mock_admin_cls: MagicMock,
     mock_consumer_cls: MagicMock,
+    mock_producer_cls: MagicMock,
     config: KafkaConnectionConfig,
 ) -> None:
     """Custom event_name topic을 생성하고 구독한다."""
+    del mock_producer_cls
     mock_admin = MagicMock()
     mock_admin.list_topics.return_value.topics.keys.return_value = set()
     mock_admin_cls.return_value = mock_admin
@@ -337,6 +391,7 @@ def test_sync_consumer_auth_deny_is_handled_without_retry(
     """DENY-style auth failures do not escape the route handler."""
     del mock_admin_cls, mock_consumer_cls
     consumer = KafkaEventConsumer(config)
+    consumer.producer = MagicMock()
 
     def handler(event: SampleEvent) -> None:
         del event
@@ -351,6 +406,8 @@ def test_sync_consumer_auth_deny_is_handled_without_retry(
     mock_message.headers.return_value = []
 
     consumer._route_event_handler(mock_message)
+
+    consumer.producer.produce.assert_not_called()
 
 
 @patch("spakky.plugins.kafka.event.consumer.Consumer")
@@ -424,18 +481,21 @@ def test_sync_consumer_run_expect_poll_and_route(
 
 @patch("spakky.plugins.kafka.event.consumer.Consumer")
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")
-def test_sync_consumer_dispose_expect_close(
+def test_sync_consumer_dispose_expect_producer_flushed_and_consumer_closed(
     mock_admin_cls: MagicMock,
     mock_consumer_cls: MagicMock,
     config: KafkaConnectionConfig,
 ) -> None:
-    """동기 consumer의 dispose가 consumer.close()를 호출하는지 검증한다."""
+    """동기 consumer의 dispose가 미발행 dead-letter를 flush하고 consumer를 닫는지 검증한다."""
     mock_inner_consumer = MagicMock()
     mock_consumer_cls.return_value = mock_inner_consumer
 
     consumer = KafkaEventConsumer(config)
+    consumer.producer = MagicMock()
+
     consumer.dispose()
 
+    consumer.producer.flush.assert_called_once_with(config.dead_letter_delivery_timeout)
     mock_inner_consumer.close.assert_called_once()
 
 
@@ -518,6 +578,36 @@ def test_async_consumer_register_auth_boundary_expect_handler_marked(
     assert handler in consumer._auth_boundary_handlers
 
 
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_auth_boundary_handler_receives_headers(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """Auth-aware async endpoints receive Kafka headers from consumer."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    captured_headers: list[dict[str, str] | None] = []
+
+    async def handler(
+        event: SampleEvent,
+        _spakky_kafka_headers: dict[str, str] | None = None,
+    ) -> None:
+        del event
+        captured_headers.append(_spakky_kafka_headers)
+
+    consumer.register(SampleEvent, handler)
+    consumer.register_auth_boundary(handler)
+    incoming_message.headers.return_value = [
+        (AUTH_CONTEXT_SNAPSHOT_HEADER_KEY, b"snapshot-envelope"),
+    ]
+
+    await consumer._route_event_handler(incoming_message)
+
+    assert captured_headers == [{AUTH_CONTEXT_SNAPSHOT_HEADER_KEY: "snapshot-envelope"}]
+
+
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")
 def test_async_consumer_create_topics_expect_topics_created(
     mock_admin_cls: MagicMock,
@@ -535,14 +625,17 @@ def test_async_consumer_create_topics_expect_topics_created(
 
 
 @pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AIOKafkaProducer")
 @patch("spakky.plugins.kafka.event.consumer.AIOConsumer")
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")
 async def test_async_consumer_initialize_async_expect_subscribe(
     mock_admin_cls: MagicMock,
     mock_aio_consumer_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
     config: KafkaConnectionConfig,
 ) -> None:
     """비동기 consumer의 initialize_async가 토픽 생성 및 구독을 수행하는지 검증한다."""
+    mock_aio_producer_cls.return_value = AsyncMock()
     mock_admin = MagicMock()
     mock_admin.list_topics.return_value.topics.keys.return_value = set()
     mock_admin_cls.return_value = mock_admin
@@ -559,14 +652,43 @@ async def test_async_consumer_initialize_async_expect_subscribe(
 
 
 @pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.consumer.AIOConsumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_initialize_async_expect_dead_letter_topic_created(
+    mock_admin_cls: MagicMock,
+    mock_aio_consumer_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """initialize_async가 구독 토픽과 함께 dead-letter 토픽도 생성한다."""
+    mock_aio_producer_cls.return_value = AsyncMock()
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = set()
+    mock_admin_cls.return_value = mock_admin
+    mock_aio_consumer_cls.return_value = AsyncMock()
+
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.register(SampleEvent, AsyncMock())
+
+    await consumer.initialize_async()
+
+    created_topics = {topic.topic for topic in mock_admin.create_topics.call_args[0][0]}
+    assert created_topics == {"SampleEvent", "SampleEvent.dlt"}
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AIOKafkaProducer")
 @patch("spakky.plugins.kafka.event.consumer.AIOConsumer")
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")
 async def test_async_consumer_initialize_custom_event_name_expect_subscribe_to_event_name(
     mock_admin_cls: MagicMock,
     mock_aio_consumer_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
     config: KafkaConnectionConfig,
 ) -> None:
     """Async consumer도 custom event_name topic을 생성하고 구독한다."""
+    mock_aio_producer_cls.return_value = AsyncMock()
     mock_admin = MagicMock()
     mock_admin.list_topics.return_value.topics.keys.return_value = set()
     mock_admin_cls.return_value = mock_admin
@@ -584,18 +706,21 @@ async def test_async_consumer_initialize_custom_event_name_expect_subscribe_to_e
 
 @pytest.mark.asyncio
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")
-async def test_async_consumer_dispose_async_expect_close(
+async def test_async_consumer_dispose_async_expect_producer_and_consumer_closed(
     mock_admin_cls: MagicMock,
     config: KafkaConnectionConfig,
 ) -> None:
-    """비동기 consumer의 dispose_async가 consumer.close()를 호출하는지 검증한다."""
+    """비동기 dispose_async가 dead-letter producer와 consumer를 모두 닫는지 검증한다."""
     mock_aio_consumer = AsyncMock()
+    mock_aio_producer = AsyncMock()
 
     consumer = AsyncKafkaEventConsumer(config)
     consumer.consumer = mock_aio_consumer
+    consumer.producer = mock_aio_producer
 
     await consumer.dispose_async()
 
+    mock_aio_producer.stop.assert_awaited_once()
     mock_aio_consumer.close.assert_awaited_once()
 
 
@@ -924,6 +1049,7 @@ def test_sync_consumer_route_handler_exception_expect_trace_context_cleared(
 ) -> None:
     """핸들러 예외 시에도 TraceContext가 정리됨을 검증한다."""
     consumer = KafkaEventConsumer(config)
+    consumer.producer = MagicMock()
     consumer.set_propagator(W3CTracePropagator())
 
     def raising_handler(event: SampleEvent) -> None:
@@ -935,6 +1061,7 @@ def test_sync_consumer_route_handler_exception_expect_trace_context_cleared(
     mock_message.error.return_value = None
     mock_message.topic.return_value = "SampleEvent"
     mock_message.value.return_value = b'{"data": "test"}'
+    mock_message.timestamp.return_value = SAMPLE_TIMESTAMP
     mock_message.headers.return_value = [
         ("traceparent", SAMPLE_TRACEPARENT.encode()),
     ]
@@ -952,6 +1079,7 @@ async def test_async_consumer_route_handler_exception_expect_trace_context_clear
 ) -> None:
     """비동기 consumer에서 핸들러 예외 시에도 TraceContext가 정리됨을 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
     consumer.set_propagator(W3CTracePropagator())
 
     async def raising_handler(event: SampleEvent) -> None:
@@ -963,6 +1091,7 @@ async def test_async_consumer_route_handler_exception_expect_trace_context_clear
     mock_message.error.return_value = None
     mock_message.topic.return_value = "SampleEvent"
     mock_message.value.return_value = b'{"data": "test"}'
+    mock_message.timestamp.return_value = SAMPLE_TIMESTAMP
     mock_message.headers.return_value = [
         ("traceparent", SAMPLE_TRACEPARENT.encode()),
     ]
@@ -1076,3 +1205,459 @@ def test_async_consumer_to_string_headers_with_none_expect_empty(
     result = consumer._to_string_headers(None)
 
     assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Dead-letter routing tests
+# ---------------------------------------------------------------------------
+
+
+EXPECTED_DEAD_LETTER_HEADERS = {
+    "traceparent": SAMPLE_TRACEPARENT,
+    DeadLetterHeaderKey.ORIGINAL_TOPIC: "SampleEvent",
+    DeadLetterHeaderKey.ORIGINAL_PARTITION: "3",
+    DeadLetterHeaderKey.ORIGINAL_OFFSET: "42",
+    DeadLetterHeaderKey.ORIGINAL_TIMESTAMP: "1700000000000",
+    DeadLetterHeaderKey.CONSUMER_GROUP: "test-group",
+    DeadLetterHeaderKey.EXCEPTION_TYPE: "RuntimeError",
+    DeadLetterHeaderKey.EXCEPTION_MESSAGE: "handler exploded",
+}
+"""Headers a reprocessing tool must find on a message that failed in `failing_handler`."""
+
+
+def failing_handler(event: SampleEvent) -> None:
+    """Handler that always fails, driving the message onto the dead-letter topic."""
+    del event
+    raise RuntimeError("handler exploded")
+
+
+async def async_failing_handler(event: SampleEvent) -> None:
+    """Async counterpart of `failing_handler`."""
+    del event
+    raise RuntimeError("handler exploded")
+
+
+def delivering_producer() -> MagicMock:
+    """Sync producer stub whose flush reports every record as delivered."""
+    producer = MagicMock()
+    producer.flush.return_value = 0
+    return producer
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_route_undeserializable_message_expect_dead_letter_without_handler_call(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """역직렬화되지 않는 메시지는 핸들러를 호출하지 않고 즉시 dead-letter로 보낸다."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = delivering_producer()
+    handler = MagicMock()
+    consumer.register(SampleEvent, handler)
+    incoming_message.value.return_value = b"not-an-event"
+
+    consumer._route_event_handler(incoming_message)
+
+    handler.assert_not_called()
+    produced = consumer.producer.produce.call_args.kwargs
+    assert produced["topic"] == "SampleEvent.dlt"
+    assert produced["value"] == b"not-an-event"
+    assert produced["headers"][DeadLetterHeaderKey.EXCEPTION_TYPE] == "ValidationError"
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_route_failing_handler_expect_dead_letter_with_origin_headers(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """핸들러가 실패하면 원본 좌표와 예외 정보를 헤더에 실어 dead-letter로 보낸다."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = delivering_producer()
+    consumer.register(SampleEvent, failing_handler)
+
+    consumer._route_event_handler(incoming_message)
+
+    produced = consumer.producer.produce.call_args.kwargs
+    assert produced["topic"] == "SampleEvent.dlt"
+    assert produced["value"] == b'{"data": "hello"}'
+    assert produced["key"] == b"order-1"
+    assert produced["headers"] == EXPECTED_DEAD_LETTER_HEADERS
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_route_failing_handler_expect_bounded_delivery_wait(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """dead-letter 발행은 delivery report를 걸고 설정된 시간까지만 배달을 기다린다."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = delivering_producer()
+    consumer.register(SampleEvent, failing_handler)
+
+    consumer._route_event_handler(incoming_message)
+
+    assert (
+        consumer.producer.produce.call_args.kwargs["callback"]
+        == consumer._dead_letter_delivery_report
+    )
+    consumer.producer.flush.assert_called_once_with(config.dead_letter_delivery_timeout)
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_route_undelivered_dead_letter_expect_error_logged(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """배달 시간 안에 나가지 못한 dead-letter 레코드는 조용히 사라지지 않고 기록된다."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = MagicMock()
+    consumer.producer.flush.return_value = 1
+    consumer.register(SampleEvent, failing_handler)
+
+    with caplog.at_level(logging.ERROR):
+        consumer._route_event_handler(incoming_message)
+
+    assert "still unsent" in caplog.text
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_delivery_report_with_broker_error_expect_error_logged(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """브로커가 dead-letter 레코드를 거절하면 delivery report가 실패를 기록한다."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config)
+    rejected = MagicMock()
+    rejected.topic.return_value = "SampleEvent.dlt"
+
+    with caplog.at_level(logging.ERROR):
+        consumer._dead_letter_delivery_report(
+            KafkaError(KafkaError._MSG_TIMED_OUT), rejected
+        )
+
+    assert "Dead-letter delivery failed for SampleEvent.dlt" in caplog.text
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_delivery_report_without_error_expect_silence(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """정상 배달된 dead-letter 레코드는 오류로 기록되지 않는다."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config)
+
+    with caplog.at_level(logging.ERROR):
+        consumer._dead_letter_delivery_report(None, MagicMock())
+
+    assert caplog.text == ""
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_route_failing_handler_with_retries_expect_retried_before_dead_letter(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """max_handler_retries만큼 핸들러를 다시 호출한 뒤에야 dead-letter로 보낸다."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config.model_copy(update={"max_handler_retries": 2}))
+    consumer.producer = delivering_producer()
+    attempts: list[SampleEvent] = []
+
+    def counting_failing_handler(event: SampleEvent) -> None:
+        attempts.append(event)
+        raise RuntimeError("handler exploded")
+
+    consumer.register(SampleEvent, counting_failing_handler)
+
+    consumer._route_event_handler(incoming_message)
+
+    assert len(attempts) == 3
+    consumer.producer.produce.assert_called_once()
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_route_successful_handler_expect_no_dead_letter(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """핸들러가 성공한 메시지는 dead-letter로 보내지 않는다."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = delivering_producer()
+    consumer.register(SampleEvent, MagicMock())
+
+    consumer._route_event_handler(incoming_message)
+
+    consumer.producer.produce.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_route_undeserializable_message_expect_dead_letter_without_handler_call(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """비동기 consumer도 역직렬화 실패 메시지를 핸들러 없이 dead-letter로 보낸다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
+    handler = AsyncMock()
+    consumer.register(SampleEvent, handler)
+    incoming_message.value.return_value = b"not-an-event"
+
+    await consumer._route_event_handler(incoming_message)
+
+    handler.assert_not_awaited()
+    sent = consumer.producer.send_and_wait.call_args.kwargs
+    assert sent["topic"] == "SampleEvent.dlt"
+    assert sent["value"] == b"not-an-event"
+    assert (
+        dict(sent["headers"])[DeadLetterHeaderKey.EXCEPTION_TYPE] == b"ValidationError"
+    )
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_route_failing_handler_expect_dead_letter_with_origin_headers(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """비동기 핸들러 실패도 원본 좌표와 예외 정보를 헤더에 실어 dead-letter로 보낸다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
+    consumer.register(SampleEvent, async_failing_handler)
+
+    await consumer._route_event_handler(incoming_message)
+
+    sent = consumer.producer.send_and_wait.call_args.kwargs
+    assert sent["topic"] == "SampleEvent.dlt"
+    assert sent["value"] == b'{"data": "hello"}'
+    assert sent["key"] == b"order-1"
+    assert {key: value.decode() for key, value in sent["headers"]} == (
+        EXPECTED_DEAD_LETTER_HEADERS
+    )
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_route_rejected_dead_letter_expect_error_logged(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """브로커가 비동기 dead-letter 발행을 거절해도 poll 루프를 죽이지 않고 기록한다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
+    consumer.producer.send_and_wait.side_effect = KafkaTimeoutError(
+        "broker unreachable"
+    )
+    consumer.register(SampleEvent, async_failing_handler)
+
+    with caplog.at_level(logging.ERROR):
+        await consumer._route_event_handler(incoming_message)
+
+    assert "Dead-letter delivery failed for SampleEvent" in caplog.text
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_route_failing_handler_with_retries_expect_retried_before_dead_letter(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """비동기 consumer도 max_handler_retries만큼 재호출한 뒤 dead-letter로 보낸다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(
+        config.model_copy(update={"max_handler_retries": 2})
+    )
+    consumer.producer = AsyncMock()
+    attempts: list[SampleEvent] = []
+
+    async def counting_failing_handler(event: SampleEvent) -> None:
+        attempts.append(event)
+        raise RuntimeError("handler exploded")
+
+    consumer.register(SampleEvent, counting_failing_handler)
+
+    await consumer._route_event_handler(incoming_message)
+
+    assert len(attempts) == 3
+    consumer.producer.send_and_wait.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_route_successful_handler_expect_no_dead_letter(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """비동기 핸들러가 성공한 메시지는 dead-letter로 보내지 않는다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
+    consumer.register(SampleEvent, AsyncMock())
+
+    await consumer._route_event_handler(incoming_message)
+
+    consumer.producer.send_and_wait.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_auth_deny_expect_no_dead_letter(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """DENY 판정 메시지는 실패가 아니므로 dead-letter로 보내지 않는다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
+
+    async def denying_handler(event: SampleEvent) -> None:
+        del event
+        raise AuthRequirementDeniedError()
+
+    consumer.register(SampleEvent, denying_handler)
+
+    await consumer._route_event_handler(incoming_message)
+
+    consumer.producer.send_and_wait.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_provider_unavailable_expect_propagated(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """검증 provider 장애는 재시도 대상이므로 dead-letter 없이 그대로 전파된다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
+
+    async def unavailable_handler(event: SampleEvent) -> None:
+        del event
+        raise AuthVerificationProviderUnavailableError()
+
+    consumer.register(SampleEvent, unavailable_handler)
+
+    with pytest.raises(AuthVerificationProviderUnavailableError):
+        await consumer._route_event_handler(incoming_message)
+
+    consumer.producer.send_and_wait.assert_not_awaited()
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_route_rejected_dead_letter_expect_error_logged(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """produce가 레코드를 거절해도 poll 스레드를 죽이지 않고 기록한다."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = delivering_producer()
+    consumer.producer.produce.side_effect = KafkaException(
+        KafkaError(KafkaError.MSG_SIZE_TOO_LARGE)
+    )
+    consumer.register(SampleEvent, failing_handler)
+
+    with caplog.at_level(logging.ERROR):
+        consumer._route_event_handler(incoming_message)
+
+    assert "Dead-letter delivery failed for SampleEvent" in caplog.text
+    consumer.producer.flush.assert_not_called()
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_route_full_producer_queue_expect_error_logged(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """로컬 큐가 가득 차 produce가 실패해도 poll 스레드를 죽이지 않고 기록한다."""
+    del mock_admin_cls, mock_consumer_cls
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = delivering_producer()
+    consumer.producer.produce.side_effect = BufferError("queue full")
+    consumer.register(SampleEvent, failing_handler)
+
+    with caplog.at_level(logging.ERROR):
+        consumer._route_event_handler(incoming_message)
+
+    assert "Dead-letter delivery failed for SampleEvent" in caplog.text
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_route_unconfirmed_dead_letter_expect_duplicate_warning(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """배달 확인이 시간 안에 오지 않으면 확정 실패와 구분해 중복 가능성을 알린다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(
+        config.model_copy(update={"dead_letter_delivery_timeout": 0.01})
+    )
+    consumer.producer = AsyncMock()
+
+    async def never_confirming_send(**kwargs: Any) -> None:
+        del kwargs
+        await sleep(3600)
+
+    consumer.producer.send_and_wait.side_effect = never_confirming_send
+    consumer.register(SampleEvent, async_failing_handler)
+
+    with caplog.at_level(logging.ERROR):
+        await consumer._route_event_handler(incoming_message)
+
+    assert "unconfirmed after" in caplog.text
+    assert "may still be delivered" in caplog.text


### PR DESCRIPTION
Closes #494

## 무엇을 고쳤나

핸들러가 실패하면 그 메시지가 갈 곳이 없었습니다. `_route_event_handler`가 예외를 잡아 로그만 남기고 다음 메시지로 넘어가므로, 역직렬화에 실패하는 메시지는 조용히 사라졌습니다.

이제 실패한 메시지는 원본 topic 이름에 `dead_letter_topic_suffix`(기본 `.dlt`)를 붙인 topic으로 전달됩니다. 원본 본문과 key는 바이트 그대로, 원본 header는 consumer가 읽은 문자열 형태로 함께 실립니다. 재처리 도구가 본문을 열지 않고 판단할 수 있도록 다음 header를 덧붙입니다.

| header | 값 |
|--------|-----|
| `x-spakky-dead-letter-original-topic` | 원본 topic |
| `x-spakky-dead-letter-original-partition` | 원본 partition |
| `x-spakky-dead-letter-original-offset` | 원본 offset |
| `x-spakky-dead-letter-original-timestamp` | 원본 timestamp |
| `x-spakky-dead-letter-consumer-group` | 실패한 consumer group |
| `x-spakky-dead-letter-exception-type` | 예외 클래스 이름 |
| `x-spakky-dead-letter-exception-message` | 예외 메시지 |

역직렬화 실패는 같은 본문으로 재시도해도 결과가 같으므로 재시도 없이 즉시 보냅니다. 핸들러 실패는 `max_handler_retries`(기본 0)만큼 재호출한 뒤 보냅니다. 이슈 권고대로 지연 재시도 topic 계층은 넣지 않았습니다 — 메시지를 다른 topic으로 빼내면 그 aggregate의 파티션 내 순서가 깨져 #492가 무의미해집니다.

## 신규 설정

| 필드 | 환경변수 | 기본값 |
|------|---------|--------|
| `dead_letter_topic_suffix` | `SPAKKY_KAFKA__DEAD_LETTER_TOPIC_SUFFIX` | `.dlt` |
| `max_handler_retries` | `SPAKKY_KAFKA__MAX_HANDLER_RETRIES` | `0` |
| `dead_letter_delivery_timeout` | `SPAKKY_KAFKA__DEAD_LETTER_DELIVERY_TIMEOUT` | `10.0` |

## 리뷰에서 잡힌 결함과 해소 (iteration 1~3)

이 PR은 리뷰 3회를 돌면서 **런타임에서 100% 실패하는 결함 2건**을 잡아냈습니다. 둘 다 처음 작성한 mock 기반 단위 테스트가 green으로 통과시킨 것이라 경위를 남깁니다.

### 1. 비동기 dead-letter가 실행되지 않았다

처음에는 async consumer가 이미 쓰던 `confluent_kafka.aio.AIOProducer`로 발행했습니다. 그런데 설치 버전(2.14.2)의 `AIOProducer.produce`는 `headers` kwarg가 들어오면 무조건 `NotImplementedError`를 던집니다 (SDK 소스: "Headers are not supported in AIOProducer batch mode"). 이 예외는 `except` 블록 **안에서** 발생하므로 다시 잡히지 않고 poll 루프까지 전파되어 **비동기 consumer task 자체가 죽습니다.** 그대로 머지되면 "메시지가 조용히 사라짐"이 "consumer가 통째로 멈춤"으로 바뀌었을 것입니다.

→ transport 선례인 `aiokafka.AIOKafkaProducer`로 교체했습니다(header를 `list[tuple[str, bytes]]`로 지원). 두 구현이 따로 갖고 있던 aiokafka 설정 매핑은 `KafkaConnectionConfig.async_producer_configuration_dict`로 올렸습니다 — 이 중복이 바로 #484(async producer security config 누락)를 만든 원인이라, 같은 드리프트가 재발하지 않도록 단일 출처로 만들었습니다.

### 2. 동기 경로에 같은 사망 경로가 남아 있었다

1을 고치면서 기존 `except Exception` 덮개를 제거했더니 동기 `produce()` 호출이 무방비로 노출됐습니다. `Producer.produce`는 `BufferError`(로컬 큐 포화)와 `KafkaException`(크기 초과 등)을 **동기적으로** raise하며, 이 호출은 poll 스레드에서 실행되므로 예외가 새면 스레드가 죽고 `stop()`은 정상 종료처럼 보입니다. dead-letter 발행은 원본 header 전량 + 신규 7개 header를 덧붙이므로, **원본 topic에서는 통과한 크기의 메시지가 dead-letter 발행에서 `message.max.bytes`를 넘길 수 있습니다.**

→ 문서화된 두 예외만 좁게 잡아 로깅하고 소비를 계속합니다. 광범위한 `Exception`으로 감싸지 않은 것은 우리 코드의 프로그래밍 오류는 계속 드러나야 하기 때문입니다.

### 3. mock 스냅샷 테스트가 위 둘을 가렸다

`MagicMock`/`AsyncMock`은 실제 SDK가 거부하는 `headers=` kwarg를 무조건 받아들이므로 두 결함이 모두 green이었습니다. 게다가 async `_route_event_handler`에 붙어 있던 `# pragma: no cover`가 신규 비동기 dead-letter 코드를 커버리지 측정에서 통째로 제외해, `fail_under = 100`이 green인 채로 한 줄도 측정되지 않았습니다.

→ 해당 pragma를 제거해 커버리지 게이트를 복구하고(누락됐던 async auth-deny·provider-unavailable 테스트도 함께 추가), 실제 브로커를 쓰는 통합 테스트 2건(동기·비동기 핸들러 실패 → `<topic>.dlt`에서 원본 본문·header 되읽기)을 추가했습니다. **이 통합 테스트가 즉시 세 번째 결함을 잡았습니다** — `aiokafka`는 header key에 `type(key) is str`를 요구해 `StrEnum` 멤버를 거부하므로, 양쪽 경로 모두 `.value`로 평문 `str`을 싣도록 고쳤습니다.

### 발행 실패 관측성

- 동기: delivery callback + `flush(timeout)` 반환값(미배달 건수) 검사
- 비동기: 배달 확인 await. **확정 실패와 미확인을 분리해 기록합니다** — `wait_for` 타임아웃은 producer 배치의 레코드를 지우지 않으므로 그 레코드는 나중에 실제로 배달될 수 있습니다. 이를 "실패"로 기록하면 운영자가 수동 재발행해 중복을 만들므로 "unconfirmed … may still be delivered"로 구분합니다.
- 종료 경로 `dispose()`의 `flush()`도 같은 timeout으로 상한을 걸어, 브로커 불통 시 종료가 영구 블로킹되지 않게 했습니다.

## 자율 결정 근거 (charter §4-B)

- **producer를 `initialize`/`initialize_async`에서 생성**: 브로커 연결은 생명주기 자원이고, async consumer가 이미 `AIOConsumer`를 `initialize_async`에서 만드는 선례를 따랐습니다.
- **`max_handler_retries` 기본 0**: 0보다 크면 해당 이벤트의 **모든** handler를 다시 실행하므로 handler 멱등성이 전제입니다. 기본값을 0으로 두어 이 PR이 전달 의미를 바꾸지 않게 했습니다.
- **음수·빈 값 차단**: `max_handler_retries`는 `NonNegativeInt`(음수면 무한 재시도), `dead_letter_topic_suffix`는 `min_length=1`(빈 접미사면 dead-letter topic이 원본 topic과 같아져 실패 메시지를 자기 topic으로 무한 재발행)로 설정 로딩에서 거부합니다.

## 범위

`#493`의 전달 의미 변경(수동 커밋·producer idempotence)은 선점하지 않았습니다. 커밋 시점과 producer 설정은 이 PR에서 건드리지 않으며, dead-letter 경로만 추가합니다. 두 이슈가 함께 풀려야 한다는 #494 본문의 지적대로, `#493`이 수동 커밋으로 바꾼 뒤에야 "발행 실패 시 커밋하지 않아 재처리"가 성립합니다 — 지금은 그 자리에서 오류 로그로 기록합니다.

`docs/api/plugins/spakky-kafka.md`는 mkdocstrings 자동 생성이라 수동 변경이 없습니다.

## Acceptance Criteria (자가 grep)

`acceptance_check: missing` — 이슈 #494 본문에 "수용 기준" grep 라인 섹션이 없습니다.

## 검증

패키지 디렉토리(`plugins/spakky-kafka`)에서 실행:

- `uv run ruff format --check .` → 22 files already formatted
- `uv run ruff check .` → All checks passed
- `uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text` → 0 diagnostics
  - **명시 경로 필수**: `.gitignore`의 `.claude/worktrees/`가 워크트리 절대경로 중간과 매치되어, 인자 없는 `pyrefly check`는 워크트리 안 모든 파일을 건너뛰고 exit 0을 반환합니다(false green). 이 하네스 결함은 #499로 분해되어 있습니다.
- `uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .` → passed
- `uv run pytest --with-integration -n0` → **114 passed**, 브랜치 커버리지 **100.00%** (Docker Kafka 컨테이너 실사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
