### PR TITLE
fix: stop excluding real code from the coverage gate (#507)

### DIFF
--- a/core/spakky-actuator/pyproject.toml
+++ b/core/spakky-actuator/pyproject.toml
@@ -62,8 +62,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/core/spakky-agent/pyproject.toml
+++ b/core/spakky-agent/pyproject.toml
@@ -68,8 +68,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/core/spakky-agent/tests/unit/test_delegation.py
+++ b/core/spakky-agent/tests/unit/test_delegation.py
@@ -217,6 +217,22 @@ async def test_remote_teammate_tool_expect_dispatches_through_delegate_port() ->
     )
 
 
+async def test_remote_teammate_tool_expect_rejects_absent_runtime_context() -> None:
+    """runtime context 없이 만든 dispatcher는 teammate tool을 디스패치하지 않는다."""
+    dispatcher = AgentToolDispatcher(
+        target=RemoteParentAgent(RecordingDelegate()),
+        catalog=Agent.get(RemoteParentAgent).tool_catalog,
+    )
+
+    with pytest.raises(AgentToolDispatchError):
+        await dispatcher.dispatch(
+            ModelToolCall(
+                name="teammate.remote.delegate",
+                arguments={"instruction": "inspect"},
+            )
+        )
+
+
 async def test_remote_teammate_tool_expect_rejects_missing_delegate_port() -> None:
     """remote teammate tool은 delegate port가 없으면 dispatch error를 낸다."""
     dispatcher = AgentToolDispatcher(

--- a/core/spakky-agent/tests/unit/test_runner.py
+++ b/core/spakky-agent/tests/unit/test_runner.py
@@ -2054,6 +2054,35 @@ def test_run_paused_event_helper_expect_accepts_top_level_tool_call_id() -> None
     assert event.allowed_decisions == ("approve",)
 
 
+def test_run_paused_event_helper_expect_ignores_non_list_allowed_decisions() -> None:
+    """단일 문자열 allowed_decisions는 문자 단위로 분해되지 않고 빈 목록이 된다."""
+    from spakky.agent.runner import _run_paused_event
+
+    event = _run_paused_event(
+        AgentState(
+            id="run-1",
+            agent_type="runner_probe",
+            status=AgentStatus.INTERRUPTED,
+            reason=AgentStateReason.APPROVAL_REQUIRED,
+            current_activity="Approve?",
+            metadata={
+                "approval": {
+                    "id": "approval-1",
+                    "call_id": "call-1",
+                    "allowed_decisions": "approve",
+                }
+            },
+        ),
+        AgentEventAttribution(
+            agent_id="runner_probe",
+            run_id="run-1",
+            conversation_id="run-1",
+        ),
+    )
+
+    assert event.allowed_decisions == ()
+
+
 def test_cancel_error_helper_expect_fallback_for_non_cancel_payload() -> None:
     """cancel error helper는 예상 밖 payload에서도 generic cancelled error를 낸다."""
     from spakky.agent.runner import _cancel_error

--- a/core/spakky-agent/tests/unit/test_signal_consumption.py
+++ b/core/spakky-agent/tests/unit/test_signal_consumption.py
@@ -92,6 +92,19 @@ def test_consume_pending_agent_signals_expect_does_not_overtake_unaccepted_signa
     ]
 
 
+def test_consume_pending_agent_signals_expect_stops_at_max_signals() -> None:
+    """max_signals에 도달하면 남은 pending signal은 다음 poll을 위해 큐에 남는다."""
+    queue = InboundSignalQueue()
+    queue.append(AgentSignal("signal-1", "run-1", AgentSignalKind.USER_MESSAGE))
+    queue.append(AgentSignal("signal-2", "run-1", AgentSignalKind.USER_MESSAGE))
+
+    batch = consume_pending_agent_signals(queue, "run-1", max_signals=1)
+
+    assert [signal.id for signal in batch.signals] == ["signal-1"]
+    assert queue.consumed_ids == ["signal-1"]
+    assert [signal.id for signal in queue.list_pending("run-1")] == ["signal-2"]
+
+
 async def test_inbound_adapter_append_expect_running_stream_polls_without_waiting() -> (
     None
 ):

--- a/core/spakky-agent/tests/unit/test_state_signal_evidence_yield.py
+++ b/core/spakky-agent/tests/unit/test_state_signal_evidence_yield.py
@@ -33,6 +33,7 @@ from spakky.agent import (
     Message,
     PII,
     Progress,
+    RedactionPolicy,
     SecretField,
     SensitiveField,
     SensitiveFieldDescriptor,
@@ -490,6 +491,25 @@ def test_agent_evidence_candidate_expect_guards_sensitive_result_payload() -> No
         "status": "ok",
     }
     assert evidence.sensitive_fields == candidate.sensitive_fields
+
+
+def test_agent_evidence_candidate_expect_drops_root_level_secret_result() -> None:
+    """전체 tool result가 root-level secret으로 표시되면 evidence는 빈 payload를 남긴다."""
+    candidate = AgentEvidenceCandidate.tool_result(
+        tool_identity="tests.VaultTools:read_credential",
+        tool_schema_name="vault.read_credential",
+        result={"token": "sk-live-1234"},
+        capture=EvidenceCapture.STRUCTURED,
+        sensitive_fields=(
+            SensitiveFieldDescriptor(
+                (),
+                SecretField(redaction=RedactionPolicy.DROP),
+            ),
+        ),
+        exposure_policy=EvidenceExposurePolicy(),
+    )
+
+    assert candidate.payload["result"] == {}
 
 
 def test_agent_evidence_candidate_expect_rejects_blank_identity() -> None:

--- a/core/spakky-auth/pyproject.toml
+++ b/core/spakky-auth/pyproject.toml
@@ -62,8 +62,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/core/spakky-auth/tests/unit/test_public_api.py
+++ b/core/spakky-auth/tests/unit/test_public_api.py
@@ -138,6 +138,20 @@ def test_effective_snapshot_propagation_config_enables_when_any_config_enabled()
     assert config.enabled
 
 
+def test_effective_snapshot_propagation_config_disables_when_no_config_registered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """스냅샷 전파 config를 아무도 등록하지 않은 앱은 전파 비활성으로 판정된다."""
+    monkeypatch.delenv(
+        f"{SPAKKY_AUTH_SNAPSHOT_PROPAGATION_CONFIG_ENV_PREFIX}ENABLED",
+        raising=False,
+    )
+
+    config = effective_auth_snapshot_propagation_config(())
+
+    assert not config.enabled
+
+
 def test_credential_carrier_preserves_boundary_local_material() -> None:
     carrier = CredentialCarrier(
         kind=CredentialCarrierKind.BEARER_TOKEN,

--- a/core/spakky-cache/pyproject.toml
+++ b/core/spakky-cache/pyproject.toml
@@ -62,8 +62,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/core/spakky-data/pyproject.toml
+++ b/core/spakky-data/pyproject.toml
@@ -61,8 +61,6 @@ exclude_lines = [
   "raise NotImplementedError",
   "@(abc\\.)?abstractmethod",
   "@(typing\\.)?overload",
-  "\\.\\.\\.\\.",
-  "pass",
 ]
 
 [tool.uv.sources]

--- a/core/spakky-domain/pyproject.toml
+++ b/core/spakky-domain/pyproject.toml
@@ -61,6 +61,4 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.\\.",
-    "pass",
 ]

--- a/core/spakky-event/pyproject.toml
+++ b/core/spakky-event/pyproject.toml
@@ -67,8 +67,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/core/spakky-outbox/pyproject.toml
+++ b/core/spakky-outbox/pyproject.toml
@@ -67,8 +67,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/core/spakky-saga/pyproject.toml
+++ b/core/spakky-saga/pyproject.toml
@@ -62,8 +62,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/core/spakky-saga/tests/unit/test_engine.py
+++ b/core/spakky-saga/tests/unit/test_engine.py
@@ -352,6 +352,35 @@ async def _make_awaitable(value: _OrderData) -> _OrderData:
     return value
 
 
+@pytest.mark.asyncio
+async def test_bare_callable_flow_item_expect_executed_as_named_step() -> None:
+    """SagaFlow에 직접 담긴 bare callable도 함수 이름을 가진 step으로 실행된다."""
+    flow = SagaFlow(items=(_succeed_with_data,))
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.COMPLETED
+    assert result.history[0].name == "_succeed_with_data"
+    assert result.data.ticket_id is not None
+
+
+@pytest.mark.asyncio
+async def test_bare_callable_flow_item_failure_expect_compensated_and_failed() -> None:
+    """bare callable step은 기본 Compensate 전략으로 정규화되어 실패 시 보상된다."""
+    flow = SagaFlow(
+        items=(
+            Transaction(action=_succeed, compensate=_compensate_logged),
+            _fail,
+        )
+    )
+    data = _OrderData(order_id=uuid4())
+    result = await run_saga_flow(flow, data)
+
+    assert result.status is SagaStatus.FAILED
+    assert result.failed_step == "_fail"
+    assert _compensation_log == ["compensated"]
+
+
 # --- Retry 전략 ---
 
 

--- a/core/spakky-task/pyproject.toml
+++ b/core/spakky-task/pyproject.toml
@@ -65,8 +65,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/core/spakky-task/tests/unit/stereotype/test_task_handler.py
+++ b/core/spakky-task/tests/unit/stereotype/test_task_handler.py
@@ -3,6 +3,12 @@
 from dataclasses import dataclass
 
 from spakky.auth import protected, public_access, require_role, require_scope
+from spakky.auth.metadata import (
+    AuthRequirement,
+    AuthRequirementKind,
+    ProtectedRequirement,
+)
+from spakky.core.common.constants import ANNOTATION_METADATA
 from spakky.core.pod.annotations.pod import Pod
 
 from spakky.task.stereotype.task_handler import (
@@ -192,6 +198,96 @@ def test_protected_marker_on_task_records_authenticated_requirement() -> None:
     metadata = collect_task_auth_metadata(handler.process)
 
     assert metadata.requirements[0].kind == "AUTHENTICATED"
+
+
+def test_requirement_declared_on_class_and_method_is_collected_once() -> None:
+    """클래스와 메서드에 같은 요구사항이 중복 선언되어도 task metadata는 한 번만 담는다."""
+
+    @require_scope("tasks:run")
+    class DuplicateScopeTaskHandler:
+        @task
+        @require_scope("tasks:run")
+        def process(self) -> None:
+            return None
+
+    handler = DuplicateScopeTaskHandler()
+    metadata = collect_task_auth_metadata(
+        handler.process,
+        owner_type=DuplicateScopeTaskHandler,
+    )
+
+    assert [(item.kind, item.ref) for item in metadata.requirements] == [
+        ("SCOPE", "tasks:run"),
+    ]
+
+
+def test_non_mapping_annotation_metadata_attribute_is_ignored() -> None:
+    """spakky annotation 속성을 dict가 아닌 값이 점유하면 요구사항을 수집하지 않는다."""
+
+    def process() -> None:
+        return None
+
+    setattr(process, ANNOTATION_METADATA, "not-a-metadata-mapping")
+
+    metadata = collect_task_auth_metadata(process)
+
+    assert metadata.requirements == ()
+    assert not metadata.public_access
+
+
+def test_annotation_metadata_entry_without_type_key_is_ignored() -> None:
+    """annotation type이 아닌 키로 등록된 metadata 항목은 요구사항으로 수집하지 않는다."""
+
+    def process() -> None:
+        return None
+
+    setattr(
+        process,
+        ANNOTATION_METADATA,
+        {
+            "not-an-annotation-type": [
+                ProtectedRequirement(
+                    requirement=AuthRequirement(
+                        kind=AuthRequirementKind.ROLE,
+                        ref="role:admin",
+                    )
+                )
+            ]
+        },
+    )
+
+    metadata = collect_task_auth_metadata(process)
+
+    assert metadata.requirements == ()
+
+
+def test_unreadable_entry_among_auth_annotations_keeps_valid_requirement() -> None:
+    """auth annotation 목록에 해석 불가 항목이 섞여도 유효한 요구사항은 보존된다."""
+
+    def process() -> None:
+        return None
+
+    setattr(
+        process,
+        ANNOTATION_METADATA,
+        {
+            ProtectedRequirement: [
+                object(),
+                ProtectedRequirement(
+                    requirement=AuthRequirement(
+                        kind=AuthRequirementKind.SCOPE,
+                        ref="tasks:run",
+                    )
+                ),
+            ]
+        },
+    )
+
+    metadata = collect_task_auth_metadata(process)
+
+    assert [(item.kind, item.ref) for item in metadata.requirements] == [
+        ("SCOPE", "tasks:run"),
+    ]
 
 
 def test_invalid_auth_annotation_payload_is_ignored() -> None:

--- a/core/spakky-tracing/pyproject.toml
+++ b/core/spakky-tracing/pyproject.toml
@@ -62,8 +62,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/core/spakky/pyproject.toml
+++ b/core/spakky/pyproject.toml
@@ -193,6 +193,4 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]

--- a/core/spakky/src/spakky/core/application/application.py
+++ b/core/spakky/src/spakky/core/application/application.py
@@ -525,7 +525,9 @@ class SpakkyApplication:
                     objects=(),
                 )
             obj = next(iter(matches))
-            if isinstance(obj, FunctionType) or isinstance(obj, type):
+            if (
+                isinstance(obj, FunctionType) or isinstance(obj, type)
+            ):  # pragma: no branch - list_objects는 class/function만 반환하므로 거짓 분기가 없음
                 discovered_objects.append(obj)
         return _DiscoveryManifestHit(
             decision=DiscoveryManifestDecision.HIT,

--- a/core/spakky/src/spakky/core/application/application_context.py
+++ b/core/spakky/src/spakky/core/application/application_context.py
@@ -416,7 +416,7 @@ class ApplicationContext(IApplicationContext):
             named = {pod for pod in pods if pod.name == name}
             if len(named) == 1:
                 return named.pop()
-            if not named:
+            if not named:  # pragma: no branch - Pod 이름은 컨테이너에서 유일하므로 named 후보는 0개 또는 1개
                 return None
 
         if binding_candidate := self.__resolve_binding_candidate_for_type(type_, pods):
@@ -629,7 +629,7 @@ class ApplicationContext(IApplicationContext):
                 pod.name: instance
                 for pod, instance in zip(pods, instances, strict=True)
             }
-        return None
+        return None  # pragma: no cover - exhaustive DependencyCollectionKind (None은 호출 지점에서 이미 분기)
 
     def __record_instantiation_attempt(self, elapsed_seconds: float) -> None:
         if self.__startup_metrics is None:

--- a/core/spakky/tests/application/test_application_context.py
+++ b/core/spakky/tests/application/test_application_context.py
@@ -396,6 +396,78 @@ def test_application_context_start_with_ambiguous_dependency_expect_dependency_d
     assert any(key == "candidates" for key, _value in diagnostic.as_detail_pairs())
 
 
+def test_application_context_start_with_ambiguous_qualifier_expect_qualified_candidates_reported() -> (
+    None
+):
+    """Qualifier가 후보를 하나로 좁히지 못하면 통과한 후보만 담은 ambiguity error가 발생함을 검증한다."""
+
+    class ISamplePod:
+        @abstractmethod
+        def do(self) -> str: ...
+
+    @Pod(name="first_remote")
+    class FirstSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "first"
+
+    @Pod(name="second_remote")
+    class SecondSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "second"
+
+    @Pod(name="local_only")
+    class LocalSamplePod(ISamplePod):
+        def do(self) -> str:
+            return "local"
+
+    @Pod()
+    class SampleService:
+        def __init__(
+            self,
+            pod: Annotated[
+                ISamplePod,
+                Qualifier(lambda candidate: candidate.name.endswith("remote")),
+            ],
+        ) -> None:
+            self.pod = pod
+
+    context: ApplicationContext = ApplicationContext()
+    context.add(FirstSamplePod)
+    context.add(SecondSamplePod)
+    context.add(LocalSamplePod)
+    context.add(SampleService)
+
+    with pytest.raises(NoUniquePodError) as error:
+        context.start()
+
+    assert [candidate.pod_name for candidate in error.value.candidates] == [
+        "first_remote",
+        "second_remote",
+    ]
+    diagnostic = error.value.dependency_diagnostic
+    assert diagnostic is not None
+    assert diagnostic.failed_pod_name == "sample_service"
+    assert diagnostic.dependency_parameter_name == "pod"
+
+
+def test_application_context_get_or_none_with_unregistered_name_expect_none() -> None:
+    """등록된 타입이라도 존재하지 않는 Pod 이름으로 조회하면 None을 반환함을 검증한다."""
+
+    @Pod(name="registered_sample")
+    class SamplePod:
+        def do(self) -> str:
+            return "registered"
+
+    context: ApplicationContext = ApplicationContext()
+    context.add(SamplePod)
+    context.start()
+
+    assert context.get_or_none(SamplePod, "unregistered_sample") is None
+    assert context.get_or_none(SamplePod, "registered_sample") is not None
+
+    context.stop()
+
+
 def test_application_context_start_with_postponed_annotated_qualifier_expect_resolution() -> (
     None
 ):

--- a/core/spakky/tests/application/test_application_context_concurrency.py
+++ b/core/spakky/tests/application/test_application_context_concurrency.py
@@ -2,8 +2,89 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from uuid import UUID, uuid4
 
+import pytest
+
+import spakky.core.application.application_context as application_context_module
 from spakky.core.application.application_context import ApplicationContext
 from spakky.core.pod.annotations.pod import Pod
+
+LOCK_HANDOFF_TIMEOUT_SECONDS = 5.0
+"""Safety net so a broken hand-off fails the test instead of hanging forever."""
+
+
+class ContentionSignalingRLock:
+    """Reentrant lock that signals when a foreign thread starts waiting for it."""
+
+    _lock: threading.RLock
+    _contention: threading.Event
+
+    def __init__(self, contention: threading.Event) -> None:
+        self._lock = threading.RLock()
+        self._contention = contention
+
+    def __enter__(self) -> "ContentionSignalingRLock":
+        if not self._lock.acquire(blocking=False):
+            self._contention.set()
+            self._lock.acquire()
+        return self
+
+    def __exit__(self, *_exception_info: object) -> None:
+        self._lock.release()
+
+
+def test_singleton_contended_lock_expect_waiting_thread_reuses_cached_instance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    싱글톤 락 획득을 기다린 스레드가 락 진입 후 자체 인스턴스를 만들지 않고
+    먼저 진입한 스레드가 캐시한 인스턴스를 그대로 반환함을 검증한다.
+    """
+    contention = threading.Event()
+    winner_holds_lock = threading.Event()
+    init_count = 0
+
+    monkeypatch.setattr(
+        application_context_module,
+        "RLock",
+        lambda: ContentionSignalingRLock(contention),
+    )
+
+    @Pod(scope=Pod.Scope.SINGLETON)
+    class SharedPod:
+        id: UUID
+
+        def __init__(self) -> None:
+            nonlocal init_count
+            init_count += 1
+            self.id = uuid4()
+            winner_holds_lock.set()
+            contention.wait(timeout=LOCK_HANDOFF_TIMEOUT_SECONDS)
+
+    context = ApplicationContext()
+    context.add(SharedPod)
+
+    winner_instances: list[SharedPod] = []
+    waiter_instances: list[SharedPod] = []
+
+    def acquire_lock_first() -> None:
+        winner_instances.append(context.get(SharedPod))
+
+    def wait_for_lock() -> None:
+        winner_holds_lock.wait(timeout=LOCK_HANDOFF_TIMEOUT_SECONDS)
+        waiter_instances.append(context.get(SharedPod))
+
+    winner = threading.Thread(target=acquire_lock_first)
+    waiter = threading.Thread(target=wait_for_lock)
+    winner.start()
+    waiter.start()
+    for thread in (winner, waiter):
+        thread.join(timeout=LOCK_HANDOFF_TIMEOUT_SECONDS)
+        assert not thread.is_alive(), "Thread did not complete the singleton hand-off"
+
+    assert contention.is_set(), "Waiting thread never contended for the singleton lock"
+    assert init_count == 1
+    assert waiter_instances[0] is winner_instances[0]
+    assert waiter_instances[0].id == winner_instances[0].id
 
 
 def test_singleton_thread_safety_expect_single_instance() -> None:

--- a/core/spakky/tests/application/test_application_scan.py
+++ b/core/spakky/tests/application/test_application_scan.py
@@ -405,3 +405,57 @@ def test_discovery_manifest_malformed_payload_expect_store_miss(
     result = DiscoveryManifestStore(manifest_path).load(fingerprint)
 
     assert result.decision is DiscoveryManifestDecision.MISS
+
+
+@pytest.mark.parametrize(
+    ("exclude", "sources", "candidates"),
+    [
+        ([1], [], []),
+        ([], "tests.dummy.dummy_package", []),
+        ([], ["tests.dummy.dummy_package"], []),
+        ([], [{"path": 1, "mtime_ns": 1, "size": 1}], []),
+        ([], [{"path": "module_a.py", "mtime_ns": "1", "size": 1}], []),
+        ([], [{"path": "module_a.py", "mtime_ns": 1, "size": "1"}], []),
+        ([], [], "tests.dummy.dummy_package.PodA"),
+        ([], [], ["tests.dummy.dummy_package.PodA"]),
+        ([], [], [{"module_name": 1, "qualname": "PodA"}]),
+        (
+            [],
+            [],
+            [{"module_name": "tests.dummy.dummy_package.module_a", "qualname": 1}],
+        ),
+    ],
+)
+def test_discovery_manifest_malformed_nested_element_expect_store_miss(
+    tmp_path: Path,
+    exclude: object,
+    sources: object,
+    candidates: object,
+) -> None:
+    """manifest의 중첩 원소 타입이 스키마와 어긋나면 store load는 miss를 반환한다."""
+    from tests.dummy import dummy_package
+
+    manifest_path = tmp_path / "discovery-manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "fingerprint": {
+                    "schema_version": 1,
+                    "python_version": "3.12",
+                    "module_name": "tests.dummy.dummy_package",
+                    "is_package": True,
+                    "exclude": exclude,
+                    "sources": sources,
+                },
+                "module_names": [],
+                "candidates": candidates,
+            }
+        ),
+        encoding="utf-8",
+    )
+    fingerprint = DiscoveryManifestFingerprint.from_scan_input(dummy_package, set())
+
+    result = DiscoveryManifestStore(manifest_path).load(fingerprint)
+
+    assert result.decision is DiscoveryManifestDecision.MISS

--- a/core/spakky/tests/application/test_startup_diagnostics.py
+++ b/core/spakky/tests/application/test_startup_diagnostics.py
@@ -398,6 +398,31 @@ def test_spakky_application_start_failure_expect_recorded_and_propagated() -> No
             app.stop()
 
 
+def test_application_context_start_constructor_failure_expect_instantiation_elapsed_recorded() -> (
+    None
+):
+    """Pod 생성자가 실패해도 그때까지의 instantiation 소요 시간이 실패 record에 누적됨을 검증한다."""
+
+    @Pod(name="exploding_pod")
+    class ExplodingPod:
+        def __init__(self) -> None:
+            raise RuntimeError("constructor failed")
+
+    context = ApplicationContext()
+    context.add(ExplodingPod)
+    recorder = ActiveStartupPhaseRecorder()
+
+    with pytest.raises(RuntimeError, match="constructor failed"):
+        context.start(recorder)
+
+    failure = recorder.report.records[-1]
+    assert failure.phase_name == STARTUP_PHASE_INSTANTIATION
+    assert failure.status is StartupPhaseStatus.FAILURE
+    assert failure.failure_summary is not None
+    assert failure.failure_summary.message == "constructor failed"
+    assert failure.elapsed_seconds > 0
+
+
 def test_application_context_start_dependency_failure_summary_expect_dependency_details() -> (
     None
 ):

--- a/core/spakky/tests/pod/test_diagnostics.py
+++ b/core/spakky/tests/pod/test_diagnostics.py
@@ -1,0 +1,62 @@
+"""Test Pod dependency resolution diagnostics detail rendering."""
+
+from spakky.core.pod.diagnostics import (
+    PodCandidateDiagnostic,
+    PodDependencyPathNode,
+    PodDependencyResolutionDiagnostic,
+)
+
+
+def test_diagnostic_without_dependency_parameter_expect_no_dependency_details() -> None:
+    """의존성 파라미터 없이 발생한 실패는 파라미터/요청 타입 detail을 남기지 않음을 검증한다."""
+    diagnostic = PodDependencyResolutionDiagnostic(
+        failed_pod_name="sample_service",
+        failed_pod_type_name="SampleService",
+        dependency_parameter_name=None,
+        requested_type_name=None,
+        path=(
+            PodDependencyPathNode(
+                pod_name="sample_service",
+                pod_type_name="SampleService",
+            ),
+        ),
+    )
+
+    assert diagnostic.as_detail_pairs() == (
+        ("failed_pod", "sample_service"),
+        ("failed_pod_type", "SampleService"),
+        ("dependency_path", "SampleService"),
+    )
+
+
+def test_diagnostic_without_dependency_parameter_expect_candidate_details_preserved() -> (
+    None
+):
+    """의존성 파라미터가 없어도 후보 진단이 있으면 candidates/hints detail은 그대로 남음을 검증한다."""
+    diagnostic = PodDependencyResolutionDiagnostic(
+        failed_pod_name="sample_service",
+        failed_pod_type_name="SampleService",
+        dependency_parameter_name=None,
+        requested_type_name=None,
+        path=(
+            PodDependencyPathNode(
+                pod_name="sample_service",
+                pod_type_name="SampleService",
+            ),
+        ),
+        candidates=(
+            PodCandidateDiagnostic(
+                pod_name="first",
+                pod_type_name="FirstSamplePod",
+                is_primary=False,
+            ),
+        ),
+        resolution_hints=("mark exactly one candidate with @Primary",),
+    )
+
+    details = dict(diagnostic.as_detail_pairs())
+
+    assert "dependency_parameter" not in details
+    assert "requested_type" not in details
+    assert details["candidates"] == "first:FirstSamplePod:primary=False"
+    assert details["resolution_hints"] == "mark exactly one candidate with @Primary"

--- a/core/spakky/tests/pod/test_pod_edge_cases.py
+++ b/core/spakky/tests/pod/test_pod_edge_cases.py
@@ -1,5 +1,8 @@
 """Test pod edge cases for complete coverage."""
 
+from typing import cast
+from collections.abc import Callable
+
 import pytest
 
 from spakky.core.pod.annotations.pod import (
@@ -54,3 +57,57 @@ def test_pod_instantiate_with_none_and_default_value() -> None:
 
     assert isinstance(instance, SamplePod)
     assert instance.dep == 10  # Default value used
+
+
+def test_pod_unresolved_annotated_without_metadata_expect_raw_annotation_dependency() -> (
+    None
+):
+    """Annotated 인자가 하나뿐인 미해결 문자열 어노테이션은 원문 문자열 의존성으로 남음을 검증한다."""
+    namespace: dict[str, object] = {"Pod": Pod}
+    exec(
+        """
+@Pod()
+class SingleArgumentAnnotatedConsumer:
+    def __init__(self, dependency: "Annotated[(MissingSamplePod,)]") -> None:
+        self.dependency = dependency
+
+def resolve_dependency() -> tuple[object, list[object]]:
+    dependency = Pod.get(SingleArgumentAnnotatedConsumer).dependencies["dependency"]
+    return dependency.type_, list(dependency.qualifiers)
+""",
+        namespace,
+    )
+
+    resolve_dependency = cast(
+        Callable[[], tuple[object, list[object]]],
+        namespace["resolve_dependency"],
+    )
+
+    assert resolve_dependency() == ("Annotated[(MissingSamplePod,)]", [])
+
+
+def test_pod_unresolved_annotated_with_invalid_metadata_expect_raw_annotation_dependency() -> (
+    None
+):
+    """미해결 문자열 어노테이션의 metadata 식이 평가 불가하면 원문 문자열 의존성으로 남음을 검증한다."""
+    namespace: dict[str, object] = {"Pod": Pod}
+    exec(
+        """
+@Pod()
+class InvalidMetadataAnnotatedConsumer:
+    def __init__(self, dependency: "Annotated[MissingSamplePod, 'tier' + 1]") -> None:
+        self.dependency = dependency
+
+def resolve_dependency() -> tuple[object, list[object]]:
+    dependency = Pod.get(InvalidMetadataAnnotatedConsumer).dependencies["dependency"]
+    return dependency.type_, list(dependency.qualifiers)
+""",
+        namespace,
+    )
+
+    resolve_dependency = cast(
+        Callable[[], tuple[object, list[object]]],
+        namespace["resolve_dependency"],
+    )
+
+    assert resolve_dependency() == ("Annotated[MissingSamplePod, 'tier' + 1]", [])

--- a/plugins/spakky-a2a/pyproject.toml
+++ b/plugins/spakky-a2a/pyproject.toml
@@ -81,8 +81,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-a2a/src/spakky/plugins/a2a/post_processors/register_grpc.py
+++ b/plugins/spakky-a2a/src/spakky/plugins/a2a/post_processors/register_grpc.py
@@ -26,7 +26,7 @@ class _GrpcServerSpecLike:
 
     def add_handler(self, handler: object) -> None:
         """Register a generic RPC handler."""
-        ...
+        ...  # pragma: no cover - runtime receiver is always the cast GrpcServerSpec
 
 
 @Order(2)

--- a/plugins/spakky-a2a/tests/unit/test_delegation.py
+++ b/plugins/spakky-a2a/tests/unit/test_delegation.py
@@ -144,6 +144,29 @@ def test_stream_mapper_expect_maps_terminal_and_artifact_events() -> None:
     ]
 
 
+def test_stream_mapper_expect_failed_task_carries_remote_failure_error() -> None:
+    """terminal Task가 failed 상태면 RunFinished가 remote 실패 error를 싣는다."""
+    events = A2AStreamEventMapper().map(
+        StreamResponse(
+            task=Task(
+                id="child-task",
+                context_id="thread-1",
+                status=TaskStatus(state=TaskState.TASK_STATE_FAILED),
+            )
+        ),
+        _packet(),
+    )
+
+    assert isinstance(events[0], RunStartedEvent)
+    finished = events[1]
+    assert isinstance(finished, RunFinishedEvent)
+    assert finished.error == {
+        "code": "remote_a2a_failed",
+        "message": "TASK_STATE_FAILED",
+    }
+    assert finished.attribution.run_id == "child-task"
+
+
 def test_stream_mapper_expect_ignores_empty_message_and_unknown_response() -> None:
     """본문 없는 message와 payload 없는 response는 이벤트를 만들지 않는다."""
     mapper = A2AStreamEventMapper()

--- a/plugins/spakky-agui/pyproject.toml
+++ b/plugins/spakky-agui/pyproject.toml
@@ -79,8 +79,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-celery/pyproject.toml
+++ b/plugins/spakky-celery/pyproject.toml
@@ -89,8 +89,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-celery/tests/unit/test_post_processor.py
+++ b/plugins/spakky-celery/tests/unit/test_post_processor.py
@@ -471,6 +471,82 @@ def test_protected_sync_endpoint_verification_error_uses_celery_retry() -> None:
     assert not handler.called
 
 
+def test_protected_sync_endpoint_expect_denial_propagates_when_retry_does_not_raise() -> (
+    None
+):
+    """celery retry가 Retry를 발생시키지 못하면 원래 auth 실패가 그대로 전파된다."""
+
+    @TaskHandler()
+    class ProtectedHandler:
+        def __init__(self) -> None:
+            self.called = False
+
+        @task
+        @require_scope("tasks:run")
+        def protected_task(self) -> None:
+            self.called = True
+
+    handler = ProtectedHandler()
+    endpoint, _ = _registered_endpoint_for_handler(
+        ProtectedHandler,
+        handler,
+        snapshot_verifier=SnapshotVerifier(AuthVerificationProviderUnavailableError()),
+        scope_checker=ScopeChecker(AuthorizationDecision.allow()),
+    )
+    mock_request = MagicMock()
+    mock_request.get.return_value = {
+        AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "snapshot-envelope"
+    }
+
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        with pytest.raises(AuthRequirementDeniedError) as excinfo:
+            endpoint()
+
+    mock_current_task.retry.assert_called_once()
+    assert excinfo.value.decision is not None
+    assert excinfo.value.decision.state is AuthorizationDecisionState.ERROR
+    assert not handler.called
+
+
+def test_schedule_only_endpoint_expect_auth_seeding_skipped() -> None:
+    """@task 없이 @schedule만 붙은 beat 메서드는 auth seeding 없이 실행된다."""
+
+    @TaskHandler()
+    class ScheduleOnlyHandler:
+        def __init__(self) -> None:
+            self.called = False
+
+        @schedule(interval=timedelta(minutes=5))
+        def refresh_cache(self) -> None:
+            self.called = True
+
+    handler = ScheduleOnlyHandler()
+    verifier = SnapshotVerifier()
+    endpoint, _ = _registered_endpoint_for_handler(
+        ScheduleOnlyHandler,
+        handler,
+        snapshot_verifier=verifier,
+        scope_checker=ScopeChecker(AuthorizationDecision.allow()),
+    )
+    mock_request = MagicMock()
+    mock_request.get.return_value = {
+        AUTH_CONTEXT_SNAPSHOT_METADATA_KEY: "snapshot-envelope"
+    }
+
+    with patch(
+        "spakky.plugins.celery.post_processor.current_task"
+    ) as mock_current_task:
+        mock_current_task.request = mock_request
+        endpoint()
+
+    assert handler.called
+    assert verifier.calls == []
+    mock_current_task.retry.assert_not_called()
+
+
 # =============================================================================
 # Scenario: Schedule registration
 # =============================================================================

--- a/plugins/spakky-cryptography/pyproject.toml
+++ b/plugins/spakky-cryptography/pyproject.toml
@@ -72,8 +72,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-cryptography/tests/test_auth_provider.py
+++ b/plugins/spakky-cryptography/tests/test_auth_provider.py
@@ -382,6 +382,22 @@ def test_invalid_claim_value_raises_invalid_snapshot() -> None:
         provider._claim_value(["unsupported"])
 
 
+def test_non_string_role_entry_raises_invalid_snapshot() -> None:
+    """roles 목록에 문자열이 아닌 항목이 섞이면 snapshot을 거절한다."""
+    provider = _provider()
+
+    with pytest.raises(InvalidAuthContextSnapshotError):
+        provider._string_tuple_value({"roles": ["role:admin", 7]}, "roles")
+
+
+def test_non_sequence_scopes_raises_invalid_snapshot() -> None:
+    """scopes가 목록이 아닌 단일 문자열이면 snapshot을 거절한다."""
+    provider = _provider()
+
+    with pytest.raises(InvalidAuthContextSnapshotError):
+        provider._string_tuple_value({"scopes": "documents:read"}, "scopes")
+
+
 def test_tampered_snapshot_verification_maps_to_challenge() -> None:
     provider = _provider()
     other_provider = CryptographyAuthProvider(

--- a/plugins/spakky-fastapi/pyproject.toml
+++ b/plugins/spakky-fastapi/pyproject.toml
@@ -71,6 +71,4 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.\\.",
-    "pass",
 ]

--- a/plugins/spakky-grpc/pyproject.toml
+++ b/plugins/spakky-grpc/pyproject.toml
@@ -89,8 +89,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-grpc/tests/unit/test_error_handling_interceptor.py
+++ b/plugins/spakky-grpc/tests/unit/test_error_handling_interceptor.py
@@ -272,6 +272,115 @@ async def test_stream_handler_catches_grpc_error_expect_abort(
     )
 
 
+async def test_stream_handler_catches_auth_error_expect_unauthenticated_abort(
+    interceptor: ErrorHandlingInterceptor,
+    context: AsyncMock,
+) -> None:
+    """An auth failure raised mid-stream should abort with UNAUTHENTICATED."""
+
+    async def stream_behavior(
+        request: object, ctx: grpc.aio.ServicerContext
+    ) -> AsyncIterator[bytes]:
+        yield b"first"
+        raise AuthenticationError()
+
+    handler = _make_handler(unary_stream=stream_behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    unary_stream = _require_unary_stream(wrapped)
+    with pytest.raises(grpc.aio.AbortError):
+        async for _ in unary_stream(b"request", context):  # type: ignore[arg-type] — grpc stubs declare sync Iterator but grpc.aio uses async
+            pass
+
+    context.abort.assert_awaited_once_with(
+        grpc.StatusCode.UNAUTHENTICATED, AuthenticationError.message
+    )
+
+
+async def test_stream_handler_catches_unexpected_error_expect_internal(
+    interceptor: ErrorHandlingInterceptor,
+    context: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unhandled exception mid-stream should be logged and abort as INTERNAL."""
+
+    async def stream_behavior(
+        request: object, ctx: grpc.aio.ServicerContext
+    ) -> AsyncIterator[bytes]:
+        yield b"first"
+        raise RuntimeError("oops")
+
+    handler = _make_handler(unary_stream=stream_behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    unary_stream = _require_unary_stream(wrapped)
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(grpc.aio.AbortError),
+    ):
+        async for _ in unary_stream(b"request", context):  # type: ignore[arg-type] — grpc stubs declare sync Iterator but grpc.aio uses async
+            pass
+
+    assert "RuntimeError('oops')" in caplog.text
+    context.abort.assert_awaited_once_with(
+        grpc.StatusCode.INTERNAL, InternalError.message
+    )
+
+
+async def test_stream_handler_debug_mode_includes_traceback(
+    debug_interceptor: ErrorHandlingInterceptor,
+    context: AsyncMock,
+) -> None:
+    """In debug mode, INTERNAL details from a stream should carry the traceback."""
+
+    async def stream_behavior(
+        request: object, ctx: grpc.aio.ServicerContext
+    ) -> AsyncIterator[bytes]:
+        yield b"first"
+        raise RuntimeError("oops")
+
+    handler = _make_handler(unary_stream=stream_behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await debug_interceptor.intercept_service(
+        continuation, _make_call_details()
+    )
+    unary_stream = _require_unary_stream(wrapped)
+    with pytest.raises(grpc.aio.AbortError):
+        async for _ in unary_stream(b"request", context):  # type: ignore[arg-type] — grpc stubs declare sync Iterator but grpc.aio uses async
+            pass
+
+    _code, details = context.abort.call_args.args
+    assert "RuntimeError" in details
+    assert "Traceback" in details
+
+
+async def test_stream_handler_reraises_grpc_rpc_error(
+    interceptor: ErrorHandlingInterceptor,
+) -> None:
+    """A gRPC error raised mid-stream should propagate instead of aborting again."""
+
+    async def stream_behavior(
+        request: object, ctx: grpc.aio.ServicerContext
+    ) -> AsyncIterator[bytes]:
+        yield b"first"
+        raise grpc.aio.AbortError(grpc.StatusCode.CANCELLED, "cancelled")
+
+    handler = _make_handler(unary_stream=stream_behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    ctx = AsyncMock(spec=grpc.aio.ServicerContext)
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    unary_stream = _require_unary_stream(wrapped)
+    with pytest.raises(grpc.aio.AbortError):
+        async for _ in unary_stream(b"request", ctx):  # type: ignore[arg-type] — grpc stubs declare sync Iterator but grpc.aio uses async
+            pass
+
+    ctx.abort.assert_not_awaited()
+
+
 async def test_multiple_error_types_map_to_correct_status(
     interceptor: ErrorHandlingInterceptor,
 ) -> None:

--- a/plugins/spakky-grpc/tests/unit/test_handler.py
+++ b/plugins/spakky-grpc/tests/unit/test_handler.py
@@ -452,6 +452,54 @@ def test_bidi_streaming_handler_has_correct_flags(
     assert handler.response_streaming is True
 
 
+async def _domain_request_frames() -> AsyncIterator[PingRequest]:
+    """Yield request frames a caller already turned into domain models."""
+    yield PingRequest(value="first")
+    yield PingRequest(value="last")
+
+
+async def test_client_streaming_behavior_with_domain_frames_expect_no_reconversion(
+    stream_handler: GrpcServiceHandler,
+) -> None:
+    """Client-streaming frames that are already domain models reach the controller as-is."""
+    stream_handler._container.get.return_value = StreamController()
+
+    details = _make_call_details("/stream.v1.StreamSvc/client_stream")
+    handler = stream_handler.service(details)
+    assert handler is not None
+    assert handler.stream_unary is not None
+
+    result = await handler.stream_unary(
+        _domain_request_frames(),  # type: ignore[arg-type] — grpc stubs declare a sync Iterator but grpc.aio delivers an async one
+        AsyncMock(spec=grpc.aio.ServicerContext),
+    )
+
+    assert isinstance(result, PingReply)
+    assert result.value == "last"
+
+
+async def test_bidi_streaming_behavior_with_domain_frames_expect_no_reconversion(
+    stream_handler: GrpcServiceHandler,
+) -> None:
+    """Bidi frames that are already domain models reach the controller as-is."""
+    stream_handler._container.get.return_value = StreamController()
+
+    details = _make_call_details("/stream.v1.StreamSvc/bidi_stream")
+    handler = stream_handler.service(details)
+    assert handler is not None
+    assert handler.stream_stream is not None
+
+    stream = cast(
+        AsyncIterator[PingReply],
+        handler.stream_stream(
+            _domain_request_frames(),  # type: ignore[arg-type] — grpc stubs declare a sync Iterator but grpc.aio delivers an async one
+            AsyncMock(spec=grpc.aio.ServicerContext),
+        ),
+    )
+
+    assert [reply.value async for reply in stream] == ["first", "last"]
+
+
 # ------------------------------------------------------------------
 # Serializer / deserializer edge cases
 # ------------------------------------------------------------------

--- a/plugins/spakky-grpc/tests/unit/test_tracing_interceptor.py
+++ b/plugins/spakky-grpc/tests/unit/test_tracing_interceptor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Awaitable, Callable
-from typing import cast
+from typing import cast, override
 from unittest.mock import AsyncMock, MagicMock
 
 import grpc
@@ -43,6 +43,25 @@ class FakePropagator(ITracePropagator):
     def fields(self) -> list[str]:
         """Return W3C trace context field names."""
         return ["traceparent", "tracestate"]
+
+
+class NonRecordingPropagator(ITracePropagator):
+    """Propagator that serialises nothing, as for a non-recording context."""
+
+    @override
+    def inject(self, carrier: dict[str, str]) -> None:
+        """Leave the carrier untouched."""
+
+    @override
+    def extract(self, carrier: dict[str, str]) -> TraceContext | None:
+        """Report that the carrier holds no inbound trace context."""
+        del carrier
+        return None
+
+    @override
+    def fields(self) -> list[str]:
+        """Report that no header fields are written."""
+        return []
 
 
 def _make_handler(
@@ -307,6 +326,48 @@ async def test_tracing_interceptor_stream_handler_injects_and_clears(
 
     assert results == [b"a", b"b"]
     context.set_trailing_metadata.assert_called_once()
+    assert TraceContext.get() is None
+
+
+async def test_tracing_interceptor_without_injected_fields_expect_no_trailing_metadata(
+    context: AsyncMock,
+) -> None:
+    """A propagator writing no fields should leave trailing metadata unset."""
+    interceptor = TracingInterceptor(propagator=NonRecordingPropagator())
+    behavior = AsyncMock(return_value=b"ok")
+    handler = _make_handler(unary_unary=behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    unary_unary = _require_unary_unary(wrapped)
+    result = await unary_unary(b"request", context)
+
+    assert result == b"ok"
+    context.set_trailing_metadata.assert_not_called()
+    assert TraceContext.get() is None
+
+
+async def test_tracing_interceptor_stream_without_injected_fields_expect_no_metadata(
+    context: AsyncMock,
+) -> None:
+    """A streaming RPC should complete unchanged when nothing is injected."""
+    interceptor = TracingInterceptor(propagator=NonRecordingPropagator())
+
+    async def stream_behavior(
+        request: object, ctx: grpc.aio.ServicerContext
+    ) -> AsyncIterator[bytes]:
+        yield b"a"
+        yield b"b"
+
+    handler = _make_handler(unary_stream=stream_behavior)
+    continuation = AsyncMock(return_value=handler)
+
+    wrapped = await interceptor.intercept_service(continuation, _make_call_details())
+    unary_stream = _require_unary_stream(wrapped)
+    results = [item async for item in unary_stream(b"request", context)]  # type: ignore[arg-type] — grpc stubs declare sync Iterator but grpc.aio uses async
+
+    assert results == [b"a", b"b"]
+    context.set_trailing_metadata.assert_not_called()
     assert TraceContext.get() is None
 
 

--- a/plugins/spakky-kafka/pyproject.toml
+++ b/plugins/spakky-kafka/pyproject.toml
@@ -80,8 +80,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-logging/pyproject.toml
+++ b/plugins/spakky-logging/pyproject.toml
@@ -63,8 +63,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-logging/tests/unit/test_logging_aspect.py
+++ b/plugins/spakky-logging/tests/unit/test_logging_aspect.py
@@ -171,6 +171,24 @@ def test_logging_aspect_log_args_false_expect_args_hidden() -> None:
     logger.removeHandler(handler)
 
 
+def test_logging_aspect_positional_args_expect_reprs_in_log() -> None:
+    """LoggingAspect가 위치 인자를 repr 형태로 호출부에 이어 로깅함을 검증한다."""
+    logger, handler = _setup_logger()
+
+    class Dummy:
+        @logged()
+        def greet(self, name: str, times: int) -> str:
+            return " ".join(["hi"] * times) + f" {name}"
+
+    aspect = LoggingAspect()
+    result = aspect.around(Dummy().greet, "John", 2)
+
+    assert result == "hi hi John"
+    assert "greet('John', 2)" in handler.log_records[0]
+
+    logger.removeHandler(handler)
+
+
 def test_logging_aspect_log_result_false_expect_result_hidden() -> None:
     """LoggingAspect가 log_result=False일 때 반환값을 숨김을 검증한다."""
     logger, handler = _setup_logger()

--- a/plugins/spakky-mcp/pyproject.toml
+++ b/plugins/spakky-mcp/pyproject.toml
@@ -78,8 +78,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-oidc/pyproject.toml
+++ b/plugins/spakky-oidc/pyproject.toml
@@ -70,8 +70,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-oidc/tests/test_provider.py
+++ b/plugins/spakky-oidc/tests/test_provider.py
@@ -29,6 +29,7 @@ from spakky.plugins.oidc.error import (
     OidcTokenValidationError,
 )
 from spakky.plugins.oidc.provider import (
+    DEFAULT_RETAINED_CLAIMS,
     OIDC_AUTH_PROVIDER_ID,
     OidcAuthenticationProvider,
     OidcProviderConfig,
@@ -414,10 +415,41 @@ def test_custom_claim_mapping_supports_string_roles_and_scope_arrays() -> None:
     assert auth_context.claims[0].name == "sub"
 
 
+def test_token_without_roles_and_scope_claims_expect_empty_refs() -> None:
+    """역할·범위 클레임을 발급하지 않는 IdP 토큰은 빈 역할·범위로 매핑된다."""
+    key = _private_key()
+    claims = _claims(datetime.now(UTC))
+    del claims["roles"]
+    del claims["scope"]
+    provider = _provider(_public_jwk(key))
+
+    auth_context = provider.authenticate(_carrier(_token(key, claims)), _invocation())
+
+    assert auth_context.subject.id == "subject-1"
+    assert auth_context.roles == ()
+    assert auth_context.scopes == ()
+
+
+def test_token_without_a_retained_claim_expect_claim_omitted_from_context() -> None:
+    """보존 대상 클레임이 토큰에 없으면 해당 클레임 없이 AuthContext가 구성된다."""
+    key = _private_key()
+    claims = _claims(datetime.now(UTC))
+    del claims["email"]
+    provider = _provider(_public_jwk(key))
+
+    auth_context = provider.authenticate(_carrier(_token(key, claims)), _invocation())
+
+    retained_names = tuple(claim.name for claim in auth_context.claims)
+    assert "email" in DEFAULT_RETAINED_CLAIMS
+    assert "email" not in retained_names
+    assert "name" in retained_names
+
+
 @pytest.mark.parametrize(
     "claim_patch",
     [
         {"roles": ["ok", 1]},
+        {"roles": 42},
         {"scope": ["ok", 1]},
         {"tenant": 42},
         {"aud": [AUDIENCE, 1]},
@@ -441,6 +473,23 @@ def test_retained_audience_claim_rejects_non_string_shapes(audience: object) -> 
 
     with pytest.raises(OidcTokenValidationError):
         provider._audience_claim_value(audience)
+
+
+@pytest.mark.parametrize("audience", [[AUDIENCE, 1], 42])
+def test_authorized_party_check_with_non_string_audience_expect_rejection(
+    audience: object,
+) -> None:
+    """azp 검증이 읽는 aud 클레임이 문자열·문자열 배열이 아니면 토큰을 거부한다.
+
+    PyJWT가 동일 형태를 decode 단계에서 먼저 거부하므로 authenticate() 경로로는
+    도달하지 않는 방어 지점이라 검증 메서드를 직접 호출한다.
+    """
+    provider = _provider(_public_jwk(_private_key()))
+
+    with pytest.raises(OidcTokenValidationError):
+        provider._validate_authorized_party(
+            {"sub": "subject-1", "iss": ISSUER, "aud": audience, "azp": CLIENT_ID}
+        )
 
 
 def test_jwks_shape_and_header_validation_fail_fast() -> None:

--- a/plugins/spakky-openfga/pyproject.toml
+++ b/plugins/spakky-openfga/pyproject.toml
@@ -70,8 +70,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-opentelemetry/pyproject.toml
+++ b/plugins/spakky-opentelemetry/pyproject.toml
@@ -81,8 +81,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-policy/pyproject.toml
+++ b/plugins/spakky-policy/pyproject.toml
@@ -70,8 +70,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [dependency-groups]

--- a/plugins/spakky-policy/tests/test_evaluator.py
+++ b/plugins/spakky-policy/tests/test_evaluator.py
@@ -1,5 +1,7 @@
 """Policy evaluator tests."""
 
+import pytest
+
 from spakky.auth import (
     AuthContext,
     AuthSubject,
@@ -248,6 +250,128 @@ def test_no_condition_statement_matches(auth_context):
     result = PolicyDocumentEvaluator(document).evaluate(
         PolicyEvaluationInput(auth_context=auth_context, policy="policy:no-condition")
     )
+    assert result.allowed is True
+
+
+@pytest.mark.parametrize(("region", "allowed"), [("kr", True), ("us", False)])
+def test_in_condition_with_scalar_value_expect_equality_semantics(
+    auth_context, region, allowed
+):
+    """단일 스칼라 value를 가진 in 조건은 동등 비교로 평가된다."""
+    document = policy_document_from_mapping(
+        {
+            "version": "1",
+            "policies": [
+                {
+                    "ref": "policy:scalar-in",
+                    "statements": [
+                        {
+                            "ref": "allow-scalar-in",
+                            "effect": "allow",
+                            "condition": {
+                                "operator": "in",
+                                "key": "region",
+                                "value": region,
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    result = PolicyDocumentEvaluator(document).evaluate(
+        PolicyEvaluationInput(auth_context=auth_context, policy="policy:scalar-in")
+    )
+    assert result.allowed is allowed
+
+
+def test_contains_condition_on_non_string_claim_expect_fails_closed(auth_context):
+    """contains 조건은 문자열이 아닌 클레임 값(mfa=True)에 대해 매칭되지 않는다."""
+    document = policy_document_from_mapping(
+        {
+            "version": "1",
+            "policies": [
+                {
+                    "ref": "policy:contains-mfa",
+                    "statements": [
+                        {
+                            "ref": "allow-contains-mfa",
+                            "effect": "allow",
+                            "condition": {
+                                "operator": "contains",
+                                "key": "mfa",
+                                "value": "true",
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    result = PolicyDocumentEvaluator(document).evaluate(
+        PolicyEvaluationInput(auth_context=auth_context, policy="policy:contains-mfa")
+    )
+    assert result.allowed is False
+    assert PolicyEvidenceKind.CONDITION_FAILED in {
+        item.kind for item in result.evidence
+    }
+
+
+def test_exists_condition_on_absent_claim_expect_fails_closed(auth_context):
+    """AuthContext가 발급하지 않은 클레임 키의 exists 조건은 매칭되지 않는다."""
+    document = policy_document_from_mapping(
+        {
+            "version": "1",
+            "policies": [
+                {
+                    "ref": "policy:requires-clearance",
+                    "statements": [
+                        {
+                            "ref": "allow-clearance",
+                            "effect": "allow",
+                            "condition": {"operator": "exists", "key": "clearance"},
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    result = PolicyDocumentEvaluator(document).evaluate(
+        PolicyEvaluationInput(
+            auth_context=auth_context, policy="policy:requires-clearance"
+        )
+    )
+    assert "clearance" not in {claim.name for claim in auth_context.claims}
+    assert result.allowed is False
+    assert PolicyEvidenceKind.CONDITION_FAILED in {
+        item.kind for item in result.evidence
+    }
+
+
+def test_statement_scope_filter_with_document_subject_grant_expect_allow(auth_context):
+    """문서 subject에 부여된 scope는 AuthContext에 없어도 statement scope 필터를 만족한다."""
+    document = policy_document_from_mapping(
+        {
+            "version": "1",
+            "subjects": [{"ref": "user:alice", "scopes": ["scope:reports"]}],
+            "policies": [
+                {
+                    "ref": "policy:report-read",
+                    "statements": [
+                        {
+                            "ref": "allow-report-scope",
+                            "effect": "allow",
+                            "scopes": ["scope:reports"],
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    result = PolicyDocumentEvaluator(document).evaluate(
+        PolicyEvaluationInput(auth_context=auth_context, policy="policy:report-read")
+    )
+    assert "scope:reports" not in auth_context.scopes
     assert result.allowed is True
 
 

--- a/plugins/spakky-rabbitmq/pyproject.toml
+++ b/plugins/spakky-rabbitmq/pyproject.toml
@@ -82,8 +82,6 @@ exclude_lines = [
   "raise NotImplementedError",
   "@(abc\\.)?abstractmethod",
   "@(typing\\.)?overload",
-  "\\.\\.\\.\\.",
-  "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-redis/pyproject.toml
+++ b/plugins/spakky-redis/pyproject.toml
@@ -83,8 +83,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-redis/tests/unit/test_redis_cache.py
+++ b/plugins/spakky-redis/tests/unit/test_redis_cache.py
@@ -6,6 +6,7 @@ import pickle
 
 import fakeredis
 import pytest
+from redis.connection import SSLConnection
 from redis.exceptions import RedisError
 from typing import override
 
@@ -296,6 +297,30 @@ class ContendedSyncClient(ISyncRedisClient):
         return iter(())
 
 
+class SecondCheckHitSyncClient(ContendedSyncClient):
+    """Lock winner whose double-checked read already finds a peer-published value."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.deleted: list[RedisKey] = []
+
+    @override
+    def get(self, name: str) -> bytes | None:
+        self.get_calls += 1
+        if self.get_calls == 1:
+            return None
+        return pickle.dumps("peer-value", protocol=pickle.HIGHEST_PROTOCOL)
+
+    @override
+    def set_if_absent(self, name: str, value: bytes, *, px: int) -> bool:
+        return True
+
+    @override
+    def delete(self, *names: RedisKey) -> int:
+        self.deleted.extend(names)
+        return len(names)
+
+
 class TimeoutSyncClient(ContendedSyncClient):
     @override
     def get(self, name: str) -> bytes | None:
@@ -360,6 +385,30 @@ class ContendedAsyncClient(IAsyncRedisClient):
     @override
     def scan_iter(self, match: str) -> AsyncIterator[RedisKey]:
         return _empty_async_keys()
+
+
+class SecondCheckHitAsyncClient(ContendedAsyncClient):
+    """Lock winner whose double-checked read already finds a peer-published value."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.deleted: list[RedisKey] = []
+
+    @override
+    async def get(self, name: str) -> bytes | None:
+        self.get_calls += 1
+        if self.get_calls == 1:
+            return None
+        return pickle.dumps("peer-value", protocol=pickle.HIGHEST_PROTOCOL)
+
+    @override
+    async def set_if_absent(self, name: str, value: bytes, *, px: int) -> bool:
+        return True
+
+    @override
+    async def delete(self, *names: RedisKey) -> int:
+        self.deleted.extend(names)
+        return len(names)
 
 
 class TimeoutAsyncClient(ContendedAsyncClient):
@@ -635,6 +684,33 @@ def test_get_or_set_contention_expect_reacquires_abandoned_lock() -> None:
     assert cache.metrics().stampede_waits == 1
 
 
+def test_get_or_set_lock_winner_expect_second_check_returns_peer_value() -> None:
+    """lock을 획득한 caller가 double-check에서 peer 값을 발견하면 factory 없이 반환한다."""
+    client = SecondCheckHitSyncClient()
+    cache = RedisCache[str](
+        config=RedisCacheConfig(),
+        client=client,
+        async_client=AsyncRedisAdapter(
+            RedisRawAsyncClient(
+                fakeredis.aioredis.FakeRedis(server=fakeredis.FakeServer())
+            )
+        ),
+    )
+    factory_calls = 0
+
+    def factory() -> str:
+        nonlocal factory_calls
+        factory_calls += 1
+        return "unused"
+
+    value = cache.get_or_set("item", factory)
+
+    assert value == "peer-value"
+    assert factory_calls == 0
+    assert cache.metrics().stampede_waits == 0
+    assert client.deleted == ["spakky:cache:__lock__:item"]
+
+
 def test_get_or_set_contention_timeout_expect_cache_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -855,6 +931,33 @@ async def test_async_get_or_set_contention_expect_reacquires_abandoned_lock() ->
     assert cache.metrics().stampede_waits == 1
 
 
+async def test_async_get_or_set_lock_winner_expect_second_check_returns_peer_value() -> (
+    None
+):
+    """async lock 획득자가 double-check에서 peer 값을 발견하면 factory 없이 반환한다."""
+    client = SecondCheckHitAsyncClient()
+    cache = RedisCache[str](
+        config=RedisCacheConfig(),
+        client=SyncRedisAdapter(
+            RedisRawSyncClient(fakeredis.FakeRedis(server=fakeredis.FakeServer()))
+        ),
+        async_client=client,
+    )
+    factory_calls = 0
+
+    async def factory() -> str:
+        nonlocal factory_calls
+        factory_calls += 1
+        return "unused"
+
+    value = await cache.get_or_set_async("item", factory)
+
+    assert value == "peer-value"
+    assert factory_calls == 0
+    assert cache.metrics().stampede_waits == 0
+    assert client.deleted == ["spakky:cache:__lock__:item"]
+
+
 async def test_async_get_or_set_contention_timeout_expect_cache_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1047,6 +1150,45 @@ async def test_async_unexpected_response_type_expect_framework_cache_error() -> 
         await cache.get_async("bad")
     with pytest.raises(RedisCacheOperationError):
         await cache.delete_async("bad")
+
+
+def test_create_client_expect_config_credentials_and_timeout_propagated() -> None:
+    """자체 생성되는 sync client가 설정된 SSL 스킴·자격증명·소켓 타임아웃을 전파하는지 검증한다."""
+    config = RedisCacheConfig.model_construct(
+        host="cache.internal",
+        port=6380,
+        db=3,
+        username="ops",
+        password="s3cret",
+        use_ssl=True,
+        key_prefix="spakky:cache:",
+        socket_timeout=2.5,
+    )
+    cache = RedisCache[object](
+        config=config,
+        client=SyncRedisAdapter(
+            RedisRawSyncClient(fakeredis.FakeRedis(server=fakeredis.FakeServer()))
+        ),
+        async_client=AsyncRedisAdapter(
+            RedisRawAsyncClient(
+                fakeredis.aioredis.FakeRedis(server=fakeredis.FakeServer())
+            )
+        ),
+    )
+
+    created = cache._create_client()
+
+    assert isinstance(created, SyncRedisAdapter)
+    raw = created._raw
+    assert isinstance(raw, RedisRawSyncClient)
+    connection_pool = raw._raw.connection_pool
+    assert connection_pool.connection_class is SSLConnection
+    assert connection_pool.connection_kwargs["host"] == "cache.internal"
+    assert connection_pool.connection_kwargs["port"] == 6380
+    assert connection_pool.connection_kwargs["db"] == 3
+    assert connection_pool.connection_kwargs["username"] == "ops"
+    assert connection_pool.connection_kwargs["password"] == "s3cret"
+    assert connection_pool.connection_kwargs["socket_timeout"] == 2.5
 
 
 def test_serialization_failure_expect_framework_cache_error() -> None:

--- a/plugins/spakky-sqlalchemy/pyproject.toml
+++ b/plugins/spakky-sqlalchemy/pyproject.toml
@@ -91,8 +91,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-typer/pyproject.toml
+++ b/plugins/spakky-typer/pyproject.toml
@@ -68,8 +68,6 @@ exclude_lines = [
   "raise NotImplementedError",
   "@(abc\\.)?abstractmethod",
   "@(typing\\.)?overload",
-  "\\.\\.\\.\\.",
-  "pass",
 ]
 
 [tool.uv.sources]

--- a/plugins/spakky-vllm/pyproject.toml
+++ b/plugins/spakky-vllm/pyproject.toml
@@ -77,8 +77,6 @@ exclude_lines = [
     "raise NotImplementedError",
     "@(abc\\.)?abstractmethod",
     "@(typing\\.)?overload",
-    "\\.\\.\\.",
-    "pass",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
## 무엇을 고쳤나

30개 워크스페이스 패키지 전부의 `[tool.coverage.report] exclude_lines`에 광역 정규식 `"\.\.\."`와 `"pass"`가 들어 있었습니다. `coverage`는 매치된 줄만이 아니라 **그 줄이 여는 블록 전체**를 제외하므로, `) -> Callable[..., object]:` 같은 시그니처 한 줄이 걸리면 함수 본문이 통째로 측정에서 사라집니다.

결과적으로 `fail_under = 100` 게이트는 초록이었지만, 그 수치는 실행된 적 없는 코드를 아예 세지 않고 있었습니다.

두 항목을 제거했습니다. 남은 항목(`pragma: no cover`, `def __repr__`, `raise AssertionError`, `raise NotImplementedError`, `@abstractmethod`, `@overload`)은 의도한 대상만 좁게 매칭하므로, 제외는 이제 우연한 부분문자열 일치가 아니라 **명시적 opt-out**입니다.

## 실측 (수정 전 → 수정 후)

동일 소스(rebase 후 `origin/develop` 기준)에 수정 전/후 `exclude_lines` 집합을 각각 적용해 `coverage.parser.PythonParser`가 세는 statement 수를 비교했습니다.

**전체: 측정 statement 16,935 → 18,501 — `+1,566`이 그동안 은폐되어 있었습니다.**

은폐량 상위 패키지:

| 패키지 | 수정 전 | 수정 후 | 드러난 statement |
|---|---:|---:|---:|
| `core/spakky` | 2,081 | 2,354 | +273 |
| `core/spakky-agent` | 2,952 | 3,189 | +237 |
| `plugins/spakky-grpc` | 942 | 1,111 | +169 |
| `plugins/spakky-cryptography` | 615 | 773 | +158 |
| `plugins/spakky-policy` | 375 | 482 | +107 |
| `plugins/spakky-redis` | 416 | 520 | +104 |
| `plugins/spakky-celery` | 331 | 413 | +82 |
| `plugins/spakky-mcp` | 433 | 507 | +74 |
| `core/spakky-auth` | 711 | 777 | +66 |
| `plugins/spakky-a2a` | 993 | 1,053 | +60 |

이슈가 지목한 `spakky-grpc/handler.py`의 behavior factory 구간(178–316행)은 `coverage.xml`에서 **측정 라인 0개 → 47개**가 되었습니다.

## 드러난 미커버를 어떻게 처리했나

제외를 좁히자 **13개 패키지에서 84개 라인**이 미커버로 드러나 `fail_under = 100`이 깨졌습니다. 그게 이 티켓의 목적이며, 수치를 맞추려고 제외를 되살리거나 임계값을 낮추지 않았습니다.

- 대부분은 **테스트를 추가**해 덮었습니다. gRPC dispatch의 스트림 에러 처리 경로, `ApplicationContext`의 qualifier 모호성·동시 인스턴스화 경로, `discovery_manifest`의 손상된 매니페스트 10종, OIDC provider·policy evaluator·redis cache·celery post-processor의 에러 분기 등입니다.
- 진짜 도달 불가한 4곳만 사유를 병기한 opt-out으로 표기했습니다.
  - `core/spakky/.../application.py` — `list_objects()`가 class/function만 반환하므로 좁히기 `if`의 거짓 분기가 없음 (`# pragma: no branch`)
  - `core/spakky/.../application_context.py` 두 곳 — Pod 이름 유일성이 `PodNameAlreadyExistsError`로 강제되어 동명 후보가 2개 이상일 수 없음 / `DependencyCollectionKind` 전수 분기 뒤의 exhaustiveness guard
  - `plugins/spakky-a2a/.../register_grpc.py` — 런타임 수신자가 항상 cast된 `GrpcServerSpec`인 구조적 스텁 본문

`src/` 변경은 이 4줄의 주석뿐이며 동작 변경은 없습니다.

## 검증

- 30개 패키지 전부 각자의 디렉토리에서 `uv run pytest` → 커버리지 100% 통과 (실패 0/30).
- `uv run ruff format src tests` / `uv run ruff check src tests` / `uv run pyrefly check src tests` 통과. `pyrefly`는 **명시 경로**로 호출했습니다 — 워크트리가 `.gitignore`의 `.claude/worktrees/`에 매치되어 무인자 호출은 0개 파일만 검사합니다.
- pre-commit / pre-push 훅 전부 통과 (우회 없음).

## Acceptance Criteria (자가 grep)

이슈 #507 수용 기준을 워크트리에서 기계적으로 실행한 결과입니다.

```
$ grep -rn --include=pyproject.toml -E '^\s*"\\\.\\\.\\\.(\\\.)?",|^\s*"pass",' . | wc -l
0                                  # 기대 0 — 광역 항목 잔존 없음

$ python -c "... coverage.xml에서 handler.py 178-316 측정 라인 ..."
measured lines in 178-316: 47      # 기대 >0 — behavior factory 본문이 측정됨

$ 30개 패키지 uv run pytest 종료 코드
0 × 30                             # 기대 — 전 패키지 커버리지 100% 통과

$ git diff HEAD | grep '^+' | grep -E 'pragma: no (cover|branch)' \
    | grep -vE 'pragma: no (cover|branch) - ' | wc -l
0                                  # 기대 0 — 새 pragma는 모두 사유 동반
```

`acceptance_check: PASS`

## 문서 동기화

`exclude_lines`를 언급하는 사용자·개발 문서가 없고(전수 grep 확인) 공개 API·환경변수·의존성 변화가 없어, `documentation.md`의 "내부 구현 세부사항만 변경(공개 API 불변)" 예외에 해당합니다.

## 참고

`#498`(메시지 없는 `@rpc` 선언 차단) 병합 이후로 rebase했습니다. `#498`이 `handler.py`의 `request_type is None` 방어 분기를 제거했으므로, 그 분기를 대상으로 먼저 작성했던 테스트 4건은 폐기하고 rebase 후 소스 기준으로 미커버를 재산출했습니다.

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)
