### PR TITLE
fix(kafka): make event delivery at-least-once (#493)

### DIFF
--- a/docs/guides/kafka.md
+++ b/docs/guides/kafka.md
@@ -149,6 +149,7 @@ sequenceDiagram
 | topic 생성 | 없으면 `number_of_partitions`, `replication_factor`로 생성 (dead-letter 토픽 포함) |
 | offset reset | `SPAKKY_KAFKA__AUTO_OFFSET_RESET` (`earliest`/`latest`/`none`) |
 | 처리 실패 | `<topic>` + `dead_letter_topic_suffix` 토픽으로 전달 |
+| offset 커밋 | 자동 커밋 없음. 실패가 dead-letter에 저장된 뒤에만 consumer가 직접 커밋 |
 
 `spakky-outbox`를 함께 로드하면 `OutboxEventBus` / `AsyncOutboxEventBus`가 기본 bus를 대체하므로 이벤트는 Kafka에 즉시 produce되지 않고 Outbox 테이블에 저장됩니다. Relay가 재시도 가능한 방식으로 Kafka transport를 호출하므로, 주문 생성 같은 DB 변경과 Kafka 발행을 원자적으로 묶어야 할 때 기본 선택은 Outbox 조합입니다.
 
@@ -177,6 +178,52 @@ dead-letter 발행은 `dead_letter_delivery_timeout`(기본 10초)까지만 배�
 `max_handler_retries`를 0보다 크게 설정하면 dead-letter로 보내기 전에 같은 메시지로 핸들러를 그 횟수만큼 다시 호출합니다. 재호출은 해당 이벤트에 등록된 모든 핸들러를 다시 실행하므로, 이 값을 올리려면 핸들러가 멱등해야 합니다. 역직렬화 실패는 같은 본문으로 다시 시도해도 결과가 같으므로 이 설정과 무관하게 즉시 dead-letter로 보냅니다.
 
 지연 재시도 토픽 계층은 두지 않습니다. 메시지를 다른 토픽으로 옮기는 순간 그 aggregate의 파티션 내 순서가 깨지기 때문입니다.
+
+---
+
+## 전달 의미와 핸들러 멱등성
+
+전달 의미는 **at-least-once**입니다. 같은 이벤트가 두 번 이상 핸들러에 전달될 수 있으므로 핸들러는 멱등해야 합니다.
+
+`KafkaConnectionConfig`가 producer 설정과 consumer 설정을 분리하고, 각각의 기본값을 프레임워크가 고정합니다. 환경변수로 바꾸는 항목이 아닙니다.
+
+| 대상 | 고정 설정 | 이유 |
+|------|----------|------|
+| Producer (이벤트 발행 + dead-letter 발행) | `enable.idempotence=true`, `acks=all` | 한 producer 세션의 재시도가 중복 발행이나 파티션 내 순서 역전을 만들지 않고, 승인된 이벤트가 파티션 리더 장애에도 남습니다 |
+| Consumer | `enable.auto.commit=false` | offset이 핸들러 실행 전에 전진하지 않습니다 |
+
+`AsyncKafkaEventTransport`는 `send` 호출마다 `AIOKafkaProducer`를 새로 만들어 닫으므로, 멱등 보장은 그 한 번의 `send`가 내부적으로 재시도하는 범위까지입니다. 서로 다른 `send` 호출 사이의 파티션 내 순서는 보장되지 않습니다.
+
+Consumer는 핸들러가 끝난 뒤, 그 메시지를 처리 완료로 볼지 다시 받을지 결정합니다.
+
+| 핸들러 결과 | offset | 이후 동작 |
+|------------|--------|----------|
+| 성공 | 커밋 | 다음 메시지로 진행 |
+| 실패 → dead-letter 발행 성공 | 커밋 | 실패가 `.dlt` 토픽에 남았으므로 파티션이 막히지 않습니다 |
+| 실패 → dead-letter 발행 실패·미확인 | 커밋 안 함 + 그 메시지로 `seek` 되감기 | 다음 poll이 같은 메시지를 다시 전달합니다 |
+| AuthContext DENY / snapshot CHALLENGE | 커밋 | 재시도해도 같은 결정이므로 파티션을 막지 않음 |
+| 검증 provider 장애 | 커밋 안 함 | 예외를 전파하여 consumer 루프를 중단합니다. 재시작하면 그 메시지부터 다시 처리합니다 |
+
+**offset은 실패가 다른 곳에 저장된 뒤에만 전진합니다.** dead-letter 발행이 실패했는데 커밋해 버리면 그 이벤트의 마지막 사본이 사라지므로, 발행 실패는 커밋 대신 되감기로 이어집니다.
+
+커밋을 건너뛰는 것만으로는 재처리가 성립하지 않습니다. `enable.auto.commit=false`는 브로커 커밋만 끄고, consumer의 소비 위치는 poll마다 전진합니다. 되감지 않으면 뒤따르는 메시지의 성공 커밋이 실패한 메시지의 offset을 지나쳐 버리고, 그 메시지는 rebalance나 재시작으로도 돌아오지 않습니다.
+
+멱등성은 보통 이벤트 식별자로 확보합니다. 이미 처리한 `AbstractIntegrationEvent`의 `event_id`를 저장해 두고 중복 수신을 건너뛰거나, 핸들러의 DB 반영을 upsert로 작성합니다.
+
+```python
+@EventHandler()
+class OrderEventHandler:
+    def __init__(self, repository: ProcessedEventRepository) -> None:
+        self._repository = repository
+
+    @on_event(OrderPlacedEvent)
+    async def on_order_placed(self, event: OrderPlacedEvent) -> None:
+        if await self._repository.exists(event.event_id):
+            return
+        await self._repository.save(event.event_id)
+```
+
+메시지 단위 동기 커밋은 브로커 왕복을 한 번 추가합니다. 처리량이 커밋 지연에 지배되면 파티션 수를 늘려 consumer를 병렬화합니다.
 
 ---
 

--- a/plugins/spakky-kafka/README.md
+++ b/plugins/spakky-kafka/README.md
@@ -53,6 +53,55 @@ export SPAKKY_KAFKA__MAX_HANDLER_RETRIES="0"
 export SPAKKY_KAFKA__DEAD_LETTER_DELIVERY_TIMEOUT="10.0"
 ```
 
+## 전달 의미 (at-least-once)
+
+`KafkaConnectionConfig`는 producer 설정과 consumer 설정을 분리하여 각각의 안전한
+기본값을 프레임워크가 고정합니다. 환경변수로 덮어쓸 수 있는 항목이 아닙니다.
+
+| 속성 | 대상 | 고정 값 | 결과 |
+|------|------|--------|------|
+| `producer_configuration_dict` | `confluent_kafka.Producer` (이벤트 발행 + dead-letter 발행) | `enable.idempotence=true`, `acks=all` | 한 producer 세션의 재시도가 중복 발행·파티션 내 재정렬을 만들지 않고, 승인된 이벤트가 파티션 리더 장애를 견딤 |
+| `async_producer_configuration_dict` | `aiokafka.AIOKafkaProducer` | `enable_idempotence=True`, `acks="all"` | 같은 값을 aiokafka 키 이름으로 표현 |
+| `consumer_configuration_dict` | `confluent_kafka.Consumer`, `AIOConsumer` | `enable.auto.commit=false` | offset이 핸들러 결과에 따라서만 전진 |
+| `connection_configuration_dict` | `AdminClient` 및 위 3종의 공통 기반 | `client.id`, `bootstrap.servers`, SASL/TLS | 클러스터 접속 정보만 담음 |
+
+`AsyncKafkaEventTransport.send`는 호출마다 producer를 새로 만들어 닫으므로, 비동기 발행
+경로의 멱등 보장 범위는 그 한 번의 `send`가 내부적으로 재시도하는 구간까지입니다. 서로
+다른 `send` 호출 사이의 파티션 내 순서는 보장하지 않습니다.
+
+Consumer는 등록된 핸들러가 끝난 뒤 그 메시지를 처리 완료로 볼지 다시 받을지 결정합니다.
+`MessageOutcome`이 그 두 결정을 나타냅니다.
+
+| 핸들러 결과 | `MessageOutcome` | offset 처리 |
+|------------|------------------|------------|
+| 성공 | `PROCESSED` | 커밋 후 다음 메시지로 진행 |
+| 실패 → dead-letter 발행 성공 | `PROCESSED` | 커밋. 실패가 `.dlt` 토픽에 남았으므로 파티션을 막지 않음 |
+| 실패 → dead-letter 발행 실패·미확인 | `RETRYABLE` | 커밋하지 않고 그 메시지로 `seek` 되감기 |
+| 역직렬화 실패 | dead-letter 결과에 따름 | 위 두 줄과 같은 규칙 |
+| AuthContext DENY / snapshot CHALLENGE | `PROCESSED` | warning 로그 후 커밋. 재시도해도 같은 결정임 |
+| 본문 없는 메시지 | `PROCESSED` | warning 로그 후 커밋. 처리할 대상이 없음 |
+| 검증 provider 장애 | (해당 없음) | 예외를 전파하여 consumer 루프를 중단. 커밋하지 않았으므로 재시작 시 그 메시지부터 다시 처리 |
+
+**offset은 실패가 다른 곳에 저장된 뒤에만 전진합니다.** dead-letter 발행이 실패했는데
+커밋해 버리면 그 이벤트의 마지막 사본이 사라집니다. 그래서 발행 실패는 커밋 대신 되감기로
+이어집니다.
+
+**커밋을 건너뛰는 것만으로는 재처리가 성립하지 않습니다.** `enable.auto.commit=false`는
+브로커 커밋만 끄고 consumer의 소비 위치는 poll마다 전진합니다. 되감지 않으면 뒤따르는
+메시지의 성공 커밋이 실패한 메시지의 offset을 지나쳐 버려 그 메시지는 rebalance나
+재시작으로도 돌아오지 않습니다. `seek` 되감기가 재처리를 성립시키는 수단입니다.
+
+전달 의미가 at-most-once에서 at-least-once로 바뀌었으므로 **같은 이벤트가 두 번 이상
+전달될 수 있습니다.** 이벤트 핸들러는 멱등해야 합니다. 이미 처리한 이벤트 식별자를
+저장하거나 upsert로 반영하는 방식이 필요합니다.
+
+커밋과 되감기 실패는 로그로 남기고 삼킵니다. consumer 루프는 background service 스레드
+(비동기는 asyncio 태스크)에서 돌기 때문에, 커밋 실패 예외를 전파하면 애플리케이션은 살아
+있는 채로 모든 구독이 멈춥니다.
+
+메시지 단위 동기 커밋은 브로커 왕복을 한 번씩 추가합니다. 처리량이 커밋 지연에 지배되는
+워크로드라면 파티션 수를 늘려 consumer를 병렬화합니다.
+
 ## 사용법
 
 ### 이벤트 발행
@@ -166,6 +215,7 @@ dead-letter topic은 consumer `initialize` 시점에 구독 topic과 함께 생�
 ## 주요 기능
 
 - **자동 topic 생성**: 이벤트 타입 이름을 기준으로 topic 생성 (dead-letter topic 포함)
+- **at-least-once 전달**: 멱등 producer + 실패가 저장된 뒤에만 전진하는 명시적 offset 커밋
 - **Dead-letter 경로**: 처리 실패 메시지를 원본 좌표·예외 header와 함께 `.dlt` topic으로 전달
 - **동기/비동기 지원**: 동기 및 비동기 publisher/consumer 모두 지원
 - **Background service 패턴**: consumer polling을 background service로 실행

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/common/config.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/common/config.py
@@ -91,12 +91,17 @@ class KafkaConnectionConfig(BaseSettings):
         super().__init__()
 
     @property
-    def configuration_dict(self) -> dict[str, str | int | float | bool]:
+    def connection_configuration_dict(self) -> dict[str, str | int | float | bool]:
+        """librdkafka settings that only describe how to reach the cluster.
+
+        Shared by the admin client, the producer, and the consumer. Delivery
+        semantics live in `producer_configuration_dict` and
+        `consumer_configuration_dict` instead, because the safe producer default
+        and the safe consumer default are opposites of each other.
+        """
         config: dict[str, str | int | float | bool] = {
-            "group.id": self.group_id,
             "client.id": self.client_id,
             "bootstrap.servers": self.bootstrap_servers,
-            "auto.offset.reset": self.auto_offset_reset.value,
         }
         if self.security_protocol:
             config["security.protocol"] = self.security_protocol
@@ -109,16 +114,50 @@ class KafkaConnectionConfig(BaseSettings):
         return config
 
     @property
-    def async_producer_configuration_dict(self) -> dict[str, str]:
-        """Same connection settings rendered as `aiokafka.AIOKafkaProducer` keywords.
+    def producer_configuration_dict(self) -> dict[str, str | int | float | bool]:
+        """Producer settings that keep retries from duplicating or reordering.
 
-        `aiokafka` takes snake_case keywords instead of the dotted librdkafka
-        property names in `configuration_dict`, so every async producer in this
-        plugin reads its settings here rather than mapping them again.
+        `enable.idempotence` makes the broker deduplicate retried batches and
+        pins `max.in.flight.requests.per.connection` low enough that a retry
+        cannot overtake an earlier batch on the same partition. `acks=all` waits
+        for every in-sync replica so an acknowledged event survives the loss of
+        the partition leader.
         """
-        config = {
+        return {
+            **self.connection_configuration_dict,
+            "enable.idempotence": True,
+            "acks": "all",
+        }
+
+    @property
+    def consumer_configuration_dict(self) -> dict[str, str | int | float | bool]:
+        """Consumer settings that tie the offset to the handler outcome.
+
+        `enable.auto.commit=false` is what makes delivery at-least-once: the
+        offset advances only when `KafkaEventConsumer` commits it after the
+        handlers finish, so a handler failure leaves the message to be
+        redelivered instead of silently dropping it.
+        """
+        return {
+            **self.connection_configuration_dict,
+            "group.id": self.group_id,
+            "auto.offset.reset": self.auto_offset_reset.value,
+            "enable.auto.commit": False,
+        }
+
+    @property
+    def async_producer_configuration_dict(self) -> dict[str, str | bool]:
+        """The same producer guarantees expressed as `aiokafka` keyword names.
+
+        `aiokafka` takes constructor keywords instead of a librdkafka property
+        dictionary, so the key spelling differs while the delivery guarantee is
+        identical to `producer_configuration_dict`.
+        """
+        config: dict[str, str | bool] = {
             "bootstrap_servers": self.bootstrap_servers,
             "client_id": self.client_id,
+            "enable_idempotence": True,
+            "acks": "all",
         }
         if self.security_protocol:
             config["security_protocol"] = self.security_protocol

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/event/consumer.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/event/consumer.py
@@ -1,4 +1,5 @@
 from asyncio import wait_for
+from enum import StrEnum
 from logging import getLogger
 from typing import Any, cast
 
@@ -9,7 +10,14 @@ from spakky.auth import (
     AuthVerificationProviderUnavailableError,
 )
 from aiokafka import AIOKafkaProducer
-from confluent_kafka import Consumer, KafkaError, KafkaException, Message, Producer
+from confluent_kafka import (
+    Consumer,
+    KafkaError,
+    KafkaException,
+    Message,
+    Producer,
+    TopicPartition,
+)
 from confluent_kafka.admin import AdminClient, NewTopic
 from confluent_kafka.aio import AIOConsumer
 from pydantic import TypeAdapter, ValidationError
@@ -34,6 +42,30 @@ from spakky.plugins.kafka.common.config import KafkaConnectionConfig
 from spakky.plugins.kafka.common.constants import DeadLetterHeaderKey
 
 logger = getLogger(__name__)
+
+
+class MessageOutcome(StrEnum):
+    """What running the handlers settled about one consumed message.
+
+    The consumer turns this into the offset action that gives the delivery
+    guarantee: an offset must never move past a message whose failure is not
+    stored anywhere else.
+    """
+
+    PROCESSED = "processed"
+    """The consumer is done with the message and commits its offset.
+
+    Covers handler success, every failure a retry cannot fix (a refused auth
+    boundary, an empty message body), and a failure whose dead-letter record
+    reached the broker.
+    """
+
+    RETRYABLE = "retryable"
+    """The message is still the only copy of its own failure, so it comes back.
+
+    Reached when dead-lettering itself failed. The consumer rewinds its position
+    to the message instead of committing, and the next poll delivers it again.
+    """
 
 
 def _event_routing_name(event: type[AbstractEvent]) -> str:
@@ -68,9 +100,9 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
         self.handlers = {}
         self._propagator = None
         self._auth_boundary_handlers = set()
-        self.admin = AdminClient(self.config.configuration_dict)
+        self.admin = AdminClient(self.config.connection_configuration_dict)
         self.consumer = Consumer(
-            self.config.configuration_dict,
+            self.config.consumer_configuration_dict,
             logger=logger,
         )
 
@@ -152,7 +184,7 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
         message: Message,
         headers: dict[str, str],
         error: Exception,
-    ) -> None:
+    ) -> bool:
         """Forward a message the handlers could not process to its dead-letter topic.
 
         The original body and key are forwarded unchanged and the decoded original
@@ -164,6 +196,11 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
             message: The Kafka message that could not be processed.
             headers: Decoded headers of the original message.
             error: Exception that ended the last processing attempt.
+
+        Returns:
+            Whether the dead-letter record reached the broker. `False` means the
+            failure is stored nowhere, so the caller must keep the original
+            message rather than commit its offset.
         """
         _, original_timestamp = message.timestamp()
         dead_letter_headers: dict[str, bytes | str | None] = {
@@ -189,13 +226,15 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
             # queue synchronously. This runs on the poll thread, so an escaping
             # exception would kill consumption while stop() still looks clean.
             logger.error(f"Dead-letter delivery failed for {topic}: {delivery_error}")
-            return
+            return False
         undelivered = self.producer.flush(self.config.dead_letter_delivery_timeout)
         if undelivered:
             logger.error(
                 f"Dead-letter record for {topic} still unsent after "
                 f"{self.config.dead_letter_delivery_timeout}s"
             )
+            return False
+        return True
 
     def _invoke_handlers(
         self,
@@ -209,13 +248,129 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
                 continue
             handler(event_data)
 
+    def _dead_letter_outcome(
+        self,
+        topic: str,
+        message: Message,
+        headers: dict[str, str],
+        error: Exception,
+    ) -> MessageOutcome:
+        """Decide what happens to the offset of a message the handlers refused.
+
+        The offset may only advance once the failure is stored somewhere else. If
+        the dead-letter record never reached the broker, committing would destroy
+        the only remaining copy of the event, so the message is kept for another
+        attempt instead.
+        """
+        if self._send_to_dead_letter(topic, message, headers, error):
+            return MessageOutcome.PROCESSED
+        return MessageOutcome.RETRYABLE
+
+    def _commit_offset(self, message: Message) -> None:
+        """Advance the committed offset past `message`.
+
+        A commit can be rejected while the consumer group rebalances or the
+        broker is unreachable. Letting that escape would end the poll loop and
+        stop every subscription this consumer owns, so the rejection is logged
+        and the next processed message commits a higher offset in its place.
+        """
+        try:
+            committed = self.consumer.commit(message=message, asynchronous=False)
+        except KafkaException as error:
+            logger.error(
+                f"Offset commit failed for event type {message.topic()}: {error}"
+            )
+            return
+        for position in committed:
+            if position.error is not None:
+                logger.error(
+                    f"Offset commit rejected for {position.topic} "
+                    f"[{position.partition}]: {position.error}"
+                )
+
+    def _rewind_to(self, position: TopicPartition) -> None:
+        """Move the consume position back so the next poll returns that message.
+
+        Leaving the offset uncommitted is not enough on its own: the consumer's
+        in-memory position has already moved past the message, so the next
+        message that succeeds would commit an offset beyond the failed one and
+        the failure would never come back.
+        """
+        try:
+            self.consumer.seek(position)
+        except KafkaException as error:
+            logger.error(
+                f"Cannot rewind {position.topic} [{position.partition}] to offset "
+                f"{position.offset}, message is not retryable: {error}"
+            )
+
+    def _dispatch_to_handlers(
+        self,
+        message: Message,
+        topic: str,
+        event_type: type[AbstractEvent],
+        headers: dict[str, str],
+    ) -> MessageOutcome:
+        """Run every handler registered for one polled message.
+
+        Returns:
+            `PROCESSED` when the consumer is done with the message, `RETRYABLE`
+            when the message must be delivered again.
+
+        Raises:
+            AuthVerificationProviderUnavailableError: Snapshot verification is
+                unavailable, which is not a verdict about this message.
+            AuthRequirementProviderUnavailableError: Authorization data is
+                unavailable, which is not a verdict about this message.
+        """
+        event_message: bytes | None = message.value()
+        if event_message is None:
+            logger.warning(f"Received empty message for event type: {topic}")
+            return MessageOutcome.PROCESSED
+        try:
+            event_data = self.type_adapters[event_type].validate_json(event_message)
+        except ValidationError as error:
+            # 역직렬화 실패는 같은 본문으로 재시도해도 결과가 같으므로 즉시 보낸다.
+            logger.error(f"Cannot deserialize message from topic {topic}: {error}")
+            return self._dead_letter_outcome(topic, message, headers, error)
+        remaining_retries = self.config.max_handler_retries
+        while True:
+            try:
+                self._invoke_handlers(event_type, event_data, headers)
+                return MessageOutcome.PROCESSED
+            except (
+                AuthVerificationProviderUnavailableError,
+                AuthRequirementProviderUnavailableError,
+            ):
+                raise
+            except (AuthContextNotFoundError, AuthRequirementDeniedError) as error:
+                logger.warning(
+                    f"Auth boundary refused message for event type {topic}, "
+                    f"discarding it: {error}"
+                )
+                return MessageOutcome.PROCESSED
+            except Exception as error:
+                if remaining_retries == 0:
+                    logger.error(
+                        f"Error processing message for event type {topic}: {error}"
+                    )
+                    return self._dead_letter_outcome(topic, message, headers, error)
+                remaining_retries -= 1
+                logger.warning(
+                    f"Retrying message for event type {topic} after error: {error}"
+                )
+
     def _route_event_handler(self, message: Message) -> None:
         if message.error():  # pragma: no cover - Kafka 브로커 에러 콜백
             logger.error(f"Consumer error: {message.error()}")
             return
         topic: str | None = message.topic()
-        if topic is None:  # pragma: no cover - Kafka 메시지 비정상 상태
-            logger.warning("Received message with no topic.")
+        partition: int | None = message.partition()
+        offset: int | None = message.offset()
+        if (  # pragma: no cover - Kafka 메시지 비정상 상태
+            topic is None or partition is None or offset is None
+        ):
+            logger.warning("Received message with no topic, partition or offset.")
             return
         event_type: type[AbstractEvent] | None = self.type_lookup.get(topic)
         if event_type is None:  # pragma: no cover - 미등록 이벤트 타입 수신 방어
@@ -228,40 +383,14 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
             ctx = parent.child() if parent is not None else TraceContext.new_root()
             TraceContext.set(ctx)
         try:
-            event_message: bytes | None = message.value()
-            if event_message is None:  # pragma: no cover - Kafka 메시지 본문 누락 방어
-                logger.warning(f"Received empty message for event type: {topic}")
-                return
-            try:
-                event_data = self.type_adapters[event_type].validate_json(event_message)
-            except ValidationError as error:
-                # 역직렬화 실패는 같은 본문으로 재시도해도 결과가 같으므로 즉시 보낸다.
-                logger.error(f"Cannot deserialize message from topic {topic}: {error}")
-                self._send_to_dead_letter(topic, message, headers, error)
-                return
-            remaining_retries = self.config.max_handler_retries
-            while True:
-                try:
-                    self._invoke_handlers(event_type, event_data, headers)
-                    return
-                except (
-                    AuthVerificationProviderUnavailableError,
-                    AuthRequirementProviderUnavailableError,
-                ):
-                    raise
-                except (AuthContextNotFoundError, AuthRequirementDeniedError):
-                    return
-                except Exception as error:
-                    if remaining_retries == 0:
-                        logger.error(
-                            f"Error processing message for event type {topic}: {error}"
-                        )
-                        self._send_to_dead_letter(topic, message, headers, error)
-                        return
-                    remaining_retries -= 1
-                    logger.warning(
-                        f"Retrying message for event type {topic} after error: {error}"
-                    )
+            outcome = self._dispatch_to_handlers(message, topic, event_type, headers)
+            match outcome:
+                case MessageOutcome.PROCESSED:
+                    self._commit_offset(message)
+                case (
+                    MessageOutcome.RETRYABLE
+                ):  # pragma: no branch - 전수 분기, 미매치 불가
+                    self._rewind_to(TopicPartition(topic, partition, offset))
         finally:
             if self._propagator is not None:
                 TraceContext.clear()
@@ -287,7 +416,7 @@ class KafkaEventConsumer(IEventConsumer, AbstractBackgroundService):
         topics: list[str] = [
             _event_routing_name(event_type) for event_type in self.handlers.keys()
         ]
-        self.producer = Producer(self.config.configuration_dict, logger=logger)
+        self.producer = Producer(self.config.producer_configuration_dict, logger=logger)
         self._create_topics(
             topics=topics
             + [f"{topic}{self.config.dead_letter_topic_suffix}" for topic in topics]
@@ -341,7 +470,7 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
         self.handlers = {}
         self._propagator = None
         self._auth_boundary_handlers = set()
-        self.admin = AdminClient(self.config.configuration_dict)
+        self.admin = AdminClient(self.config.connection_configuration_dict)
 
     def set_propagator(self, propagator: ITracePropagator) -> None:
         """Set the trace propagator for extracting trace context from messages.
@@ -408,7 +537,7 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
         message: Message,
         headers: dict[str, str],
         error: Exception,
-    ) -> None:
+    ) -> bool:
         """Forward a message the handlers could not process to its dead-letter topic.
 
         The original body and key are forwarded unchanged and the decoded original
@@ -422,6 +551,13 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
             message: The Kafka message that could not be processed.
             headers: Decoded headers of the original message.
             error: Exception that ended the last processing attempt.
+
+        Returns:
+            Whether the dead-letter record is confirmed at the broker. `False`
+            means the failure may be stored nowhere, so the caller must keep the
+            original message rather than commit its offset. An unconfirmed
+            timeout also reports `False`: keeping the message can duplicate the
+            dead-letter record, which is the recoverable direction.
         """
         _, original_timestamp = message.timestamp()
         dead_letter_headers: dict[str, str] = {
@@ -456,8 +592,11 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
                 f"{self.config.dead_letter_delivery_timeout}s; "
                 "it may still be delivered"
             )
+            return False
         except Exception as delivery_error:
             logger.error(f"Dead-letter delivery failed for {topic}: {delivery_error}")
+            return False
+        return True
 
     async def _invoke_handlers(
         self,
@@ -471,13 +610,131 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
                 continue
             await handler(event_data)
 
+    async def _dead_letter_outcome(
+        self,
+        topic: str,
+        message: Message,
+        headers: dict[str, str],
+        error: Exception,
+    ) -> MessageOutcome:
+        """Decide what happens to the offset of a message the handlers refused.
+
+        The offset may only advance once the failure is stored somewhere else. If
+        the dead-letter record is not confirmed at the broker, committing would
+        destroy the only remaining copy of the event, so the message is kept for
+        another attempt instead.
+        """
+        if await self._send_to_dead_letter(topic, message, headers, error):
+            return MessageOutcome.PROCESSED
+        return MessageOutcome.RETRYABLE
+
+    async def _commit_offset(self, message: Message) -> None:
+        """Advance the committed offset past `message`.
+
+        A commit can be rejected while the consumer group rebalances or the
+        broker is unreachable. Letting that escape would end the polling task and
+        stop every subscription this consumer owns, so the rejection is logged
+        and the next processed message commits a higher offset in its place.
+        """
+        try:
+            committed = await self.consumer.commit(message=message, asynchronous=False)
+        except KafkaException as error:
+            logger.error(
+                f"Offset commit failed for event type {message.topic()}: {error}"
+            )
+            return
+        for position in committed:
+            if position.error is not None:
+                logger.error(
+                    f"Offset commit rejected for {position.topic} "
+                    f"[{position.partition}]: {position.error}"
+                )
+
+    async def _rewind_to(self, position: TopicPartition) -> None:
+        """Move the consume position back so the next poll returns that message.
+
+        Leaving the offset uncommitted is not enough on its own: the consumer's
+        in-memory position has already moved past the message, so the next
+        message that succeeds would commit an offset beyond the failed one and
+        the failure would never come back.
+        """
+        try:
+            await self.consumer.seek(position)
+        except KafkaException as error:
+            logger.error(
+                f"Cannot rewind {position.topic} [{position.partition}] to offset "
+                f"{position.offset}, message is not retryable: {error}"
+            )
+
+    async def _dispatch_to_handlers(
+        self,
+        message: Message,
+        topic: str,
+        event_type: type[AbstractEvent],
+        headers: dict[str, str],
+    ) -> MessageOutcome:
+        """Run every handler registered for one polled message.
+
+        Returns:
+            `PROCESSED` when the consumer is done with the message, `RETRYABLE`
+            when the message must be delivered again.
+
+        Raises:
+            AuthVerificationProviderUnavailableError: Snapshot verification is
+                unavailable, which is not a verdict about this message.
+            AuthRequirementProviderUnavailableError: Authorization data is
+                unavailable, which is not a verdict about this message.
+        """
+        event_message: bytes | None = message.value()
+        if event_message is None:
+            logger.warning(f"Received empty message for event type: {topic}")
+            return MessageOutcome.PROCESSED
+        try:
+            event_data = self.type_adapters[event_type].validate_json(event_message)
+        except ValidationError as error:
+            # 역직렬화 실패는 같은 본문으로 재시도해도 결과가 같으므로 즉시 보낸다.
+            logger.error(f"Cannot deserialize message from topic {topic}: {error}")
+            return await self._dead_letter_outcome(topic, message, headers, error)
+        remaining_retries = self.config.max_handler_retries
+        while True:
+            try:
+                await self._invoke_handlers(event_type, event_data, headers)
+                return MessageOutcome.PROCESSED
+            except (
+                AuthVerificationProviderUnavailableError,
+                AuthRequirementProviderUnavailableError,
+            ):
+                raise
+            except (AuthContextNotFoundError, AuthRequirementDeniedError) as error:
+                logger.warning(
+                    f"Auth boundary refused message for event type {topic}, "
+                    f"discarding it: {error}"
+                )
+                return MessageOutcome.PROCESSED
+            except Exception as error:
+                if remaining_retries == 0:
+                    logger.error(
+                        f"Error processing message for event type {topic}: {error}"
+                    )
+                    return await self._dead_letter_outcome(
+                        topic, message, headers, error
+                    )
+                remaining_retries -= 1
+                logger.warning(
+                    f"Retrying message for event type {topic} after error: {error}"
+                )
+
     async def _route_event_handler(self, message: Message) -> None:
         if message.error():  # pragma: no cover - Kafka 브로커 에러 콜백
             logger.error(f"Consumer error: {message.error()}")
             return
         topic: str | None = message.topic()
-        if topic is None:  # pragma: no cover - Kafka 메시지 비정상 상태
-            logger.warning("Received message with no topic.")
+        partition: int | None = message.partition()
+        offset: int | None = message.offset()
+        if (  # pragma: no cover - Kafka 메시지 비정상 상태
+            topic is None or partition is None or offset is None
+        ):
+            logger.warning("Received message with no topic, partition or offset.")
             return
         event_type: type[AbstractEvent] | None = self.type_lookup.get(topic)
         if event_type is None:  # pragma: no cover - 미등록 이벤트 타입 수신 방어
@@ -490,40 +747,16 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
             ctx = parent.child() if parent is not None else TraceContext.new_root()
             TraceContext.set(ctx)
         try:
-            event_message: bytes | None = message.value()
-            if event_message is None:  # pragma: no cover - Kafka 메시지 본문 누락 방어
-                logger.warning(f"Received empty message for event type: {topic}")
-                return
-            try:
-                event_data = self.type_adapters[event_type].validate_json(event_message)
-            except ValidationError as error:
-                # 역직렬화 실패는 같은 본문으로 재시도해도 결과가 같으므로 즉시 보낸다.
-                logger.error(f"Cannot deserialize message from topic {topic}: {error}")
-                await self._send_to_dead_letter(topic, message, headers, error)
-                return
-            remaining_retries = self.config.max_handler_retries
-            while True:
-                try:
-                    await self._invoke_handlers(event_type, event_data, headers)
-                    return
-                except (
-                    AuthVerificationProviderUnavailableError,
-                    AuthRequirementProviderUnavailableError,
-                ):
-                    raise
-                except (AuthContextNotFoundError, AuthRequirementDeniedError):
-                    return
-                except Exception as error:
-                    if remaining_retries == 0:
-                        logger.error(
-                            f"Error processing message for event type {topic}: {error}"
-                        )
-                        await self._send_to_dead_letter(topic, message, headers, error)
-                        return
-                    remaining_retries -= 1
-                    logger.warning(
-                        f"Retrying message for event type {topic} after error: {error}"
-                    )
+            outcome = await self._dispatch_to_handlers(
+                message, topic, event_type, headers
+            )
+            match outcome:
+                case MessageOutcome.PROCESSED:
+                    await self._commit_offset(message)
+                case (
+                    MessageOutcome.RETRYABLE
+                ):  # pragma: no branch - 전수 분기, 미매치 불가
+                    await self._rewind_to(TopicPartition(topic, partition, offset))
         finally:
             if self._propagator is not None:
                 TraceContext.clear()
@@ -546,7 +779,7 @@ class AsyncKafkaEventConsumer(IAsyncEventConsumer, AbstractAsyncBackgroundServic
     @override
     async def initialize_async(self) -> None:
         """Create Kafka topics, open the dead-letter producer, and subscribe."""
-        self.consumer = AIOConsumer(self.config.configuration_dict)
+        self.consumer = AIOConsumer(self.config.consumer_configuration_dict)
         self.producer = AIOKafkaProducer(
             **self.config.async_producer_configuration_dict
         )

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/event/transport.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/event/transport.py
@@ -27,8 +27,11 @@ class KafkaEventTransport(IEventTransport):
     def __init__(self, config: KafkaConnectionConfig) -> None:
         """Initialize the Kafka producer with connection config."""
         self.config = config
-        self.admin = AdminClient(self.config.configuration_dict)
-        self.producer = Producer(self.config.configuration_dict, logger=logger)
+        self.admin = AdminClient(self.config.connection_configuration_dict)
+        self.producer = Producer(
+            self.config.producer_configuration_dict,
+            logger=logger,
+        )
 
     def _create_topic(self, topic: str) -> None:
         existing_topics: set[str] = set(self.admin.list_topics().topics.keys())
@@ -93,7 +96,7 @@ class AsyncKafkaEventTransport(IAsyncEventTransport):
     def __init__(self, config: KafkaConnectionConfig) -> None:
         """Initialize the async Kafka transport with connection config."""
         self.config = config
-        self.admin = AdminClient(self.config.configuration_dict)
+        self.admin = AdminClient(self.config.connection_configuration_dict)
 
     def _create_topic(  # pragma: no cover - Kafka 브로커 콜백으로 커버리지 수집 불가
         self, topic: str

--- a/plugins/spakky-kafka/tests/unit/test_config.py
+++ b/plugins/spakky-kafka/tests/unit/test_config.py
@@ -106,28 +106,111 @@ def test_kafka_config_default_values(clean_env: None) -> None:
     assert config.dead_letter_delivery_timeout == 10.0
 
 
-def test_kafka_config_configuration_dict_basic(clean_env: None) -> None:
-    """configuration_dict가 올바른 기본 설정 딕셔너리를 반환하는지 검증한다."""
+def test_kafka_config_connection_configuration_dict_basic(clean_env: None) -> None:
+    """connection_configuration_dict가 클러스터 접속 설정만 담는지 검증한다."""
     environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "my-group"
     environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "my-client"
     environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = "localhost:9092"
     environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}AUTO_OFFSET_RESET"] = "earliest"
 
     config = KafkaConnectionConfig()
-    config_dict = config.configuration_dict
+    config_dict = config.connection_configuration_dict
 
-    assert config_dict["group.id"] == "my-group"
     assert config_dict["client.id"] == "my-client"
     assert config_dict["bootstrap.servers"] == "localhost:9092"
-    assert config_dict["auto.offset.reset"] == "earliest"
+    assert "group.id" not in config_dict
+    assert "auto.offset.reset" not in config_dict
     assert "security.protocol" not in config_dict
     assert "sasl.mechanism" not in config_dict
     assert "sasl.username" not in config_dict
     assert "sasl.password" not in config_dict
 
 
-def test_kafka_config_configuration_dict_with_sasl(clean_env: None) -> None:
-    """SASL 설정이 구성된 경우 configuration_dict에 SASL 설정이 포함되는지 검증한다."""
+def test_kafka_config_producer_configuration_dict_expect_idempotent_delivery(
+    clean_env: None,
+) -> None:
+    """producer_configuration_dict가 중복·재정렬을 막는 기본값을 고정하는지 검증한다."""
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "my-group"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "my-client"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = "localhost:9092"
+
+    config = KafkaConnectionConfig()
+    config_dict = config.producer_configuration_dict
+
+    assert config_dict["enable.idempotence"] is True
+    assert config_dict["acks"] == "all"
+    assert config_dict["client.id"] == "my-client"
+    assert config_dict["bootstrap.servers"] == "localhost:9092"
+    assert "group.id" not in config_dict
+    assert "enable.auto.commit" not in config_dict
+
+
+def test_kafka_config_consumer_configuration_dict_expect_manual_offset_commit(
+    clean_env: None,
+) -> None:
+    """consumer_configuration_dict가 자동 커밋을 끄고 소비 그룹 설정을 담는지 검증한다."""
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "my-group"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "my-client"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = "localhost:9092"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}AUTO_OFFSET_RESET"] = "earliest"
+
+    config = KafkaConnectionConfig()
+    config_dict = config.consumer_configuration_dict
+
+    assert config_dict["enable.auto.commit"] is False
+    assert config_dict["group.id"] == "my-group"
+    assert config_dict["auto.offset.reset"] == "earliest"
+    assert config_dict["client.id"] == "my-client"
+    assert config_dict["bootstrap.servers"] == "localhost:9092"
+    assert "enable.idempotence" not in config_dict
+
+
+def test_kafka_config_async_producer_configuration_dict_expect_idempotent_delivery(
+    clean_env: None,
+) -> None:
+    """async_producer_configuration_dict가 aiokafka 키 이름으로 같은 보장을 담는지 검증한다."""
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "my-group"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "my-client"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = "localhost:9092"
+
+    config = KafkaConnectionConfig()
+
+    assert config.async_producer_configuration_dict == {
+        "bootstrap_servers": "localhost:9092",
+        "client_id": "my-client",
+        "enable_idempotence": True,
+        "acks": "all",
+    }
+
+
+def test_kafka_config_async_producer_configuration_dict_with_sasl(
+    clean_env: None,
+) -> None:
+    """async_producer_configuration_dict가 SASL 설정을 aiokafka 키로 전달하는지 검증한다."""
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "secure-group"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "secure-client"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = "secure:9093"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SECURITY_PROTOCOL"] = "SASL_SSL"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SASL_MECHANISM"] = "PLAIN"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SASL_USERNAME"] = "api-key"
+    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SASL_PASSWORD"] = "api-secret"
+
+    config = KafkaConnectionConfig()
+
+    assert config.async_producer_configuration_dict == {
+        "bootstrap_servers": "secure:9093",
+        "client_id": "secure-client",
+        "enable_idempotence": True,
+        "acks": "all",
+        "security_protocol": "SASL_SSL",
+        "sasl_mechanism": "PLAIN",
+        "sasl_plain_username": "api-key",
+        "sasl_plain_password": "api-secret",
+    }
+
+
+def test_kafka_config_connection_configuration_dict_with_sasl(clean_env: None) -> None:
+    """SASL 설정이 구성된 경우 connection_configuration_dict에 포함되는지 검증한다."""
     environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "secure-group"
     environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "secure-client"
     environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = (
@@ -140,7 +223,7 @@ def test_kafka_config_configuration_dict_with_sasl(clean_env: None) -> None:
     environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}AUTO_OFFSET_RESET"] = "latest"
 
     config = KafkaConnectionConfig()
-    config_dict = config.configuration_dict
+    config_dict = config.connection_configuration_dict
 
     assert config_dict["security.protocol"] == "SASL_SSL"
     assert config_dict["sasl.mechanism"] == "SCRAM-SHA-256"
@@ -158,7 +241,9 @@ def test_kafka_config_auto_offset_reset_values(clean_env: None) -> None:
         environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}AUTO_OFFSET_RESET"] = reset_type.value
         config = KafkaConnectionConfig()
         assert config.auto_offset_reset == reset_type
-        assert config.configuration_dict["auto.offset.reset"] == reset_type.value
+        assert (
+            config.consumer_configuration_dict["auto.offset.reset"] == reset_type.value
+        )
 
 
 def test_kafka_config_with_custom_partitions_and_replication(clean_env: None) -> None:
@@ -213,46 +298,6 @@ def test_kafka_config_with_empty_dead_letter_topic_suffix_expect_rejected(
 
     with pytest.raises(ValidationError):
         KafkaConnectionConfig()
-
-
-def test_kafka_config_async_producer_configuration_dict_with_sasl(
-    clean_env: None,
-) -> None:
-    """비동기 producer 설정이 aiokafka 키워드로 SASL 자격까지 전달하는지 검증한다."""
-    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "test-group"
-    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "secure-client"
-    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = "secure:9093"
-    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SECURITY_PROTOCOL"] = "SASL_SSL"
-    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SASL_MECHANISM"] = "PLAIN"
-    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SASL_USERNAME"] = "api-key"
-    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}SASL_PASSWORD"] = "api-secret"
-
-    config = KafkaConnectionConfig()
-
-    assert config.async_producer_configuration_dict == {
-        "bootstrap_servers": "secure:9093",
-        "client_id": "secure-client",
-        "security_protocol": "SASL_SSL",
-        "sasl_mechanism": "PLAIN",
-        "sasl_plain_username": "api-key",
-        "sasl_plain_password": "api-secret",
-    }
-
-
-def test_kafka_config_async_producer_configuration_dict_without_sasl(
-    clean_env: None,
-) -> None:
-    """SASL 미설정 환경에서는 연결 정보만 aiokafka 키워드로 전달한다."""
-    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}GROUP_ID"] = "test-group"
-    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}CLIENT_ID"] = "plain-client"
-    environ[f"{SPAKKY_KAFKA_CONFIG_ENV_PREFIX}BOOTSTRAP_SERVERS"] = "localhost:9092"
-
-    config = KafkaConnectionConfig()
-
-    assert config.async_producer_configuration_dict == {
-        "bootstrap_servers": "localhost:9092",
-        "client_id": "plain-client",
-    }
 
 
 def test_kafka_config_env_prefix_is_correct() -> None:

--- a/plugins/spakky-kafka/tests/unit/test_consumer.py
+++ b/plugins/spakky-kafka/tests/unit/test_consumer.py
@@ -116,7 +116,7 @@ def test_sync_consumer_init_expect_success(
     assert consumer.type_lookup == {}
     assert consumer.type_adapters == {}
     assert consumer.handlers == {}
-    mock_admin_cls.assert_called_once_with(config.configuration_dict)
+    mock_admin_cls.assert_called_once_with(config.connection_configuration_dict)
     mock_consumer_cls.assert_called_once()
 
 
@@ -506,12 +506,13 @@ def test_async_consumer_init_expect_success(
 ) -> None:
     """비동기 AsyncKafkaEventConsumer가 올바르게 초기화되는지 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
 
     assert consumer.config is config
     assert consumer.type_lookup == {}
     assert consumer.type_adapters == {}
     assert consumer.handlers == {}
-    mock_admin_cls.assert_called_once_with(config.configuration_dict)
+    mock_admin_cls.assert_called_once_with(config.connection_configuration_dict)
 
 
 @patch("spakky.plugins.kafka.event.consumer.AdminClient")
@@ -521,6 +522,7 @@ def test_async_consumer_register_expect_handler_stored(
 ) -> None:
     """비동기 consumer의 register가 핸들러를 올바르게 저장하는지 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     handler = AsyncMock()
 
     consumer.register(SampleEvent, handler)
@@ -538,6 +540,7 @@ def test_async_consumer_register_custom_event_name_expect_topic_lookup(
 ) -> None:
     """Async custom event_name 등록도 outbound topic identity를 사용한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     handler = AsyncMock()
 
     consumer.register(RenamedEvent, handler)
@@ -553,6 +556,7 @@ def test_async_consumer_register_multiple_handlers_expect_all_stored(
 ) -> None:
     """비동기 consumer에 동일 이벤트에 복수 핸들러 등록이 가능한지 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     handler1 = AsyncMock()
     handler2 = AsyncMock()
 
@@ -570,6 +574,7 @@ def test_async_consumer_register_auth_boundary_expect_handler_marked(
     """Async consumer records auth-aware endpoints for header delivery."""
     del mock_admin_cls
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     handler = AsyncMock()
 
     consumer.register(SampleEvent, handler)
@@ -588,6 +593,7 @@ async def test_async_consumer_auth_boundary_handler_receives_headers(
     """Auth-aware async endpoints receive Kafka headers from consumer."""
     del mock_admin_cls
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     captured_headers: list[dict[str, str] | None] = []
 
     async def handler(
@@ -619,6 +625,7 @@ def test_async_consumer_create_topics_expect_topics_created(
     mock_admin_cls.return_value = mock_admin
 
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     consumer._create_topics(["topic1"])
 
     mock_admin.create_topics.assert_called_once()
@@ -644,6 +651,7 @@ async def test_async_consumer_initialize_async_expect_subscribe(
     mock_aio_consumer_cls.return_value = mock_aio_consumer
 
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     consumer.register(SampleEvent, AsyncMock())
 
     await consumer.initialize_async()
@@ -669,6 +677,7 @@ async def test_async_consumer_initialize_async_expect_dead_letter_topic_created(
     mock_aio_consumer_cls.return_value = AsyncMock()
 
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     consumer.register(SampleEvent, AsyncMock())
 
     await consumer.initialize_async()
@@ -697,6 +706,7 @@ async def test_async_consumer_initialize_custom_event_name_expect_subscribe_to_e
     mock_aio_consumer_cls.return_value = mock_aio_consumer
 
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     consumer.register(RenamedEvent, AsyncMock())
 
     await consumer.initialize_async()
@@ -777,6 +787,7 @@ async def test_async_consumer_route_with_traceparent_expect_child_context_set(
 ) -> None:
     """비동기 consumer에서 traceparent 헤더가 있으면 child TraceContext가 활성화됨을 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     consumer.set_propagator(W3CTracePropagator())
 
     captured_ctx: list[TraceContext | None] = []
@@ -843,6 +854,7 @@ async def test_async_consumer_route_without_propagator_expect_no_trace_context(
 ) -> None:
     """비동기 consumer에서 propagator 미설정 시 TraceContext가 설정되지 않음을 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
 
     captured_ctx: list[TraceContext | None] = []
 
@@ -905,6 +917,7 @@ async def test_async_consumer_route_with_none_headers_expect_new_root_trace(
 ) -> None:
     """비동기 consumer에서 headers가 None이면 new root TraceContext가 생성됨을 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     consumer.set_propagator(W3CTracePropagator())
 
     captured_ctx: list[TraceContext | None] = []
@@ -968,6 +981,7 @@ async def test_async_consumer_route_with_empty_headers_expect_new_root_trace(
 ) -> None:
     """비동기 consumer에서 headers가 빈 리스트이면 new root TraceContext가 생성됨을 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     consumer.set_propagator(W3CTracePropagator())
 
     captured_ctx: list[TraceContext | None] = []
@@ -1024,6 +1038,7 @@ async def test_async_consumer_route_trace_context_cleared_after_handler(
 ) -> None:
     """비동기 consumer에서 핸들러 완료 후 TraceContext가 정리됨을 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
     consumer.set_propagator(W3CTracePropagator())
     consumer.register(SampleEvent, AsyncMock())
 
@@ -1080,6 +1095,7 @@ async def test_async_consumer_route_handler_exception_expect_trace_context_clear
     """비동기 consumer에서 핸들러 예외 시에도 TraceContext가 정리됨을 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
     consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
     consumer.set_propagator(W3CTracePropagator())
 
     async def raising_handler(event: SampleEvent) -> None:
@@ -1164,6 +1180,7 @@ def test_async_consumer_to_string_headers_with_bytes_expect_decoded(
 ) -> None:
     """비동기 consumer의 _to_string_headers가 bytes 값을 문자열로 디코딩하는지 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
 
     result = consumer._to_string_headers(
         [
@@ -1182,6 +1199,7 @@ def test_async_consumer_to_string_headers_with_mixed_values_expect_str_and_bytes
 ) -> None:
     """비동기 consumer의 _to_string_headers가 str, bytes, None 혼합 값을 올바르게 처리하는지 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
 
     result = consumer._to_string_headers(
         [
@@ -1201,6 +1219,7 @@ def test_async_consumer_to_string_headers_with_none_expect_empty(
 ) -> None:
     """비동기 consumer의 _to_string_headers가 None 입력에 빈 dict를 반환하는지 검증한다."""
     consumer = AsyncKafkaEventConsumer(config)
+    consumer.consumer = AsyncMock()
 
     result = consumer._to_string_headers(None)
 
@@ -1433,6 +1452,7 @@ async def test_async_consumer_route_undeserializable_message_expect_dead_letter_
     del mock_admin_cls
     consumer = AsyncKafkaEventConsumer(config)
     consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
     handler = AsyncMock()
     consumer.register(SampleEvent, handler)
     incoming_message.value.return_value = b"not-an-event"
@@ -1459,6 +1479,7 @@ async def test_async_consumer_route_failing_handler_expect_dead_letter_with_orig
     del mock_admin_cls
     consumer = AsyncKafkaEventConsumer(config)
     consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
     consumer.register(SampleEvent, async_failing_handler)
 
     await consumer._route_event_handler(incoming_message)
@@ -1484,6 +1505,7 @@ async def test_async_consumer_route_rejected_dead_letter_expect_error_logged(
     del mock_admin_cls
     consumer = AsyncKafkaEventConsumer(config)
     consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
     consumer.producer.send_and_wait.side_effect = KafkaTimeoutError(
         "broker unreachable"
     )
@@ -1508,6 +1530,7 @@ async def test_async_consumer_route_failing_handler_with_retries_expect_retried_
         config.model_copy(update={"max_handler_retries": 2})
     )
     consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
     attempts: list[SampleEvent] = []
 
     async def counting_failing_handler(event: SampleEvent) -> None:
@@ -1533,6 +1556,7 @@ async def test_async_consumer_route_successful_handler_expect_no_dead_letter(
     del mock_admin_cls
     consumer = AsyncKafkaEventConsumer(config)
     consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
     consumer.register(SampleEvent, AsyncMock())
 
     await consumer._route_event_handler(incoming_message)
@@ -1551,6 +1575,7 @@ async def test_async_consumer_auth_deny_expect_no_dead_letter(
     del mock_admin_cls
     consumer = AsyncKafkaEventConsumer(config)
     consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
 
     async def denying_handler(event: SampleEvent) -> None:
         del event
@@ -1574,6 +1599,7 @@ async def test_async_consumer_provider_unavailable_expect_propagated(
     del mock_admin_cls
     consumer = AsyncKafkaEventConsumer(config)
     consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
 
     async def unavailable_handler(event: SampleEvent) -> None:
         del event
@@ -1648,6 +1674,7 @@ async def test_async_consumer_route_unconfirmed_dead_letter_expect_duplicate_war
         config.model_copy(update={"dead_letter_delivery_timeout": 0.01})
     )
     consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
 
     async def never_confirming_send(**kwargs: Any) -> None:
         del kwargs
@@ -1661,3 +1688,342 @@ async def test_async_consumer_route_unconfirmed_dead_letter_expect_duplicate_war
 
     assert "unconfirmed after" in caplog.text
     assert "may still be delivered" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Offset commit policy — at-least-once delivery
+# ---------------------------------------------------------------------------
+
+
+def accepted_commit() -> list[MagicMock]:
+    """Commit result stub in which every partition was accepted."""
+    position = MagicMock()
+    position.error = None
+    return [position]
+
+
+def rejected_commit() -> list[MagicMock]:
+    """Commit result stub in which the broker refused one partition."""
+    position = MagicMock()
+    position.topic = "SampleEvent"
+    position.partition = 3
+    position.error = KafkaError(KafkaError.REBALANCE_IN_PROGRESS)
+    return [position]
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_successful_handler_expect_offset_committed(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """핸들러가 성공하면 그 메시지의 offset을 동기 커밋한다."""
+    del mock_admin_cls
+    inner_consumer = MagicMock()
+    inner_consumer.commit.return_value = accepted_commit()
+    mock_consumer_cls.return_value = inner_consumer
+
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = delivering_producer()
+    consumer.register(SampleEvent, MagicMock())
+
+    consumer._route_event_handler(incoming_message)
+
+    inner_consumer.commit.assert_called_once_with(
+        message=incoming_message, asynchronous=False
+    )
+    inner_consumer.seek.assert_not_called()
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_dead_lettered_failure_expect_offset_committed(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """dead-letter 발행이 성공하면 실패한 메시지의 offset을 커밋해 파티션을 진행시킨다."""
+    del mock_admin_cls
+    inner_consumer = MagicMock()
+    inner_consumer.commit.return_value = accepted_commit()
+    mock_consumer_cls.return_value = inner_consumer
+
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = delivering_producer()
+    consumer.register(SampleEvent, failing_handler)
+
+    consumer._route_event_handler(incoming_message)
+
+    inner_consumer.commit.assert_called_once()
+    inner_consumer.seek.assert_not_called()
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_undelivered_dead_letter_expect_position_rewound(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """dead-letter 발행이 실패하면 커밋하지 않고 소비 위치를 되감아 원본을 지킨다."""
+    del mock_admin_cls
+    inner_consumer = MagicMock()
+    mock_consumer_cls.return_value = inner_consumer
+
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = MagicMock()
+    consumer.producer.flush.return_value = 1
+    consumer.register(SampleEvent, failing_handler)
+
+    consumer._route_event_handler(incoming_message)
+
+    inner_consumer.commit.assert_not_called()
+    rewound = inner_consumer.seek.call_args[0][0]
+    assert rewound.topic == "SampleEvent"
+    assert rewound.partition == 3
+    assert rewound.offset == 42
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_commit_failure_expect_poll_loop_survives(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """커밋이 KafkaException으로 실패해도 예외가 poll 루프를 죽이지 않는다."""
+    del mock_admin_cls
+    inner_consumer = MagicMock()
+    inner_consumer.commit.side_effect = KafkaException("broker unreachable")
+    mock_consumer_cls.return_value = inner_consumer
+
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = delivering_producer()
+    consumer.register(SampleEvent, MagicMock())
+
+    with caplog.at_level(logging.ERROR):
+        consumer._route_event_handler(incoming_message)
+
+    assert "Offset commit failed for event type SampleEvent" in caplog.text
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_commit_rejected_partition_expect_error_logged(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """파티션별 커밋 거부는 예외가 아닌 반환값으로 오므로 로그로 드러낸다."""
+    del mock_admin_cls
+    inner_consumer = MagicMock()
+    inner_consumer.commit.return_value = rejected_commit()
+    mock_consumer_cls.return_value = inner_consumer
+
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = delivering_producer()
+    consumer.register(SampleEvent, MagicMock())
+
+    with caplog.at_level(logging.ERROR):
+        consumer._route_event_handler(incoming_message)
+
+    assert "Offset commit rejected for SampleEvent [3]" in caplog.text
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_rewind_failure_expect_poll_loop_survives(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """되감기가 실패하면 재처리 불가 사실을 로그로 남기고 루프를 지킨다."""
+    del mock_admin_cls
+    inner_consumer = MagicMock()
+    inner_consumer.seek.side_effect = KafkaException("partition not assigned")
+    mock_consumer_cls.return_value = inner_consumer
+
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = MagicMock()
+    consumer.producer.flush.return_value = 1
+    consumer.register(SampleEvent, failing_handler)
+
+    with caplog.at_level(logging.ERROR):
+        consumer._route_event_handler(incoming_message)
+
+    assert "is not retryable" in caplog.text
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_successful_handler_expect_offset_committed(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """비동기 핸들러가 성공하면 그 메시지의 offset을 커밋한다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
+    consumer.consumer.commit.return_value = accepted_commit()
+    consumer.register(SampleEvent, AsyncMock())
+
+    await consumer._route_event_handler(incoming_message)
+
+    consumer.consumer.commit.assert_awaited_once_with(
+        message=incoming_message, asynchronous=False
+    )
+    consumer.consumer.seek.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_unconfirmed_dead_letter_expect_position_rewound(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """dead-letter 확인이 불가하면 커밋하지 않고 소비 위치를 되감아 원본을 지킨다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
+    consumer.producer.send_and_wait.side_effect = KafkaTimeoutError(
+        "broker unreachable"
+    )
+    consumer.consumer = AsyncMock()
+    consumer.register(SampleEvent, async_failing_handler)
+
+    await consumer._route_event_handler(incoming_message)
+
+    consumer.consumer.commit.assert_not_awaited()
+    rewound = consumer.consumer.seek.await_args[0][0]
+    assert rewound.topic == "SampleEvent"
+    assert rewound.partition == 3
+    assert rewound.offset == 42
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_commit_failure_expect_polling_task_survives(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """비동기 커밋이 KafkaException으로 실패해도 polling 태스크가 죽지 않는다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
+    consumer.consumer.commit.side_effect = KafkaException("broker unreachable")
+    consumer.register(SampleEvent, AsyncMock())
+
+    with caplog.at_level(logging.ERROR):
+        await consumer._route_event_handler(incoming_message)
+
+    assert "Offset commit failed for event type SampleEvent" in caplog.text
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_commit_rejected_partition_expect_error_logged(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """비동기 consumer도 파티션별 커밋 거부를 로그로 드러낸다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
+    consumer.consumer.commit.return_value = rejected_commit()
+    consumer.register(SampleEvent, AsyncMock())
+
+    with caplog.at_level(logging.ERROR):
+        await consumer._route_event_handler(incoming_message)
+
+    assert "Offset commit rejected for SampleEvent [3]" in caplog.text
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_rewind_failure_expect_polling_task_survives(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """비동기 되감기 실패도 로그로 남기고 polling 태스크를 지킨다."""
+    del mock_admin_cls
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
+    consumer.producer.send_and_wait.side_effect = KafkaTimeoutError(
+        "broker unreachable"
+    )
+    consumer.consumer = AsyncMock()
+    consumer.consumer.seek.side_effect = KafkaException("partition not assigned")
+    consumer.register(SampleEvent, async_failing_handler)
+
+    with caplog.at_level(logging.ERROR):
+        await consumer._route_event_handler(incoming_message)
+
+    assert "is not retryable" in caplog.text
+
+
+@patch("spakky.plugins.kafka.event.consumer.Consumer")
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+def test_sync_consumer_empty_message_expect_offset_committed_without_dead_letter(
+    mock_admin_cls: MagicMock,
+    mock_consumer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """본문 없는 메시지는 처리할 대상도 보낼 대상도 없으므로 커밋만 한다."""
+    del mock_admin_cls
+    inner_consumer = MagicMock()
+    inner_consumer.commit.return_value = accepted_commit()
+    mock_consumer_cls.return_value = inner_consumer
+    incoming_message.value.return_value = None
+
+    consumer = KafkaEventConsumer(config)
+    consumer.producer = delivering_producer()
+    consumer.register(SampleEvent, MagicMock())
+
+    consumer._route_event_handler(incoming_message)
+
+    inner_consumer.commit.assert_called_once()
+    consumer.producer.produce.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.consumer.AdminClient")
+async def test_async_consumer_empty_message_expect_offset_committed_without_dead_letter(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    incoming_message: MagicMock,
+) -> None:
+    """비동기 consumer도 본문 없는 메시지를 커밋만 하고 dead-letter로 보내지 않는다."""
+    del mock_admin_cls
+    incoming_message.value.return_value = None
+    consumer = AsyncKafkaEventConsumer(config)
+    consumer.producer = AsyncMock()
+    consumer.consumer = AsyncMock()
+    consumer.consumer.commit.return_value = accepted_commit()
+    consumer.register(SampleEvent, AsyncMock())
+
+    await consumer._route_event_handler(incoming_message)
+
+    consumer.consumer.commit.assert_awaited_once()
+    consumer.producer.send_and_wait.assert_not_awaited()

--- a/plugins/spakky-kafka/tests/unit/test_transport.py
+++ b/plugins/spakky-kafka/tests/unit/test_transport.py
@@ -49,12 +49,14 @@ def test_sync_transport_init_expect_success(
     mock_producer_cls: MagicMock,
     config: KafkaConnectionConfig,
 ) -> None:
-    """동기 KafkaEventTransport가 올바르게 초기화되는지 검증한다."""
+    """동기 KafkaEventTransport가 멱등 발행 설정으로 producer를 만드는지 검증한다."""
     transport = KafkaEventTransport(config)
 
     assert transport.config is config
-    mock_admin_cls.assert_called_once_with(config.configuration_dict)
-    mock_producer_cls.assert_called_once()
+    mock_admin_cls.assert_called_once_with(config.connection_configuration_dict)
+    producer_config = mock_producer_cls.call_args[0][0]
+    assert producer_config["enable.idempotence"] is True
+    assert producer_config["acks"] == "all"
 
 
 @patch("spakky.plugins.kafka.event.transport.Producer")
@@ -149,7 +151,7 @@ def test_async_transport_init_expect_success(
     transport = AsyncKafkaEventTransport(config)
 
     assert transport.config is config
-    mock_admin_cls.assert_called_once_with(config.configuration_dict)
+    mock_admin_cls.assert_called_once_with(config.connection_configuration_dict)
 
 
 @pytest.mark.asyncio
@@ -176,6 +178,8 @@ async def test_async_transport_send_expect_produce_and_flush(
     mock_aio_producer_cls.assert_called_once_with(
         bootstrap_servers=config.bootstrap_servers,
         client_id=config.client_id,
+        enable_idempotence=True,
+        acks="all",
     )
     mock_producer.start.assert_awaited_once()
     mock_producer.send_and_wait.assert_awaited_once_with(
@@ -220,6 +224,8 @@ async def test_async_transport_send_with_sasl_config_expect_security_kwargs(
     mock_aio_producer_cls.assert_called_once_with(
         bootstrap_servers="secure:9093",
         client_id="secure-client",
+        enable_idempotence=True,
+        acks="all",
         security_protocol="SASL_SSL",
         sasl_mechanism="PLAIN",
         sasl_plain_username="api-key",


### PR DESCRIPTION
Closes #493

> **#494(dead-letter, PR #501) 병합 후 rebase하여 두 기능을 합성했습니다.** 합성 지점은 아래 "dead-letter와의 합성" 절입니다.

## 무엇이 문제였나

`KafkaConnectionConfig.configuration_dict` 하나가 producer와 consumer에 같은 설정을 넘겼기 때문에 양쪽 모두 librdkafka 기본값으로 돌았습니다. 그중 `enable.auto.commit=true`가 가장 심각했습니다 — consumer가 핸들러 예외를 로깅만 하고 넘어가는 동안 offset은 이미 전진해 있어서 그 메시지는 영구히 사라졌습니다.

## 무엇을 바꿨나

### 설정 분리와 안전 기본값

| 속성 | 대상 | 고정 값 |
|------|------|--------|
| `connection_configuration_dict` | `AdminClient` + 아래 3종의 공통 기반 | `client.id`, `bootstrap.servers`, SASL/TLS |
| `producer_configuration_dict` | `confluent_kafka.Producer` (이벤트 발행 + dead-letter 발행) | `enable.idempotence=true`, `acks=all` |
| `async_producer_configuration_dict` | `aiokafka.AIOKafkaProducer` | `enable_idempotence=True`, `acks="all"` |
| `consumer_configuration_dict` | `confluent_kafka.Consumer`, `AIOConsumer` | `enable.auto.commit=false` |

`configuration_dict`는 제거했습니다(하위 호환 alias 없음). #494가 도입한 dead-letter producer도 `producer_configuration_dict`를 쓰므로 실패 메시지 발행에도 같은 보장이 걸립니다.

### 커밋 정책 — `MessageOutcome`

| 핸들러 결과 | `MessageOutcome` | offset 처리 |
|------------|------------------|------------|
| 성공 | `PROCESSED` | 커밋 |
| 실패 → dead-letter 발행 성공 | `PROCESSED` | 커밋 |
| 실패 → dead-letter 발행 실패·미확인 | `RETRYABLE` | 커밋하지 않고 그 메시지로 `seek` 되감기 |
| 역직렬화 실패 | dead-letter 결과에 따름 | 위 두 줄과 동일 |
| AuthContext DENY / snapshot CHALLENGE | `PROCESSED` | warning 로그 후 커밋 |
| 본문 없는 메시지 | `PROCESSED` | warning 로그 후 커밋 |
| 검증 provider 장애 | (해당 없음) | 예외 전파. 커밋하지 않았으므로 재시작 시 재처리 |

## dead-letter와의 합성 (#494)

**offset은 실패가 다른 곳에 저장된 뒤에만 전진합니다.** `_send_to_dead_letter`가 발행 성공 여부를 반환하도록 바꾸고, 그 결과로 커밋/되감기를 결정합니다.

- 동기: `produce()`가 `BufferError`/`KafkaException`을 던지거나 `flush(timeout)`가 미배달 건수를 반환하면 `False`.
- 비동기: `send_and_wait`가 실패하거나 `dead_letter_delivery_timeout` 안에 확인되지 않으면 `False`. **미확인(timeout)도 `False`로 취급합니다** — 원본을 남기면 dead-letter 레코드가 중복될 수 있지만, 커밋해 버리면 그 이벤트의 마지막 사본이 사라집니다. 중복이 복구 가능한 방향입니다.

이 합성이 없으면 #494가 이슈 본문에서 경고한 "데이터 손실이 가용성 장애로 바뀔 뿐"의 반대편, 즉 **dead-letter 발행이 실패했는데도 offset이 전진하는 조용한 유실**이 남습니다.

## 왜 `seek` 되감기가 필요한가

**커밋을 건너뛰는 것만으로는 재처리가 성립하지 않습니다.** `enable.auto.commit=false`는 브로커 커밋만 끄고 consumer의 in-memory 소비 위치는 poll마다 전진합니다.

```
파티션 0:  offset 100 (실패, 커밋 안 함)
           offset 101 (성공 → offset 102 커밋)
→ 100은 어떤 rebalance·재시작에서도 다시 오지 않는다
```

즉 커밋 생략만으로는 유실 여부가 "실패 직후 프로세스가 죽는지"라는 트래픽 의존 조건에 좌우됩니다. 되감기가 재처리를 성립시키는 수단이며, 레포 선례인 `plugins/spakky-rabbitmq/.../event/consumer.py`의 `basic_nack(requeue=True)`와 같은 의미입니다 (`review-heuristics.md` 원칙 1-A).

합성 결과 되감기는 **dead-letter 발행 자체가 실패한 경우에만** 일어나므로, 정상 운영에서 poison pill이 파티션을 영구 정지시키지 않습니다.

## 커밋·되감기 실패를 삼키는 이유

`Consumer.commit`은 `KafkaException`을 던지고(rebalance 중 `UNKNOWN_MEMBER_ID`, 브로커 불통 등), poll 루프는 `AbstractBackgroundService`가 띄운 daemon 스레드(비동기는 asyncio 태스크)에서 돕니다. 예외를 전파하면 애플리케이션은 살아 있는 채로 **모든 구독이 무성 중단**됩니다. 따라서 `_commit_offset`/`_rewind_to`는 실패를 로깅하고 루프를 지킵니다. `asynchronous=False` 커밋은 파티션별 실패를 예외가 아닌 반환 리스트의 `error` 필드로 알리므로 그것도 함께 확인합니다.

동기 커밋(`asynchronous=False`)을 유지한 근거: `asynchronous=True`는 커밋 실패가 반환값·예외 어느 쪽으로도 관측되지 않아 위 실패 처리가 불가능해집니다. `store_offsets` + 주기 커밋은 `enable.auto.commit=true`를 요구하여 이슈 본문의 명시 요구와 어긋납니다. 처리량이 커밋 지연에 지배되면 파티션 수를 늘리도록 문서에 적었습니다.

## 검증

- unit **123 passed / branch coverage 100.00%** (`uv run pytest tests/unit`)
- integration **6 passed** — #494의 dead-letter 2건 포함 (`uv run pytest --with-integration -m integration --no-cov`, 실제 Kafka testcontainer)
- `uv run ruff check .` clean
- `uv run pyrefly check src tests` → 0 errors (무인자 `pyrefly check`는 이 워크트리 경로가 `.gitignore`의 `.claude/worktrees/`에 매치되어 아무 파일도 검사하지 않고 exit 0을 냅니다 — 하네스 gap #499)
- 위 전 항목을 `origin/develop` (f110ca56, #494 병합본) rebase 후 재실행

신규 유닛 테스트가 커밋/되감기 결정을 분기별로 고정합니다: 성공 → 커밋, dead-letter 성공 → 커밋, dead-letter 실패/미확인 → 커밋 없음 + 되감기(되감은 `TopicPartition`의 topic·partition·offset 검증), 커밋 `KafkaException` → 루프 생존, 파티션별 커밋 거부 → 로그, 되감기 실패 → 로그. 동기·비동기 각각 확인합니다.

되감기 경로를 integration이 아닌 unit으로 검증한 이유: dead-letter 발행 실패를 실제 브로커에서 결정적으로 유도하려면 타이밍이나 잘못된 토픽명에 의존해야 하고, 그것은 레포가 금지하는 flaky 테스트가 됩니다.

`AsyncKafkaEventConsumer._route_event_handler`의 함수 단위 `# pragma: no cover`를 제거했습니다. 유닛 테스트가 이 메서드를 직접 `await`하는데도 pragma가 커밋 분기 전체를 계측에서 제외하고 있었습니다.

## Breaking change

전달 의미가 **at-most-once → at-least-once**로 바뀝니다.

- 같은 이벤트가 두 번 이상 핸들러에 전달될 수 있습니다. **이벤트 핸들러는 멱등해야 합니다** — 처리한 `event_id`를 저장해 중복을 건너뛰거나 DB 반영을 upsert로 작성합니다. `docs/guides/kafka.md`에 예시를 넣었습니다.
- `KafkaConnectionConfig.configuration_dict`가 사라졌습니다. 용도에 맞는 4종 중 하나로 옮겨야 합니다 (`python-code.md` "Breaking change 우선" — alias 없음).

## 문서

`plugins/spakky-kafka/README.md`와 `docs/guides/kafka.md`에 #494의 dead-letter 서술과 모순되지 않도록 합성된 표를 넣었습니다. 리뷰에서 지적된 async producer 순서 보장 과장은 사실 범위로 좁혔습니다 — `AsyncKafkaEventTransport.send`가 호출마다 producer를 새로 만들어 닫으므로 멱등 보장은 한 번의 `send` 재시도 범위까지이며 호출 간 순서는 보장하지 않는다고 명시했습니다 (producer 수명주기 자체는 #495 범위).

## Acceptance Criteria (자가 grep)

`acceptance_check: missing` — 이슈 #493 본문에 "수용 기준" 섹션과 grep 라인이 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
