### PR TITLE
fix(harness): filter informational monitor cache updates (#512)

### DIFF
--- a/.agents/skills/monitor-pr/scripts/collect_comments.sh
+++ b/.agents/skills/monitor-pr/scripts/collect_comments.sh
@@ -30,12 +30,16 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=comment_filters.sh
+source "$script_dir/comment_filters.sh"
+
 # REVIEW_NOISE_FILTER: APPROVED는 ceremonial. 본문 비어있는 COMMENTED/REQUESTED_CHANGES는
 # 개별 인라인 코멘트의 container 역할만 하므로 CH1에서 이미 집계됨 — CH3에서 중복 제외.
-ACTIONABLE_COMMENT_FILTER='
+ACTIONABLE_COMMENT_FILTER="${INFORMATIONAL_BOT_FILTER}"'
   def actionable_comment:
     (((.body // "") | test("<!-- [a-zA-Z0-9_-]*linkback -->")) | not)
-    and (((.user.login // "") | test("^(codecov|linear)(\\[bot\\])?$")) | not);
+    and (informational_bot | not);
 
   def review_noise:
     select(.state != "APPROVED") | select((.body // "") | length > 0);

--- a/.agents/skills/monitor-pr/scripts/comment_filters.sh
+++ b/.agents/skills/monitor-pr/scripts/comment_filters.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# jq definitions shared by comment collection and monitor state snapshots.
+
+INFORMATIONAL_BOT_FILTER='
+  def informational_bot:
+    (.user.login // "") | test("^(codecov|linear)(\\[bot\\])?$");
+'

--- a/.agents/skills/monitor-pr/scripts/test_awaiting_human_review.sh
+++ b/.agents/skills/monitor-pr/scripts/test_awaiting_human_review.sh
@@ -127,7 +127,8 @@ chmod +x "$TMPDIR/bin/sleep"
 TEST_WATCH_SH="$TMPDIR/watch_under_test.sh"
 grep -v '^export PATH="/opt/homebrew/bin' "$WATCH_SH" > "$TEST_WATCH_SH"
 
-PATH="$TMPDIR/bin:/usr/bin:/bin" \
+MONITOR_PR_SCRIPTS_DIR="$SCRIPT_DIR" \
+  PATH="$TMPDIR/bin:/usr/bin:/bin" \
   REPO=E5presso/spakky-framework \
   PR_NUMBER=99999 \
   PREV_STATE_FILE="$TMPDIR/prev_state.json" \

--- a/.agents/skills/monitor-pr/scripts/test_awaiting_human_review_ch3.sh
+++ b/.agents/skills/monitor-pr/scripts/test_awaiting_human_review_ch3.sh
@@ -121,7 +121,8 @@ chmod +x "$TMPDIR/bin/sleep"
 TEST_WATCH_SH="$TMPDIR/watch_under_test.sh"
 grep -v '^export PATH="/opt/homebrew/bin' "$WATCH_SH" > "$TEST_WATCH_SH"
 
-PATH="$TMPDIR/bin:/usr/bin:/bin" \
+MONITOR_PR_SCRIPTS_DIR="$SCRIPT_DIR" \
+  PATH="$TMPDIR/bin:/usr/bin:/bin" \
   REPO=E5presso/spakky-framework \
   PR_NUMBER=99999 \
   PREV_STATE_FILE="$TMPDIR/prev_state.json" \

--- a/.agents/skills/monitor-pr/scripts/test_bot_stuck_auto_approvable_gate.sh
+++ b/.agents/skills/monitor-pr/scripts/test_bot_stuck_auto_approvable_gate.sh
@@ -111,7 +111,8 @@ EOF_SLEEP
   # watch.sh 무한 루프이므로 timeout 으로 강제 종료. heartbeat threshold=6 cycle 도달 시
   # EVENT reason=heartbeat emit → exit 0. 태그 부재 case 에서 bot-stuck 미송신을 검증할 때
   # heartbeat 가 정상 경로가 된다.
-  PATH="$TMPDIR/bin:/usr/bin:/bin" \
+  MONITOR_PR_SCRIPTS_DIR="$SCRIPT_DIR" \
+    PATH="$TMPDIR/bin:/usr/bin:/bin" \
     REPO=E5presso/spakky-framework \
     PR_NUMBER=99999 \
     PREV_STATE_FILE="$TMPDIR/prev_state.json" \

--- a/.agents/skills/monitor-pr/scripts/test_informational_bot_cache.sh
+++ b/.agents/skills/monitor-pr/scripts/test_informational_bot_cache.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Verifies that monitor cache drift ignores informational bots while retaining actionable reviews.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+watch_sh="$script_dir/watch.sh"
+
+run_case() {
+  local fake_case="$1" expected_reason="$2" expected_stale_id="${3:-}"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmp_dir'" RETURN
+
+  mkdir -p "$tmp_dir/bin"
+  cat > "$tmp_dir/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "view" ]; then
+  cat <<'JSON'
+{
+  "mergeStateStatus": "BLOCKED",
+  "reviewDecision": "REVIEW_REQUIRED",
+  "statusCheckRollup": [
+    {"name": "ci", "status": "IN_PROGRESS", "conclusion": null, "workflowName": "ci"}
+  ],
+  "comments": [],
+  "state": "OPEN",
+  "headRefOid": "abc123def456",
+  "labels": []
+}
+JSON
+  exit 0
+fi
+
+if [ "${1:-}" != "api" ]; then
+  echo "unsupported gh invocation: $*" >&2
+  exit 1
+fi
+
+case "${2:-}" in
+  repos/*/pulls/*/comments)
+    if [ "$FAKE_CASE" = "actionable" ]; then
+      cat <<'JSON'
+[{"id":201,"user":{"login":"chatgpt-codex-connector[bot]"},"body":"P1 feedback","created_at":"2026-08-01T00:00:00Z","updated_at":"2026-08-01T00:10:00Z"}]
+JSON
+    else
+      printf '[]\n'
+    fi
+    ;;
+  repos/*/issues/*/comments)
+    cat <<'JSON'
+[{"id":100,"user":{"login":"codecov[bot]"},"body":"Coverage report","created_at":"2026-08-01T00:00:00Z","updated_at":"2026-08-01T00:10:00Z"}]
+JSON
+    ;;
+  repos/*/pulls/*/reviews)
+    printf '[]\n'
+    ;;
+  repos/*/commits/*)
+    printf '2026-08-01T00:00:00Z\n'
+    ;;
+  *)
+    echo "unsupported gh api path: ${2:-}" >&2
+    exit 1
+    ;;
+esac
+SH
+  chmod +x "$tmp_dir/bin/gh"
+
+  cat > "$tmp_dir/bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$tmp_dir/bin/sleep"
+
+  cat > "$tmp_dir/prev_state.json" <<'JSON'
+{"ch1":{"201":"2026-08-01T00:00:00Z"},"ch2":{"100":"2026-08-01T00:00:00Z"},"ch3":{},"reviewDecision":"REVIEW_REQUIRED"}
+JSON
+
+  grep -v '^export PATH="/opt/homebrew/bin' "$watch_sh" > "$tmp_dir/watch_under_test.sh"
+  FAKE_CASE="$fake_case" \
+    MONITOR_PR_SCRIPTS_DIR="$script_dir" \
+    PATH="$tmp_dir/bin:/usr/bin:/bin" \
+    REPO=E5presso/spakky-framework \
+    PR_NUMBER=99999 \
+    PREV_STATE_FILE="$tmp_dir/prev_state.json" \
+    bash "$tmp_dir/watch_under_test.sh" > "$tmp_dir/stdout.log" 2> "$tmp_dir/stderr.log"
+
+  grep -q "^reason=$expected_reason$" "$tmp_dir/stdout.log"
+  if [ -n "$expected_stale_id" ]; then
+    grep -q "^staleHandledIds=$expected_stale_id$" "$tmp_dir/stdout.log"
+  fi
+}
+
+run_case informational heartbeat
+run_case actionable comments-changed 201
+
+echo "monitor-pr informational bot cache checks passed"

--- a/.agents/skills/monitor-pr/scripts/test_mergeable_clean_pending_checks.sh
+++ b/.agents/skills/monitor-pr/scripts/test_mergeable_clean_pending_checks.sh
@@ -108,7 +108,8 @@ EOF_SLEEP
   local TEST_WATCH_SH="$TMPDIR/watch_under_test.sh"
   grep -v '^export PATH="/opt/homebrew/bin' "$WATCH_SH" > "$TEST_WATCH_SH"
 
-  PATH="$TMPDIR/bin:/usr/bin:/bin" \
+  MONITOR_PR_SCRIPTS_DIR="$SCRIPT_DIR" \
+    PATH="$TMPDIR/bin:/usr/bin:/bin" \
     REPO=E5presso/spakky-framework \
     PR_NUMBER=99999 \
     PREV_STATE_FILE="$TMPDIR/prev_state.json" \

--- a/.agents/skills/monitor-pr/scripts/test_review_decision_persisted.sh
+++ b/.agents/skills/monitor-pr/scripts/test_review_decision_persisted.sh
@@ -109,7 +109,8 @@ EOF_SLEEP
   grep -v '^export PATH="/opt/homebrew/bin' "$WATCH_SH" > "$TEST_WATCH_SH"
 
   # PREV_REVIEW_DECISION 을 전달하지 않는다 — reviewDecision baseline 은 PREV_STATE_FILE 에서만 로드됨을 검증.
-  PATH="$TMPDIR/bin:/usr/bin:/bin" \
+  MONITOR_PR_SCRIPTS_DIR="$SCRIPT_DIR" \
+    PATH="$TMPDIR/bin:/usr/bin:/bin" \
     REPO=E5presso/spakky-framework \
     PR_NUMBER=99999 \
     PREV_STATE_FILE="$TMPDIR/prev_state.json" \

--- a/.agents/skills/monitor-pr/scripts/test_status_context_failed_checks.sh
+++ b/.agents/skills/monitor-pr/scripts/test_status_context_failed_checks.sh
@@ -99,7 +99,8 @@ EOF_SLEEP
   local TEST_WATCH_SH="$TMPDIR/watch_under_test.sh"
   grep -v '^export PATH="/opt/homebrew/bin' "$WATCH_SH" > "$TEST_WATCH_SH"
 
-  PATH="$TMPDIR/bin:/usr/bin:/bin" \
+  MONITOR_PR_SCRIPTS_DIR="$SCRIPT_DIR" \
+    PATH="$TMPDIR/bin:/usr/bin:/bin" \
     REPO=E5presso/spakky-framework \
     PR_NUMBER=99999 \
     PREV_STATE_FILE="$TMPDIR/prev_state.json" \

--- a/.agents/skills/monitor-pr/scripts/watch.sh
+++ b/.agents/skills/monitor-pr/scripts/watch.sh
@@ -101,6 +101,10 @@ fi
 : "${REPO:?REPO env required}"
 : "${PR_NUMBER:?PR_NUMBER env required}"
 
+monitor_pr_scripts_dir="${MONITOR_PR_SCRIPTS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+# shellcheck source=comment_filters.sh
+source "$monitor_pr_scripts_dir/comment_filters.sh"
+
 prev_state_file="${PREV_STATE_FILE:-}"
 interrupt_file="${INTERRUPT_FILE:-}"
 
@@ -259,11 +263,11 @@ while true; do
     --argjson ch1 "$ch1_raw" \
     --argjson ch2 "$ch2_raw" \
     --argjson ch3 "$ch3_raw" \
-    --arg review_decision "$review_decision" '
+    --arg review_decision "$review_decision" "${INFORMATIONAL_BOT_FILTER}"'
     {
-      ch1: ($ch1 | map({(.id|tostring): (.updated_at // .created_at)}) | add // {}),
-      ch2: ($ch2 | map({(.id|tostring): (.updated_at // .created_at)}) | add // {}),
-      ch3: ($ch3 | map({(.id|tostring): (.submitted_at // "")}) | add // {}),
+      ch1: ($ch1 | map(select(informational_bot | not) | {(.id|tostring): (.updated_at // .created_at)}) | add // {}),
+      ch2: ($ch2 | map(select(informational_bot | not) | {(.id|tostring): (.updated_at // .created_at)}) | add // {}),
+      ch3: ($ch3 | map(select(informational_bot | not) | {(.id|tostring): (.submitted_at // "")}) | add // {}),
       reviewDecision: $review_decision
     }
   ')


### PR DESCRIPTION
## 요약

- Codecov·Linear 정보성 봇 판별을 공유 jq 정의로 분리해 코멘트 수집기와 변화 감지기가 같은 정책을 사용하도록 했습니다.
- 세 코멘트 채널의 `(id, updatedAt)` 스냅샷에서 정보성 봇 row를 제외해 coverage report 갱신이 `comments-changed`를 반복 발화하지 않게 했습니다.
- 정보성 봇 갱신은 무시하면서 actionable 리뷰 갱신은 기존처럼 stale ID와 함께 감지하는 회귀 테스트를 추가했습니다.

## 검증

- monitor-pr shell 회귀 테스트 8개 통과
- 변경 shell 스크립트 `bash -n` 통과
- pre-commit Python harness / monorepo / commitizen hooks 통과
- pre-push 변경 프로젝트 검사 통과
- 독립 `/review-code` + `/evaluate-harness`: Critical 0

## Acceptance Criteria (자가 grep)

acceptance_check: missing

이슈 본문에 실행 가능한 수용 기준 grep 라인이 없습니다. 대신 정보성 봇과 actionable 봇의 in-place 갱신을 분리하는 실제 `watch.sh` 회귀 테스트로 동작을 검증했습니다.

## 후속 하네스 gap

- #514 — review-delegate의 존재하지 않는 persona 정본 참조를 별도 분해했습니다.

Closes #512
