### PR TITLE
fix(kafka): async transport가 애플리케이션 수명 동안 producer 하나를 유지하도록 수정 (#495)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -817,7 +817,7 @@ flowchart TD
   - `AbstractDomainEvent` → `EventMediator` (인프로세스 dispatch)
   - `AbstractIntegrationEvent` → `IEventBus` (외부 전송)
 - **EventBus** (`IEventBus`): `send(event: AbstractIntegrationEvent)` — Integration Event 발행 진입점, Outbox seam 역할. `DirectEventBus` / `AsyncDirectEventBus`는 기존 tracing header를 보존하고, `SPAKKY_AUTH_SNAPSHOT_PROPAGATION_ENABLED=true`와 request-scope `AuthContext`가 있으면 raw bearer token 대신 signed `AuthContextSnapshot` envelope를 `spakky.auth.context_snapshot` metadata로 주입합니다.
-- **EventTransport** (`IEventTransport`): `send(event_name, payload, headers, partition_key)` — 실제 메시지 브로커 전송 (Kafka/RabbitMQ 구현). `partition_key`가 `None`이면 브로커가 라운드로빈으로 분산합니다.
+- **EventTransport** (`IEventTransport`): `send(event_name, payload, headers, partition_key)` / `flush()` — 실제 메시지 브로커 전송 (Kafka/RabbitMQ 구현). `send`는 broker client에 레코드를 넘기고, 호출자가 배치 끝에 부르는 `flush`가 전송을 확정합니다. `partition_key`가 `None`이면 브로커가 라운드로빈으로 분산합니다.
 - **Dispatcher**: `dispatch(event)` — 등록된 핸들러에 인프로세스 전달
 - **Consumer**: `register(event_type, handler)` — 이벤트 타입과 콜백 연결
 
@@ -943,7 +943,7 @@ flowchart TD
     outbox_bus["OutboxEventBus<br/>@Primary"]
     table["outbox_table.insert()<br/>같은 트랜잭션"]
     relay["OutboxRelay<br/>background"]
-    transport["IEventTransport.send()"]
+    transport["IEventTransport.send()<br/>+ 배치 끝 flush()"]
     broker["Kafka / RabbitMQ"]
 
     event_bus --> direct
@@ -1146,7 +1146,7 @@ flowchart TD
 |---------|------|
 | `IOutboxStorage` / `IAsyncOutboxStorage` | 아웃박스 메시지 저장소 포트 |
 | `OutboxEventBus` / `AsyncOutboxEventBus` | `@Primary`로 `DirectEventBus`를 교체하는 EventBus seam. 저장되는 Outbox headers에는 tracing metadata와 signed `AuthContextSnapshot` metadata가 함께 보존되며 raw bearer token은 저장하지 않음 |
-| `OutboxRelayBackgroundService` / `AsyncOutboxRelayBackgroundService` | 백그라운드 릴레이 (polling → `IEventTransport.send()`) |
+| `OutboxRelayBackgroundService` / `AsyncOutboxRelayBackgroundService` | 백그라운드 릴레이 (polling → 배치 `IEventTransport.send()` → 배치 끝 `flush()` → 발행 완료 표시) |
 | `OutboxConfig` | 환경변수 기반 설정 (polling interval, batch size, retry 등) |
 | `OutboxMessage` | 아웃박스 메시지 모델 |
 

--- a/core/spakky-event/README.md
+++ b/core/spakky-event/README.md
@@ -119,7 +119,7 @@ app = (
 |-----------|-------------|
 | `IEventPublisher` / `IAsyncEventPublisher` | Event publish 진입점(type-based routing) |
 | `IEventBus` / `IAsyncEventBus` | Integration event send 진입점(Outbox 경계) |
-| `IEventTransport` / `IAsyncEventTransport` | 실제 message broker transport |
+| `IEventTransport` / `IAsyncEventTransport` | 실제 message broker transport. `send`로 payload를 넘기고, 배치 끝에서 `flush`로 전송을 확정합니다. 애플리케이션 수명 밖의 발행은 `EventTransportNotRunningError`로 거부됩니다 |
 | `IEventConsumer` / `IAsyncEventConsumer` | Handler callback 등록 |
 | `IEventDispatcher` / `IAsyncEventDispatcher` | In-process handler dispatch |
 
@@ -135,7 +135,7 @@ app = (
 
 ### 전파 metadata
 
-`DirectEventBus`와 `AsyncDirectEventBus`는 `IEventTransport.send(event_name, payload, headers, partition_key)` public signature로 outbound header를 구성하고, 이벤트가 선언한 partition key를 그대로 넘깁니다.
+`DirectEventBus`와 `AsyncDirectEventBus`는 `IEventTransport.send(event_name, payload, headers, partition_key)` public signature로 outbound header를 구성하고, 이벤트가 선언한 partition key를 그대로 넘깁니다. 직접 발행은 1건 배치이므로 두 bus는 `send` 직후 `flush`를 호출하여 전송을 확정한 뒤 반환합니다.
 
 | metadata | 조건 | 설명 |
 |----------|------|------|

--- a/core/spakky-event/src/spakky/event/__init__.py
+++ b/core/spakky-event/src/spakky/event/__init__.py
@@ -13,6 +13,7 @@ from spakky.event.error import (
     AbstractSpakkyEventError,
     AuthSnapshotPropagationContextUnavailableError,
     AuthSnapshotPropagationSignerUnavailableError,
+    EventTransportNotRunningError,
     InvalidMessageError,
 )
 from spakky.event.event_consumer import (
@@ -76,6 +77,7 @@ __all__ = [
     "AbstractSpakkyEventError",
     "AuthSnapshotPropagationContextUnavailableError",
     "AuthSnapshotPropagationSignerUnavailableError",
+    "EventTransportNotRunningError",
     "InvalidMessageError",
 ]
 

--- a/core/spakky-event/src/spakky/event/bus/transport_event_bus.py
+++ b/core/spakky-event/src/spakky/event/bus/transport_event_bus.py
@@ -41,7 +41,11 @@ class DirectEventBus(IEventBus):
 
     @override
     def send(self, event: AbstractIntegrationEvent) -> None:
-        """Serialize and send an integration event via transport."""
+        """Serialize and send an integration event via transport.
+
+        A direct publish is a batch of one, so the transport is flushed before
+        returning and the caller gets the same delivery guarantee as before.
+        """
         event_type = type(event)
         if event_type not in self._adapters:
             self._adapters[event_type] = TypeAdapter(event_type)
@@ -55,6 +59,7 @@ class DirectEventBus(IEventBus):
             headers,
             event.partition_key,
         )
+        self._transport.flush()
 
 
 @Pod()
@@ -82,7 +87,11 @@ class AsyncDirectEventBus(IAsyncEventBus):
 
     @override
     async def send(self, event: AbstractIntegrationEvent) -> None:
-        """Serialize and send an integration event via async transport."""
+        """Serialize and send an integration event via async transport.
+
+        A direct publish is a batch of one, so the transport is flushed before
+        returning and the caller gets the same delivery guarantee as before.
+        """
         event_type = type(event)
         if event_type not in self._adapters:
             self._adapters[event_type] = TypeAdapter(event_type)
@@ -96,3 +105,4 @@ class AsyncDirectEventBus(IAsyncEventBus):
             headers,
             event.partition_key,
         )
+        await self._transport.flush()

--- a/core/spakky-event/src/spakky/event/error.py
+++ b/core/spakky-event/src/spakky/event/error.py
@@ -25,6 +25,17 @@ class AuthSnapshotPropagationContextUnavailableError(AbstractSpakkyEventError):
     message = "Auth snapshot propagation context is unavailable"
 
 
+class EventTransportNotRunningError(AbstractSpakkyEventError):
+    """Raised when a transport is used outside the application lifecycle.
+
+    Transports whose broker client is opened at application start and closed at
+    application stop raise this instead of publishing into a closed client, so
+    that callers can tell a shutdown window apart from a delivery failure.
+    """
+
+    message = "Event transport is not running"
+
+
 class UnknownEventTypeError(AbstractSpakkyEventError):
     """Raised when an event type is neither domain nor integration."""
 

--- a/core/spakky-event/src/spakky/event/event_publisher.py
+++ b/core/spakky-event/src/spakky/event/event_publisher.py
@@ -48,7 +48,12 @@ class IAsyncEventBus(ABC):
 
 
 class IEventTransport(ABC):
-    """Low-level synchronous transport for pre-serialized event payloads."""
+    """Low-level synchronous transport for pre-serialized event payloads.
+
+    The caller owns the publish batch boundary: hand one or more payloads to
+    send() and call flush() once at the end of the batch. Transports may buffer
+    payloads until flush() so that broker round trips are batched.
+    """
 
     @abstractmethod
     def send(
@@ -58,7 +63,7 @@ class IEventTransport(ABC):
         headers: dict[str, str],
         partition_key: str | None = None,
     ) -> None:
-        """Send a serialized event payload to the message broker.
+        """Hand a serialized event payload to the broker client for delivery.
 
         Args:
             event_name: Destination topic / routing key.
@@ -66,12 +71,33 @@ class IEventTransport(ABC):
             headers: Metadata headers for trace and auth propagation.
             partition_key: Key pinning the payload to one broker partition.
                 None spreads payloads round-robin.
+
+        Raises:
+            EventTransportNotRunningError: When the transport's broker client is
+                not open, which happens outside the application lifecycle.
+        """
+        ...
+
+    @abstractmethod
+    def flush(self) -> None:
+        """Block until the broker client has finished sending what send() handed over.
+
+        A successful return means the client drained its send queue. Whether a
+        rejected record raises depends on the broker client, so an implementation
+        documents what it surfaces.
         """
         ...
 
 
 class IAsyncEventTransport(ABC):
-    """Low-level asynchronous transport for pre-serialized event payloads."""
+    """Low-level asynchronous transport for pre-serialized event payloads.
+
+    The caller owns the publish batch boundary: hand one or more payloads to
+    send() and call flush() once at the end of the batch. Transports may buffer
+    payloads until flush() so that broker round trips are batched. Publishers
+    share one transport, so a batch's send() and flush() belong to the same
+    execution context and flush() reports only that publisher's payloads.
+    """
 
     @abstractmethod
     async def send(
@@ -81,7 +107,7 @@ class IAsyncEventTransport(ABC):
         headers: dict[str, str],
         partition_key: str | None = None,
     ) -> None:
-        """Send a serialized event payload to the message broker.
+        """Hand a serialized event payload to the broker client for delivery.
 
         Args:
             event_name: Destination topic / routing key.
@@ -89,5 +115,19 @@ class IAsyncEventTransport(ABC):
             headers: Metadata headers for trace and auth propagation.
             partition_key: Key pinning the payload to one broker partition.
                 None spreads payloads round-robin.
+
+        Raises:
+            EventTransportNotRunningError: When the transport's broker client is
+                not open, which happens outside the application lifecycle.
+        """
+        ...
+
+    @abstractmethod
+    async def flush(self) -> None:
+        """Block until the broker client has finished sending what send() handed over.
+
+        A successful return means the client drained its send queue. Whether a
+        rejected record raises depends on the broker client, so an implementation
+        documents what it surfaces.
         """
         ...

--- a/core/spakky-event/tests/integration/conftest.py
+++ b/core/spakky-event/tests/integration/conftest.py
@@ -86,6 +86,10 @@ class InMemoryEventTransport(IEventTransport):
     ) -> None:
         pass
 
+    def flush(self) -> None:
+        """No-op flush."""
+        pass
+
 
 @Pod()
 class InMemoryAsyncEventTransport(IAsyncEventTransport):
@@ -98,6 +102,10 @@ class InMemoryAsyncEventTransport(IAsyncEventTransport):
         headers: dict[str, str],
         partition_key: str | None = None,
     ) -> None:
+        pass
+
+    async def flush(self) -> None:
+        """No-op flush."""
         pass
 
 

--- a/core/spakky-event/tests/unit/bus/test_transport_event_bus.py
+++ b/core/spakky-event/tests/unit/bus/test_transport_event_bus.py
@@ -17,10 +17,11 @@ class SampleIntegrationEvent(AbstractIntegrationEvent):
 
 
 class RecordingTransport(IEventTransport):
-    """Transport that records sent events."""
+    """Transport that records sent events and flush calls."""
 
     def __init__(self) -> None:
         self.sent: list[tuple[str, bytes, dict[str, str]]] = []
+        self.flush_count: int = 0
 
     def send(
         self,
@@ -31,12 +32,16 @@ class RecordingTransport(IEventTransport):
     ) -> None:
         self.sent.append((event_name, payload, headers))
 
+    def flush(self) -> None:
+        self.flush_count += 1
+
 
 class AsyncRecordingTransport(IAsyncEventTransport):
-    """Async transport that records sent events."""
+    """Async transport that records sent events and flush calls."""
 
     def __init__(self) -> None:
         self.sent: list[tuple[str, bytes, dict[str, str]]] = []
+        self.flush_count: int = 0
 
     async def send(
         self,
@@ -46,6 +51,9 @@ class AsyncRecordingTransport(IAsyncEventTransport):
         partition_key: str | None = None,
     ) -> None:
         self.sent.append((event_name, payload, headers))
+
+    async def flush(self) -> None:
+        self.flush_count += 1
 
 
 def test_direct_event_bus_send_single_expect_transport_called() -> None:
@@ -104,3 +112,28 @@ async def test_async_direct_event_bus_send_same_type_twice_expect_adapter_cached
     assert len(transport.sent) == 2
     assert SampleIntegrationEvent in bus._adapters
     assert len(bus._adapters) == 1
+
+
+def test_direct_event_bus_send_expect_transport_flushed_once_per_event() -> None:
+    """DirectEventBus.send가 발행 1건마다 transport.flush를 한 번 호출함을 검증한다."""
+    transport = RecordingTransport()
+    bus = DirectEventBus(transport, W3CTracePropagator())
+
+    bus.send(SampleIntegrationEvent(message="first"))
+    bus.send(SampleIntegrationEvent(message="second"))
+
+    assert transport.flush_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_direct_event_bus_send_expect_transport_flushed_once_per_event() -> (
+    None
+):
+    """AsyncDirectEventBus.send가 발행 1건마다 transport.flush를 한 번 호출함을 검증한다."""
+    transport = AsyncRecordingTransport()
+    bus = AsyncDirectEventBus(transport, W3CTracePropagator())
+
+    await bus.send(SampleIntegrationEvent(message="first"))
+    await bus.send(SampleIntegrationEvent(message="second"))
+
+    assert transport.flush_count == 2

--- a/core/spakky-event/tests/unit/bus/test_transport_event_bus_headers.py
+++ b/core/spakky-event/tests/unit/bus/test_transport_event_bus_headers.py
@@ -51,6 +51,9 @@ class RecordingTransport(IEventTransport):
     ) -> None:
         self.sent.append((event_name, payload, headers))
 
+    def flush(self) -> None:
+        """Nothing is buffered, so flushing is immediate."""
+
 
 class AsyncRecordingTransport(IAsyncEventTransport):
     """Async transport that records sent events with headers."""
@@ -66,6 +69,9 @@ class AsyncRecordingTransport(IAsyncEventTransport):
         partition_key: str | None = None,
     ) -> None:
         self.sent.append((event_name, payload, headers))
+
+    async def flush(self) -> None:
+        """Nothing is buffered, so flushing is immediate."""
 
 
 class FakePropagator(ITracePropagator):

--- a/core/spakky-event/tests/unit/bus/test_transport_event_bus_partition_key.py
+++ b/core/spakky-event/tests/unit/bus/test_transport_event_bus_partition_key.py
@@ -47,6 +47,10 @@ class PartitionKeyRecordingTransport(IEventTransport):
     ) -> None:
         self.partition_keys.append(partition_key)
 
+    @override
+    def flush(self) -> None:
+        """Nothing is buffered, so flushing is immediate."""
+
 
 class AsyncPartitionKeyRecordingTransport(IAsyncEventTransport):
     """Async transport that records the partition key it was handed."""
@@ -63,6 +67,10 @@ class AsyncPartitionKeyRecordingTransport(IAsyncEventTransport):
         partition_key: str | None = None,
     ) -> None:
         self.partition_keys.append(partition_key)
+
+    @override
+    async def flush(self) -> None:
+        """Nothing is buffered, so flushing is immediate."""
 
 
 def test_direct_event_bus_forwards_event_partition_key() -> None:

--- a/core/spakky-event/tests/unit/publisher/test_transport_event_bus.py
+++ b/core/spakky-event/tests/unit/publisher/test_transport_event_bus.py
@@ -31,6 +31,9 @@ class InMemorySyncTransport(IEventTransport):
     ) -> None:
         self.sent.append((event_name, payload, headers))
 
+    def flush(self) -> None:
+        """Nothing is buffered, so flushing is immediate."""
+
 
 class InMemoryAsyncTransport(IAsyncEventTransport):
     def __init__(self) -> None:
@@ -44,6 +47,9 @@ class InMemoryAsyncTransport(IAsyncEventTransport):
         partition_key: str | None = None,
     ) -> None:
         self.sent.append((event_name, payload, headers))
+
+    async def flush(self) -> None:
+        """Nothing is buffered, so flushing is immediate."""
 
 
 def test_direct_event_bus_send_delegates_to_transport() -> None:

--- a/core/spakky-event/tests/unit/test_event_publisher.py
+++ b/core/spakky-event/tests/unit/test_event_publisher.py
@@ -29,10 +29,12 @@ def test_async_event_bus_interface() -> None:
 
 
 def test_event_transport_interface() -> None:
-    """IEventTransport 인터페이스가 send 메서드를 가짐을 검증한다."""
+    """IEventTransport 인터페이스가 send/flush 메서드를 가짐을 검증한다."""
     assert hasattr(IEventTransport, "send")
+    assert hasattr(IEventTransport, "flush")
 
 
 def test_async_event_transport_interface() -> None:
-    """IAsyncEventTransport 인터페이스가 send 메서드를 가짐을 검증한다."""
+    """IAsyncEventTransport 인터페이스가 send/flush 메서드를 가짐을 검증한다."""
     assert hasattr(IAsyncEventTransport, "send")
+    assert hasattr(IAsyncEventTransport, "flush")

--- a/core/spakky-event/tests/unit/test_event_transport_headers.py
+++ b/core/spakky-event/tests/unit/test_event_transport_headers.py
@@ -22,6 +22,9 @@ class StubTransport(IEventTransport):
         self.called = True
         self.last_headers = headers
 
+    def flush(self) -> None:
+        """Nothing is buffered, so flushing is immediate."""
+
 
 class AsyncStubTransport(IAsyncEventTransport):
     """Async stub transport that records call arguments."""
@@ -39,6 +42,9 @@ class AsyncStubTransport(IAsyncEventTransport):
     ) -> None:
         self.called = True
         self.last_headers = headers
+
+    async def flush(self) -> None:
+        """Nothing is buffered, so flushing is immediate."""
 
 
 def test_transport_send_with_empty_headers_expect_empty_dict() -> None:

--- a/core/spakky-outbox/src/spakky/outbox/relay/relay.py
+++ b/core/spakky-outbox/src/spakky/outbox/relay/relay.py
@@ -2,12 +2,14 @@
 
 import logging
 from asyncio import wait_for
+from uuid import UUID
 
 from spakky.core.pod.annotations.pod import Pod
 from spakky.core.service.background import (
     AbstractAsyncBackgroundService,
     AbstractBackgroundService,
 )
+from spakky.event.error import EventTransportNotRunningError
 from spakky.event.event_publisher import IAsyncEventTransport, IEventTransport
 from typing import override
 
@@ -58,6 +60,7 @@ class OutboxRelayBackgroundService(AbstractBackgroundService):
             self._config.batch_size,
             self._config.max_retry_count,
         )
+        relayed_message_ids: list[UUID] = []
         for message in messages:
             try:
                 self._transport.send(
@@ -66,13 +69,38 @@ class OutboxRelayBackgroundService(AbstractBackgroundService):
                     message.headers,
                     message.partition_key,
                 )
-                self._storage.mark_published(message.id)
+            except EventTransportNotRunningError:
+                # Application shutdown closed the transport. The batch is left
+                # untouched: a shutdown is nobody's delivery failure, and
+                # charging retries here would exhaust healthy messages.
+                logger.info(
+                    "Transport stopped while relaying; deferring %d outbox messages",
+                    len(messages) - len(relayed_message_ids),
+                )
+                return
             except Exception:
                 logger.exception(
                     "Failed to relay outbox message %s",
                     message.id,
                 )
                 self._storage.increment_retry(message.id)
+                continue
+            relayed_message_ids.append(message.id)
+        if not relayed_message_ids:
+            return
+        # The batch is marked published only after flush() returns, so a batch
+        # that never left the client stays pending. Retry counts are not charged
+        # here: a flush failure belongs to the transport, not to any one message.
+        try:
+            self._transport.flush()
+        except Exception:
+            logger.exception(
+                "Failed to flush %d relayed outbox messages",
+                len(relayed_message_ids),
+            )
+            return
+        for message_id in relayed_message_ids:
+            self._storage.mark_published(message_id)
 
 
 @Pod()
@@ -123,6 +151,7 @@ class AsyncOutboxRelayBackgroundService(AbstractAsyncBackgroundService):
             self._config.batch_size,
             self._config.max_retry_count,
         )
+        relayed_message_ids: list[UUID] = []
         for message in messages:
             try:
                 await self._transport.send(
@@ -131,10 +160,35 @@ class AsyncOutboxRelayBackgroundService(AbstractAsyncBackgroundService):
                     message.headers,
                     message.partition_key,
                 )
-                await self._storage.mark_published(message.id)
+            except EventTransportNotRunningError:
+                # Application shutdown closed the transport. The batch is left
+                # untouched: a shutdown is nobody's delivery failure, and
+                # charging retries here would exhaust healthy messages.
+                logger.info(
+                    "Transport stopped while relaying; deferring %d outbox messages",
+                    len(messages) - len(relayed_message_ids),
+                )
+                return
             except Exception:
                 logger.exception(
                     "Failed to relay outbox message %s",
                     message.id,
                 )
                 await self._storage.increment_retry(message.id)
+                continue
+            relayed_message_ids.append(message.id)
+        if not relayed_message_ids:
+            return
+        # The batch is marked published only after flush() returns, so a batch
+        # that never left the client stays pending. Retry counts are not charged
+        # here: a flush failure belongs to the transport, not to any one message.
+        try:
+            await self._transport.flush()
+        except Exception:
+            logger.exception(
+                "Failed to flush %d relayed outbox messages",
+                len(relayed_message_ids),
+            )
+            return
+        for message_id in relayed_message_ids:
+            await self._storage.mark_published(message_id)

--- a/core/spakky-outbox/tests/unit/test_outbox_relay.py
+++ b/core/spakky-outbox/tests/unit/test_outbox_relay.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import TypeAdapter
 from spakky.core.common.mutability import immutable
 from spakky.domain.models.event import AbstractIntegrationEvent
+from spakky.event.error import EventTransportNotRunningError
 from spakky.event.event_publisher import IAsyncEventTransport, IEventTransport
 
 from spakky.outbox.common.config import OutboxConfig
@@ -33,6 +34,7 @@ class SpySyncTransport(IEventTransport):
     def __init__(self) -> None:
         self.sent: list[tuple[str, bytes]] = []
         self.partition_keys: list[str | None] = []
+        self.flush_marks: list[int] = []
 
     def send(
         self,
@@ -44,6 +46,9 @@ class SpySyncTransport(IEventTransport):
         self.sent.append((event_name, payload))
         self.partition_keys.append(partition_key)
 
+    def flush(self) -> None:
+        self.flush_marks.append(len(self.sent))
+
 
 class FailingSyncTransport(IEventTransport):
     def send(
@@ -54,6 +59,37 @@ class FailingSyncTransport(IEventTransport):
         partition_key: str | None = None,
     ) -> None:
         raise ConnectionError("Transport unavailable")
+
+    def flush(self) -> None:
+        """Never reached: send fails before the batch is flushed."""
+
+
+class FailingFlushSyncTransport(IEventTransport):
+    def send(
+        self,
+        event_name: str,
+        payload: bytes,
+        headers: dict[str, str],
+        partition_key: str | None = None,
+    ) -> None:
+        """Accept the payload; the failure happens when the batch is flushed."""
+
+    def flush(self) -> None:
+        raise ConnectionError("Broker unreachable")
+
+
+class StoppedSyncTransport(IEventTransport):
+    def send(
+        self,
+        event_name: str,
+        payload: bytes,
+        headers: dict[str, str],
+        partition_key: str | None = None,
+    ) -> None:
+        raise EventTransportNotRunningError
+
+    def flush(self) -> None:
+        """Never reached: the transport refuses the batch at the first send."""
 
 
 class InMemorySyncOutboxStorage(IOutboxStorage):
@@ -86,6 +122,7 @@ class SpyAsyncTransport(IAsyncEventTransport):
     def __init__(self) -> None:
         self.sent: list[tuple[str, bytes]] = []
         self.partition_keys: list[str | None] = []
+        self.flush_marks: list[int] = []
 
     async def send(
         self,
@@ -97,6 +134,9 @@ class SpyAsyncTransport(IAsyncEventTransport):
         self.sent.append((event_name, payload))
         self.partition_keys.append(partition_key)
 
+    async def flush(self) -> None:
+        self.flush_marks.append(len(self.sent))
+
 
 class FailingAsyncTransport(IAsyncEventTransport):
     async def send(
@@ -107,6 +147,37 @@ class FailingAsyncTransport(IAsyncEventTransport):
         partition_key: str | None = None,
     ) -> None:
         raise ConnectionError("Transport unavailable")
+
+    async def flush(self) -> None:
+        """Never reached: send fails before the batch is flushed."""
+
+
+class FailingFlushAsyncTransport(IAsyncEventTransport):
+    async def send(
+        self,
+        event_name: str,
+        payload: bytes,
+        headers: dict[str, str],
+        partition_key: str | None = None,
+    ) -> None:
+        """Accept the payload; the failure happens when the batch is flushed."""
+
+    async def flush(self) -> None:
+        raise ConnectionError("Broker unreachable")
+
+
+class StoppedAsyncTransport(IAsyncEventTransport):
+    async def send(
+        self,
+        event_name: str,
+        payload: bytes,
+        headers: dict[str, str],
+        partition_key: str | None = None,
+    ) -> None:
+        raise EventTransportNotRunningError
+
+    async def flush(self) -> None:
+        """Never reached: the transport refuses the batch at the first send."""
 
 
 class InMemoryAsyncOutboxStorage(IAsyncOutboxStorage):
@@ -184,6 +255,62 @@ def test_relay_batch_publishes_raw_payload_to_transport() -> None:
     assert message.id in storage.published_ids
 
 
+def test_relay_batch_with_three_messages_expect_single_flush_after_last_send() -> None:
+    """배치 전체를 보낸 뒤 flush를 한 번만 호출하고 그 후 발행 완료로 표시한다."""
+    messages = [
+        _make_message(RelayTestIntegrationEvent(order_id=f"ORD-{index}"))
+        for index in range(3)
+    ]
+
+    storage = InMemorySyncOutboxStorage(pending=messages)
+    transport = SpySyncTransport()
+    config = _make_config()
+
+    relay = OutboxRelayBackgroundService(storage, transport, config)
+    relay._relay_batch()
+
+    assert transport.flush_marks == [3]
+    assert storage.published_ids == [message.id for message in messages]
+
+
+def test_relay_batch_flush_failure_expect_batch_left_pending_without_retry_charge() -> (
+    None
+):
+    """배치 flush가 실패하면 발행 완료로 표시하지 않고 retry count도 올리지 않는다."""
+    messages = [
+        _make_message(RelayTestIntegrationEvent(order_id=f"ORD-{index}"))
+        for index in range(2)
+    ]
+
+    storage = InMemorySyncOutboxStorage(pending=messages)
+    config = _make_config()
+
+    relay = OutboxRelayBackgroundService(storage, FailingFlushSyncTransport(), config)
+    relay._relay_batch()
+
+    assert storage.published_ids == []
+    assert storage.retried_ids == []
+
+
+def test_relay_batch_transport_stopped_expect_batch_left_pending_without_retry_charge() -> (
+    None
+):
+    """종료로 transport가 닫히면 배치를 그대로 두고 retry count를 올리지 않는다."""
+    messages = [
+        _make_message(RelayTestIntegrationEvent(order_id=f"ORD-{index}"))
+        for index in range(3)
+    ]
+
+    storage = InMemorySyncOutboxStorage(pending=messages)
+    config = _make_config()
+
+    relay = OutboxRelayBackgroundService(storage, StoppedSyncTransport(), config)
+    relay._relay_batch()
+
+    assert storage.published_ids == []
+    assert storage.retried_ids == []
+
+
 def test_relay_batch_increments_retry_on_transport_failure() -> None:
     """Transport 전송 실패 시 _relay_batch가 retry count를 증가시키는지 검증한다."""
     event = RelayTestIntegrationEvent(order_id="ORD-FAIL")
@@ -234,6 +361,69 @@ async def test_async_relay_batch_publishes_raw_payload_to_transport() -> None:
     assert event_name == "RelayTestIntegrationEvent"
     assert payload == message.payload
     assert message.id in storage.published_ids
+
+
+@pytest.mark.asyncio
+async def test_async_relay_batch_with_three_messages_expect_single_flush_after_last_send() -> (
+    None
+):
+    """배치 전체를 보낸 뒤 flush를 한 번만 호출하고 그 후 발행 완료로 표시한다."""
+    messages = [
+        _make_message(RelayTestIntegrationEvent(order_id=f"ORD-{index}"))
+        for index in range(3)
+    ]
+
+    storage = InMemoryAsyncOutboxStorage(pending=messages)
+    transport = SpyAsyncTransport()
+    config = _make_config()
+
+    relay = AsyncOutboxRelayBackgroundService(storage, transport, config)
+    await relay._relay_batch()
+
+    assert transport.flush_marks == [3]
+    assert storage.published_ids == [message.id for message in messages]
+
+
+@pytest.mark.asyncio
+async def test_async_relay_batch_flush_failure_expect_batch_left_pending_without_retry_charge() -> (
+    None
+):
+    """배치 flush가 실패하면 발행 완료로 표시하지 않고 retry count도 올리지 않는다."""
+    messages = [
+        _make_message(RelayTestIntegrationEvent(order_id=f"ORD-{index}"))
+        for index in range(2)
+    ]
+
+    storage = InMemoryAsyncOutboxStorage(pending=messages)
+    config = _make_config()
+
+    relay = AsyncOutboxRelayBackgroundService(
+        storage, FailingFlushAsyncTransport(), config
+    )
+    await relay._relay_batch()
+
+    assert storage.published_ids == []
+    assert storage.retried_ids == []
+
+
+@pytest.mark.asyncio
+async def test_async_relay_batch_transport_stopped_expect_batch_left_pending_without_retry_charge() -> (
+    None
+):
+    """종료로 transport가 닫히면 배치를 그대로 두고 retry count를 올리지 않는다."""
+    messages = [
+        _make_message(RelayTestIntegrationEvent(order_id=f"ORD-{index}"))
+        for index in range(3)
+    ]
+
+    storage = InMemoryAsyncOutboxStorage(pending=messages)
+    config = _make_config()
+
+    relay = AsyncOutboxRelayBackgroundService(storage, StoppedAsyncTransport(), config)
+    await relay._relay_batch()
+
+    assert storage.published_ids == []
+    assert storage.retried_ids == []
 
 
 @pytest.mark.asyncio

--- a/docs/event-system.md
+++ b/docs/event-system.md
@@ -237,7 +237,7 @@ class UserEventHandler:
 |-----------|------|------|
 | `IEventPublisher` / `IAsyncEventPublisher` | `publish` | 단일 발행 진입점 (타입 기반 라우팅) |
 | `IEventBus` / `IAsyncEventBus` | `send` | Integration Event 발행 진입점 (Outbox seam) |
-| `IEventTransport` / `IAsyncEventTransport` | `send` | 실제 메시지 브로커 전송 (`event_name`, `payload`, `headers`, `partition_key`) |
+| `IEventTransport` / `IAsyncEventTransport` | `send` / `flush` | 실제 메시지 브로커 전송 (`event_name`, `payload`, `headers`, `partition_key`). `send`는 payload를 broker client에 넘기고, 배치 끝에 호출하는 `flush`가 전송을 확정합니다 |
 | `IEventConsumer` / `IAsyncEventConsumer` | `register` | 핸들러 콜백 등록 (통합) |
 | `IEventDispatcher` / `IAsyncEventDispatcher` | `dispatch` | 인프로세스 핸들러 전달 (통합) |
 

--- a/docs/guides/kafka.md
+++ b/docs/guides/kafka.md
@@ -11,6 +11,8 @@
 2. Integration Event 발행 시 `KafkaEventTransport`가 Kafka 토픽으로 전송
 3. `KafkaEventConsumer`가 백그라운드 서비스로 토픽을 소비하며 핸들러에 dispatch
 
+Transport는 producer를 발행마다 새로 만들지 않고 하나를 재사용합니다. 비동기 transport는 애플리케이션이 서비스를 시작할 때 producer를 열고 종료할 때 닫으므로, 브로커 연결과 메타데이터 조회가 발행마다 반복되지 않고 producer 단위 설정(배치·멱등 발행)이 수명 내내 유지됩니다. 시작 시점에 브로커에 연결하지 못하면 `app.start()`가 실패하며, 애플리케이션 수명 밖의 발행은 `EventTransportNotRunningError`로 거부됩니다.
+
 ---
 
 ## 설정
@@ -146,7 +148,7 @@ class OrderPlacedEvent(AbstractIntegrationEvent):
 !!! warning "파티션 키만으로는 순서가 완결되지 않습니다"
     파티션 키는 "같은 키가 같은 파티션으로 간다"만 보장합니다. 같은 파티션 안의 상대 순서는 아래 세 경로에서 여전히 뒤집힐 수 있습니다.
 
-    - **producer 재시도**: producer 멱등(idempotence)이 꺼져 있으면 재시도가 순서를 뒤집습니다. 현재 `KafkaConnectionConfig`는 `enable.idempotence`·`acks`·`max.in.flight.requests.per.connection`을 노출하지 않으므로 이 설정을 프레임워크에서 조정할 수 없습니다 — 설정 표면 추가는 #493에서 다룹니다.
+    - **producer 재시도**: 프레임워크가 `enable.idempotence=true`를 고정하고 transport가 producer를 애플리케이션 수명 동안 하나로 유지하므로, 그 수명 안의 재시도는 파티션 내 순서를 뒤집지 않습니다. 다만 프로세스가 재시작하면 새 producer 세션이 시작되어 이전 세션과의 상대 순서까지는 보장하지 않습니다.
     - **Outbox 릴레이의 개별 메시지 재시도**: `OutboxRelayBackgroundService`는 메시지 전송이 실패하면 재시도 횟수만 올리고 **다음 메시지로 넘어갑니다.** 같은 키의 후속 메시지가 먼저 발행되고 실패한 메시지는 다음 폴링에서 재전송되므로 순서가 뒤집힙니다.
     - **릴레이 다중 인스턴스**: `fetch_pending()`의 `SELECT ... FOR UPDATE SKIP LOCKED`는 같은 키의 연속 메시지가 서로 다른 배치로 나뉘어 병렬 발행되는 것을 막지 않습니다.
 
@@ -231,7 +233,7 @@ dead-letter 발행은 `dead_letter_delivery_timeout`(기본 10초)까지만 배�
 | Producer (이벤트 발행 + dead-letter 발행) | `enable.idempotence=true`, `acks=all` | 한 producer 세션의 재시도가 중복 발행이나 파티션 내 순서 역전을 만들지 않고, 승인된 이벤트가 파티션 리더 장애에도 남습니다 |
 | Consumer | `enable.auto.commit=false` | offset이 핸들러 실행 전에 전진하지 않습니다 |
 
-`AsyncKafkaEventTransport`는 `send` 호출마다 `AIOKafkaProducer`를 새로 만들어 닫으므로, 멱등 보장은 그 한 번의 `send`가 내부적으로 재시도하는 범위까지입니다. 서로 다른 `send` 호출 사이의 파티션 내 순서는 보장되지 않습니다.
+`AsyncKafkaEventTransport`는 `AIOKafkaProducer`를 애플리케이션 수명 동안 하나로 유지하므로, 멱등 producer의 시퀀스 번호가 그 수명 내내 이어집니다. 서로 다른 `send` 호출 사이에서도 중복 발행과 파티션 내 순서 역전이 막힙니다 — 멱등 시퀀스는 producer 인스턴스에 묶여 있어, 발행마다 producer를 새로 만들면 이 보장이 성립하지 않습니다.
 
 Consumer는 핸들러가 끝난 뒤, 그 메시지를 처리 완료로 볼지 다시 받을지 결정합니다.
 

--- a/docs/guides/outbox.md
+++ b/docs/guides/outbox.md
@@ -143,6 +143,12 @@ from spakky.outbox.bus.outbox_event_bus import OutboxEventBus, AsyncOutboxEventB
 
 백그라운드 서비스로 실행되며, Outbox 테이블에서 미전송 메시지를 주기적으로 가져와 `IEventTransport`로 전송합니다.
 
+한 번 가져온 배치는 전부 `send`한 뒤 `flush`를 한 번만 호출하고, flush가 성공한 다음에 발행 완료로 표시합니다.
+
+- 개별 메시지의 `send`가 실패하면 그 메시지의 retry count만 올립니다.
+- 배치 `flush`가 실패하면 어느 메시지의 잘못인지 가릴 수 없으므로 retry count를 올리지 않고 배치를 미발행 상태로 남깁니다. 다음 폴링에서 같은 배치를 다시 발행하므로 소비자 멱등성이 전제입니다(at-least-once).
+- 애플리케이션 종료로 transport가 닫히면(`EventTransportNotRunningError`) 남은 배치를 그대로 두고 릴레이를 멈춥니다. 종료는 전달 실패가 아니므로 retry count를 소모하지 않습니다.
+
 ```python
 from spakky.outbox.relay.relay import (
     OutboxRelayBackgroundService,

--- a/plugins/spakky-kafka/README.md
+++ b/plugins/spakky-kafka/README.md
@@ -65,9 +65,11 @@ export SPAKKY_KAFKA__DEAD_LETTER_DELIVERY_TIMEOUT="10.0"
 | `consumer_configuration_dict` | `confluent_kafka.Consumer`, `AIOConsumer` | `enable.auto.commit=false` | offset이 핸들러 결과에 따라서만 전진 |
 | `connection_configuration_dict` | `AdminClient` 및 위 3종의 공통 기반 | `client.id`, `bootstrap.servers`, SASL/TLS | 클러스터 접속 정보만 담음 |
 
-`AsyncKafkaEventTransport.send`는 호출마다 producer를 새로 만들어 닫으므로, 비동기 발행
-경로의 멱등 보장 범위는 그 한 번의 `send`가 내부적으로 재시도하는 구간까지입니다. 서로
-다른 `send` 호출 사이의 파티션 내 순서는 보장하지 않습니다.
+`AsyncKafkaEventTransport`는 producer를 애플리케이션 수명 동안 하나로 유지하므로, 멱등
+producer의 시퀀스 번호가 그 수명 내내 이어집니다. 따라서 위 `enable_idempotence` 설정이
+서로 다른 `send` 호출 사이에서도 중복 발행과 파티션 내 재정렬을 막습니다. 발행마다
+producer를 새로 만들면 시퀀스가 초기화되어 이 보장이 성립하지 않습니다 — 자세한 수명주기는
+아래 "Producer 수명주기"를 참고하십시오.
 
 Consumer는 등록된 핸들러가 끝난 뒤 그 메시지를 처리 완료로 볼지 다시 받을지 결정합니다.
 `MessageOutcome`이 그 두 결정을 나타냅니다.
@@ -212,6 +214,16 @@ dead-letter 발행은 `dead_letter_delivery_timeout`(기본 10초)까지만 배�
 
 dead-letter topic은 consumer `initialize` 시점에 구독 topic과 함께 생성됩니다.
 
+## Producer 수명주기
+
+- 두 transport 모두 producer를 하나만 두고 재사용합니다. 비동기 transport는 `IAsyncService`로 등록되어 애플리케이션이 서비스를 시작할 때 `AIOKafkaProducer`를 열고 종료할 때 닫습니다. 시작 시점에 브로커에 연결하지 못하면 `app.start()`가 실패합니다.
+- `send()`는 레코드를 producer에 넘기고 broker 응답을 기다리지 않으므로 연속 발행이 한 배치로 묶입니다. 배치 끝에서 호출하는 `flush()`가 배치를 내보내고 결과를 확정합니다. `DirectEventBus`는 발행 1건마다, outbox relay는 배치 1개마다 `flush()`를 호출합니다.
+- 비동기 `flush()`는 브로커가 거부한 레코드의 예외를 그대로 올립니다. 동기 `flush()`는 confluent-kafka 계약상 거부를 예외로 올리지 않고 delivery 콜백 로그로 남깁니다.
+- 비동기 `flush()`가 확정하는 대상은 **그 발행자가 넘긴 레코드**입니다. 여러 발행자가 같은 transport Pod를 동시에 쓰더라도 한 발행자의 flush가 다른 발행자의 거부를 대신 받거나 삼키지 않습니다. 따라서 한 배치의 `send`와 `flush`는 같은 실행 문맥(asyncio 태스크)에서 호출해야 하며, event bus와 outbox relay가 그렇게 호출합니다.
+- 애플리케이션이 transport를 시작하기 전이나 종료한 뒤의 비동기 발행은 `EventTransportNotRunningError`로 거부됩니다. outbox relay는 이 에러를 전달 실패와 구분하여 retry count를 올리지 않고 배치를 그대로 남깁니다.
+- aiokafka는 producer를 생성한 event loop에 묶으므로, 다른 loop(HTTP 요청 핸들러·테스트)에서 발행하면 transport가 producer의 loop로 호출을 넘깁니다.
+- dead-letter 발행은 consumer가 자기 producer로 수행하므로 위 수명주기와 무관합니다.
+
 ## 주요 기능
 
 - **자동 topic 생성**: 이벤트 타입 이름을 기준으로 topic 생성 (dead-letter topic 포함)
@@ -229,7 +241,7 @@ dead-letter topic은 consumer `initialize` 시점에 구독 topic과 함께 생�
 | 컴포넌트 | 설명 |
 |-----------|-------------|
 | `KafkaEventTransport` | 동기 event transport(`IEventTransport`) |
-| `AsyncKafkaEventTransport` | 비동기 event transport(`IAsyncEventTransport`) |
+| `AsyncKafkaEventTransport` | 비동기 event transport(`IAsyncEventTransport`, `IAsyncService`) |
 | `KafkaEventConsumer` | 동기 event consumer(background service) |
 | `AsyncKafkaEventConsumer` | 비동기 event consumer(background service) |
 | `KafkaConnectionConfig` | 환경변수 기반 설정 |

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/event/transport.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/event/transport.py
@@ -1,11 +1,28 @@
+from asyncio import (
+    AbstractEventLoop,
+    Future,
+    gather,
+    get_running_loop,
+    locks,
+    run_coroutine_threadsafe,
+    wrap_future,
+)
+from collections.abc import Coroutine
+from contextvars import ContextVar
 from logging import getLogger
+from threading import Event
+from typing import Any
 
 from aiokafka import AIOKafkaProducer
+from aiokafka.structs import RecordMetadata
 from confluent_kafka import KafkaError, Message, Producer
 from confluent_kafka.admin import AdminClient, NewTopic
 from typing import override
 
+from spakky.core.common.mutability import immutable
 from spakky.core.pod.annotations.pod import Pod
+from spakky.core.service.interfaces.service import IAsyncService, IService
+from spakky.event.error import EventTransportNotRunningError
 from spakky.event.event_publisher import (
     IAsyncEventTransport,
     IEventTransport,
@@ -15,10 +32,29 @@ from spakky.plugins.kafka.common.config import KafkaConnectionConfig
 
 logger = getLogger(__name__)
 
+_pending_deliveries: ContextVar[list[Future[RecordMetadata]] | None] = ContextVar(
+    "spakky_kafka_pending_deliveries",
+    default=None,
+)
+"""Records the publisher in this execution context handed over, awaiting its flush.
+
+Publishers share the transport Pod, so delivery outcomes are tracked per execution
+context (asyncio task or thread) instead of per transport. A publisher's flush then
+reports exactly the records it sent, and never consumes the rejection belonging to a
+publisher running next to it. send() and flush() of one batch therefore belong to the
+same task — which is how the event bus and the outbox relay call them.
+"""
+
 
 @Pod()
-class KafkaEventTransport(IEventTransport):
-    """Synchronous Kafka event transport using confluent_kafka Producer."""
+class KafkaEventTransport(IEventTransport, IService):
+    """Synchronous Kafka event transport using confluent_kafka Producer.
+
+    One producer is created with the transport and reused for every publish.
+    send() only queues a record for the producer's own batching, so the transport
+    flushes when the application stops, closing the window where a queued record
+    would die with the process.
+    """
 
     config: KafkaConnectionConfig
     admin: AdminClient
@@ -62,6 +98,19 @@ class KafkaEventTransport(IEventTransport):
             )
 
     @override
+    def set_stop_event(self, stop_event: Event) -> None:
+        """Ignore the shutdown signal: publishing is on demand, with no loop to stop."""
+
+    @override
+    def start(self) -> None:
+        """Open nothing: the producer is created together with the transport."""
+
+    @override
+    def stop(self) -> None:
+        """Deliver records still queued in the producer before the process exits."""
+        self.producer.flush()
+
+    @override
     def send(
         self,
         event_name: str,
@@ -69,7 +118,10 @@ class KafkaEventTransport(IEventTransport):
         headers: dict[str, str],
         partition_key: str | None = None,
     ) -> None:
-        """Send a pre-serialized event payload to Kafka.
+        """Hand a pre-serialized event payload to the Kafka producer queue.
+
+        The payload is queued for the producer's own batching and is confirmed
+        only by flush(), which the caller invokes at the end of its batch.
 
         Args:
             event_name: Topic name (typically the event class name).
@@ -87,20 +139,61 @@ class KafkaEventTransport(IEventTransport):
             callback=self._message_delivery_report,
         )
         self.producer.poll(0)
+
+    @override
+    def flush(self) -> None:
+        """Block until the producer has sent every queued record.
+
+        A record the broker rejects is reported to the delivery callback, which
+        logs it — confluent_kafka surfaces no error here, so a rejected record
+        does not make this call fail.
+        """
         self.producer.flush()
 
 
+@immutable
+class _LoopBoundProducer:
+    """A running producer together with the event loop that owns it."""
+
+    producer: AIOKafkaProducer
+    """Producer opened at application start."""
+
+    loop: AbstractEventLoop
+    """Event loop the producer was created on and must be driven from."""
+
+
 @Pod()
-class AsyncKafkaEventTransport(IAsyncEventTransport):
-    """Asynchronous Kafka event transport using aiokafka AIOKafkaProducer."""
+class AsyncKafkaEventTransport(IAsyncEventTransport, IAsyncService):
+    """Asynchronous Kafka event transport using aiokafka AIOKafkaProducer.
+
+    The producer lives as long as the application: it is opened when the
+    application starts services and closed when the application stops them.
+    A producer per publish would reopen the broker connection every time, defeat
+    batching, and reset the idempotent producer sequence, which is bound to a
+    producer instance lifetime.
+
+    send() hands a record over without waiting for its broker acknowledgement, so
+    consecutive publishes fill one batch; flush() sends the batch out and reports
+    whichever record the broker rejected. A publisher only ever learns the outcome
+    of the records it handed over itself, because concurrent publishers share this
+    Pod and one publisher's flush must not swallow another's rejected record.
+
+    aiokafka binds a producer to the event loop that created it, while the
+    ApplicationContext runs its services on an internal event loop of its own.
+    Publishers living on another loop (HTTP request handlers, tests) therefore
+    have their producer calls routed back to the producer's own loop.
+    """
 
     config: KafkaConnectionConfig
     admin: AdminClient
+    _running: _LoopBoundProducer | None
+    """Producer bound to its loop while the application runs, None outside it."""
 
     def __init__(self, config: KafkaConnectionConfig) -> None:
         """Initialize the async Kafka transport with connection config."""
         self.config = config
         self.admin = AdminClient(self.config.connection_configuration_dict)
+        self._running = None
 
     def _create_topic(  # pragma: no cover - Kafka 브로커 콜백으로 커버리지 수집 불가
         self, topic: str
@@ -118,6 +211,103 @@ class AsyncKafkaEventTransport(IAsyncEventTransport):
             ]
         )
 
+    @property
+    def _running_producer(self) -> _LoopBoundProducer:
+        """Return the running producer, refusing to publish into a closed one."""
+        if self._running is None:
+            raise EventTransportNotRunningError
+        return self._running
+
+    async def _on_producer_loop[ResultT](
+        self,
+        # Coroutine send and yield types are opaque asyncio internals.
+        producer_call: Coroutine[Any, Any, ResultT],
+        producer_loop: AbstractEventLoop,
+    ) -> ResultT:
+        """Await a producer call on the event loop that owns the producer."""
+        if get_running_loop() is producer_loop:
+            return await producer_call
+        return await wrap_future(run_coroutine_threadsafe(producer_call, producer_loop))
+
+    @staticmethod
+    def _record_delivery(delivery: Future[RecordMetadata]) -> None:
+        """Attribute a handed-over record to the publisher that sent it."""
+        deliveries = _pending_deliveries.get()
+        if deliveries is None:
+            deliveries = []
+            _pending_deliveries.set(deliveries)
+        deliveries.append(delivery)
+
+    @staticmethod
+    def _claim_deliveries() -> list[Future[RecordMetadata]]:
+        """Take the records this publisher handed over since its previous flush."""
+        deliveries = _pending_deliveries.get()
+        if deliveries is None:
+            return []
+        _pending_deliveries.set([])
+        return deliveries
+
+    async def _confirm_deliveries(
+        self,
+        producer: AIOKafkaProducer,
+        deliveries: list[Future[RecordMetadata]],
+    ) -> None:
+        """Send buffered batches out and raise whatever the broker rejected.
+
+        Only the claimed records are awaited. Records another publisher handed
+        over stay with that publisher, so a rejection is reported to whoever sent
+        the record rather than to whoever happened to flush first.
+        """
+        await producer.flush()
+        outcomes = await gather(*deliveries, return_exceptions=True)
+        for outcome in outcomes:
+            if isinstance(outcome, BaseException):
+                # Every outcome is retrieved before raising, so a second rejected
+                # record does not linger as an unretrieved exception.
+                raise outcome
+
+    @override
+    def set_stop_event(self, stop_event: locks.Event) -> None:
+        """Ignore the shutdown signal: publishing is on demand, with no loop to stop."""
+
+    @override
+    async def start_async(self) -> None:
+        """Open the producer that serves every publish until the application stops."""
+        producer = AIOKafkaProducer(**self.config.async_producer_configuration_dict)
+        await producer.start()
+        self._running = _LoopBoundProducer(producer=producer, loop=get_running_loop())
+
+    @override
+    async def stop_async(self) -> None:
+        """Deliver what is still buffered, then close the producer.
+
+        The transport stops accepting publishes before the producer closes, so a
+        service still running during shutdown is told the transport stopped
+        instead of being handed a delivery failure.
+        """
+        running = self._running_producer
+        self._running = None
+        await self._on_producer_loop(
+            self._close_producer(running.producer, self._claim_deliveries()),
+            running.loop,
+        )
+
+    async def _close_producer(
+        self,
+        producer: AIOKafkaProducer,
+        deliveries: list[Future[RecordMetadata]],
+    ) -> None:
+        """Confirm outstanding records, then close the producer regardless.
+
+        producer.stop() delivers whatever any publisher left buffered; only the
+        records this context claimed can have their outcome inspected here.
+        """
+        try:
+            await self._confirm_deliveries(producer, deliveries)
+        except Exception:
+            logger.exception("Failed to deliver records buffered at shutdown")
+        await producer.stop()
+
     @override
     async def send(
         self,
@@ -126,7 +316,10 @@ class AsyncKafkaEventTransport(IAsyncEventTransport):
         headers: dict[str, str],
         partition_key: str | None = None,
     ) -> None:
-        """Asynchronously send a pre-serialized event payload to Kafka.
+        """Hand a pre-serialized event payload to the long-lived Kafka producer.
+
+        The record joins the producer's current batch and is confirmed only by
+        flush(), which the caller invokes at the end of its batch.
 
         Args:
             event_name: Topic name (typically the event class name).
@@ -134,16 +327,36 @@ class AsyncKafkaEventTransport(IAsyncEventTransport):
             headers: Metadata headers for trace propagation.
             partition_key: Key routing the message to one partition. None lets
                 Kafka assign partitions round-robin.
+
+        Raises:
+            EventTransportNotRunningError: When the application has not started
+                the transport's producer, or has already stopped it.
         """
         self._create_topic(topic=event_name)
-        producer = AIOKafkaProducer(**self.config.async_producer_configuration_dict)
-        await producer.start()
-        try:
-            await producer.send_and_wait(
-                topic=event_name,
-                value=payload,
-                key=partition_key.encode() if partition_key is not None else None,
-                headers=[(k, v.encode()) for k, v in headers.items()],
+        running = self._running_producer
+        self._record_delivery(
+            await self._on_producer_loop(
+                running.producer.send(
+                    topic=event_name,
+                    value=payload,
+                    key=partition_key.encode() if partition_key is not None else None,
+                    headers=[(k, v.encode()) for k, v in headers.items()],
+                ),
+                running.loop,
             )
-        finally:
-            await producer.stop()
+        )
+
+    @override
+    async def flush(self) -> None:
+        """Block until the producer sent every record this publisher handed over.
+
+        Raises:
+            EventTransportNotRunningError: When the application has not started
+                the transport's producer, or has already stopped it.
+            KafkaError: When the broker rejected one of this publisher's records.
+        """
+        running = self._running_producer
+        await self._on_producer_loop(
+            self._confirm_deliveries(running.producer, self._claim_deliveries()),
+            running.loop,
+        )

--- a/plugins/spakky-kafka/tests/integration/test_event.py
+++ b/plugins/spakky-kafka/tests/integration/test_event.py
@@ -71,6 +71,7 @@ def test_synchronous_event(app: SpakkyApplication) -> None:
     event2 = SampleEvent(message="Goodbye, World!")
     transport.send("SampleEvent", _sample_event_type_adapter.dump_json(event1), {})
     transport.send("SampleEvent", _sample_event_type_adapter.dump_json(event2), {})
+    transport.flush()
     wait_for_count(handler, initial_count + 2)
     assert handler.count == initial_count + 2
 
@@ -89,6 +90,7 @@ async def test_asynchronous_event(app: SpakkyApplication) -> None:
     await transport.send(
         "SampleEvent", _sample_event_type_adapter.dump_json(event2), {}
     )
+    await transport.flush()
     await async_wait_for_count(handler, initial_count + 2)
     assert handler.count == initial_count + 2
 
@@ -170,6 +172,7 @@ def test_synchronous_handler_failure_expect_dead_letter_record(
     payload = TypeAdapter(FailingEvent).dump_json(event)
 
     transport.send("FailingEvent", payload, {})
+    transport.flush()
 
     record = read_dead_letter_record("FailingEvent.dlt")
     assert record.value() == payload
@@ -192,6 +195,7 @@ async def test_asynchronous_handler_failure_expect_dead_letter_record(
     payload = TypeAdapter(AsyncFailingEvent).dump_json(event)
 
     await transport.send("AsyncFailingEvent", payload, {})
+    await transport.flush()
 
     record = read_dead_letter_record("AsyncFailingEvent.dlt")
     assert record.value() == payload

--- a/plugins/spakky-kafka/tests/unit/test_transport.py
+++ b/plugins/spakky-kafka/tests/unit/test_transport.py
@@ -4,17 +4,63 @@ Tests send, topic creation, and delivery reporting
 for both synchronous and asynchronous Kafka event transports.
 """
 
+from asyncio import (
+    Future,
+    create_task,
+    get_running_loop,
+    locks,
+    new_event_loop,
+    run_coroutine_threadsafe,
+)
+from threading import Event, Thread
 from typing import Any
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aiokafka.structs import RecordMetadata, TopicPartition
+from spakky.event.error import EventTransportNotRunningError
 
 from spakky.plugins.kafka.common.config import KafkaConnectionConfig
 from spakky.plugins.kafka.event.transport import (
     AsyncKafkaEventTransport,
     KafkaEventTransport,
+    _pending_deliveries,
 )
+
+
+def _delivered_record() -> Future[RecordMetadata]:
+    """Return the delivery an aiokafka producer resolves once the broker acked."""
+    delivery: Future[RecordMetadata] = get_running_loop().create_future()
+    delivery.set_result(
+        RecordMetadata(
+            topic="TestEvent",
+            partition=0,
+            topic_partition=TopicPartition("TestEvent", 0),
+            offset=0,
+            timestamp=0,
+            timestamp_type=0,
+            log_start_offset=0,
+        )
+    )
+    return delivery
+
+
+async def _delivered_record_async() -> Future[RecordMetadata]:
+    """Return a resolved delivery created on the currently running loop."""
+    return _delivered_record()
+
+
+def _rejected_record(rejection: Exception) -> Future[RecordMetadata]:
+    """Return the delivery an aiokafka producer resolves when the broker rejects."""
+    delivery: Future[RecordMetadata] = get_running_loop().create_future()
+    delivery.set_exception(rejection)
+    return delivery
+
+
+def _claimed_deliveries() -> list[Future[RecordMetadata]]:
+    """Return the records this execution context still owes a flush."""
+    return _pending_deliveries.get() or []
 
 
 @pytest.fixture(name="config")
@@ -116,12 +162,12 @@ def test_sync_transport_message_delivery_report_success_expect_log(
 
 @patch("spakky.plugins.kafka.event.transport.Producer")
 @patch("spakky.plugins.kafka.event.transport.AdminClient")
-def test_sync_transport_send_expect_produce_and_flush(
+def test_sync_transport_send_expect_produce_without_flush(
     mock_admin_cls: MagicMock,
     mock_producer_cls: MagicMock,
     config: KafkaConnectionConfig,
 ) -> None:
-    """동기 transport의 send가 produce, poll, flush를 호출하는지 검증한다."""
+    """동기 transport의 send가 produce와 poll만 호출하고 flush는 미루는지 검증한다."""
     mock_admin = MagicMock()
     mock_admin.list_topics.return_value.topics.keys.return_value = set()
     mock_admin_cls.return_value = mock_admin
@@ -140,6 +186,54 @@ def test_sync_transport_send_expect_produce_and_flush(
         callback=transport._message_delivery_report,
     )
     mock_producer.poll.assert_called_once_with(0)
+    mock_producer.flush.assert_not_called()
+
+
+@patch("spakky.plugins.kafka.event.transport.Producer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+def test_sync_transport_batch_expect_single_flush_for_two_sends(
+    mock_admin_cls: MagicMock,
+    mock_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """동기 transport가 2건 발행 후 flush 1회로 배치를 확정하는지 검증한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+
+    mock_producer = MagicMock()
+    mock_producer_cls.return_value = mock_producer
+
+    transport = KafkaEventTransport(config)
+    transport.send("TestEvent", b"{}", {})
+    transport.send("TestEvent", b"{}", {})
+    transport.flush()
+
+    assert mock_producer.produce.call_count == 2
+    mock_producer.flush.assert_called_once()
+
+
+@patch("spakky.plugins.kafka.event.transport.Producer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+def test_sync_transport_stop_expect_queued_records_flushed(
+    mock_admin_cls: MagicMock,
+    mock_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """애플리케이션 종료 시 큐에 남은 레코드를 flush로 내보내는지 검증한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+
+    mock_producer = MagicMock()
+    mock_producer_cls.return_value = mock_producer
+
+    transport = KafkaEventTransport(config)
+    transport.set_stop_event(Event())
+    transport.start()
+    transport.send("TestEvent", b"{}", {})
+    transport.stop()
+
     mock_producer.flush.assert_called_once()
 
 
@@ -158,20 +252,22 @@ def test_async_transport_init_expect_success(
 @pytest.mark.asyncio
 @patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
 @patch("spakky.plugins.kafka.event.transport.AdminClient")
-async def test_async_transport_send_expect_produce_and_flush(
+async def test_async_transport_send_expect_record_handed_to_started_producer(
     mock_admin_cls: MagicMock,
     mock_aio_producer_cls: MagicMock,
     config: KafkaConnectionConfig,
 ) -> None:
-    """비동기 transport의 send가 AIOKafkaProducer를 통해 메시지를 전송하는지 검증한다."""
+    """비동기 transport의 send가 시작된 producer에 레코드를 넘기는지 검증한다."""
     mock_admin = MagicMock()
     mock_admin.list_topics.return_value.topics.keys.return_value = set()
     mock_admin_cls.return_value = mock_admin
 
     mock_producer = AsyncMock()
+    mock_producer.send.return_value = _delivered_record()
     mock_aio_producer_cls.return_value = mock_producer
 
     transport = AsyncKafkaEventTransport(config)
+    await transport.start_async()
     await transport.send(
         "TestEvent", b'{"key": "value"}', {"traceparent": "00-abc-def-01"}
     )
@@ -183,19 +279,256 @@ async def test_async_transport_send_expect_produce_and_flush(
         acks="all",
     )
     mock_producer.start.assert_awaited_once()
-    mock_producer.send_and_wait.assert_awaited_once_with(
+    mock_producer.send.assert_awaited_once_with(
         topic="TestEvent",
         value=b'{"key": "value"}',
         key=None,
         headers=[("traceparent", b"00-abc-def-01")],
     )
+    mock_producer.stop.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_send_expect_no_broker_wait_before_flush(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """send가 broker ack를 기다리지 않아 두 레코드가 한 배치로 묶이는지 검증한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+
+    mock_producer = AsyncMock()
+    mock_producer.send.side_effect = [_delivered_record(), _delivered_record()]
+    mock_aio_producer_cls.return_value = mock_producer
+
+    transport = AsyncKafkaEventTransport(config)
+    await transport.start_async()
+    await transport.send("TestEvent", b"{}", {})
+    await transport.send("TestEvent", b"{}", {})
+
+    assert mock_producer.send.await_count == 2
+    mock_producer.flush.assert_not_awaited()
+
+    await transport.flush()
+
+    mock_aio_producer_cls.assert_called_once()
+    mock_producer.flush.assert_awaited_once()
+    assert _claimed_deliveries() == []
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_flush_rejected_record_expect_broker_error_raised(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """broker가 거부한 레코드가 있으면 배치 끝 flush가 그 실패를 올리는지 검증한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+
+    mock_producer = AsyncMock()
+    mock_producer.send.side_effect = [
+        _rejected_record(ConnectionError("Broker rejected the record")),
+        _delivered_record(),
+    ]
+    mock_aio_producer_cls.return_value = mock_producer
+
+    transport = AsyncKafkaEventTransport(config)
+    await transport.start_async()
+    await transport.send("TestEvent", b"{}", {})
+    await transport.send("TestEvent", b"{}", {})
+
+    with pytest.raises(ConnectionError):
+        await transport.flush()
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_concurrent_publishers_expect_rejection_to_its_own_sender(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """동시 발행에서 거부된 레코드의 실패가 그 레코드를 보낸 발행자에게만 전달된다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+
+    mock_producer = AsyncMock()
+    mock_aio_producer_cls.return_value = mock_producer
+
+    transport = AsyncKafkaEventTransport(config)
+    await transport.start_async()
+
+    rejected_publisher_started = locks.Event()
+    healthy_publisher_flushed = locks.Event()
+
+    async def publish_rejected_record() -> None:
+        """발행자 A: 거부될 레코드를 보내고, 동시 발행자가 flush를 마친 뒤 flush한다."""
+        mock_producer.send.return_value = _rejected_record(
+            ConnectionError("Broker rejected the record")
+        )
+        await transport.send("TestEvent", b'{"sender": "rejected"}', {})
+        rejected_publisher_started.set()
+        await healthy_publisher_flushed.wait()
+        await transport.flush()
+
+    async def publish_healthy_record() -> None:
+        """발행자 B: 정상 레코드를 보내고 먼저 flush한다."""
+        await rejected_publisher_started.wait()
+        mock_producer.send.return_value = _delivered_record()
+        await transport.send("TestEvent", b'{"sender": "healthy"}', {})
+        await transport.flush()
+        healthy_publisher_flushed.set()
+
+    healthy_publisher = create_task(publish_healthy_record())
+    with pytest.raises(ConnectionError):
+        await publish_rejected_record()
+    await healthy_publisher
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_stop_async_expect_buffered_record_delivered_then_closed(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """애플리케이션 종료 시 남은 레코드를 내보낸 뒤 producer를 닫는지 검증한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    mock_producer = AsyncMock()
+    mock_producer.send.return_value = _delivered_record()
+    mock_aio_producer_cls.return_value = mock_producer
+
+    transport = AsyncKafkaEventTransport(config)
+    await transport.start_async()
+    await transport.send("TestEvent", b"{}", {})
+    await transport.stop_async()
+
+    mock_producer.flush.assert_awaited_once()
     mock_producer.stop.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 @patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
 @patch("spakky.plugins.kafka.event.transport.AdminClient")
-async def test_async_transport_send_with_sasl_config_expect_security_kwargs(
+async def test_async_transport_stop_async_with_rejected_record_expect_producer_closed(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """종료 시 마지막 레코드가 거부되어도 producer를 닫고 예외를 밖으로 내지 않는다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    mock_producer = AsyncMock()
+    mock_producer.send.return_value = _rejected_record(
+        ConnectionError("Broker rejected the record")
+    )
+    mock_aio_producer_cls.return_value = mock_producer
+
+    transport = AsyncKafkaEventTransport(config)
+    await transport.start_async()
+    await transport.send("TestEvent", b"{}", {})
+    await transport.stop_async()
+
+    mock_producer.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_send_before_start_expect_not_running_error(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """애플리케이션이 transport를 시작하기 전 발행은 not-running 에러로 거부된다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+
+    transport = AsyncKafkaEventTransport(config)
+
+    with pytest.raises(EventTransportNotRunningError):
+        await transport.send("TestEvent", b"{}", {})
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_send_after_stop_expect_not_running_error(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """종료 후 도착한 발행은 전달 실패가 아니라 not-running 에러로 구분된다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    mock_producer = AsyncMock()
+    mock_aio_producer_cls.return_value = mock_producer
+
+    transport = AsyncKafkaEventTransport(config)
+    await transport.start_async()
+    await transport.stop_async()
+
+    with pytest.raises(EventTransportNotRunningError):
+        await transport.send("TestEvent", b"{}", {})
+    with pytest.raises(EventTransportNotRunningError):
+        await transport.flush()
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_send_from_other_loop_expect_routed_to_producer_loop(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """producer를 만든 루프가 아닌 곳에서 발행해도 producer 루프로 라우팅됨을 검증한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    mock_producer = AsyncMock()
+    mock_aio_producer_cls.return_value = mock_producer
+
+    transport = AsyncKafkaEventTransport(config)
+    producer_loop = new_event_loop()
+    producer_loop_thread = Thread(target=producer_loop.run_forever, daemon=True)
+    producer_loop_thread.start()
+    try:
+        run_coroutine_threadsafe(transport.start_async(), producer_loop).result()
+        mock_producer.send.return_value = run_coroutine_threadsafe(
+            _delivered_record_async(), producer_loop
+        ).result()
+
+        await transport.send("TestEvent", b"{}", {})
+        await transport.flush()
+
+        assert transport._running_producer.loop is producer_loop
+        mock_producer.send.assert_awaited_once()
+        mock_producer.flush.assert_awaited_once()
+    finally:
+        producer_loop.call_soon_threadsafe(producer_loop.stop)
+        producer_loop_thread.join()
+        producer_loop.close()
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_start_async_with_sasl_config_expect_security_kwargs(
     mock_admin_cls: MagicMock,
     mock_aio_producer_cls: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
@@ -221,7 +554,7 @@ async def test_async_transport_send_with_sasl_config_expect_security_kwargs(
 
     config = KafkaConnectionConfig()
     transport = AsyncKafkaEventTransport(config)
-    await transport.send("SecureEvent", b"{}", {})
+    await transport.start_async()
 
     mock_aio_producer_cls.assert_called_once_with(
         bootstrap_servers="secure:9093",
@@ -276,14 +609,29 @@ async def test_async_transport_send_with_partition_key_expect_encoded_key(
     mock_admin_cls.return_value = mock_admin
 
     mock_producer = AsyncMock()
+    mock_producer.send.return_value = _delivered_record()
     mock_aio_producer_cls.return_value = mock_producer
 
     transport = AsyncKafkaEventTransport(config)
+    await transport.start_async()
     await transport.send("TestEvent", b"{}", {}, "ORD-43")
 
-    mock_producer.send_and_wait.assert_awaited_once_with(
+    mock_producer.send.assert_awaited_once_with(
         topic="TestEvent",
         value=b"{}",
         key=b"ORD-43",
         headers=[],
     )
+
+
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+def test_async_transport_set_stop_event_expect_no_producer_interaction(
+    mock_admin_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """transport는 폴링 루프가 없으므로 stop event를 받아도 아무 것도 하지 않는다."""
+    mock_admin_cls.return_value = MagicMock()
+
+    transport = AsyncKafkaEventTransport(config)
+
+    assert transport.set_stop_event(locks.Event()) is None

--- a/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/transport.py
+++ b/plugins/spakky-rabbitmq/src/spakky/plugins/rabbitmq/event/transport.py
@@ -80,6 +80,10 @@ class RabbitMQEventTransport(IEventTransport):
         channel.close()
         connection.close()
 
+    @override
+    def flush(self) -> None:
+        """Return immediately: send() publishes and closes its own connection."""
+
 
 @Pod()
 class AsyncRabbitMQEventTransport(IAsyncEventTransport):
@@ -141,3 +145,7 @@ class AsyncRabbitMQEventTransport(IAsyncEventTransport):
                 routing_key=event_name,
             )
             await channel.close()
+
+    @override
+    async def flush(self) -> None:
+        """Return immediately: send() publishes and closes its own connection."""

--- a/plugins/spakky-rabbitmq/tests/unit/test_transport.py
+++ b/plugins/spakky-rabbitmq/tests/unit/test_transport.py
@@ -202,3 +202,37 @@ async def test_async_transport_send_with_partition_key_expect_routing_unchanged(
     assert mock_default_exchange.publish.call_args.kwargs == {
         "routing_key": "test_event"
     }
+
+
+def test_sync_transport_flush_expect_no_broker_round_trip() -> None:
+    """send가 이미 발행을 마치므로 flush가 브로커에 다시 접속하지 않음을 검증한다."""
+    config = MagicMock(spec=RabbitMQConnectionConfig)
+    config.connection_string = "amqp://test:test@localhost:5672/"
+    config.exchange_name = None
+
+    transport = RabbitMQEventTransport(config)
+
+    with patch(
+        "spakky.plugins.rabbitmq.event.transport.BlockingConnection"
+    ) as mock_connection_cls:
+        assert transport.flush() is None
+
+    mock_connection_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_transport_flush_expect_no_broker_round_trip() -> None:
+    """send가 이미 발행을 마치므로 flush가 브로커에 다시 접속하지 않음을 검증한다."""
+    config = MagicMock(spec=RabbitMQConnectionConfig)
+    config.connection_string = "amqp://test:test@localhost:5672/"
+    config.exchange_name = None
+
+    transport = AsyncRabbitMQEventTransport(config)
+
+    with patch(
+        "spakky.plugins.rabbitmq.event.transport.connect_robust",
+        new_callable=AsyncMock,
+    ) as mock_connect:
+        assert await transport.flush() is None
+
+    mock_connect.assert_not_awaited()


### PR DESCRIPTION
## 무엇을 고쳤나

`AsyncKafkaEventTransport.send()`가 발행 한 건마다 `AIOKafkaProducer`를 새로 만들고 닫았습니다. 발행마다 브로커 연결과 메타데이터 조회가 반복되고, 두 레코드가 한 배치에 묶일 수 없으며, **producer 인스턴스 수명에 묶여 있는 멱등 발행 시퀀스가 매번 초기화**되어 `enable.idempotence`를 켜도 async 경로는 보호되지 않았습니다.

producer를 애플리케이션 수명 하나로 고정하고, 시작·종료에 열고 닫습니다.

## 주요 변경

### 1. producer 수명 = 애플리케이션 수명

`AsyncKafkaEventTransport`가 `IAsyncService`가 되어 `start_async`에서 producer를 열고 `stop_async`에서 닫습니다. `ServicePostProcessor`가 자동 등록하므로 사용자 코드 변경은 없습니다.

aiokafka는 producer를 **생성한 event loop에 묶습니다.** 그런데 `ApplicationContext`는 서비스를 자체 내부 loop(별도 스레드)에서 돌리므로, HTTP 요청 핸들러나 테스트처럼 다른 loop에서 발행하면 그 producer를 쓸 수 없습니다. 그래서 다른 loop의 호출은 `run_coroutine_threadsafe` + `wrap_future`로 producer의 loop에 위임합니다(같은 loop면 `is` 비교로 단락). 이 경로는 실제 브로커 통합 테스트(`test_asynchronous_event`)가 커버합니다 — 앱은 내부 loop에서 시작되고 테스트는 pytest loop에서 발행합니다.

### 2. 배치 성립 — `send`는 넘기고 `flush`가 확정 (리뷰 C1)

리뷰에서 "producer만 재사용하고 `send_and_wait`을 유지하면 레코드마다 broker 왕복이 생겨 배치가 여전히 성립하지 않는다"는 지적을 받았고, **수정 선택지 ①(실제 배치 성립)** 을 택했습니다. 이슈 본문이 지목한 세 결함 중 (b)를 문서로 얼버무리지 않고 실제로 해소하기 위함입니다.

- `send()`는 `producer.send()`로 레코드를 넘기고 ack를 기다리지 않습니다. 반환된 delivery future를 transport가 들고 있습니다.
- `flush()`가 배치를 내보낸 뒤 그 future들을 회수하여 **브로커가 거부한 레코드의 예외를 그대로 올립니다.** 즉 확인 의미(per-record 실패 검출)는 유지한 채 왕복만 배치 단위로 접었습니다.
- 릴레이 순서 보장을 위해 relay에서 `gather` 동시 발행 대신 순차 `send` + 1회 `flush`를 유지했습니다. 동시 발행은 같은 파티션 내 상대 순서를 뒤집을 수 있어 #492의 목적과 충돌합니다.
- flush 진행 중 다른 발행자가 넘긴 레코드는 pending에 남겨 그 발행자의 flush가 확정하도록 했습니다(두 발행자가 서로의 확인을 훔치지 않도록).

`flush()`는 `IEventTransport` / `IAsyncEventTransport` 계약에 추가되었습니다. 배치 경계는 호출자가 압니다 — `DirectEventBus`는 1건 배치이므로 `send` 직후, outbox relay는 배치 끝에 한 번 호출합니다. 동기 transport도 `send`마다 `flush`하지 않고 배치 끝 flush를 따릅니다.

동기 `flush()` 문구는 구현에 맞췄습니다: confluent-kafka는 개별 레코드 거부를 예외로 올리지 않고 delivery 콜백으로 로깅하므로, 계약 docstring에 "무엇을 올리는지는 구현이 명시한다"로 적었습니다(리뷰 W3). 동기 경로의 per-record 실패 귀속은 이 PR 범위 밖이며 dead-letter(#494) 영역입니다.

### 3. 종료 창에서 retry 예산 소모 차단 (리뷰 C2)

`__stop_services()`는 서비스 목록을 **정방향**으로 순회하므로 의존(transport)이 dependent(relay)보다 먼저 닫힙니다. 그 사이 relay가 깨어나면 닫힌 producer에 발행하다 실패하고, `except Exception`이 이를 삼켜 **배치 전원(기본 100건)의 retry count가 올라갑니다.** 배포를 반복하면 정상 메시지가 `max_retry_count` 천장을 넘어 영구히 제외됩니다.

코어 `application_context.py`의 종료 순서를 뒤집는 대신(프레임워크 코어 변경이라 승인 필요) **transport 쪽에서 해소**했습니다:

- transport는 producer를 닫기 **전에** 발행 접수를 멈추고, 이후 발행을 `EventTransportNotRunningError`(신규, `spakky-event`)로 거부합니다.
- relay는 이 에러를 전달 실패와 구분하여 retry를 올리지 않고 배치를 그대로 둔 채 릴레이를 멈춥니다. 종료는 어느 메시지의 잘못도 아니기 때문입니다.

이 에러는 리뷰 W1(시작 전 발행 시 `AttributeError`, 정지 후 `RuntimeError: Event loop is closed`)도 함께 해소합니다 — 불가능한 상태를 커스텀 에러로 실패시킵니다.

### 4. 배치 flush 실패의 retry 귀속 (리뷰 W4 — 정책 확정)

**flush 실패 시 retry count를 올리지 않습니다.** 근거: retry 카운터는 개별 메시지의 poison 여부를 세는 예산인데, 브로커 순간 장애로 인한 flush 실패는 어느 메시지에도 귀속되지 않습니다. 배치 전원에 부과하면 브로커 재시작 5회에 정상 메시지가 천장에 닿아 **조용히 영구 제외**됩니다(현재 dead-letter 라우팅 없음). 배치를 미발행으로 남기면 실패는 로그로 계속 드러나고 데이터는 보존됩니다 — 가시적 정체가 조용한 유실보다 안전한 실패 모드입니다. 개별 `send` 실패는 그 메시지에 귀속되므로 종전대로 retry를 올립니다.

### 5. 동기 transport 종료 flush (리뷰 W2)

`send`가 더 이상 flush하지 않으므로, `KafkaEventTransport`가 `IService`가 되어 애플리케이션 종료 시 큐 잔류 레코드를 flush합니다. 레포 자신의 통합 테스트도 producer linger에 암묵 의존하지 않도록 배치 끝 `flush()`를 명시 호출하게 고쳤습니다.

## 검증

4개 패키지(`spakky-event`, `spakky-outbox`, `spakky-kafka`, `spakky-rabbitmq`) 각 디렉토리에서:

- `uv run ruff format .` / `uv run ruff check .` — 통과
- `uv run pyrefly check src tests` — 0 errors (무인자 호출은 워크트리가 `.gitignore` 대상이라 아무것도 검사하지 않으므로 명시 경로 사용, 하네스 gap #499)
- `uv run pytest --with-integration` — 전부 통과, 변경 패키지 커버리지 100% 유지
- Kafka·RabbitMQ 통합 테스트는 testcontainers 실제 브로커로 통과 (127 / 90 passed)
- `uv run mkdocs build --strict` — 통과

`origin/develop` rebase 시 #492(partition key)·#494(dead-letter)와 합성했습니다: `send(..., partition_key)` 인자와 `flush()`·수명주기를 양쪽 모두 살렸고, producer 설정은 #494가 승격한 `KafkaConnectionConfig.async_producer_configuration_dict`를 사용합니다(중복 매핑 재도입 없음). #492가 새로 추가한 test double에도 `flush`를 채웠습니다.

## 문서

`ARCHITECTURE.md`, `core/spakky-event/README.md`, `plugins/spakky-kafka/README.md`, `docs/event-system.md`, `docs/guides/kafka.md`, `docs/guides/outbox.md`에 flush 계약·producer 수명주기·시작 실패(fail-fast)·retry 귀속 정책을 반영했습니다.

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)
