### PR TITLE
fix(grpc): reject messageless @rpc declarations at controller registration (#498)

### DIFF
--- a/docs/error-hierarchy.md
+++ b/docs/error-hierarchy.md
@@ -793,6 +793,7 @@ from spakky.plugins.grpc.error import (
 | `ProtoFieldNumberConflictError`       | 명시 `ProtoField` 번호가 자동 부여 필드의 번호와 충돌 |
 | `InvalidProtoFieldNumberError`        | 명시 `ProtoField(number=...)`가 protobuf 유효 범위 밖이거나 reserved band에 있음 |
 | `DuplicateProtoFieldNumberError`      | 같은 message 안에서 두 필드가 같은 명시 `ProtoField` 번호를 사용 |
+| `MessagelessRpcMethodError`           | `@rpc` 메서드가 request 또는 response 모델을 선언하지 않음. protobuf는 모든 method에 input/output 메시지를 요구하므로 컨트롤러 등록 시점(`build_service_descriptor`)에 차단되며, 클라이언트 호출 생성 시점에도 같은 에러가 발생 |
 
 **전송 보안 설정 에러:**
 
@@ -807,7 +808,6 @@ from spakky.plugins.grpc.error import (
 | ----------------------------- | ------------------------------------------ |
 | `NotAnRpcMethodError`         | `@rpc`가 붙지 않은 메서드로 호출을 만들려 함 |
 | `RpcMethodTypeMismatchError`  | 메서드가 선언한 스트리밍 패턴과 다른 호출 형태를 요청 |
-| `MessagelessRpcMethodError`   | `@rpc` 메서드가 request 또는 response 모델을 선언하지 않음 |
 
 ### spakky-openfga
 

--- a/docs/guides/grpc.md
+++ b/docs/guides/grpc.md
@@ -119,6 +119,8 @@ class UserServiceController:
         return GetUserResponse(user_id=user.uid, name=user.name)
 ```
 
+protobuf는 모든 method에 input/output 메시지 타입을 요구하므로 request 모델(첫 번째 인자)과 response 모델(반환 타입)을 모두 선언해야 합니다. 둘 중 하나라도 빠지면 컨트롤러 등록 시점에 `MessagelessRpcMethodError`가 발생하며, 에러의 `method_name`에 `컨트롤러명.메서드명`이 담깁니다.
+
 ### RpcMethodType
 
 | 값 | 설명 |
@@ -317,6 +319,7 @@ spakky-grpc-descriptor-snapshot apps | diff - descriptors.json
 | `UnsupportedFieldTypeError` | 지원하지 않는 protobuf 필드 타입 |
 | `DescriptorAlreadyRegisteredError` | 이미 등록된 descriptor 재등록 시도 |
 | `ProtoFieldNumberConflictError` | 명시 `ProtoField` 번호가 자동 부여 필드의 번호와 충돌 |
+| `MessagelessRpcMethodError` | `@rpc` 메서드가 request 또는 response 모델을 선언하지 않음 — 컨트롤러 등록 시점과 클라이언트 호출 생성 시점 모두에서 발생 |
 
 ### 전송 보안 설정 에러
 
@@ -331,7 +334,6 @@ spakky-grpc-descriptor-snapshot apps | diff - descriptors.json
 |------|------|
 | `NotAnRpcMethodError` | `@rpc`가 없는 메서드로 호출을 만들려 함 |
 | `RpcMethodTypeMismatchError` | 선언된 스트리밍 패턴과 다른 호출 형태를 요청 |
-| `MessagelessRpcMethodError` | `@rpc` 메서드가 request 또는 response 모델을 선언하지 않음 |
 
 ---
 

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/client.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/client.py
@@ -199,7 +199,7 @@ class GrpcClient:
                 method.__name__, expected, rpc_annotation.method_type
             )
         if rpc_annotation.request_type is None or rpc_annotation.response_type is None:
-            raise MessagelessRpcMethodError(method.__name__)
+            raise MessagelessRpcMethodError(method.__qualname__)
         # `Rpc` stores both models as bare `type` objects erased of their identity,
         # while `RequestT`/`ResponseT` come from the controller method signature the
         # caller passed in — the same classes by construction of the `@rpc` decorator.

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/decorators/rpc.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/decorators/rpc.py
@@ -11,6 +11,7 @@ from inspect import signature
 from typing import get_args, get_origin, get_type_hints
 from collections.abc import Callable
 
+from pydantic import BaseModel
 from spakky.core.common.annotation import FunctionAnnotation
 
 
@@ -30,15 +31,23 @@ class RpcMethodType(StrEnum):
     BIDI_STREAMING = auto()
 
 
-def _unwrap_streaming_type(annotation: object | None) -> type | None:
-    """Return the message type inside supported streaming annotations."""
+def _unwrap_streaming_type(annotation: object | None) -> type[BaseModel] | None:
+    """Return the message model inside supported streaming annotations.
+
+    Only a pydantic ``BaseModel`` subclass can become a protobuf message, so
+    anything else — a bare ``AsyncIterator``, the ``NoneType`` behind a
+    ``-> None`` hint, a plain ``str`` parameter — is reported as absent.
+    Keeping ``None`` the single marker for "this method declares no message
+    here" lets every consumer of ``Rpc`` test one condition instead of
+    inspecting the type it received.
+    """
     if annotation is AsyncIteratorABC:
         return None
     candidate = annotation
     if get_origin(annotation) is AsyncIteratorABC and get_args(annotation):
         args = get_args(annotation)
         candidate = args[0]
-    if isinstance(candidate, type):
+    if isinstance(candidate, type) and issubclass(candidate, BaseModel):
         return candidate
     return None
 
@@ -52,15 +61,15 @@ class Rpc(FunctionAnnotation):
 
     Attributes:
         method_type: gRPC streaming pattern for this method.
-        request_type: Request message type. Auto-extracted from type hints
-            if not provided.
-        response_type: Response message type. Auto-extracted from type hints
-            if not provided.
+        request_type: Request message model, or ``None`` when the method
+            declares none. Auto-extracted from type hints if not provided.
+        response_type: Response message model, or ``None`` when the method
+            declares none. Auto-extracted from type hints if not provided.
     """
 
     method_type: RpcMethodType = RpcMethodType.UNARY
-    request_type: type | None = None
-    response_type: type | None = None
+    request_type: type[BaseModel] | None = None
+    response_type: type[BaseModel] | None = None
 
     def __call__[T](self, obj: Callable[..., T]) -> Callable[..., T]:
         """Annotate a method as an RPC endpoint.
@@ -98,8 +107,8 @@ class Rpc(FunctionAnnotation):
 
 def rpc[T](
     method_type: RpcMethodType = RpcMethodType.UNARY,
-    request_type: type | None = None,
-    response_type: type | None = None,
+    request_type: type[BaseModel] | None = None,
+    response_type: type[BaseModel] | None = None,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Decorator to mark a controller method as a gRPC RPC endpoint.
 
@@ -108,9 +117,9 @@ def rpc[T](
 
     Args:
         method_type: gRPC streaming pattern for this method.
-        request_type: Request message type. Auto-extracted from type hints
+        request_type: Request message model. Auto-extracted from type hints
             if not provided.
-        response_type: Response message type. Auto-extracted from type hints
+        response_type: Response message model. Auto-extracted from type hints
             if not provided.
 
     Returns:

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/error.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/error.py
@@ -265,6 +265,12 @@ class MessagelessRpcMethodError(AbstractSpakkyGrpcError):
     method missing either cannot be addressed over the wire. Reporting it here
     names the offending method instead of surfacing an opaque descriptor-pool
     rejection about an unresolvable empty type name.
+
+    Raised from two places that reach the same invalid declaration: controller
+    registration (``build_service_descriptor``) and client callable
+    construction. Both carry ``method_name`` as ``<controller>.<method>`` so a
+    log line identifies the declaration even when several controllers share a
+    method name.
     """
 
     message = "RPC method must declare both a request and a response model"

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/handler.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/handler.py
@@ -21,7 +21,10 @@ import grpc
 import grpc.aio
 from spakky.plugins.grpc.codec import basemodel_to_protobuf, protobuf_to_basemodel
 from spakky.plugins.grpc.decorators.rpc import Rpc, RpcMethodType
-from spakky.plugins.grpc.error import UnsupportedResponseTypeError
+from spakky.plugins.grpc.error import (
+    MessagelessRpcMethodError,
+    UnsupportedResponseTypeError,
+)
 from spakky.plugins.grpc.auth import seed_grpc_auth_context
 from spakky.plugins.grpc.schema.registry import DescriptorRegistry
 
@@ -100,7 +103,15 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
     # ------------------------------------------------------------------
 
     def _build_handlers(self) -> None:
-        """Pre-build ``RpcMethodHandler`` for every ``@rpc`` method."""
+        """Pre-build ``RpcMethodHandler`` for every ``@rpc`` method.
+
+        Raises:
+            MessagelessRpcMethodError: If an ``@rpc`` method declares no
+                request or no response model. ``build_file_descriptor`` rejects
+                the same declaration before a handler is ever built for a
+                registered controller; repeating the check here keeps the
+                invariant true for handlers constructed directly.
+        """
         for method_name, method in getmembers(
             self._controller_type, predicate=isfunction
         ):
@@ -108,15 +119,21 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
             if rpc_annotation is None:
                 continue
 
+            request_type = rpc_annotation.request_type
+            response_type = rpc_annotation.response_type
+            if request_type is None or response_type is None:
+                raise MessagelessRpcMethodError(
+                    f"{self._controller_type.__name__}.{method_name}"
+                )
+
             full_method = f"/{self._full_service_name}/{method_name}"
-            request_deserializer = self._make_deserializer(rpc_annotation.request_type)
-            response_serializer = self._make_serializer(rpc_annotation.response_type)
             handler = self._make_rpc_method_handler(
                 full_method=full_method,
                 method_name=method_name,
-                rpc_annotation=rpc_annotation,
-                request_deserializer=request_deserializer,
-                response_serializer=response_serializer,
+                method_type=rpc_annotation.method_type,
+                request_type=request_type,
+                request_deserializer=self._make_deserializer(request_type),
+                response_serializer=self._make_serializer(response_type),
             )
             self._handlers[full_method] = handler
             logger.debug(
@@ -129,23 +146,22 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
         *,
         full_method: str,
         method_name: str,
-        rpc_annotation: Rpc,
-        request_deserializer: Callable[[bytes], object] | None,
-        response_serializer: Callable[[object], bytes] | None,
+        method_type: RpcMethodType,
+        request_type: type[BaseModel],
+        request_deserializer: Callable[[bytes], object],
+        response_serializer: Callable[[object], bytes],
     ) -> grpc.RpcMethodHandler:
         """Create a ``grpc.RpcMethodHandler`` for a single ``@rpc`` method."""
-        method_type = rpc_annotation.method_type
-
         if method_type is RpcMethodType.UNARY:
             return grpc.unary_unary_rpc_method_handler(
-                self._make_unary_behavior(full_method, method_name, rpc_annotation),
+                self._make_unary_behavior(full_method, method_name, request_type),
                 request_deserializer=request_deserializer,
                 response_serializer=response_serializer,
             )
         if method_type is RpcMethodType.SERVER_STREAMING:
             return grpc.unary_stream_rpc_method_handler(
                 self._make_server_streaming_behavior(
-                    full_method, method_name, rpc_annotation
+                    full_method, method_name, request_type
                 ),
                 request_deserializer=request_deserializer,
                 response_serializer=response_serializer,
@@ -153,16 +169,14 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
         if method_type is RpcMethodType.CLIENT_STREAMING:
             return grpc.stream_unary_rpc_method_handler(
                 self._make_client_streaming_behavior(
-                    full_method, method_name, rpc_annotation
+                    full_method, method_name, request_type
                 ),
                 request_deserializer=request_deserializer,
                 response_serializer=response_serializer,
             )
         # BIDI_STREAMING
         return grpc.stream_stream_rpc_method_handler(
-            self._make_bidi_streaming_behavior(
-                full_method, method_name, rpc_annotation
-            ),
+            self._make_bidi_streaming_behavior(full_method, method_name, request_type),
             request_deserializer=request_deserializer,
             response_serializer=response_serializer,
         )
@@ -173,10 +187,9 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
         self,
         full_method: str,
         method_name: str,
-        rpc_annotation: Rpc,
+        request_type: type[BaseModel],
     ) -> Callable[..., object]:
         """Build an async unary-unary handler."""
-        request_type = rpc_annotation.request_type
 
         async def _behavior(
             request: object,
@@ -192,8 +205,6 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
             instance = self._container.get(self._controller_type)
             # framework 내부 디스패치: @rpc 등록 메서드명을 런타임에 조회
             handler_method = getattr(instance, method_name)  # RPC handler method lookup
-            if request_type is None:
-                return await handler_method()
             domain_request = (
                 protobuf_to_basemodel(request, request_type)
                 if isinstance(request, Message)
@@ -207,10 +218,9 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
         self,
         full_method: str,
         method_name: str,
-        rpc_annotation: Rpc,
+        request_type: type[BaseModel],
     ) -> Callable[..., AsyncIterator[object]]:
         """Build an async unary-stream (server streaming) handler."""
-        request_type = rpc_annotation.request_type
 
         async def _behavior(
             request: object,
@@ -226,10 +236,6 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
             instance = self._container.get(self._controller_type)
             # framework 내부 디스패치: @rpc 등록 메서드명을 런타임에 조회
             handler_method = getattr(instance, method_name)  # RPC handler method lookup
-            if request_type is None:
-                async for item in handler_method():
-                    yield item
-                return
             domain_request = (
                 protobuf_to_basemodel(request, request_type)
                 if isinstance(request, Message)
@@ -244,10 +250,9 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
         self,
         full_method: str,
         method_name: str,
-        rpc_annotation: Rpc,
+        request_type: type[BaseModel],
     ) -> Callable[..., object]:
         """Build an async stream-unary (client streaming) handler."""
-        request_type = rpc_annotation.request_type
 
         async def _behavior(
             request_iterator: AsyncIterator[object],
@@ -266,7 +271,7 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
 
             async def _convert_stream() -> AsyncIterator[object]:
                 async for request in request_iterator:
-                    if request_type is not None and isinstance(request, Message):
+                    if isinstance(request, Message):
                         yield protobuf_to_basemodel(request, request_type)
                     else:
                         yield request
@@ -279,10 +284,9 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
         self,
         full_method: str,
         method_name: str,
-        rpc_annotation: Rpc,
+        request_type: type[BaseModel],
     ) -> Callable[..., AsyncIterator[object]]:
         """Build an async stream-stream (bidirectional streaming) handler."""
-        request_type = rpc_annotation.request_type
 
         async def _behavior(
             request_iterator: AsyncIterator[object],
@@ -301,7 +305,7 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
 
             async def _convert_stream() -> AsyncIterator[object]:
                 async for request in request_iterator:
-                    if request_type is not None and isinstance(request, Message):
+                    if isinstance(request, Message):
                         yield protobuf_to_basemodel(request, request_type)
                     else:
                         yield request
@@ -315,12 +319,9 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
 
     def _make_deserializer(
         self,
-        request_type: type[BaseModel] | None,
-    ) -> Callable[[bytes], object] | None:
+        request_type: type[BaseModel],
+    ) -> Callable[[bytes], object]:
         """Build a bytes → protobuf Message deserializer."""
-        if request_type is None:
-            return None
-
         full_name = (
             f"{self._full_service_name.rsplit('.', 1)[0]}.{request_type.__name__}"
         )
@@ -335,12 +336,9 @@ class GrpcServiceHandler(grpc.GenericRpcHandler):
 
     def _make_serializer(
         self,
-        response_type: type[BaseModel] | None,
-    ) -> Callable[[object], bytes] | None:
+        response_type: type[BaseModel],
+    ) -> Callable[[object], bytes]:
         """Build a ``BaseModel``/``Message`` → bytes serializer."""
-        if response_type is None:
-            return None
-
         full_name = (
             f"{self._full_service_name.rsplit('.', 1)[0]}.{response_type.__name__}"
         )

--- a/plugins/spakky-grpc/src/spakky/plugins/grpc/schema/descriptor_builder.py
+++ b/plugins/spakky-grpc/src/spakky/plugins/grpc/schema/descriptor_builder.py
@@ -19,6 +19,7 @@ from google.protobuf.descriptor_pb2 import (
 )
 from pydantic import BaseModel
 from spakky.plugins.grpc.decorators.rpc import Rpc, RpcMethodType
+from spakky.plugins.grpc.error import MessagelessRpcMethodError
 from spakky.plugins.grpc.schema.field_number import assign_field_numbers
 from spakky.plugins.grpc.schema.type_map import resolve_type
 from spakky.plugins.grpc.stereotypes.grpc_controller import GrpcController
@@ -103,6 +104,12 @@ def build_service_descriptor(
 
     Returns:
         A ``ServiceDescriptorProto`` for the controller.
+
+    Raises:
+        MessagelessRpcMethodError: If an ``@rpc`` method declares no request
+            or no response model. protobuf requires every method to name an
+            input and an output message, so such a declaration cannot be
+            expressed as a descriptor at all.
     """
     service = ServiceDescriptorProto(name=service_name)
 
@@ -113,23 +120,16 @@ def build_service_descriptor(
         rpc_annotation = Rpc.get(method)
         request_type = rpc_annotation.request_type
         response_type = rpc_annotation.response_type
+        if request_type is None or response_type is None:
+            raise MessagelessRpcMethodError(f"{controller_type.__name__}.{method_name}")
 
-        if request_type is not None:
-            build_message_descriptor(request_type, collected)
-            input_type = f".{package}.{request_type.__name__}"
-        else:
-            input_type = ""
-
-        if response_type is not None:
-            build_message_descriptor(response_type, collected)
-            output_type = f".{package}.{response_type.__name__}"
-        else:
-            output_type = ""
+        build_message_descriptor(request_type, collected)
+        build_message_descriptor(response_type, collected)
 
         method_desc = MethodDescriptorProto(
             name=method_name,
-            input_type=input_type,
-            output_type=output_type,
+            input_type=f".{package}.{request_type.__name__}",
+            output_type=f".{package}.{response_type.__name__}",
             client_streaming=rpc_annotation.method_type
             in {RpcMethodType.CLIENT_STREAMING, RpcMethodType.BIDI_STREAMING},
             server_streaming=rpc_annotation.method_type
@@ -152,6 +152,10 @@ def build_file_descriptor(controller_type: type) -> FileDescriptorProto:
 
     Returns:
         A ``FileDescriptorProto`` ready for ``descriptor_pool`` registration.
+
+    Raises:
+        MessagelessRpcMethodError: If an ``@rpc`` method declares no request
+            or no response model.
     """
     annotation = GrpcController.get(controller_type)
     package = annotation.package

--- a/plugins/spakky-grpc/tests/unit/test_descriptor_builder.py
+++ b/plugins/spakky-grpc/tests/unit/test_descriptor_builder.py
@@ -3,11 +3,13 @@
 from typing import Annotated
 from collections.abc import AsyncIterator
 
+import pytest
 from google.protobuf.descriptor_pb2 import FieldDescriptorProto
 from pydantic import BaseModel
 
 from spakky.plugins.grpc.annotations.field import ProtoField
 from spakky.plugins.grpc.decorators.rpc import RpcMethodType, rpc
+from spakky.plugins.grpc.error import MessagelessRpcMethodError
 from spakky.plugins.grpc.schema.descriptor_builder import (
     build_file_descriptor,
     build_message_descriptor,
@@ -266,8 +268,8 @@ def test_build_message_descriptor_optional_field() -> None:
     assert field.proto3_optional is True
 
 
-def test_build_service_descriptor_no_request_type() -> None:
-    """request_type이 None인 rpc 메서드에서 input_type이 빈 문자열인지 검증한다."""
+def test_build_service_descriptor_missing_request_expect_messageless_error() -> None:
+    """request 모델이 없는 rpc 선언이 메서드 이름과 함께 차단되는지 검증한다."""
 
     @GrpcController(package="test.v1")
     class NoRequestService:
@@ -279,16 +281,15 @@ def test_build_service_descriptor_no_request_type() -> None:
             ...
 
     collected: dict = {}
-    service = build_service_descriptor(
-        NoRequestService, "test.v1", "NoRequestService", collected
-    )
-    method = service.method[0]
-    assert method.input_type == ""
-    assert method.output_type == ".test.v1.HelloResponse"
+    with pytest.raises(MessagelessRpcMethodError) as raised:
+        build_service_descriptor(
+            NoRequestService, "test.v1", "NoRequestService", collected
+        )
+    assert raised.value.method_name == "NoRequestService.no_request"
 
 
-def test_build_service_descriptor_no_response_type() -> None:
-    """response_type이 None인 rpc 메서드에서 output_type이 빈 문자열인지 검증한다."""
+def test_build_service_descriptor_missing_response_expect_messageless_error() -> None:
+    """response 모델이 없는 rpc 선언이 메서드 이름과 함께 차단되는지 검증한다."""
 
     @GrpcController(package="test.v1")
     class NoResponseService:
@@ -300,12 +301,28 @@ def test_build_service_descriptor_no_response_type() -> None:
             ...
 
     collected: dict = {}
-    service = build_service_descriptor(
-        NoResponseService, "test.v1", "NoResponseService", collected
-    )
-    method = service.method[0]
-    assert method.input_type == ".test.v1.HelloRequest"
-    assert method.output_type == ""
+    with pytest.raises(MessagelessRpcMethodError) as raised:
+        build_service_descriptor(
+            NoResponseService, "test.v1", "NoResponseService", collected
+        )
+    assert raised.value.method_name == "NoResponseService.fire_and_forget"
+
+
+def test_build_file_descriptor_missing_response_expect_messageless_error() -> None:
+    """컨트롤러 등록 경로에서도 메시지 없는 rpc가 기동 전에 차단되는지 검증한다."""
+
+    @GrpcController(package="test.v1")
+    class ProbeService:
+        """Controller registered with a void-return rpc."""
+
+        @rpc()
+        async def ping(self) -> None:
+            """RPC declaring neither a request nor a response model."""
+            ...
+
+    with pytest.raises(MessagelessRpcMethodError) as raised:
+        build_file_descriptor(ProbeService)
+    assert raised.value.method_name == "ProbeService.ping"
 
 
 def test_build_service_descriptor_skips_non_rpc_methods() -> None:

--- a/plugins/spakky-grpc/tests/unit/test_handler.py
+++ b/plugins/spakky-grpc/tests/unit/test_handler.py
@@ -23,7 +23,11 @@ from spakky.core.pod.interfaces.container import IContainer
 from typing import override
 from spakky.plugins.grpc.annotations.field import ProtoField
 from spakky.plugins.grpc.decorators.rpc import RpcMethodType, rpc
-from spakky.plugins.grpc.error import Unavailable, UnsupportedResponseTypeError
+from spakky.plugins.grpc.error import (
+    MessagelessRpcMethodError,
+    Unavailable,
+    UnsupportedResponseTypeError,
+)
 from spakky.plugins.grpc.codec import basemodel_to_protobuf, protobuf_to_basemodel
 from spakky.plugins.grpc.handler import GrpcServiceHandler
 from spakky.plugins.grpc.schema.descriptor_builder import build_file_descriptor
@@ -483,38 +487,27 @@ async def test_serializer_rejects_unsupported_type(
     assert excinfo.value.value_type is str
 
 
-def test_make_deserializer_returns_none_when_no_request_type() -> None:
-    """_make_deserializer should return None when request_type is None."""
-    registry = _build_registry_for(PingController)
-    container = MagicMock(spec=IContainer)
-    application_context = MagicMock(spec=IApplicationContext)
-    handler = GrpcServiceHandler(
-        controller_type=PingController,
-        package="handler.v1",
-        service_name="PingController",
-        container=container,
-        application_context=application_context,
-        registry=registry,
-    )
-    result = handler._make_deserializer(None)
-    assert result is None
+def test_build_handlers_messageless_rpc_expect_messageless_error() -> None:
+    """등록 경로를 우회해 만든 핸들러도 메시지 없는 rpc를 통과시키지 않는지 검증한다."""
 
+    @GrpcController(package="handler.v1", service_name="Probe")
+    class ProbeController:
+        """Controller whose rpc declares no response model."""
 
-def test_make_serializer_returns_none_when_no_response_type() -> None:
-    """_make_serializer should return None when response_type is None."""
-    registry = _build_registry_for(PingController)
-    container = MagicMock(spec=IContainer)
-    application_context = MagicMock(spec=IApplicationContext)
-    handler = GrpcServiceHandler(
-        controller_type=PingController,
-        package="handler.v1",
-        service_name="PingController",
-        container=container,
-        application_context=application_context,
-        registry=registry,
-    )
-    result = handler._make_serializer(None)
-    assert result is None
+        @rpc()
+        async def ping(self, request: PingRequest) -> None:
+            """RPC without a response model."""
+
+    with pytest.raises(MessagelessRpcMethodError) as excinfo:
+        GrpcServiceHandler(
+            controller_type=ProbeController,
+            package="handler.v1",
+            service_name="Probe",
+            container=MagicMock(spec=IContainer),
+            application_context=MagicMock(spec=IApplicationContext),
+            registry=_build_registry_for(PingController),
+        )
+    assert excinfo.value.method_name == "ProbeController.ping"
 
 
 # ------------------------------------------------------------------

--- a/plugins/spakky-grpc/tests/unit/test_rpc.py
+++ b/plugins/spakky-grpc/tests/unit/test_rpc.py
@@ -91,6 +91,18 @@ def test_rpc_streaming_hint_without_type_arg_returns_none() -> None:
     assert annotation.response_type is HelloResponse
 
 
+def test_rpc_void_return_hint_expect_response_type_none() -> None:
+    """A ``-> None`` hint should report an absent response model, not NoneType."""
+
+    @rpc()
+    async def ping(self: object, request: HelloRequest) -> None:
+        """Ping without a response model."""
+        ...
+
+    annotation = Rpc.get(ping)
+    assert annotation.response_type is None
+
+
 def test_rpc_extracts_request_type_from_hints() -> None:
     """@rpc() should auto-extract request type from type hints."""
 


### PR DESCRIPTION
## 무엇을 바꿨나

`@rpc`가 request 또는 response 모델을 선언하지 않은 컨트롤러를 등록하면, 애플리케이션 기동 시 프레임워크 에러가 아니라 raw 예외로 죽었습니다. protobuf는 모든 method에 input/output 메시지 타입을 요구하므로 이런 선언은 애초에 descriptor로 표현할 수 없는데, 사용자는 어느 메서드가 원인인지 알 수 없었습니다.

이제 컨트롤러 등록 시점에 `MessagelessRpcMethodError`로 차단하고, 에러의 `method_name`에 `컨트롤러명.메서드명`이 담깁니다.

## 근본 원인

이슈에 기록된 두 재현은 서로 다른 원인이었습니다.

1. **`-> None` 케이스** — `_unwrap_streaming_type`이 `-> None` 힌트가 해석된 `NoneType`을 "진짜 `type`"으로 받아들여 `response_type`에 채웠습니다. `NoneType`은 타입이지만 메시지 모델이 아니므로, 뒤늦게 `assign_field_numbers`가 `NoneType.model_fields`에 접근하며 `AttributeError`로 터졌습니다.
2. **request 부재 케이스** — `request_type`이 `None`으로 남아 `descriptor_builder`가 `input_type=""`인 descriptor를 만들었고, descriptor pool이 이를 거부했습니다.

`_unwrap_streaming_type`이 **pydantic `BaseModel` 서브클래스만** 메시지 모델로 인정하도록 정규화하여 두 경로를 하나로 모았습니다. 이제 `None`이 "여기엔 메시지 선언이 없다"의 단일 표식이므로, `Rpc` 소비자는 조건 하나만 검사하면 됩니다.

이 정규화는 리뷰에서 드러난 세 번째 케이스도 함께 막습니다 — `async def bad(self, request: str) -> Hello`처럼 `BaseModel`이 아닌 임의의 `type`이 가드를 통과해 **같은 raw `AttributeError`로 죽던** 경로입니다.

## 변경 내용

| 파일 | 변경 |
|------|------|
| `decorators/rpc.py` | `_unwrap_streaming_type`이 `BaseModel` 서브클래스만 반환. `Rpc.request_type`/`response_type`과 `rpc()` 인자를 `type[BaseModel] \| None`로 좁혀 계약을 타입으로 강제 |
| `schema/descriptor_builder.py` | `build_service_descriptor`가 메시지 없는 선언을 `MessagelessRpcMethodError`로 차단. 도달 불가해진 `input_type`/`output_type` 빈 문자열 분기 제거 |
| `handler.py` | `_build_handlers`에 동일 가드 추가. 등록이 선행 차단하므로 도달 불가해진 `request_type is None` 분기 6곳과 `_make_deserializer`/`_make_serializer`의 `None` 반환 제거 |
| `client.py` | 같은 에러의 `method_name`을 서버 경로와 같은 `컨트롤러명.메서드명` 형식으로 통일 |
| `error.py` | `MessagelessRpcMethodError` docstring에 두 발생 경로와 `method_name` 형식 명시 |
| `docs/error-hierarchy.md`, `docs/guides/grpc.md` | 이 에러를 클라이언트 전용에서 스키마 에러로 재분류. `@rpc` 절에 두 모델 선언 의무 기술 |

## 자율 결정 근거

- **기존 `MessagelessRpcMethodError` 재사용** — 이슈가 "같은 에러를 쓰거나 동일 계열 에러를 추가" 중 선택을 열어두었고, #497이 이미 클라이언트 경로에 정의한 에러가 같은 무효 선언을 가리키므로 새 클래스를 만들지 않았습니다.
- **`method_name`에 컨트롤러명 포함** — 서로 다른 컨트롤러가 같은 메서드명을 가지면 bare 메서드명만으로는 로그에서 식별이 불가능합니다. 등록 경로는 실제 등록된 `controller_type`을, 클라이언트 경로는 `__qualname__`을 사용합니다.
- **`handler.py` 방어 분기 제거** — `RegisterServicesPostProcessor`가 `build_file_descriptor`를 핸들러 생성보다 먼저 호출하므로, 등록 경로에서 메시지 없는 컨트롤러는 핸들러가 만들어지기 전에 차단됩니다. 남은 분기는 "messageless도 지원한다"는 반대 계약을 유지해 유지보수자가 어느 쪽을 불변식으로 삼을지 판정할 수 없게 만들므로 제거했습니다.
- **에러 메시지 형식** — 레포 규칙상 에러 `message`는 클래스 속성 고정값이고 컨텍스트는 속성으로 전달하므로, 메서드 이름은 `method_name` 속성에 담았습니다.

## Acceptance Criteria (자가 grep)

`acceptance_check: PASS`

| 수용 기준 | 검증 | 결과 |
|---|---|---|
| request/response 모델이 없는 `@rpc` 컨트롤러 등록 시 `AbstractSpakkyGrpcError` 하위 에러 + 메서드 이름 | `test_build_file_descriptor_missing_response_expect_messageless_error` 등 4건 | PASS |
| `grep -n 'input_type = ""' plugins/spakky-grpc/src/spakky/plugins/grpc/schema/descriptor_builder.py` 결과 공백 | grep exit 1 (0건) | PASS |
| `cd plugins/spakky-grpc && uv run pytest` 커버리지 100% 통과 | 292 passed, 커버리지 100.00% | PASS |

검증 명령 전문:

```
cd plugins/spakky-grpc
uv run ruff format --check src tests   # 66 files already formatted
uv run ruff check src tests            # All checks passed!
uv run pyrefly check src tests         # INFO 0 errors (2 suppressed)
uv run pytest                          # 292 passed, coverage 100.00%
```

`pyrefly`는 무인자 호출 시 이 워크트리 경로가 `.gitignore`에 매치되어 아무것도 검사하지 않으므로(하네스 gap #499) 명시 경로로 호출했습니다.

**크로스패키지 확인**: `Rpc.request_type`/`response_type` 타입을 좁혔으므로 워크스페이스 소비자를 전수 확인했습니다. `spakky-grpc` 밖에서 이 심볼을 쓰는 곳은 `spakky-a2a`뿐이며 `@GrpcController`/`@rpc`를 사용하지 않습니다 — `spakky-a2a` 147 passed, 커버리지 100%.

## 후속 이슈

- #507 — 커버리지 게이트가 광역 `exclude_lines` 정규식으로 일반 코드 줄을 제외한다. 리뷰 중 실측으로 확인된 pre-existing 결함이며, 워크스페이스 30개 `pyproject.toml` 전부에 같은 설정이 있습니다. 본 PR 범위 밖이라 분리했습니다.

Closes #498
