### PR TITLE
feat(domain,event,outbox,kafka,sqlalchemy): route integration event partition key to broker (#492)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -817,7 +817,7 @@ flowchart TD
   - `AbstractDomainEvent` → `EventMediator` (인프로세스 dispatch)
   - `AbstractIntegrationEvent` → `IEventBus` (외부 전송)
 - **EventBus** (`IEventBus`): `send(event: AbstractIntegrationEvent)` — Integration Event 발행 진입점, Outbox seam 역할. `DirectEventBus` / `AsyncDirectEventBus`는 기존 tracing header를 보존하고, `SPAKKY_AUTH_SNAPSHOT_PROPAGATION_ENABLED=true`와 request-scope `AuthContext`가 있으면 raw bearer token 대신 signed `AuthContextSnapshot` envelope를 `spakky.auth.context_snapshot` metadata로 주입합니다.
-- **EventTransport** (`IEventTransport`): `send(event: AbstractIntegrationEvent)` — 실제 메시지 브로커 전송 (Kafka/RabbitMQ 구현)
+- **EventTransport** (`IEventTransport`): `send(event_name, payload, headers, partition_key)` — 실제 메시지 브로커 전송 (Kafka/RabbitMQ 구현). `partition_key`가 `None`이면 브로커가 라운드로빈으로 분산합니다.
 - **Dispatcher**: `dispatch(event)` — 등록된 핸들러에 인프로세스 전달
 - **Consumer**: `register(event_type, handler)` — 이벤트 타입과 콜백 연결
 

--- a/core/spakky-domain/src/spakky/domain/models/event.py
+++ b/core/spakky-domain/src/spakky/domain/models/event.py
@@ -148,4 +148,14 @@ class AbstractIntegrationEvent(AbstractEvent, ABC):
     to communicate significant domain changes.
     """
 
-    ...
+    @property
+    def partition_key(self) -> str | None:
+        """Get the key that pins this event to a single broker partition.
+
+        Returns:
+            None by default, which lets the broker spread events round-robin.
+            Override to return a stable value (typically the aggregate id) so
+            that every event of the same aggregate lands on one partition and
+            keeps its relative publication order.
+        """
+        return None

--- a/core/spakky-domain/tests/models/test_integration_event.py
+++ b/core/spakky-domain/tests/models/test_integration_event.py
@@ -1,0 +1,32 @@
+"""Tests for AbstractIntegrationEvent partition key exposure."""
+
+from typing import override
+
+from spakky.core.common.mutability import immutable
+
+from spakky.domain.models.event import AbstractIntegrationEvent
+
+
+def test_integration_event_partition_key_defaults_to_none() -> None:
+    """partition_key를 재정의하지 않은 integration event가 None을 반환함을 검증한다."""
+
+    @immutable
+    class SampleIntegrationEvent(AbstractIntegrationEvent):
+        order_id: str
+
+    assert SampleIntegrationEvent(order_id="ORD-1").partition_key is None
+
+
+def test_integration_event_partition_key_override_returns_declared_value() -> None:
+    """partition_key를 재정의한 integration event가 그 값을 반환함을 검증한다."""
+
+    @immutable
+    class OrderScopedIntegrationEvent(AbstractIntegrationEvent):
+        order_id: str
+
+        @property
+        @override
+        def partition_key(self) -> str | None:
+            return self.order_id
+
+    assert OrderScopedIntegrationEvent(order_id="ORD-2").partition_key == "ORD-2"

--- a/core/spakky-event/README.md
+++ b/core/spakky-event/README.md
@@ -135,7 +135,7 @@ app = (
 
 ### 전파 metadata
 
-`DirectEventBus`와 `AsyncDirectEventBus`는 `IEventTransport.send(event_name, payload, headers)` public signature를 유지하면서 outbound header를 구성합니다.
+`DirectEventBus`와 `AsyncDirectEventBus`는 `IEventTransport.send(event_name, payload, headers, partition_key)` public signature로 outbound header를 구성하고, 이벤트가 선언한 partition key를 그대로 넘깁니다.
 
 | metadata | 조건 | 설명 |
 |----------|------|------|

--- a/core/spakky-event/src/spakky/event/bus/transport_event_bus.py
+++ b/core/spakky-event/src/spakky/event/bus/transport_event_bus.py
@@ -53,6 +53,7 @@ class DirectEventBus(IEventBus):
             event.event_name,
             adapter.dump_json(event),
             headers,
+            event.partition_key,
         )
 
 
@@ -93,4 +94,5 @@ class AsyncDirectEventBus(IAsyncEventBus):
             event.event_name,
             adapter.dump_json(event),
             headers,
+            event.partition_key,
         )

--- a/core/spakky-event/src/spakky/event/event_publisher.py
+++ b/core/spakky-event/src/spakky/event/event_publisher.py
@@ -56,8 +56,17 @@ class IEventTransport(ABC):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
-        """Send a serialized event payload to the message broker."""
+        """Send a serialized event payload to the message broker.
+
+        Args:
+            event_name: Destination topic / routing key.
+            payload: Pre-serialized event bytes.
+            headers: Metadata headers for trace and auth propagation.
+            partition_key: Key pinning the payload to one broker partition.
+                None spreads payloads round-robin.
+        """
         ...
 
 
@@ -70,6 +79,15 @@ class IAsyncEventTransport(ABC):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
-        """Send a serialized event payload to the message broker."""
+        """Send a serialized event payload to the message broker.
+
+        Args:
+            event_name: Destination topic / routing key.
+            payload: Pre-serialized event bytes.
+            headers: Metadata headers for trace and auth propagation.
+            partition_key: Key pinning the payload to one broker partition.
+                None spreads payloads round-robin.
+        """
         ...

--- a/core/spakky-event/tests/integration/conftest.py
+++ b/core/spakky-event/tests/integration/conftest.py
@@ -82,6 +82,7 @@ class InMemoryEventTransport(IEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         pass
 
@@ -95,6 +96,7 @@ class InMemoryAsyncEventTransport(IAsyncEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         pass
 

--- a/core/spakky-event/tests/unit/bus/test_transport_event_bus.py
+++ b/core/spakky-event/tests/unit/bus/test_transport_event_bus.py
@@ -27,6 +27,7 @@ class RecordingTransport(IEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         self.sent.append((event_name, payload, headers))
 
@@ -42,6 +43,7 @@ class AsyncRecordingTransport(IAsyncEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         self.sent.append((event_name, payload, headers))
 

--- a/core/spakky-event/tests/unit/bus/test_transport_event_bus_headers.py
+++ b/core/spakky-event/tests/unit/bus/test_transport_event_bus_headers.py
@@ -47,6 +47,7 @@ class RecordingTransport(IEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         self.sent.append((event_name, payload, headers))
 
@@ -62,6 +63,7 @@ class AsyncRecordingTransport(IAsyncEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         self.sent.append((event_name, payload, headers))
 

--- a/core/spakky-event/tests/unit/bus/test_transport_event_bus_partition_key.py
+++ b/core/spakky-event/tests/unit/bus/test_transport_event_bus_partition_key.py
@@ -1,0 +1,107 @@
+"""Unit tests for partition key propagation from event bus to transport."""
+
+from typing import override
+
+import pytest
+from spakky.core.common.mutability import immutable
+from spakky.domain.models.event import AbstractIntegrationEvent
+from spakky.tracing import W3CTracePropagator
+
+from spakky.event.bus.transport_event_bus import AsyncDirectEventBus, DirectEventBus
+from spakky.event.event_publisher import IAsyncEventTransport, IEventTransport
+
+
+@immutable
+class UnkeyedIntegrationEvent(AbstractIntegrationEvent):
+    """Integration event that leaves partition assignment to the broker."""
+
+    message: str
+
+
+@immutable
+class OrderKeyedIntegrationEvent(AbstractIntegrationEvent):
+    """Integration event pinned to the order it belongs to."""
+
+    order_id: str
+
+    @property
+    @override
+    def partition_key(self) -> str | None:
+        """Return the order id so one order's events keep their order."""
+        return self.order_id
+
+
+class PartitionKeyRecordingTransport(IEventTransport):
+    """Transport that records the partition key it was handed."""
+
+    def __init__(self) -> None:
+        self.partition_keys: list[str | None] = []
+
+    @override
+    def send(
+        self,
+        event_name: str,
+        payload: bytes,
+        headers: dict[str, str],
+        partition_key: str | None = None,
+    ) -> None:
+        self.partition_keys.append(partition_key)
+
+
+class AsyncPartitionKeyRecordingTransport(IAsyncEventTransport):
+    """Async transport that records the partition key it was handed."""
+
+    def __init__(self) -> None:
+        self.partition_keys: list[str | None] = []
+
+    @override
+    async def send(
+        self,
+        event_name: str,
+        payload: bytes,
+        headers: dict[str, str],
+        partition_key: str | None = None,
+    ) -> None:
+        self.partition_keys.append(partition_key)
+
+
+def test_direct_event_bus_forwards_event_partition_key() -> None:
+    """DirectEventBus가 이벤트의 partition_key를 transport에 전달함을 검증한다."""
+    transport = PartitionKeyRecordingTransport()
+    bus = DirectEventBus(transport, W3CTracePropagator())
+
+    bus.send(OrderKeyedIntegrationEvent(order_id="ORD-501"))
+
+    assert transport.partition_keys == ["ORD-501"]
+
+
+def test_direct_event_bus_forwards_none_for_unkeyed_event() -> None:
+    """partition_key 미선언 이벤트는 transport에 None으로 전달됨을 검증한다."""
+    transport = PartitionKeyRecordingTransport()
+    bus = DirectEventBus(transport, W3CTracePropagator())
+
+    bus.send(UnkeyedIntegrationEvent(message="hello"))
+
+    assert transport.partition_keys == [None]
+
+
+@pytest.mark.asyncio
+async def test_async_direct_event_bus_forwards_event_partition_key() -> None:
+    """AsyncDirectEventBus가 이벤트의 partition_key를 transport에 전달함을 검증한다."""
+    transport = AsyncPartitionKeyRecordingTransport()
+    bus = AsyncDirectEventBus(transport, W3CTracePropagator())
+
+    await bus.send(OrderKeyedIntegrationEvent(order_id="ORD-502"))
+
+    assert transport.partition_keys == ["ORD-502"]
+
+
+@pytest.mark.asyncio
+async def test_async_direct_event_bus_forwards_none_for_unkeyed_event() -> None:
+    """비동기 경로에서 partition_key 미선언 이벤트가 None으로 전달됨을 검증한다."""
+    transport = AsyncPartitionKeyRecordingTransport()
+    bus = AsyncDirectEventBus(transport, W3CTracePropagator())
+
+    await bus.send(UnkeyedIntegrationEvent(message="hello"))
+
+    assert transport.partition_keys == [None]

--- a/core/spakky-event/tests/unit/publisher/test_transport_event_bus.py
+++ b/core/spakky-event/tests/unit/publisher/test_transport_event_bus.py
@@ -27,6 +27,7 @@ class InMemorySyncTransport(IEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         self.sent.append((event_name, payload, headers))
 
@@ -40,6 +41,7 @@ class InMemoryAsyncTransport(IAsyncEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         self.sent.append((event_name, payload, headers))
 

--- a/core/spakky-event/tests/unit/test_event_transport_headers.py
+++ b/core/spakky-event/tests/unit/test_event_transport_headers.py
@@ -17,6 +17,7 @@ class StubTransport(IEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         self.called = True
         self.last_headers = headers
@@ -34,6 +35,7 @@ class AsyncStubTransport(IAsyncEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         self.called = True
         self.last_headers = headers

--- a/core/spakky-outbox/src/spakky/outbox/bus/outbox_event_bus.py
+++ b/core/spakky-outbox/src/spakky/outbox/bus/outbox_event_bus.py
@@ -53,6 +53,7 @@ class OutboxEventBus(IEventBus):
             payload=adapter.dump_json(event),
             headers=headers,
             created_at=datetime.now(UTC),
+            partition_key=event.partition_key,
         )
         self._storage.save(message)
 
@@ -94,5 +95,6 @@ class AsyncOutboxEventBus(IAsyncEventBus):
             payload=adapter.dump_json(event),
             headers=headers,
             created_at=datetime.now(UTC),
+            partition_key=event.partition_key,
         )
         await self._storage.save(message)

--- a/core/spakky-outbox/src/spakky/outbox/common/message.py
+++ b/core/spakky-outbox/src/spakky/outbox/common/message.py
@@ -17,3 +17,7 @@ class OutboxMessage:
     published_at: datetime | None = field(default=None)
     retry_count: int = field(default=0)
     claimed_at: datetime | None = field(default=None)
+    # Appended last so existing positional construction by out-of-tree
+    # IOutboxStorage implementations keeps binding to the same fields.
+    partition_key: str | None = field(default=None)
+    """Key pinning the message to one broker partition. None spreads round-robin."""

--- a/core/spakky-outbox/src/spakky/outbox/relay/relay.py
+++ b/core/spakky-outbox/src/spakky/outbox/relay/relay.py
@@ -61,7 +61,10 @@ class OutboxRelayBackgroundService(AbstractBackgroundService):
         for message in messages:
             try:
                 self._transport.send(
-                    message.event_name, message.payload, message.headers
+                    message.event_name,
+                    message.payload,
+                    message.headers,
+                    message.partition_key,
                 )
                 self._storage.mark_published(message.id)
             except Exception:
@@ -123,7 +126,10 @@ class AsyncOutboxRelayBackgroundService(AbstractAsyncBackgroundService):
         for message in messages:
             try:
                 await self._transport.send(
-                    message.event_name, message.payload, message.headers
+                    message.event_name,
+                    message.payload,
+                    message.headers,
+                    message.partition_key,
                 )
                 await self._storage.mark_published(message.id)
             except Exception:

--- a/core/spakky-outbox/tests/unit/test_outbox_event_bus.py
+++ b/core/spakky-outbox/tests/unit/test_outbox_event_bus.py
@@ -289,3 +289,61 @@ async def test_async_send_stores_signed_snapshot_metadata_in_headers() -> None:
     assert AUTH_CONTEXT_SNAPSHOT_METADATA_KEY in headers
     assert "authorization" not in headers
     assert all("raw-token" not in value for value in headers.values())
+
+
+# ── partition key propagation ──
+
+
+@immutable
+class OrderShippedIntegrationEvent(AbstractIntegrationEvent):
+    """Integration event that pins its records to the order it belongs to."""
+
+    order_id: str
+
+    @property
+    @override
+    def partition_key(self) -> str | None:
+        """Return the order id so every record of one order shares a partition."""
+        return self.order_id
+
+
+def test_send_stores_partition_key_from_event() -> None:
+    """OutboxEventBus.send가 이벤트의 partition_key를 OutboxMessage에 기록하는지 검증한다."""
+    storage = InMemorySyncOutboxStorage()
+    bus = OutboxEventBus(storage, W3CTracePropagator())
+
+    bus.send(OrderShippedIntegrationEvent(order_id="ORD-777"))
+
+    assert storage.saved[0].partition_key == "ORD-777"
+
+
+def test_send_stores_none_partition_key_when_event_declares_none() -> None:
+    """partition_key를 오버라이드하지 않은 이벤트는 None으로 저장되는지 검증한다."""
+    storage = InMemorySyncOutboxStorage()
+    bus = OutboxEventBus(storage, W3CTracePropagator())
+
+    bus.send(OrderConfirmedIntegrationEvent(order_id="ORD-778", amount=100))
+
+    assert storage.saved[0].partition_key is None
+
+
+@pytest.mark.asyncio
+async def test_async_send_stores_partition_key_from_event() -> None:
+    """AsyncOutboxEventBus.send가 이벤트의 partition_key를 기록하는지 검증한다."""
+    storage = InMemoryAsyncOutboxStorage()
+    bus = AsyncOutboxEventBus(storage, W3CTracePropagator())
+
+    await bus.send(OrderShippedIntegrationEvent(order_id="ORD-888"))
+
+    assert storage.saved[0].partition_key == "ORD-888"
+
+
+@pytest.mark.asyncio
+async def test_async_send_stores_none_partition_key_when_event_declares_none() -> None:
+    """비동기 경로에서 partition_key 미선언 이벤트가 None으로 저장되는지 검증한다."""
+    storage = InMemoryAsyncOutboxStorage()
+    bus = AsyncOutboxEventBus(storage, W3CTracePropagator())
+
+    await bus.send(OrderConfirmedIntegrationEvent(order_id="ORD-889", amount=100))
+
+    assert storage.saved[0].partition_key is None

--- a/core/spakky-outbox/tests/unit/test_outbox_relay.py
+++ b/core/spakky-outbox/tests/unit/test_outbox_relay.py
@@ -32,14 +32,17 @@ class RelayTestIntegrationEvent(AbstractIntegrationEvent):
 class SpySyncTransport(IEventTransport):
     def __init__(self) -> None:
         self.sent: list[tuple[str, bytes]] = []
+        self.partition_keys: list[str | None] = []
 
     def send(
         self,
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         self.sent.append((event_name, payload))
+        self.partition_keys.append(partition_key)
 
 
 class FailingSyncTransport(IEventTransport):
@@ -48,6 +51,7 @@ class FailingSyncTransport(IEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         raise ConnectionError("Transport unavailable")
 
@@ -81,14 +85,17 @@ class InMemorySyncOutboxStorage(IOutboxStorage):
 class SpyAsyncTransport(IAsyncEventTransport):
     def __init__(self) -> None:
         self.sent: list[tuple[str, bytes]] = []
+        self.partition_keys: list[str | None] = []
 
     async def send(
         self,
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         self.sent.append((event_name, payload))
+        self.partition_keys.append(partition_key)
 
 
 class FailingAsyncTransport(IAsyncEventTransport):
@@ -97,6 +104,7 @@ class FailingAsyncTransport(IAsyncEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         raise ConnectionError("Transport unavailable")
 
@@ -127,13 +135,17 @@ class InMemoryAsyncOutboxStorage(IAsyncOutboxStorage):
 # ── Common helpers ──
 
 
-def _make_message(event: AbstractIntegrationEvent) -> OutboxMessage:
+def _make_message(
+    event: AbstractIntegrationEvent,
+    partition_key: str | None = None,
+) -> OutboxMessage:
     adapter: TypeAdapter[AbstractIntegrationEvent] = TypeAdapter(type(event))
     return OutboxMessage(
         id=uuid4(),
         event_name=event.event_name,
         payload=adapter.dump_json(event),
         headers={"traceparent": "00-abc123-def456-01"},
+        partition_key=partition_key,
         created_at=datetime.now(UTC),
     )
 
@@ -377,3 +389,76 @@ async def test_async_relay_run_async_exits_immediately_when_already_stopped() ->
     await relay.run_async()
 
     assert len(transport.sent) == 0
+
+
+# ── partition key propagation tests ──
+
+
+def test_relay_batch_forwards_stored_partition_key_to_transport() -> None:
+    """_relay_batch가 저장된 partition_key를 Transport에 그대로 전달하는지 검증한다."""
+    message = _make_message(
+        RelayTestIntegrationEvent(order_id="ORD-100"),
+        partition_key="ORD-100",
+    )
+
+    transport = SpySyncTransport()
+    relay = OutboxRelayBackgroundService(
+        InMemorySyncOutboxStorage(pending=[message]),
+        transport,
+        _make_config(),
+    )
+    relay._relay_batch()
+
+    assert transport.partition_keys == ["ORD-100"]
+
+
+def test_relay_batch_forwards_none_when_message_has_no_partition_key() -> None:
+    """partition_key가 없는 메시지는 Transport에 None으로 전달되는지 검증한다."""
+    message = _make_message(RelayTestIntegrationEvent(order_id="ORD-101"))
+
+    transport = SpySyncTransport()
+    relay = OutboxRelayBackgroundService(
+        InMemorySyncOutboxStorage(pending=[message]),
+        transport,
+        _make_config(),
+    )
+    relay._relay_batch()
+
+    assert transport.partition_keys == [None]
+
+
+@pytest.mark.asyncio
+async def test_async_relay_batch_forwards_stored_partition_key_to_transport() -> None:
+    """비동기 _relay_batch가 저장된 partition_key를 Transport에 전달하는지 검증한다."""
+    message = _make_message(
+        RelayTestIntegrationEvent(order_id="ORD-200"),
+        partition_key="ORD-200",
+    )
+
+    transport = SpyAsyncTransport()
+    relay = AsyncOutboxRelayBackgroundService(
+        InMemoryAsyncOutboxStorage(pending=[message]),
+        transport,
+        _make_config(),
+    )
+    await relay._relay_batch()
+
+    assert transport.partition_keys == ["ORD-200"]
+
+
+@pytest.mark.asyncio
+async def test_async_relay_batch_forwards_none_when_message_has_no_partition_key() -> (
+    None
+):
+    """비동기 경로에서 partition_key 없는 메시지가 None으로 전달되는지 검증한다."""
+    message = _make_message(RelayTestIntegrationEvent(order_id="ORD-201"))
+
+    transport = SpyAsyncTransport()
+    relay = AsyncOutboxRelayBackgroundService(
+        InMemoryAsyncOutboxStorage(pending=[message]),
+        transport,
+        _make_config(),
+    )
+    await relay._relay_batch()
+
+    assert transport.partition_keys == [None]

--- a/docs/event-system.md
+++ b/docs/event-system.md
@@ -237,7 +237,7 @@ class UserEventHandler:
 |-----------|------|------|
 | `IEventPublisher` / `IAsyncEventPublisher` | `publish` | 단일 발행 진입점 (타입 기반 라우팅) |
 | `IEventBus` / `IAsyncEventBus` | `send` | Integration Event 발행 진입점 (Outbox seam) |
-| `IEventTransport` / `IAsyncEventTransport` | `send` | 실제 메시지 브로커 전송 |
+| `IEventTransport` / `IAsyncEventTransport` | `send` | 실제 메시지 브로커 전송 (`event_name`, `payload`, `headers`, `partition_key`) |
 | `IEventConsumer` / `IAsyncEventConsumer` | `register` | 핸들러 콜백 등록 (통합) |
 | `IEventDispatcher` / `IAsyncEventDispatcher` | `dispatch` | 인프로세스 핸들러 전달 (통합) |
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -545,6 +545,16 @@ Integration Event 전송을 2단 인터페이스로 분리:
 - **EventBus** (`IEventBus`) — Integration Event 발행 진입점. Outbox seam 역할
 - **EventTransport** (`IEventTransport`) — 실제 메시지 브로커 전송 (Kafka/RabbitMQ 구현)
 
+### 파티션 키 (partition key)
+
+Integration Event가 어느 브로커 파티션으로 갈지 결정하는 값입니다. `AbstractIntegrationEvent.partition_key` property로 노출되며, 기본값 `None`은 "키 없음"을 의미하여 브로커가 라운드로빈으로 분산합니다.
+
+같은 파티션 키를 가진 이벤트는 항상 같은 파티션으로 갑니다 — Kafka가 보장하는 순서는 파티션 안에서만 성립하므로, 파티션 키는 순서 보장의 **전제 조건**입니다. 보통 aggregate id를 키로 사용합니다.
+
+다만 파티션 키만으로 순서가 완결되지는 않습니다. producer 재시도, Outbox 릴레이의 개별 메시지 재시도, 릴레이 다중 인스턴스는 같은 파티션 안에서도 상대 순서를 뒤집을 수 있습니다 — 상세는 [Kafka 가이드](guides/kafka.md)의 파티션 키 절 참조.
+
+전달 경로: 이벤트 → `IEventBus` → (`OutboxMessage.partition_key` 컬럼 경유) → `IEventTransport.send(..., partition_key=...)` → Kafka `produce(key=...)`. RabbitMQ transport는 파티션 개념이 없어 이 값을 라우팅에 사용하지 않습니다.
+
 ---
 
 ## 태스크 시스템 (spakky-task)

--- a/docs/guides/kafka.md
+++ b/docs/guides/kafka.md
@@ -116,6 +116,44 @@ class OrderEventHandler:
 
 ---
 
+## 파티션 키로 순서 보장하기
+
+Kafka가 보장하는 순서는 파티션 안에서만 성립합니다. 파티션이 2개 이상인 토픽에서 같은 주문의 생성/취소 이벤트가 서로 다른 파티션으로 흩어지면, 소비자는 생성보다 취소를 먼저 볼 수 있습니다.
+
+`AbstractIntegrationEvent.partition_key`를 오버라이드하면 같은 키를 가진 이벤트가 항상 같은 파티션으로 갑니다. 보통 aggregate id를 키로 씁니다. 파티션 키는 순서 보장의 **전제 조건**이며, 그것만으로 순서가 완결되지는 않습니다(아래 주의 참조).
+
+```python
+from spakky.core.common.mutability import immutable
+from spakky.domain.models.event import AbstractIntegrationEvent
+from typing import override
+
+
+@immutable
+class OrderPlacedEvent(AbstractIntegrationEvent):
+    order_id: str
+    total_amount: int
+
+    @property
+    @override
+    def partition_key(self) -> str | None:
+        return self.order_id
+```
+
+기본값은 `None`이고, 이때 Kafka는 지금까지와 동일하게 라운드로빈으로 파티션을 배정합니다. 즉 `partition_key`를 선언하지 않은 기존 이벤트의 동작은 바뀌지 않습니다.
+
+`spakky-outbox`를 함께 쓰면 bus가 이벤트의 `partition_key`를 Outbox 레코드의 `partition_key` 컬럼에 저장하고, Relay가 그 값을 그대로 Kafka transport에 넘깁니다.
+
+!!! warning "파티션 키만으로는 순서가 완결되지 않습니다"
+    파티션 키는 "같은 키가 같은 파티션으로 간다"만 보장합니다. 같은 파티션 안의 상대 순서는 아래 세 경로에서 여전히 뒤집힐 수 있습니다.
+
+    - **producer 재시도**: producer 멱등(idempotence)이 꺼져 있으면 재시도가 순서를 뒤집습니다. 현재 `KafkaConnectionConfig`는 `enable.idempotence`·`acks`·`max.in.flight.requests.per.connection`을 노출하지 않으므로 이 설정을 프레임워크에서 조정할 수 없습니다 — 설정 표면 추가는 #493에서 다룹니다.
+    - **Outbox 릴레이의 개별 메시지 재시도**: `OutboxRelayBackgroundService`는 메시지 전송이 실패하면 재시도 횟수만 올리고 **다음 메시지로 넘어갑니다.** 같은 키의 후속 메시지가 먼저 발행되고 실패한 메시지는 다음 폴링에서 재전송되므로 순서가 뒤집힙니다.
+    - **릴레이 다중 인스턴스**: `fetch_pending()`의 `SELECT ... FOR UPDATE SKIP LOCKED`는 같은 키의 연속 메시지가 서로 다른 배치로 나뉘어 병렬 발행되는 것을 막지 않습니다.
+
+    Outbox 경로에서 키 단위 순서가 요구사항이면 위 릴레이 동작을 먼저 확인하십시오.
+
+---
+
 ## 운영 흐름
 
 `IAsyncEventPublisher.publish()`는 Integration Event를 `IAsyncEventBus`로 넘기고, `AsyncDirectEventBus`가 이벤트를 JSON bytes로 직렬화한 뒤 `AsyncKafkaEventTransport`에 전달합니다. Kafka transport는 이벤트 이름을 topic으로 사용하고 trace header를 Kafka headers로 보냅니다.
@@ -132,7 +170,7 @@ sequenceDiagram
 
     UseCase->>Publisher: publish(OrderPlacedEvent)
     Publisher->>Bus: send(integration_event)
-    Bus->>Transport: send(event_name, json_payload, trace_headers)
+    Bus->>Transport: send(event_name, json_payload, trace_headers, partition_key)
     Transport->>Broker: produce topic=OrderPlacedEvent
     Consumer->>Broker: poll topic=OrderPlacedEvent
     Consumer->>Handler: on_order_placed(event)
@@ -145,6 +183,7 @@ sequenceDiagram
 | topic | `AbstractIntegrationEvent.event_name` 값, 기본은 클래스명 |
 | payload | Pydantic `TypeAdapter`가 만든 JSON bytes |
 | headers | `ITracePropagator.inject()`가 넣은 trace header |
+| partition key | `AbstractIntegrationEvent.partition_key` 값, 기본은 `None`(라운드로빈) |
 | consumer group | `SPAKKY_KAFKA__GROUP_ID` |
 | topic 생성 | 없으면 `number_of_partitions`, `replication_factor`로 생성 (dead-letter 토픽 포함) |
 | offset reset | `SPAKKY_KAFKA__AUTO_OFFSET_RESET` (`earliest`/`latest`/`none`) |

--- a/docs/guides/outbox.md
+++ b/docs/guides/outbox.md
@@ -181,10 +181,30 @@ from spakky.outbox.common.message import OutboxMessage
 | `event_name` | `str` | 이벤트 이름 (라우팅 키) |
 | `payload` | `bytes` | 직렬화된 이벤트 데이터 |
 | `headers` | `dict[str, str]` | 메타데이터 헤더 (트레이스 전파 등) |
+| `partition_key` | `str \| None` | 브로커 파티션을 고정하는 키. bus가 이벤트의 `partition_key`를 그대로 옮기며, `None`이면 라운드로빈 분산 |
 | `created_at` | `datetime` | 생성 시각 |
 | `published_at` | `datetime \| None` | 전송 완료 시각 |
 | `retry_count` | `int` | 재시도 횟수 |
 | `claimed_at` | `datetime \| None` | 잠금 시각 |
+
+---
+
+## 스키마 업그레이드 — `partition_key` 컬럼 추가
+
+`spakky-sqlalchemy`의 `OutboxMessageTable`은 migration용 table metadata만 제공하고, 운영 스키마 적용은 사용자 migration이 소유합니다(`SchemaRegistry`). 따라서 이미 `spakky_event_outbox` 테이블이 배포된 환경을 이 버전으로 올릴 때는 컬럼 추가 DDL을 직접 실행해야 합니다.
+
+```sql
+ALTER TABLE spakky_event_outbox ADD COLUMN partition_key TEXT NULL;
+```
+
+DDL을 실행하지 않은 채 배포하면 다음 두 곳이 깨집니다.
+
+| 위치 | 증상 |
+|------|------|
+| `IOutboxStorage.save()` | 존재하지 않는 컬럼을 참조하는 INSERT가 실패합니다. `save()`는 비즈니스 트랜잭션 안에서 호출되므로 **이벤트를 발행하는 모든 UseCase가 함께 롤백됩니다.** |
+| `OutboxRelayBackgroundService` | `fetch_pending()`의 SELECT가 실패하고, 이 예외는 릴레이의 재시도 `try` 블록 밖에서 발생하므로 **릴레이 백그라운드 서비스가 종료됩니다.** |
+
+컬럼의 `NULL` 허용은 "파티션 키 없음"(라운드로빈 발행)이라는 도메인 값을 표현하기 위한 것이며, 마이그레이션을 대신하지 않습니다. 기존 row는 DDL 적용 후 `partition_key`가 `NULL`이 되어 이전과 동일하게 라운드로빈으로 발행됩니다.
 
 ---
 

--- a/docs/guides/rabbitmq.md
+++ b/docs/guides/rabbitmq.md
@@ -117,6 +117,9 @@ class OrderEventHandler:
 
 큐 이름은 이벤트 인스턴스의 `event_name`과 같은 값으로 자동 결정됩니다. 기본값은 이벤트 클래스명(예: `OrderPlacedEvent`)이며, custom `event_name` property를 오버라이드하면 발행 routing key와 소비 queue 이름이 함께 그 값을 사용합니다.
 
+!!! note "`partition_key`는 RabbitMQ 라우팅에 사용되지 않습니다"
+    `AbstractIntegrationEvent.partition_key`는 `IEventTransport` 계약의 일부라 RabbitMQ transport에도 전달되지만, RabbitMQ에는 파티션 개념이 없고 단일 queue는 이미 FIFO 순서이므로 **라우팅에 반영되지 않습니다.** 이 값을 오버라이드해도 exchange·routing key·발행 결과는 그대로이며, 경고나 예외도 발생하지 않습니다. 파티션 키로 순서를 제어하려면 Kafka transport를 사용하십시오.
+
 ---
 
 ## 운영 흐름

--- a/plugins/spakky-kafka/README.md
+++ b/plugins/spakky-kafka/README.md
@@ -167,6 +167,7 @@ dead-letter topic은 consumer `initialize` 시점에 구독 topic과 함께 생�
 
 - **자동 topic 생성**: 이벤트 타입 이름을 기준으로 topic 생성 (dead-letter topic 포함)
 - **Dead-letter 경로**: 처리 실패 메시지를 원본 좌표·예외 header와 함께 `.dlt` topic으로 전달
+- **파티션 키 라우팅**: `AbstractIntegrationEvent.partition_key`를 오버라이드하면 같은 키의 이벤트가 같은 파티션으로 가서 순서가 유지됩니다. 기본값 `None`은 라운드로빈 분산
 - **동기/비동기 지원**: 동기 및 비동기 publisher/consumer 모두 지원
 - **Background service 패턴**: consumer polling을 background service로 실행
 - **Pydantic 직렬화**: 이벤트를 Pydantic으로 직렬화/역직렬화

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/event/transport.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/event/transport.py
@@ -64,6 +64,7 @@ class KafkaEventTransport(IEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         """Send a pre-serialized event payload to Kafka.
 
@@ -71,11 +72,14 @@ class KafkaEventTransport(IEventTransport):
             event_name: Topic name (typically the event class name).
             payload: Pre-serialized JSON bytes.
             headers: Metadata headers for trace propagation.
+            partition_key: Key routing the message to one partition. None lets
+                Kafka assign partitions round-robin.
         """
         self._create_topic(topic=event_name)
         self.producer.produce(
             topic=event_name,
             value=payload,
+            key=partition_key.encode() if partition_key is not None else None,
             headers=dict(headers),
             callback=self._message_delivery_report,
         )
@@ -117,6 +121,7 @@ class AsyncKafkaEventTransport(IAsyncEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         """Asynchronously send a pre-serialized event payload to Kafka.
 
@@ -124,6 +129,8 @@ class AsyncKafkaEventTransport(IAsyncEventTransport):
             event_name: Topic name (typically the event class name).
             payload: Pre-serialized JSON bytes.
             headers: Metadata headers for trace propagation.
+            partition_key: Key routing the message to one partition. None lets
+                Kafka assign partitions round-robin.
         """
         self._create_topic(topic=event_name)
         producer = AIOKafkaProducer(**self.config.async_producer_configuration_dict)
@@ -132,6 +139,7 @@ class AsyncKafkaEventTransport(IAsyncEventTransport):
             await producer.send_and_wait(
                 topic=event_name,
                 value=payload,
+                key=partition_key.encode() if partition_key is not None else None,
                 headers=[(k, v.encode()) for k, v in headers.items()],
             )
         finally:

--- a/plugins/spakky-kafka/tests/unit/test_transport.py
+++ b/plugins/spakky-kafka/tests/unit/test_transport.py
@@ -133,6 +133,7 @@ def test_sync_transport_send_expect_produce_and_flush(
     mock_producer.produce.assert_called_once_with(
         topic="TestEvent",
         value=b'{"key": "value"}',
+        key=None,
         headers={},
         callback=transport._message_delivery_report,
     )
@@ -181,6 +182,7 @@ async def test_async_transport_send_expect_produce_and_flush(
     mock_producer.send_and_wait.assert_awaited_once_with(
         topic="TestEvent",
         value=b'{"key": "value"}',
+        key=None,
         headers=[("traceparent", b"00-abc-def-01")],
     )
     mock_producer.stop.assert_awaited_once()
@@ -224,4 +226,58 @@ async def test_async_transport_send_with_sasl_config_expect_security_kwargs(
         sasl_mechanism="PLAIN",
         sasl_plain_username="api-key",
         sasl_plain_password="api-secret",
+    )
+
+
+@patch("spakky.plugins.kafka.event.transport.Producer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+def test_sync_transport_send_with_partition_key_expect_encoded_key(
+    mock_admin_cls: MagicMock,
+    mock_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """동기 transport가 partition_key를 bytes key로 인코딩해 produce하는지 검증한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = set()
+    mock_admin_cls.return_value = mock_admin
+
+    mock_producer = MagicMock()
+    mock_producer_cls.return_value = mock_producer
+
+    transport = KafkaEventTransport(config)
+    transport.send("TestEvent", b"{}", {}, "ORD-42")
+
+    mock_producer.produce.assert_called_once_with(
+        topic="TestEvent",
+        value=b"{}",
+        key=b"ORD-42",
+        headers={},
+        callback=transport._message_delivery_report,
+    )
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_send_with_partition_key_expect_encoded_key(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """비동기 transport가 partition_key를 bytes key로 인코딩해 전송하는지 검증한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = set()
+    mock_admin_cls.return_value = mock_admin
+
+    mock_producer = AsyncMock()
+    mock_aio_producer_cls.return_value = mock_producer
+
+    transport = AsyncKafkaEventTransport(config)
+    await transport.send("TestEvent", b"{}", {}, "ORD-43")
+
+    mock_producer.send_and_wait.assert_awaited_once_with(
+        topic="TestEvent",
+        value=b"{}",
+        key=b"ORD-43",
+        headers=[],
     )

--- a/plugins/spakky-rabbitmq/README.md
+++ b/plugins/spakky-rabbitmq/README.md
@@ -128,6 +128,7 @@ class AsyncUserService:
 - **Background service 패턴**: consumer polling을 background service로 실행
 - **Pydantic 직렬화**: 이벤트를 Pydantic으로 직렬화/역직렬화
 - **Exchange 라우팅**: pub/sub 메시지 패턴을 위한 선택적 exchange
+- **파티션 키 미사용**: `AbstractIntegrationEvent.partition_key`는 transport 인터페이스 계약상 전달되지만 RabbitMQ 라우팅에는 **사용되지 않습니다**. RabbitMQ에는 파티션 개념이 없고 단일 queue는 이미 FIFO 순서이므로, 이 값을 오버라이드해도 발행 결과가 달라지지 않습니다
 - **SSL 지원**: AMQPS protocol 기반 보안 연결
 - **분산 트레이싱**: 서비스 간 trace 전파를 위한 `spakky-tracing` 통합
 - **인증/인가 보호 경계**: signed `AuthContextSnapshot` 검증 및 protected handler fail-closed 처리

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/transport.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/transport.py
@@ -50,6 +50,7 @@ class RabbitMQEventTransport(IEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         """Send a pre-serialized event payload to RabbitMQ.
 
@@ -60,6 +61,9 @@ class RabbitMQEventTransport(IEventTransport):
             event_name: Routing key / queue name for the event.
             payload: Pre-serialized JSON bytes.
             headers: Metadata headers for trace propagation.
+            partition_key: Accepted for transport interface parity and not used
+                for routing — RabbitMQ has no partitions and a single queue is
+                already FIFO ordered, so there is nothing to pin the payload to.
         """
         connection = BlockingConnection(URLParameters(self.connection_string))
         channel = connection.channel()
@@ -107,6 +111,7 @@ class AsyncRabbitMQEventTransport(IAsyncEventTransport):
         event_name: str,
         payload: bytes,
         headers: dict[str, str],
+        partition_key: str | None = None,
     ) -> None:
         """Send a pre-serialized event payload to RabbitMQ asynchronously.
 
@@ -117,6 +122,9 @@ class AsyncRabbitMQEventTransport(IAsyncEventTransport):
             event_name: Routing key / queue name for the event.
             payload: Pre-serialized JSON bytes.
             headers: Metadata headers for trace propagation.
+            partition_key: Accepted for transport interface parity and not used
+                for routing — RabbitMQ has no partitions and a single queue is
+                already FIFO ordered, so there is nothing to pin the payload to.
         """
         async with await connect_robust(self.connection_string) as connection:
             channel = await connection.channel()

--- a/plugins/spakky-rabbitmq/tests/unit/test_transport.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_transport.py
@@ -142,3 +142,63 @@ async def test_async_transport_send_with_exchange_name_expect_exchange_declared(
     mock_channel.declare_queue.assert_called_once_with("test_event", durable=True)
     mock_queue.bind.assert_called_once_with(mock_exchange, "test_event")
     mock_exchange.publish.assert_called_once()
+
+
+def test_sync_transport_send_with_partition_key_expect_routing_unchanged() -> None:
+    """partition_key를 받아도 RabbitMQ 발행 인자가 달라지지 않음을 검증한다."""
+    config = MagicMock(spec=RabbitMQConnectionConfig)
+    config.connection_string = "amqp://test:test@localhost:5672/"
+    config.exchange_name = None
+
+    transport = RabbitMQEventTransport(config)
+
+    mock_channel = MagicMock()
+    mock_connection = MagicMock()
+    mock_connection.channel.return_value = mock_channel
+
+    with patch(
+        "spakky.plugins.rabbitmq.event.transport.BlockingConnection",
+        return_value=mock_connection,
+    ):
+        transport.send("test_event", b'{"key": "value"}', {}, "ORD-1")
+
+    mock_channel.basic_publish.assert_called_once_with(
+        "",
+        "test_event",
+        b'{"key": "value"}',
+        properties=BasicProperties(headers={}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_transport_send_with_partition_key_expect_routing_unchanged() -> (
+    None
+):
+    """비동기 경로에서 partition_key가 라우팅 키를 바꾸지 않음을 검증한다."""
+    config = MagicMock(spec=RabbitMQConnectionConfig)
+    config.connection_string = "amqp://test:test@localhost:5672/"
+    config.exchange_name = None
+
+    transport = AsyncRabbitMQEventTransport(config)
+
+    mock_default_exchange = AsyncMock()
+    mock_channel = AsyncMock()
+    mock_channel.default_exchange = mock_default_exchange
+    mock_channel.declare_queue = AsyncMock()
+    mock_channel.close = AsyncMock()
+
+    mock_connection = AsyncMock()
+    mock_connection.channel = AsyncMock(return_value=mock_channel)
+    mock_connection.__aenter__ = AsyncMock(return_value=mock_connection)
+    mock_connection.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "spakky.plugins.rabbitmq.event.transport.connect_robust",
+        new_callable=AsyncMock,
+        return_value=mock_connection,
+    ):
+        await transport.send("test_event", b'{"key": "value"}', {}, "ORD-1")
+
+    assert mock_default_exchange.publish.call_args.kwargs == {
+        "routing_key": "test_event"
+    }

--- a/plugins/spakky-sqlalchemy/README.md
+++ b/plugins/spakky-sqlalchemy/README.md
@@ -253,6 +253,21 @@ from spakky.plugins.sqlalchemy.outbox.storage import AsyncSqlAlchemyOutboxStorag
 storage = app.container.get(type_=AsyncSqlAlchemyOutboxStorage)
 ```
 
+### 스키마 업그레이드 — `partition_key` 컬럼 추가
+
+`OutboxMessageTable`은 migration용 metadata만 제공하고 운영 스키마 적용은 사용자
+migration이 소유합니다. 이미 `spakky_event_outbox`가 배포된 환경을 이 버전으로
+올릴 때는 아래 DDL을 직접 실행해야 합니다.
+
+```sql
+ALTER TABLE spakky_event_outbox ADD COLUMN partition_key TEXT NULL;
+```
+
+미적용 시 `save()`의 INSERT가 비즈니스 트랜잭션과 함께 롤백되고, 릴레이의
+`fetch_pending()` SELECT 실패는 재시도 `try` 블록 밖이라 릴레이 백그라운드
+서비스가 종료됩니다. 증상과 배경은 Outbox 가이드(`docs/guides/outbox.md`)를
+참고하십시오.
+
 ## Agent Persistence Contribution
 
 `spakky-agent`의 durable state, signal, evidence repository는 production

--- a/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/outbox/storage.py
+++ b/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/outbox/storage.py
@@ -59,6 +59,7 @@ class SqlAlchemyOutboxStorage(IOutboxStorage):
             event_name=message.event_name,
             payload=message.payload,
             headers=message.headers,
+            partition_key=message.partition_key,
             created_at=message.created_at,
         )
         self._session_manager.session.add(row)
@@ -103,6 +104,7 @@ class SqlAlchemyOutboxStorage(IOutboxStorage):
                     event_name=row.event_name,
                     payload=row.payload,
                     headers=row.headers,
+                    partition_key=row.partition_key,
                     created_at=row.created_at,
                     published_at=row.published_at,
                     retry_count=row.retry_count,
@@ -166,6 +168,7 @@ class AsyncSqlAlchemyOutboxStorage(IAsyncOutboxStorage):
             event_name=message.event_name,
             payload=message.payload,
             headers=message.headers,
+            partition_key=message.partition_key,
             created_at=message.created_at,
         )
         self._session_manager.session.add(row)
@@ -210,6 +213,7 @@ class AsyncSqlAlchemyOutboxStorage(IAsyncOutboxStorage):
                     event_name=row.event_name,
                     payload=row.payload,
                     headers=row.headers,
+                    partition_key=row.partition_key,
                     created_at=row.created_at,
                     published_at=row.published_at,
                     retry_count=row.retry_count,

--- a/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/outbox/table.py
+++ b/plugins/spakky-sqlalchemy/src/spakky/plugins/sqlalchemy/outbox/table.py
@@ -22,6 +22,11 @@ class OutboxMessageTable(AbstractTable):
     event_name: Mapped[str] = mapped_column(Text, nullable=False)
     payload: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     headers: Mapped[dict[str, str]] = mapped_column(JSON, nullable=False, default=dict)
+    # NULL carries the domain meaning "no key" — the broker spreads such
+    # messages round-robin. Adding this column to an already-deployed table
+    # still requires an explicit migration: see the schema upgrade section of
+    # docs/guides/outbox.md.
+    partition_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     published_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True

--- a/plugins/spakky-sqlalchemy/tests/unit/outbox/test_storage.py
+++ b/plugins/spakky-sqlalchemy/tests/unit/outbox/test_storage.py
@@ -319,3 +319,133 @@ async def test_async_storage_increment_retry_increases_count() -> None:
 
     mock_session.execute.assert_awaited_once()
     mock_session.commit.assert_awaited_once()
+
+
+# --- partition key round-trip ---
+
+
+def test_sync_storage_save_writes_partition_key_to_row() -> None:
+    """save()가 메시지의 partition_key를 테이블 row에 기록하는지 검증한다."""
+    mock_session_manager = MagicMock(spec=SessionManager)
+    mock_connection_manager = MagicMock(spec=ConnectionManager)
+    mock_connection_manager.connection = MagicMock()
+    mock_session = MagicMock()
+    mock_session_manager.session = mock_session
+
+    storage = SqlAlchemyOutboxStorage(
+        mock_session_manager, mock_connection_manager, config=None
+    )
+
+    storage.save(
+        OutboxMessage(
+            id=uuid4(),
+            event_name="test.event",
+            payload=b"test payload",
+            headers={},
+            partition_key="ORD-901",
+            created_at=datetime.now(UTC),
+        )
+    )
+
+    assert mock_session.add.call_args.args[0].partition_key == "ORD-901"
+
+
+def test_sync_storage_fetch_pending_reads_partition_key_from_row() -> None:
+    """fetch_pending()이 row의 partition_key를 OutboxMessage로 옮기는지 검증한다."""
+    mock_session_manager = MagicMock(spec=SessionManager)
+    mock_connection_manager = MagicMock(spec=ConnectionManager)
+    mock_connection_manager.connection = MagicMock()
+
+    storage = SqlAlchemyOutboxStorage(
+        mock_session_manager, mock_connection_manager, config=None
+    )
+
+    mock_session = MagicMock()
+    mock_result = MagicMock()
+    mock_row = MagicMock(spec=OutboxMessageTable)
+    mock_row.id = uuid4()
+    mock_row.event_name = "test.event"
+    mock_row.payload = b"payload"
+    mock_row.headers = {}
+    mock_row.partition_key = "ORD-902"
+    mock_row.created_at = datetime.now(UTC)
+    mock_row.published_at = None
+    mock_row.retry_count = 0
+    mock_row.claimed_at = None
+    mock_result.scalars.return_value.all.return_value = [mock_row]
+    mock_session.execute.return_value = mock_result
+
+    storage._session_factory = MagicMock(return_value=MagicMock())
+    storage._session_factory.return_value.__enter__ = MagicMock(
+        return_value=mock_session
+    )
+    storage._session_factory.return_value.__exit__ = MagicMock(return_value=None)
+
+    result = storage.fetch_pending(limit=10, max_retry=3)
+
+    assert result[0].partition_key == "ORD-902"
+
+
+@pytest.mark.asyncio
+async def test_async_storage_save_writes_partition_key_to_row() -> None:
+    """비동기 save()가 메시지의 partition_key를 테이블 row에 기록하는지 검증한다."""
+    mock_session_manager = MagicMock(spec=AsyncSessionManager)
+    mock_connection_manager = MagicMock(spec=AsyncConnectionManager)
+    mock_connection_manager.connection = MagicMock()
+    mock_session = MagicMock()
+    mock_session.flush = AsyncMock()
+    mock_session_manager.session = mock_session
+
+    storage = AsyncSqlAlchemyOutboxStorage(
+        mock_session_manager, mock_connection_manager, config=None
+    )
+
+    await storage.save(
+        OutboxMessage(
+            id=uuid4(),
+            event_name="test.event",
+            payload=b"test payload",
+            headers={},
+            partition_key="ORD-903",
+            created_at=datetime.now(UTC),
+        )
+    )
+
+    assert mock_session.add.call_args.args[0].partition_key == "ORD-903"
+
+
+@pytest.mark.asyncio
+async def test_async_storage_fetch_pending_reads_partition_key_from_row() -> None:
+    """비동기 fetch_pending()이 row의 partition_key를 옮기는지 검증한다."""
+    mock_session_manager = MagicMock(spec=AsyncSessionManager)
+    mock_connection_manager = MagicMock(spec=AsyncConnectionManager)
+    mock_connection_manager.connection = MagicMock()
+
+    storage = AsyncSqlAlchemyOutboxStorage(
+        mock_session_manager, mock_connection_manager, config=None
+    )
+
+    mock_session = MagicMock()
+    mock_result = MagicMock()
+    mock_row = MagicMock(spec=OutboxMessageTable)
+    mock_row.id = uuid4()
+    mock_row.event_name = "test.event"
+    mock_row.payload = b"payload"
+    mock_row.headers = {}
+    mock_row.partition_key = "ORD-904"
+    mock_row.created_at = datetime.now(UTC)
+    mock_row.published_at = None
+    mock_row.retry_count = 0
+    mock_row.claimed_at = None
+    mock_result.scalars.return_value.all.return_value = [mock_row]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.commit = AsyncMock()
+
+    mock_context = MagicMock()
+    mock_context.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_context.__aexit__ = AsyncMock(return_value=None)
+    storage._session_factory = MagicMock(return_value=mock_context)
+
+    result = await storage.fetch_pending(limit=10, max_retry=3)
+
+    assert result[0].partition_key == "ORD-904"

--- a/plugins/spakky-sqlalchemy/tests/unit/outbox/test_table.py
+++ b/plugins/spakky-sqlalchemy/tests/unit/outbox/test_table.py
@@ -23,3 +23,9 @@ def test_outbox_message_table_inherits_abstract_table() -> None:
     assert issubclass(OutboxMessageTable, AbstractTable)
     assert Table.get(OutboxMessageTable).domain is None
     assert Table.get(OutboxMessageTable).table is OutboxMessageTable
+
+
+def test_outbox_message_table_partition_key_is_nullable() -> None:
+    """partition_key 컬럼이 nullable이어서 기존 레코드가 그대로 읽히는지 검증한다."""
+    assert isinstance(OutboxMessageTable.__table__, SQLAlchemyTable)
+    assert OutboxMessageTable.__table__.columns["partition_key"].nullable is True


### PR DESCRIPTION
Closes #492

## 배경

Kafka가 보장하는 순서는 파티션 내 순서뿐인데, integration event에 partition key를 실을 경로가 없어 애플리케이션이 그 보장을 사용할 수 없었습니다. 같은 aggregate에서 나온 이벤트가 서로 다른 파티션으로 흩어지면 소비자가 생성 이벤트보다 삭제 이벤트를 먼저 볼 수 있습니다.

## 전달 지점 선택

이벤트 객체가 아직 살아 있는 **bus**를 전달 지점으로 삼았습니다. `save()` 시점에는 payload가 이미 바이트라서 key를 얻으려면 되파싱해야 하고, 그것은 계약이 아니라 추측입니다. 이슈 본문이 확정한 제약대로 outbox storage 확장으로 풀지 않았습니다.

```
이벤트.partition_key
  → IEventBus (DirectEventBus / OutboxEventBus)
  → [Outbox 경로] OutboxMessage.partition_key 컬럼 → 릴레이
  → IEventTransport.send(..., partition_key=...)
  → Kafka produce(key=...) / send_and_wait(key=...)
```

## 변경 내용

| 패키지 | 변경 |
|--------|------|
| `spakky-domain` | `AbstractIntegrationEvent.partition_key` property 추가. 기본값 `None` = 키 없음 |
| `spakky-event` | `IEventTransport` / `IAsyncEventTransport.send`에 `partition_key` 인자 추가. `DirectEventBus` / `AsyncDirectEventBus`가 이벤트 값을 전달 |
| `spakky-outbox` | `OutboxMessage.partition_key` 필드. `OutboxEventBus` 양쪽이 이벤트에서 기록하고 릴레이 양쪽이 transport로 전달 |
| `spakky-kafka` | `produce(key=)` / `send_and_wait(key=)`로 전달. 키가 없으면 `None` |
| `spakky-rabbitmq` | 인자만 수용 (파티션 개념 없음) |
| `spakky-sqlalchemy` | `OutboxMessageTable`에 nullable `partition_key` 컬럼 + storage 왕복 |

## 기존 사용처 무영향

`partition_key`를 선언하지 않은 이벤트는 도메인 기본값 `None`이 bus → outbox → relay → transport 전 구간을 `None`으로 통과하고, Kafka transport가 `key=None`으로 produce하므로 지금까지와 동일하게 라운드로빈 분산됩니다. 프레임워크의 어느 경로도 빈 키(`b""`)를 만들지 않습니다 — 기존 테스트가 `key=None`을 명시적으로 assert합니다.

transport `send`의 새 인자에는 기본값이 있어, 갱신하지 않은 out-of-tree 구현체도 ABC를 계속 만족합니다.

## 자율 결정 근거 (charter §4-B)

- **`partition_key`를 필드가 아닌 property로 노출**: `AbstractEvent`는 `kw_only` frozen dataclass이고, 필드로 두면 payload에 직렬화되어 전송 메타데이터가 이벤트 본문에 섞입니다. 기존 `event_name`과 같은 non-serialized property 형태를 따랐습니다.
- **어휘 `partition key`**: 이슈 본문이 확정한 용어이며, `number_of_partitions`("토픽 파티션 수")로 이미 레포에 파티션 어휘가 있습니다. `docs/glossary.md`에 용어를 등록했습니다.
- **`OutboxMessage.partition_key`를 맨 뒤에 추가**: `OutboxMessage`는 `kw_only`가 아닌 frozen dataclass입니다. 중간에 삽입하면 위치 인자로 생성하는 out-of-tree `IOutboxStorage` 구현이 조용히 다른 필드에 바인딩됩니다(`fetch_pending`은 공개 포트 시그니처). 맨 뒤 추가는 비용 0으로 그 위험을 제거합니다.
- **RabbitMQ는 라우팅에 반영하지 않음**: RabbitMQ에는 파티션이 없고 단일 queue는 이미 FIFO입니다. 조용한 no-op이 되지 않도록 docstring과 RabbitMQ README·가이드에 "라우팅에 사용되지 않는다"를 명시했습니다.

## ⚠️ 스키마 마이그레이션 필요

`create_all`은 테스트 전용이고 운영 스키마는 사용자 migration이 소유합니다(`SchemaRegistry`). 이미 `spakky_event_outbox`가 배포된 환경은 아래 DDL을 실행해야 합니다.

```sql
ALTER TABLE spakky_event_outbox ADD COLUMN partition_key TEXT NULL;
```

미적용 시 `save()`의 INSERT가 **비즈니스 트랜잭션과 함께 롤백**되고, 릴레이의 `fetch_pending()` SELECT 실패는 재시도 `try` 블록 밖이라 **릴레이 백그라운드 서비스가 종료**됩니다. 컬럼의 `NULL` 허용은 "키 없음"이라는 도메인 값 표현이며 마이그레이션을 대신하지 않습니다. 이 내용을 Outbox 가이드와 `spakky-sqlalchemy` README에 적었습니다.

## 순서 보장의 남은 한계 (문서로 명시)

파티션 키는 순서 보장의 **전제 조건**이며 그것만으로 완결되지 않습니다. 릴레이의 개별 메시지 재시도(실패 시 다음 메시지로 진행)와 다중 인스턴스 `SKIP LOCKED` claim은 같은 파티션 안에서도 순서를 뒤집습니다. 이는 릴레이 재시도 설계 문제로 본 PR 범위가 아니며 **#502**로 분해했고, 문서가 순서를 무조건 약속하지 않도록 정정했습니다. producer 멱등 설정 표면 부재는 #493이 담당합니다.

## 검증

7개 패키지에서 각각 패키지 디렉토리 안에서 실행 (`.gitignore`의 `.claude/worktrees/` 때문에 무인자 `pyrefly check`가 false green이 되는 것을 피하려고 **명시 경로 인자** 사용 — 하네스 gap은 #499):

```
uv run ruff check src tests
uv run pyrefly check src tests
uv run pytest
```

| 패키지 | lint | pyrefly | pytest | 커버리지 |
|--------|------|---------|--------|----------|
| `spakky` | ✓ | 0 errors | 420 passed | 100% |
| `spakky-domain` | ✓ | 0 errors | 45 passed | 100% |
| `spakky-event` | ✓ | 0 errors | 63 passed, 12 skipped | 100% |
| `spakky-outbox` | ✓ | 0 errors | 31 passed | 100% |
| `spakky-kafka` | ✓ | 0 errors | 84 passed, 4 skipped | 100% |
| `spakky-rabbitmq` | ✓ | 0 errors | 83 passed, 5 skipped | 100% |
| `spakky-sqlalchemy` | ✓ | 0 errors | 123 passed, 152 skipped | 100% |

pre-push 훅이 영향 8개 프로젝트(위 + `spakky-data`, `spakky-saga`) 테스트를 모두 통과했습니다.

## Acceptance Criteria (자가 grep)

`acceptance_check: missing`

이슈 #492 본문에 "수용 기준" grep 라인 섹션이 없습니다. 대신 이슈가 "확인한 지점"으로 지목한 4개 결함 지점이 모두 해소되었음을 grep으로 확인했습니다: transport 인터페이스 key 인자, Kafka `produce(key=)`, `OutboxMessage` key 필드, SQLAlchemy 테이블 컬럼, bus의 이벤트 멤버 읽기.

## 리뷰 반영

`/review-code` 외부 게이트 1회 실행 → Critical 2건 + Warning 3건 전부 반영:

- **C1** 컬럼 추가가 기존 배포를 깨뜨리는 경로 → DDL·증상 문서화 + `table.py` 주석에서 "nullable"과 "마이그레이션 필요"를 분리
- **C2** 문서가 코드 사실을 초과하는 순서 보장 주장 → 조건부로 정정 + 릴레이 재정렬 요인 명시 + #502 분해
- **W1** 존재하지 않는 멱등 설정 표면 안내 → 미노출 사실 명시 + #493 참조
- **W2** RabbitMQ no-op이 RabbitMQ 문서에 부재 → README·가이드에 1줄씩 추가
- **W3** 신규 필드 중간 삽입의 조용한 위치 인자 오배치 → 맨 뒤로 이동

## 참고

문서 동기화는 리뷰가 지목한 항목을 인라인으로 반영했습니다(`/sync-docs` 별도 실행 아님). 갱신 대상: `ARCHITECTURE.md`, `docs/event-system.md`, `docs/glossary.md`, `docs/guides/kafka.md`, `docs/guides/outbox.md`, `docs/guides/rabbitmq.md`, `core/spakky-event/README.md`, `plugins/spakky-kafka/README.md`, `plugins/spakky-rabbitmq/README.md`, `plugins/spakky-sqlalchemy/README.md`.
