### PR TITLE
fix(harness): align pyrefly invocation form with actual pre-commit configs (#499)

### DIFF
--- a/.agents/rules/monorepo.md
+++ b/.agents/rules/monorepo.md
@@ -10,10 +10,12 @@ paths:
 모든 pre-commit 도구(pyrefly, ruff 등)는 **패키지 디렉토리 내에서** 실행:
 
 ```bash
-cd core/spakky && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text
+cd core/spakky && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text
 cd core/spakky && uv run ruff check .
 cd core/spakky && uv run pytest
 ```
+
+pyrefly는 경로 인자를 생략하면 git 무시 규칙을 적용하므로, 워크트리(`.claude/worktrees/<branch>`)에서는 소스 전체가 검사 대상에서 빠진다. 소스가 제외되지 않는 형태로 호출한다 — 경로 인자(`src tests`) 또는 `--disable-project-excludes-heuristics`.
 
 **금지**: 루트에서 `uv run pyrefly check`, `uv run ruff check`, `uv run pytest` 직접 실행
 

--- a/.agents/skills/check/SKILL.md
+++ b/.agents/skills/check/SKILL.md
@@ -21,7 +21,7 @@ user-invocable: true
 2. **Python 하네스 규칙 검증** — `uv run python ../../.agents/skills/check/scripts/validate_python_harness.py .` (패키지 디렉토리 내에서, root pre-commit도 전체 실행)
 3. **레이어 의존 방향 검증** — 패키지 간 역방향 import가 없는지 확인.
 4. **Lint** — `uv run ruff check .` (패키지 디렉토리 내에서)
-5. **타입 체크** — `uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text` (패키지 디렉토리 내에서, warning도 실패로 처리)
+5. **타입 체크** — `uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text` (패키지 디렉토리 내에서, warning도 실패로 처리)
 6. **테스트** — `uv run pytest` (패키지 디렉토리 내에서)
 
 ## 1. Python 하네스 규칙 검증
@@ -78,7 +78,7 @@ cd <package-dir> && uv run ruff check .
 ## 4. 타입 체크
 
 ```bash
-cd <package-dir> && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text
+cd <package-dir> && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text
 ```
 
 - 실패하거나 warning이 출력되면 → 테스트 실행하지 않고 타입 오류/경고부터 수정 후 재실행.

--- a/.agents/skills/onboarding/SKILL.md
+++ b/.agents/skills/onboarding/SKILL.md
@@ -66,7 +66,7 @@ uv run pre-commit install
 
 ```bash
 # 코어 패키지 예시
-cd core/spakky && uv run ruff check . && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text
+cd core/spakky && uv run ruff check . && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text
 ```
 
 ## Step 6: 테스트 실행

--- a/.agents/skills/refactor-code/SKILL.md
+++ b/.agents/skills/refactor-code/SKILL.md
@@ -50,10 +50,10 @@ user-invocable: true
 
 ```bash
 # 패키지별로 실행
-cd <package-dir> && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text
+cd <package-dir> && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text
 ```
 
-> **주의**: `uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text`가 `0 errors (N suppressed)`를 반환해도
+> **주의**: `uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text`가 `0 errors (N suppressed)`를 반환해도
 > VS Code 익스텐션이 오류를 표시할 수 있다.
 > pyrefly 프로젝트 모드는 다른 패키지의 `src/` 디렉토리를 `project_excludes`로 자동 제외하므로
 > cross-package TypeVar 추론 오류가 suppressed 처리된다.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,7 @@ Fixes #
 - [ ] 새 test와 기존 test가 local에서 통과합니다(각 package directory에서 `uv run pytest` 실행).
 - [ ] linter를 실행했습니다(`uv run ruff check`).
 - [ ] formatter를 실행했습니다(`uv run ruff format`).
-- [ ] type checker를 실행했습니다(`uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text`).
+- [ ] type checker를 실행했습니다(`uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text`).
 - [ ] 필요한 경우 문서를 업데이트했습니다.
 - [ ] commit이 [Conventional Commits](https://www.conventionalcommits.org/) format을 따릅니다.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ flowchart TD
 ```yaml
 # root에서 동작: cd core/spakky 후 실행
 # standalone에서 동작: 현재 디렉토리에서 실행
-entry: bash -c 'if [ -d "core/spakky" ]; then cd core/spakky; fi && uv run pyrefly check --min-severity warn --no-progress-bar --output-format min-text'
+entry: bash -c 'if [ -d "core/spakky" ]; then cd core/spakky; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
 ```
 
 pre-commit 설정에는 다음 항목이 포함됩니다.

--- a/scripts/create_package.py
+++ b/scripts/create_package.py
@@ -238,7 +238,7 @@ def generate_precommit_config(name: str, pkg_type: PackageType) -> str:
     hooks:
       - id: pyrefly-typecheck
         name: Pyrefly (type checking)
-        entry: bash -c 'if [ -d "{package_dir}" ]; then cd {package_dir}; fi && uv run pyrefly check --disable-project-excludes-heuristics'
+        entry: bash -c 'if [ -d "{package_dir}" ]; then cd {package_dir}; fi && uv run pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text'
         language: system
         types: [python]
         pass_filenames: false


### PR DESCRIPTION
## 이슈의 원 전제가 반증되어 범위를 재조준했다

이슈 #499의 최초 본문은 "워크트리에서 무인자 `pyrefly check`가 exit 0으로 끝나 `/check` 타입 게이트가 상시 false green이고, 이번 자동화 실행 전체가 그 위에서 진행됐다"고 주장했다. **이 전제는 실측으로 반증됐다.**

| 최초 주장 | 실측 근거 |
|---|---|
| 무인자 호출이 **exit 0** | **exit 1**이다 (pyrefly 1.1.1). `No Python files matched`를 명시 출력하며 `0 diagnostics` 줄 자체가 나오지 않는다 — silent pass가 아니다 |
| 커밋 게이트가 false green | 21개 패키지 `.pre-commit-config.yaml` 중 **20개가 이미 `pyrefly check src tests ...`** 를 쓴다. 커밋 `729e7636` "fix(harness): type-check src and tests in worktree pre-commit pyrefly (#431)" (2026-06-25)에서 이미 고쳐졌다. 나머지 1개(`plugins/spakky-mcp`)는 `--disable-project-excludes-heuristics` 형식이며 이 형식도 워크트리에서 정상 검출된다 |
| CI 타입 체크도 무력 | CI(`.github/workflows/ci.yml:131`)는 무인자지만 clean checkout이라 gitignore 매치가 없고, `^[[:space:]]+WARN` grep으로 이미 exit 1 시킨다 |

공허했던 것은 **에이전트가 검증용으로 손수 돌린 무인자 호출**뿐이다. 실제 커밋 차단 게이트는 처음부터 정상이었다. 이슈 본문·제목은 위 사실로 정정했다.

## 실재하는 결함 — 지시문·템플릿이 실제 설정과 불일치

무인자 형식이 남은 곳은 게이트가 아니라 **지시문·템플릿**이며, 이들이 20/21 실제 설정과 어긋난다.

- `scripts/create_package.py:241` — 새 패키지의 pre-commit 설정을 무인자 형식으로 생성한다. 앞으로 만들어지는 모든 패키지가 기존 20개와 다른 형식으로 시작하는 **재발 생성원**이다. (현재 유일한 비순응 config인 `plugins/spakky-mcp`가 이 템플릿 산물이다.)
- `.github/PULL_REQUEST_TEMPLATE.md:34`, `CONTRIBUTING.md:120` — 기여자·에이전트가 따르는 지시문이 실제 검증 형식과 다르다.
- `.agents/skills/check/SKILL.md`, `.agents/rules/monorepo.md`, `.agents/skills/refactor-code/SKILL.md`, `.agents/skills/onboarding/SKILL.md` — 무인자 형식을 지시한다. `/check`·`/refactor-code`는 워크트리에서 실행되므로 지시대로 따르면 아무 파일도 검사되지 않는다.

## 기전

루트 `.gitignore`의 `.claude/worktrees/` 항목이 원인이다. pyrefly는 워크트리의 git 디렉터리를 메인 체크아웃으로 해석해 그 무시 규칙을 워크트리 경로에 적용하므로, 경로 인자를 생략하면 워크트리 안의 모든 소스가 ignore 대상이 된다. 메인 체크아웃에서는 재현되지 않는다.

## 변경 내용

무인자 형식을 지시하는 7개 지점을 실제 설정 20/21이 쓰는 형식으로 통일했다.

- `scripts/create_package.py` — 생성 템플릿이 기존 20개 config와 같은 entry를 만든다.
- `.github/PULL_REQUEST_TEMPLATE.md`, `CONTRIBUTING.md` — 예시를 실제 config와 일치시켰다.
- `.agents/skills/check/SKILL.md`, `.agents/skills/refactor-code/SKILL.md`, `.agents/skills/onboarding/SKILL.md` — pyrefly 호출에 경로 인자를 명시했다.
- `.agents/rules/monorepo.md` — 기전과 **두 가지 유효 호출 형식**(`src tests` / `--disable-project-excludes-heuristics`)을 SSOT 1곳에 서술했다. 다른 파일에 축자 중복은 두지 않았다.

### 결정 근거

- **"항상 `src tests`"로 단정하지 않았다.** `--disable-project-excludes-heuristics`도 유효하고 레포가 이미 쓰므로, 규칙은 결과 조건("소스가 검사 대상에서 제외되지 않게 호출한다")으로 표현하고 두 형식을 모두 인정한다.
- **"검사 대상 0건은 실패" 판정 규칙을 넣었다가 철회했다.** 무인자 실행이 이미 exit 1이고 CI도 WARN grep으로 차단하므로 그 규칙이 막는 실제 실패 경로가 없다 (`harness-writing.md` 5-테스트 1·4 미통과).
- **`monorepo.md`의 `**금지**` 줄은 원복했다.** 그 문장은 실행 **위치(루트)** 금지이지 인자 형식과 무관한데, 인자를 붙이면 "루트에서 무인자 pyrefly는 금지가 아니다"로 범위가 축소된다.
- **`create_package.py` 템플릿 변경은 기존 config 20개 형식을 따랐다** — 레포 선례가 정당성 (charter §2 차원 7).

## 검증

워크트리에서 의도적 타입 오류(`bad-return`) 파일을 심어 두 형식을 대조했다.

```
### 무인자 호출 (변경 전 지시문 형태)
 WARN Skipping include pattern `.../core/spakky/**/*.py*` because it is matched by
      `project-excludes` or an ignore file.
No Python files matched patterns `.../core/spakky/**/*.py*`, `.../**/*.ipynb`
→ 심어둔 타입 오류 미검출

### 경로 인자 호출 (변경 후 지시문 형태)
ERROR src/spakky/_false_green_probe.py:2:12-24: Returned type `Literal['not an int']`
      is not assignable to declared return type `int` [bad-return]
→ 검출
```

probe 파일은 커밋에 포함하지 않았다.

## Acceptance Criteria (자가 grep)

`acceptance_check: PASS` — 정정된 이슈 본문의 수용 기준 전 항목 충족.

| 기준 | 결과 |
|---|---|
| `create_package.py` 생성 entry가 기존 20개 config와 같은 형식 | PASS — `pyrefly check src tests --min-severity warn --no-progress-bar --output-format min-text` |
| PR 템플릿 type checker 항목이 실제 형식과 일치 | PASS (`PULL_REQUEST_TEMPLATE.md:34`) |
| `CONTRIBUTING.md` pre-commit entry 예시가 실제 config와 일치 | PASS (`CONTRIBUTING.md:120`) |
| 하네스 4개 파일의 pyrefly 호출이 경로 인자 포함 | PASS (`check/SKILL.md:24,81`, `monorepo.md:13`, `refactor-code/SKILL.md:53,56`, `onboarding/SKILL.md:69`) |
| 기전·두 형식이 SSOT 1곳에 서술 (축자 중복 없음) | PASS — `.agents/` 내 기전 서술은 `monorepo.md` 단독 |
| 워크트리 실행 시 의도적 타입 오류 검출 | PASS (위 검증 절) |

Closes #499
