### PR TITLE
fix(outbox): distinguish record rejection from transport failure (#513)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1146,7 +1146,7 @@ flowchart TD
 |---------|------|
 | `IOutboxStorage` / `IAsyncOutboxStorage` | 아웃박스 메시지 저장소 포트. 파티션 키를 통째로 claim하고, 재시도를 소진한 메시지를 발행 포기(abandoned) 상태로 분리 |
 | `OutboxEventBus` / `AsyncOutboxEventBus` | `@Primary`로 `DirectEventBus`를 교체하는 EventBus seam. 저장되는 Outbox headers에는 tracing metadata와 signed `AuthContextSnapshot` metadata가 함께 보존되며 raw bearer token은 저장하지 않음 |
-| `OutboxRelayBackgroundService` / `AsyncOutboxRelayBackgroundService` | 백그라운드 릴레이 (polling → 배치 `IEventTransport.send()` → 배치 끝 `flush()` → 발행 완료 표시). 전송이 실패한 파티션 키는 그 배치의 후속 메시지를 보류하여 키 단위 순서를 보전하고, 재시도를 소진한 메시지는 발행 포기 처리하여 키를 다시 진행 |
+| `OutboxRelayBackgroundService` / `AsyncOutboxRelayBackgroundService` | 백그라운드 릴레이 (polling → 배치 `IEventTransport.send()` → 배치 끝 `flush()` → 발행 완료 표시). transport가 개별 레코드의 거부를 확정한 경우에만 retry 예산을 소모하고, transport 자체 장애에는 배치를 미발행으로 보존한다. 거부된 파티션 키는 그 배치의 후속 메시지를 보류하여 키 단위 순서를 보전하고, 재시도를 소진한 메시지는 발행 포기 처리하여 키를 다시 진행 |
 | `OutboxConfig` | 환경변수 기반 설정 (polling interval, batch size, retry 등) |
 | `OutboxMessage` | 아웃박스 메시지 모델 |
 

--- a/core/spakky-event/src/spakky/event/error.py
+++ b/core/spakky-event/src/spakky/event/error.py
@@ -37,11 +37,11 @@ class EventTransportNotRunningError(AbstractSpakkyEventError):
 
 
 class EventDeliveryRejectedError(AbstractSpakkyEventError):
-    """Raised by flush() when the broker refused records it was confirming.
+    """Raised when a transport attributes a permanent rejection to a record.
 
-    Clients that report a rejection through a delivery callback rather than
-    through the publish call raise this from flush(), so a caller that batches
-    records still learns that the batch did not arrive.
+    A client may report the rejection synchronously from send() or later through
+    a delivery callback consumed by flush(). Both paths use this error so callers
+    can distinguish record-specific failure from a transport-wide outage.
     """
 
     message = "Broker rejected event delivery"

--- a/core/spakky-event/src/spakky/event/event_publisher.py
+++ b/core/spakky-event/src/spakky/event/event_publisher.py
@@ -65,6 +65,11 @@ class IEventTransport(ABC):
     ) -> None:
         """Hand a serialized event payload to the broker client for delivery.
 
+        A permanent rejection attributable to this record must be reported as
+        `EventDeliveryRejectedError`. A connection, timeout, queue, or other
+        transport-wide failure keeps the client exception's original type so a
+        caller does not spend this record's retry budget.
+
         Args:
             event_name: Destination topic / routing key.
             payload: Pre-serialized event bytes.
@@ -73,6 +78,8 @@ class IEventTransport(ABC):
                 None spreads payloads round-robin.
 
         Raises:
+            EventDeliveryRejectedError: When the transport permanently rejects
+                this specific record.
             EventTransportNotRunningError: When the transport's broker client is
                 not open, which happens outside the application lifecycle.
         """
@@ -87,6 +94,15 @@ class IEventTransport(ABC):
         delivery callback collects it and raises here — a caller that batches
         records has no other moment to learn that the batch did not arrive, and
         would otherwise record undelivered events as published.
+
+        Implementations must preserve the same failure taxonomy as send(): only
+        a permanent record-specific rejection becomes
+        `EventDeliveryRejectedError`; transport-wide failures retain the broker
+        client's original exception type.
+
+        Raises:
+            EventDeliveryRejectedError: When one or more records are permanently
+                rejected for a record-specific cause.
         """
         ...
 
@@ -111,6 +127,11 @@ class IAsyncEventTransport(ABC):
     ) -> None:
         """Hand a serialized event payload to the broker client for delivery.
 
+        A permanent rejection attributable to this record must be reported as
+        `EventDeliveryRejectedError`. A connection, timeout, queue, or other
+        transport-wide failure keeps the client exception's original type so a
+        caller does not spend this record's retry budget.
+
         Args:
             event_name: Destination topic / routing key.
             payload: Pre-serialized event bytes.
@@ -119,6 +140,8 @@ class IAsyncEventTransport(ABC):
                 None spreads payloads round-robin.
 
         Raises:
+            EventDeliveryRejectedError: When the transport permanently rejects
+                this specific record.
             EventTransportNotRunningError: When the transport's broker client is
                 not open, which happens outside the application lifecycle.
         """
@@ -133,5 +156,14 @@ class IAsyncEventTransport(ABC):
         delivery callback collects it and raises here — a caller that batches
         records has no other moment to learn that the batch did not arrive, and
         would otherwise record undelivered events as published.
+
+        Implementations must preserve the same failure taxonomy as send(): only
+        a permanent record-specific rejection becomes
+        `EventDeliveryRejectedError`; transport-wide failures retain the broker
+        client's original exception type.
+
+        Raises:
+            EventDeliveryRejectedError: When one or more records are permanently
+                rejected for a record-specific cause.
         """
         ...

--- a/core/spakky-outbox/README.md
+++ b/core/spakky-outbox/README.md
@@ -18,7 +18,7 @@ pip install spakky-outbox "spakky-sqlalchemy[outbox]"
 
 - **트랜잭셔널 Outbox**: 이벤트를 비즈니스 데이터와 원자적으로 저장
 - **자동 relay**: background relay가 이벤트를 외부 transport(Kafka, RabbitMQ)로 발행
-- **재시도 지원**: 실패 메시지를 설정 가능한 한도 내에서 재시도
+- **재시도 지원**: transport가 개별 레코드의 거부를 확정한 경우에만 설정 가능한 한도 내에서 재시도하며, transport 자체 장애는 메시지별 retry 예산을 소모하지 않음
 - **다중 인스턴스 안전성**: 원자적 claim으로 중복 발행 방지
 - **파티션 키 단위 순서 보전**: 파티션 키를 통째로 claim하고, 전송이 실패한 키의 후속 메시지를 보류
 - **발행 포기 상태**: 재시도를 소진한 메시지를 `abandoned` 처리하여 키가 무기한 막히지 않게 함

--- a/core/spakky-outbox/src/spakky/outbox/relay/relay.py
+++ b/core/spakky-outbox/src/spakky/outbox/relay/relay.py
@@ -153,10 +153,19 @@ class OutboxRelayBackgroundService(AbstractBackgroundService):
                     len(messages) - len(relayed),
                 )
                 return
-            except Exception:
-                logger.exception("Failed to relay outbox message %s", message.id)
+            except EventDeliveryRejectedError:
+                logger.exception("Transport rejected outbox message %s", message.id)
                 self.__register_refusal(message, halted_partition_keys)
                 continue
+            except Exception:
+                # A transport-wide failure is not attributable to this record.
+                # Preserve the whole batch without charging any message's retry
+                # budget, just as the one-at-a-time confirmation path does.
+                logger.exception(
+                    "Transport failed while relaying outbox message %s",
+                    message.id,
+                )
+                return
             relayed.append(message)
         if not relayed:
             return
@@ -313,10 +322,19 @@ class AsyncOutboxRelayBackgroundService(AbstractAsyncBackgroundService):
                     len(messages) - len(relayed),
                 )
                 return
-            except Exception:
-                logger.exception("Failed to relay outbox message %s", message.id)
+            except EventDeliveryRejectedError:
+                logger.exception("Transport rejected outbox message %s", message.id)
                 await self.__register_refusal(message, halted_partition_keys)
                 continue
+            except Exception:
+                # A transport-wide failure is not attributable to this record.
+                # Preserve the whole batch without charging any message's retry
+                # budget, just as the one-at-a-time confirmation path does.
+                logger.exception(
+                    "Transport failed while relaying outbox message %s",
+                    message.id,
+                )
+                return
             relayed.append(message)
         if not relayed:
             return

--- a/core/spakky-outbox/tests/unit/test_outbox_relay.py
+++ b/core/spakky-outbox/tests/unit/test_outbox_relay.py
@@ -110,7 +110,7 @@ class SelectivelyFailingSyncTransport(IEventTransport):
         partition_key: str | None = None,
     ) -> None:
         if payload in self.rejected_payloads:
-            raise ConnectionError("Transport rejected the message")
+            raise EventDeliveryRejectedError(["Transport rejected the message"])
         self.sent_payloads.append(payload)
 
     def flush(self) -> None:
@@ -271,7 +271,7 @@ class SelectivelyFailingAsyncTransport(IAsyncEventTransport):
         partition_key: str | None = None,
     ) -> None:
         if payload in self.rejected_payloads:
-            raise ConnectionError("Transport rejected the message")
+            raise EventDeliveryRejectedError(["Transport rejected the message"])
         self.sent_payloads.append(payload)
 
     async def flush(self) -> None:
@@ -463,8 +463,10 @@ def test_relay_batch_transport_stopped_expect_batch_left_pending_without_retry_c
     assert storage.retried_ids == []
 
 
-def test_relay_batch_increments_retry_on_transport_failure() -> None:
-    """Transport 전송 실패 시 _relay_batch가 retry count를 증가시키는지 검증한다."""
+def test_relay_batch_transport_failure_expect_message_left_pending_without_retry() -> (
+    None
+):
+    """Transport 전송 장애는 메시지 retry 예산을 소모하지 않는다."""
     event = RelayTestIntegrationEvent(order_id="ORD-FAIL")
     message = _make_message(event)
 
@@ -475,8 +477,9 @@ def test_relay_batch_increments_retry_on_transport_failure() -> None:
     relay = OutboxRelayBackgroundService(storage, transport, config)
     relay._relay_batch()
 
-    assert len(storage.published_ids) == 0
-    assert message.id in storage.retried_ids
+    assert storage.published_ids == []
+    assert storage.retried_ids == []
+    assert storage.abandoned_ids == []
 
 
 def test_relay_batch_partition_key_after_failure_expect_rest_of_key_held_back() -> None:
@@ -755,8 +758,10 @@ async def test_async_relay_batch_transport_stopped_expect_batch_left_pending_wit
 
 
 @pytest.mark.asyncio
-async def test_async_relay_batch_increments_retry_on_transport_failure() -> None:
-    """Transport 전송 실패 시 _relay_batch가 retry count를 증가시키는지 검증한다."""
+async def test_async_relay_batch_transport_failure_expect_message_left_pending_without_retry() -> (
+    None
+):
+    """비동기 Transport 전송 장애는 메시지 retry 예산을 소모하지 않는다."""
     event = RelayTestIntegrationEvent(order_id="ORD-FAIL")
     message = _make_message(event)
 
@@ -767,8 +772,9 @@ async def test_async_relay_batch_increments_retry_on_transport_failure() -> None
     relay = AsyncOutboxRelayBackgroundService(storage, transport, config)
     await relay._relay_batch()
 
-    assert len(storage.published_ids) == 0
-    assert message.id in storage.retried_ids
+    assert storage.published_ids == []
+    assert storage.retried_ids == []
+    assert storage.abandoned_ids == []
 
 
 @pytest.mark.asyncio

--- a/docs/error-hierarchy.md
+++ b/docs/error-hierarchy.md
@@ -344,6 +344,8 @@ from spakky.event.error import (
     AbstractSpakkyEventError,
     AuthSnapshotPropagationContextUnavailableError,
     AuthSnapshotPropagationSignerUnavailableError,
+    EventDeliveryRejectedError,
+    EventTransportNotRunningError,
     InvalidMessageError,
     UnknownEventTypeError,
 )
@@ -353,6 +355,8 @@ from spakky.event.error import (
 | ---- | ---- |
 | `AuthSnapshotPropagationContextUnavailableError` | snapshot 전파가 활성화되었지만 `ApplicationContext`를 읽을 수 없음 |
 | `AuthSnapshotPropagationSignerUnavailableError` | snapshot 전파가 활성화되었지만 signer provider가 없음 |
+| `EventDeliveryRejectedError` | Transport가 영구적인 전달 거부를 특정 레코드에 귀속함. Outbox가 메시지별 retry/abandon 예산을 쓰는 경계 |
+| `EventTransportNotRunningError` | Transport가 애플리케이션 lifecycle 밖에서 사용됨. 레코드 전달 실패가 아니므로 Outbox retry 예산을 소모하지 않음 |
 | `InvalidMessageError` | 잘못된 메시지 형식 |
 | `UnknownEventTypeError` | Domain/Integration Event가 아닌 타입 발행 |
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -551,7 +551,7 @@ Integration Event가 어느 브로커 파티션으로 갈지 결정하는 값입
 
 같은 파티션 키를 가진 이벤트는 항상 같은 파티션으로 갑니다 — Kafka가 보장하는 순서는 파티션 안에서만 성립하므로, 파티션 키는 순서 보장의 **전제 조건**입니다. 보통 aggregate id를 키로 사용합니다.
 
-Outbox를 경유하는 경로에서는 릴레이가 키 단위 순서를 함께 지킵니다. 전송이 실패한 키는 그 메시지가 발행될 때까지 후속 메시지를 보류하고, `fetch_pending`이 키를 통째로 claim하여 여러 릴레이 인스턴스가 같은 키를 병렬 발행하지 않습니다. 재시도를 소진한 메시지는 발행 포기(abandoned) 처리되어 키를 다시 열어 줍니다 — 상세와 그 대가는 [Kafka 가이드](guides/kafka.md)의 파티션 키 절 참조.
+Outbox를 경유하는 경로에서는 릴레이가 키 단위 순서를 함께 지킵니다. Transport가 영구적이고 특정 레코드에 귀속 가능한 거부를 `EventDeliveryRejectedError`로 확정하면 그 키의 후속 메시지를 보류하고 retry 예산을 쓰지만, 연결·timeout·queue·그 밖의 transport 장애는 원래 예외 타입을 유지하며 그 장애 자체로 예산을 소모하지 않습니다. `fetch_pending`은 키를 통째로 claim하여 여러 릴레이 인스턴스가 같은 키를 병렬 발행하지 않으며, 영구 레코드 귀속 거부로 retry를 소진한 메시지는 발행 포기(abandoned) 처리되어 키를 다시 열어 줍니다 — 상세와 그 대가는 [Kafka 가이드](guides/kafka.md)의 파티션 키 절 참조.
 
 전달 경로: 이벤트 → `IEventBus` → (`OutboxMessage.partition_key` 컬럼 경유) → `IEventTransport.send(..., partition_key=...)` → Kafka `produce(key=...)`. RabbitMQ transport는 파티션 개념이 없어 이 값을 라우팅에 사용하지 않습니다.
 
@@ -680,7 +680,7 @@ Repository 저장 경로에서 AggregateRoot 참조를 수집하는 컴포넌트
 
 ### OutboxEventBus
 
-`@Primary`로 기본 `IEventBus`를 대체하여, Integration Event를 브로커 대신 Outbox 테이블에 저장합니다. 비즈니스 데이터와 같은 트랜잭션 내에서 원자적으로 기록되므로 at-least-once 전달을 보장합니다.
+`@Primary`로 기본 `IEventBus`를 대체하여, Integration Event를 브로커 대신 Outbox 테이블에 저장합니다. 비즈니스 데이터와 같은 트랜잭션 내에서 원자적으로 기록하고, 브로커가 수락 가능한 레코드는 확인될 때까지 재전송하므로 성공 전달 경로는 중복 가능한 at-least-once 의미를 갖습니다. 영구 레코드 귀속 거부는 retry 소진 후 abandoned 처리되어 성공 전달이 0회일 수 있습니다.
 
 ```python
 from spakky.outbox.bus.outbox_event_bus import OutboxEventBus, AsyncOutboxEventBus
@@ -688,7 +688,7 @@ from spakky.outbox.bus.outbox_event_bus import OutboxEventBus, AsyncOutboxEventB
 
 ### OutboxMessage
 
-영속성에 독립적인 Outbox 메시지 모델. `id`, `event_name`, `payload`, `headers`, `created_at`, `published_at`, `retry_count`, `claimed_at` 필드를 가집니다.
+영속성에 독립적인 Outbox 메시지 모델. `id`, `event_name`, `payload`, `headers`, `partition_key`, `created_at`, `published_at`, `retry_count`, `claimed_at`, `abandoned_at` 필드를 가집니다.
 
 ```python
 from spakky.outbox.common.message import OutboxMessage

--- a/docs/guides/kafka.md
+++ b/docs/guides/kafka.md
@@ -146,15 +146,17 @@ class OrderPlacedEvent(AbstractIntegrationEvent):
 `spakky-outbox`를 함께 쓰면 bus가 이벤트의 `partition_key`를 Outbox 레코드의 `partition_key` 컬럼에 저장하고, Relay가 그 값을 그대로 Kafka transport에 넘깁니다.
 
 !!! note "Outbox 경로에서 키 단위 순서가 지켜지는 방식"
-    `spakky-outbox`를 경유하면 릴레이가 파티션 키 단위 상대 순서를 보전합니다. 순서를 지키는 대가는 실패한 키의 지연입니다.
+    `spakky-outbox`를 경유하면 릴레이가 파티션 키 단위 상대 순서를 보전합니다. 순서를 지키는 대가는 영구 레코드 귀속 거부가 확정된 키의 지연입니다.
 
-    - **배치 확정과 거부 귀속**: 릴레이는 배치의 메시지를 순차로 `send`한 뒤 배치 끝에서 `flush()` 한 번으로 확정합니다. `flush()`가 실패하면 어느 레코드가 거부됐는지 그 자리에서 알 수 없으므로, 릴레이가 같은 배치를 1건씩 다시 `send` + `flush` 하여 거부를 메시지에 귀속시킵니다. 거부된 메시지만 자기 키를 보류하고 재시도 예산을 씁니다 — 이 귀속이 없으면 브로커가 영구 거부하는 메시지(메시지 크기 초과·ACL 거부 등)의 재시도 횟수가 영원히 오르지 않아 그 키가 무기한 정지합니다. 반대로 브로커에 닿지 못해 실패한 경우에는 재확인을 멈추고 배치를 미발행으로 남깁니다 — 장애로 멀쩡한 메시지의 예산을 소모시키지 않습니다.
-    - **개별 전송 실패**: 어떤 키의 메시지를 producer에 넘기는 것 자체가 실패하거나 위 재확인에서 거부되면 릴레이는 같은 배치에 있는 그 키의 후속 메시지를 발행하지 않고 보류합니다. 그 키는 실패한 메시지가 발행될 때까지 진행하지 않으며, 재개는 그 메시지의 claim이 만료된 뒤(`claim_timeout_seconds`, 기본 300초)입니다.
+    - **배치 확정과 거부 귀속**: 릴레이는 배치의 메시지를 순차로 `send`한 뒤 배치 끝에서 `flush()` 한 번으로 확정합니다. `flush()`가 실패하면 어느 레코드가 거부됐는지 그 자리에서는 가릴 수 없으므로, 릴레이가 같은 배치를 1건씩 다시 `send` + `flush` 하여 결과를 메시지에 귀속시킵니다. 이 재확인에서 영구적인 레코드 귀속 거부인 `EventDeliveryRejectedError`가 난 메시지만 자기 키를 보류하고 retry 예산을 씁니다. Transport 장애가 나면 원래 예외 타입을 유지한 채 재확인을 멈추고 배치를 DB에서 미발행으로 보존합니다. 브로커가 수락 가능한 레코드는 다시 전송될 수 있어 전달 의미가 at-least-once이지만, 영구 거부 후 abandoned된 레코드는 성공 전달이 0회일 수 있습니다.
+    - **Kafka의 영구 레코드 거부**: 동기 `KafkaEventTransport`는 confluent-kafka가 `KafkaError.MSG_SIZE_TOO_LARGE`로 거부한 레코드를, 비동기 `AsyncKafkaEventTransport`는 aiokafka의 `MessageSizeTooLargeError`를 `EventDeliveryRejectedError`로 변환합니다. Delivery callback/future에서도 메시지 크기 초과만 같은 공통 예외로 보고합니다. Outbox retry/abandon 예산을 소모하는 것은 이 영구 레코드 귀속 예외뿐입니다.
+    - **transport 전체 장애**: 동기 producer의 로컬 queue 포화(`BufferError`), 메시지 크기와 무관한 `KafkaException`, 연결 끊김·타임아웃 등은 원래 예외 타입으로 전파합니다. 비동기 경로도 `MessageSizeTooLargeError` 이외의 send/flush/delivery future 예외를 원래 타입으로 전파합니다. 영구 거부와 transport 장애가 한 flush에 섞여도 transport 장애가 우선하므로, Relay는 그 예외 자체에 retry/abandon 예산을 쓰지 않고 1건씩 재확인합니다. 재확인에서도 transport 장애가 나면 남은 메시지를 미확정 상태로 보존하며, 이후 `EventDeliveryRejectedError`가 독립적으로 확인된 레코드만 예산을 씁니다.
+    - **파티션 키 보류**: 영구적인 `EventDeliveryRejectedError`가 귀속된 메시지에 파티션 키가 있고 retry 예산이 남아 있으면, 릴레이는 같은 배치에 있는 그 키의 후속 메시지를 보류합니다. 다음 시도는 그 메시지의 claim이 만료된 뒤(`claim_timeout_seconds`, 기본 300초)입니다. 마지막 예산을 쓴 메시지는 즉시 abandoned 처리되므로 같은 배치의 후속 메시지가 계속 진행할 수 있습니다. Transport 전체 장애는 특정 키의 retry 예산을 쓰지 않고 배치 처리를 멈춥니다.
     - **릴레이 다중 인스턴스**: `fetch_pending()`은 파티션 키를 통째로 claim합니다. 그 키의 가장 오래된 미발행 메시지를 잡은 인스턴스만 그 키를 진행하므로, 두 인스턴스가 같은 키를 병렬 발행하지 않습니다.
-    - **재시도 소진**: 어떤 메시지가 `max_retry_count`를 소진하면 릴레이가 그 메시지를 발행 포기(abandoned) 처리하고 키를 다시 진행시킵니다. 그 키의 순서 보장은 포기된 메시지까지이며, 그 이후 메시지는 포기된 메시지 없이 발행됩니다. 포기 사실은 `abandoned_at`으로 남으므로 운영자가 무엇이 빠졌는지 조회할 수 있습니다 — 조회 쿼리는 [Outbox 가이드](outbox.md) 참조.
+    - **재시도 소진**: 영구 레코드 귀속 거부가 반복되어 어떤 메시지가 `max_retry_count`를 소진하면 릴레이가 그 메시지를 발행 포기(abandoned) 처리하고 키를 다시 진행시킵니다. 이 메시지는 성공 전달 0회로 끝날 수 있으며, 그 이후 메시지는 포기된 메시지 없이 발행됩니다. 포기 사실은 `abandoned_at`으로 남으므로 운영자가 무엇이 빠졌는지 조회할 수 있습니다 — 조회 쿼리는 [Outbox 가이드](outbox.md) 참조.
     - **producer 재시도**: 프레임워크가 `enable.idempotence=true`를 고정하고 transport가 producer를 애플리케이션 수명 동안 하나로 유지하므로, 그 수명 안의 재시도는 파티션 내 순서를 뒤집지 않습니다. 다만 프로세스가 재시작하면 새 producer 세션이 시작되어 이전 세션과의 상대 순서까지는 보장하지 않습니다.
 
-    파티션 키가 없는 메시지에는 보류 제약이 적용되지 않습니다 — 실패한 메시지를 건너뛰고 계속 발행합니다. 키 단위 claim은 파티션 키가 있는 행에만 조건을 걸므로 키 없는 메시지의 claim 경로도 종전과 같습니다.
+    파티션 키가 없는 메시지에는 영구 레코드 귀속 거부에 따른 보류 제약이 적용되지 않습니다 — 거부된 메시지는 retry/abandon 처리하고 같은 배치의 후속 메시지를 계속 발행합니다. Transport 전체 장애는 키 유무와 관계없이 배치 처리를 멈춥니다. 키 단위 claim은 파티션 키가 있는 행에만 조건을 걸므로 키 없는 메시지의 claim 경로도 종전과 같습니다.
 
     **storage 구현 조건**: 위 다중 인스턴스 보장은 Outbox storage가 키 단위 claim을 구현할 때 성립합니다. 프레임워크가 제공하는 `SqlAlchemyOutboxStorage`는 `SELECT ... FOR UPDATE SKIP LOCKED`를 지원하는 백엔드(PostgreSQL 9.5+, MySQL 8.0+)에서 이를 구현합니다 — 지원하지 않는 백엔드에서는 릴레이를 단일 인스턴스로 운영해야 합니다.
 
@@ -196,7 +198,7 @@ sequenceDiagram
 | 처리 실패 | `<topic>` + `dead_letter_topic_suffix` 토픽으로 전달 |
 | offset 커밋 | 자동 커밋 없음. 실패가 dead-letter에 저장된 뒤에만 consumer가 직접 커밋 |
 
-`spakky-outbox`를 함께 로드하면 `OutboxEventBus` / `AsyncOutboxEventBus`가 기본 bus를 대체하므로 이벤트는 Kafka에 즉시 produce되지 않고 Outbox 테이블에 저장됩니다. Relay가 재시도 가능한 방식으로 Kafka transport를 호출하므로, 주문 생성 같은 DB 변경과 Kafka 발행을 원자적으로 묶어야 할 때 기본 선택은 Outbox 조합입니다.
+`spakky-outbox`를 함께 로드하면 `OutboxEventBus` / `AsyncOutboxEventBus`가 기본 bus를 대체하므로 이벤트는 Kafka에 즉시 produce되지 않고 Outbox 테이블에 저장됩니다. Relay는 Kafka transport가 영구적이고 특정 레코드에 귀속 가능한 거부를 `EventDeliveryRejectedError`로 보고한 경우에만 retry/abandon 예산을 씁니다. Transport 전체 장애 자체에는 예산을 쓰지 않으며, 배치 `flush()` 장애는 1건씩 재확인하고 최초 `send()`나 재확인의 장애는 미확정 메시지를 그대로 둡니다. 주문 생성 같은 DB 변경과 Kafka 발행을 원자적으로 묶어야 할 때 기본 선택은 Outbox 조합입니다. 브로커가 수락 가능한 레코드는 장애 후 재전송으로 중복 전달될 수 있어 소비자가 멱등해야 하지만, 영구 거부 후 abandoned된 레코드는 성공 전달이 0회일 수 있습니다.
 
 ---
 

--- a/docs/guides/outbox.md
+++ b/docs/guides/outbox.md
@@ -1,8 +1,8 @@
 # Transactional Outbox
 
-> `spakky-outbox`로 transaction 이후 Integration Event를 at-least-once로 전달하는 흐름을, 개념과 사용법으로 나누어 설명합니다.
+> `spakky-outbox`로 transaction 이후 Integration Event를 확인 전까지 재전송하는 at-least-once 흐름과, 영구 거부된 레코드를 발행 포기하는 경계를 설명합니다.
 
-`spakky-outbox`는 Transactional Outbox 패턴을 구현하여 Integration Event의 at-least-once 전달을 보장합니다. events·outbox·saga가 함께 동작하는 전체 그림은 [이벤트 기반 아키텍처 통합 가이드](event-driven.md)를 참고하세요.
+`spakky-outbox`는 Transactional Outbox 패턴으로 비즈니스 변경과 Integration Event 기록을 원자적으로 묶습니다. 브로커가 수락 가능한 레코드는 확인될 때까지 재전송하므로 성공 전달 경로는 중복 가능한 at-least-once 의미를 갖지만, 영구적인 레코드 귀속 거부는 retry 예산을 소진하면 abandoned 처리되어 성공 전달이 0회일 수 있습니다. events·outbox·saga가 함께 동작하는 전체 그림은 [이벤트 기반 아키텍처 통합 가이드](event-driven.md)를 참고하세요.
 
 ---
 
@@ -20,11 +20,11 @@ Outbox는 이벤트를 **비즈니스 데이터와 같은 DB 트랜잭션 안에
 2. Integration Event 발행 시 메시지 브로커 대신 Outbox 테이블에 저장합니다 (트랜잭션 내).
 3. `OutboxRelayBackgroundService`가 주기적으로 Outbox 테이블을 폴링합니다.
 4. 미전송 메시지를 `IEventTransport`(Kafka/RabbitMQ)를 통해 실제 전송합니다.
-5. 전송 성공 시 메시지를 published 처리, 실패 시 재시도 카운트를 증가시킵니다. 실패한 메시지에 파티션 키가 있으면 같은 배치에 있는 그 키의 후속 메시지를 보류하고, `max_retry_count`를 소진하면 그 메시지를 발행 포기(abandoned) 처리하여 키를 다시 진행시킵니다.
+5. 전송 성공 시 메시지를 published 처리합니다. Transport가 영구적이고 특정 레코드에 귀속 가능한 거부를 `EventDeliveryRejectedError`로 확정한 경우에만 그 메시지의 retry count를 증가시키고, `max_retry_count`를 소진하면 발행 포기(abandoned) 처리합니다. 연결 끊김·타임아웃·queue 포화·그 밖의 transport 장애는 원래 예외 타입을 유지하며, Relay는 그 예외 때문에 retry/abandon 예산을 쓰지 않습니다. 배치 `flush()` 실패는 1건씩 재확인하고, 최초 `send()`나 1건 재확인의 transport 장애는 미확정 메시지를 그대로 남깁니다.
 
 ### 폴링 → 전송 흐름
 
-발행 측(UseCase 트랜잭션)과 전송 측(Relay 폴링)이 시간적으로 분리됩니다. Relay는 `fetch_pending`으로 미전송 메시지를 원자적으로 claim한 뒤 전송하고, 성공·실패에 따라 상태를 갱신합니다. 파티션 키가 있는 메시지는 키 단위로 claim·발행되어 상대 순서가 보전됩니다 — [Kafka 가이드](kafka.md)의 파티션 키 절 참조.
+발행 측(UseCase 트랜잭션)과 전송 측(Relay 폴링)이 시간적으로 분리됩니다. Relay는 `fetch_pending`으로 미전송 메시지를 원자적으로 claim한 뒤 전송하고, 배치 확정 성공·영구 레코드 귀속 거부·transport 장애를 구분해 상태를 갱신합니다. 파티션 키가 있는 메시지는 키 단위로 claim·발행되어 상대 순서가 보전됩니다 — [Kafka 가이드](kafka.md)의 파티션 키 절 참조.
 
 ```mermaid
 sequenceDiagram
@@ -41,12 +41,14 @@ sequenceDiagram
   loop polling_interval_seconds 주기
     Relay->>Storage: fetch_pending(batch_size, max_retry)
     Storage-->>Relay: 미전송 메시지 (claim)
-    Relay->>Transport: send(event_name, payload, headers)
-    alt 전송 성공
-      Transport->>Broker: 메시지 전달
+    Relay->>Transport: send(...) 후 배치 끝 flush()
+    alt 배치 확정 성공
+      Transport->>Broker: 메시지 전달 확정
       Relay->>Storage: mark_published(id)
-    else 전송 실패
-      Relay->>Storage: increment_retry(id)
+    else EventDeliveryRejectedError (영구 레코드 귀속 거부)
+      Relay->>Storage: increment_retry(id) 또는 mark_abandoned(id)
+    else transport 장애 (원래 예외 타입 유지)
+      Note over Relay,Storage: 이 장애로 retry/abandon 예산을 쓰지 않음
     end
   end
 ```
@@ -57,15 +59,16 @@ sequenceDiagram
 stateDiagram-v2
   [*] --> Pending: save (트랜잭션 commit)
   Pending --> Claimed: fetch_pending (claimed_at 기록)
-  Claimed --> Published: 전송 성공 → mark_published
-  Claimed --> Pending: 전송 실패 → increment_retry
-  Claimed --> Abandoned: 마지막 재시도까지 실패 → mark_abandoned
+  Claimed --> Published: 배치 확정 성공 → mark_published
+  Claimed --> Claimed: 영구 레코드 귀속 거부 → increment_retry
+  Claimed --> Abandoned: 영구 레코드 귀속 거부 + retry 소진 → mark_abandoned
+  Claimed --> Claimed: transport 장애 → 상태·retry 불변
   Claimed --> Pending: claim_timeout 초과 (크래시 복구)
   Published --> [*]
   Abandoned --> [*]
 ```
 
-`Abandoned`는 `max_retry_count`를 소진하고도 전송되지 못한 메시지의 종착 상태입니다. 이 상태로 넘기지 않으면 메시지가 조회 대상에서만 빠진 채 "가장 오래된 미발행 메시지"로 남아 같은 파티션 키의 후속 메시지를 영구히 막습니다. `abandoned_at`이 찍힌 row는 발행 대기열을 떠나므로 그 키가 다시 진행하며, row 자체는 남아 있어 운영자가 무엇이 버려졌는지 조회할 수 있습니다.
+`Abandoned`는 영구적이고 개별 레코드에 귀속된 거부가 반복되어 `max_retry_count`를 소진한 메시지의 종착 상태입니다. Transport 전체 장애는 이 상태로 전이시키지 않습니다. 레코드 거부를 소진 뒤에도 그대로 두면 메시지가 조회 대상에서만 빠진 채 "가장 오래된 미발행 메시지"로 남아 같은 파티션 키의 후속 메시지를 영구히 막습니다. `abandoned_at`이 찍힌 row는 발행 대기열을 떠나므로 그 키가 다시 진행하며, row 자체는 남아 있어 운영자가 성공 전달 0회로 끝난 메시지를 조회할 수 있습니다.
 
 ```sql
 SELECT id, event_name, partition_key, retry_count, abandoned_at
@@ -115,7 +118,7 @@ export SPAKKY_OUTBOX__CLAIM_TIMEOUT_SECONDS=300.0
 |------|---------|--------|------|
 | `polling_interval_seconds` | `SPAKKY_OUTBOX__POLLING_INTERVAL_SECONDS` | `1.0` | 폴링 주기 (초) |
 | `batch_size` | `SPAKKY_OUTBOX__BATCH_SIZE` | `100` | 배치당 처리 메시지 수 |
-| `max_retry_count` | `SPAKKY_OUTBOX__MAX_RETRY_COUNT` | `5` | 최대 재시도 횟수. 소진 시 메시지를 발행 포기 처리 |
+| `max_retry_count` | `SPAKKY_OUTBOX__MAX_RETRY_COUNT` | `5` | 영구 레코드 귀속 거부의 최대 retry 횟수. 소진 시 발행 포기하며 transport 장애에는 소모하지 않음 |
 | `claim_timeout_seconds` | `SPAKKY_OUTBOX__CLAIM_TIMEOUT_SECONDS` | `300.0` | 메시지 잠금 타임아웃 (초) |
 
 ### 이벤트 발행
@@ -156,10 +159,10 @@ from spakky.outbox.bus.outbox_event_bus import OutboxEventBus, AsyncOutboxEventB
 
 한 번 가져온 배치는 전부 `send`한 뒤 `flush`를 한 번만 호출하고, flush가 성공한 다음에 발행 완료로 표시합니다.
 
-- 개별 메시지의 `send`가 실패하면 그 메시지의 retry count만 올립니다.
+- `send()` 또는 1건 재확인이 영구적인 레코드 귀속 거부인 `EventDeliveryRejectedError`를 올린 경우에만 그 레코드의 retry count를 올립니다. 남은 예산이 없으면 `mark_abandoned()`로 발행 대기열에서 제외합니다.
 - 배치 `flush`가 실패하면 어느 메시지의 잘못인지 그 자리에서는 가릴 수 없으므로, 릴레이가 **같은 배치를 메시지 1건씩 다시 `send` + `flush`** 하여 브로커의 판정을 메시지에 귀속시킵니다. 이미 배치에서 전달된 레코드가 재확인 과정에서 다시 전달될 수 있으므로 소비자 멱등성이 전제입니다(at-least-once).
-- 재확인에서 브로커가 **그 레코드를 거부**하면(`EventDeliveryRejectedError`) 그 메시지만 retry count를 올리고 자기 파티션 키를 보류합니다. 재시도해도 같은 결과가 나올 메시지이므로 예산을 소모시켜 결국 발행 포기에 도달하게 하는 것이 맞습니다.
-- 재확인이 **브로커에 닿지 못해서**(연결 끊김·타임아웃) 실패하면 재확인을 멈추고 남은 배치를 미발행으로 남깁니다. retry count를 올리지 않습니다 — 장애는 어느 메시지의 잘못도 아니므로, 여기서 예산을 물리면 멀쩡한 메시지가 발행 포기로 버려집니다. 애플리케이션 종료로 transport가 닫힌 경우도 같습니다.
+- 재확인에서 브로커가 **그 레코드를 영구 거부**하면(`EventDeliveryRejectedError`) 그 메시지만 retry count를 올리고 자기 파티션 키를 보류합니다. 재시도해도 같은 결과가 나올 메시지이므로 예산을 소모시켜 결국 발행 포기에 도달하게 하는 것이 맞습니다.
+- 최초 `send`나 재확인이 연결 끊김·타임아웃·queue 포화·그 밖의 transport 장애로 실패하면 transport는 원래 예외 타입을 유지합니다. Relay는 처리를 멈추고 배치를 DB에서 미발행 상태로 남기며 retry count와 abandoned 상태를 바꾸지 않습니다. 브로커가 앞선 레코드를 이미 받았을 가능성은 남아 있어, 다음 claim의 재전송은 중복을 만들 수 있습니다. 이것이 at-least-once 전달에서 소비자 멱등성이 필요한 이유입니다.
 - 재확인은 실패 경로에서만 일어납니다. 정상 경로는 종전대로 배치 1개당 `flush` 1회이므로 처리량이 바뀌지 않습니다.
 - 애플리케이션 종료로 transport가 닫히면(`EventTransportNotRunningError`) 남은 배치를 그대로 두고 릴레이를 멈춥니다. 종료는 전달 실패가 아니므로 retry count를 소모하지 않습니다.
 

--- a/plugins/spakky-kafka/README.md
+++ b/plugins/spakky-kafka/README.md
@@ -218,7 +218,7 @@ dead-letter topic은 consumer `initialize` 시점에 구독 topic과 함께 생�
 
 - 두 transport 모두 producer를 하나만 두고 재사용합니다. 비동기 transport는 `IAsyncService`로 등록되어 애플리케이션이 서비스를 시작할 때 `AIOKafkaProducer`를 열고 종료할 때 닫습니다. 시작 시점에 브로커에 연결하지 못하면 `app.start()`가 실패합니다.
 - `send()`는 레코드를 producer에 넘기고 broker 응답을 기다리지 않으므로 연속 발행이 한 배치로 묶입니다. 배치 끝에서 호출하는 `flush()`가 배치를 내보내고 결과를 확정합니다. `DirectEventBus`는 발행 1건마다, outbox relay는 배치 1개마다 `flush()`를 호출합니다.
-- 비동기 `flush()`는 브로커가 거부한 레코드의 예외를 그대로 올립니다. 동기 `flush()`는 confluent-kafka가 delivery 콜백으로만 알려 주는 거부를 모아 `EventDeliveryRejectedError`로 올립니다 — 그러지 않으면 거부된 레코드를 호출자가 발행 완료로 기록합니다.
+- 동기·비동기 `send()`는 producer가 즉시 보고한 레코드 크기 거부를 `EventDeliveryRejectedError`로 올립니다. 동기 경로의 로컬 producer 큐 포화(`BufferError`)와 그 밖의 Kafka 장애는 transport 장애로 그대로 전파합니다. 비동기 `flush()`는 브로커가 거부한 레코드의 예외를 같은 공통 예외로 올리고, 동기 `flush()`도 delivery 콜백으로 알려진 거부를 모아 올립니다 — 그러지 않으면 거부된 레코드를 호출자가 발행 완료로 기록하거나, transport 장애가 무고한 레코드의 retry 예산을 소모합니다.
 - 비동기 `flush()`가 확정하는 대상은 **그 발행자가 넘긴 레코드**입니다. 여러 발행자가 같은 transport Pod를 동시에 쓰더라도 한 발행자의 flush가 다른 발행자의 거부를 대신 받거나 삼키지 않습니다. 따라서 한 배치의 `send`와 `flush`는 같은 실행 문맥(asyncio 태스크)에서 호출해야 하며, event bus와 outbox relay가 그렇게 호출합니다.
 - 애플리케이션이 transport를 시작하기 전이나 종료한 뒤의 비동기 발행은 `EventTransportNotRunningError`로 거부됩니다. outbox relay는 이 에러를 전달 실패와 구분하여 retry count를 올리지 않고 배치를 그대로 남깁니다.
 - aiokafka는 producer를 생성한 event loop에 묶으므로, 다른 loop(HTTP 요청 핸들러·테스트)에서 발행하면 transport가 producer의 loop로 호출을 넘깁니다.

--- a/plugins/spakky-kafka/src/spakky/plugins/kafka/event/transport.py
+++ b/plugins/spakky-kafka/src/spakky/plugins/kafka/event/transport.py
@@ -14,8 +14,9 @@ from threading import Event
 from typing import Any
 
 from aiokafka import AIOKafkaProducer
+from aiokafka.errors import MessageSizeTooLargeError
 from aiokafka.structs import RecordMetadata
-from confluent_kafka import KafkaError, Message, Producer
+from confluent_kafka import KafkaError, KafkaException, Message, Producer
 from confluent_kafka.admin import AdminClient, NewTopic
 from typing import override
 
@@ -62,7 +63,7 @@ class KafkaEventTransport(IEventTransport, IService):
     config: KafkaConnectionConfig
     admin: AdminClient
     producer: Producer
-    _delivery_rejections: list[str]
+    _delivery_errors: list[KafkaError]
 
     def __init__(self, config: KafkaConnectionConfig) -> None:
         """Initialize the Kafka producer with connection config."""
@@ -72,7 +73,7 @@ class KafkaEventTransport(IEventTransport, IService):
             self.config.producer_configuration_dict,
             logger=logger,
         )
-        self._delivery_rejections = []
+        self._delivery_errors = []
 
     def _create_topic(self, topic: str) -> None:
         existing_topics: set[str] = set(self.admin.list_topics().topics.keys())
@@ -95,10 +96,10 @@ class KafkaEventTransport(IEventTransport, IService):
     ) -> None:
         if error is not None:
             logger.error(f"Message delivery failed: {error}")
-            # confluent_kafka reports a rejection only here. Keeping it lets
-            # flush() fail, so the caller does not record an undelivered record
-            # as published.
-            self._delivery_rejections.append(str(error))
+            # confluent_kafka reports both record rejections and transport
+            # failures here. Keep the KafkaError so flush() can preserve that
+            # distinction instead of charging every failure to the record.
+            self._delivery_errors.append(error)
         else:
             logger.info(
                 f"Message delivered to {message.topic()} [{message.partition()}] at offset {message.offset()}"
@@ -136,35 +137,61 @@ class KafkaEventTransport(IEventTransport, IService):
             headers: Metadata headers for trace propagation.
             partition_key: Key routing the message to one partition. None lets
                 Kafka assign partitions round-robin.
+
+        Raises:
+            EventDeliveryRejectedError: The producer rejected this record as too
+                large.
+            BufferError: The local producer queue is full.
+            KafkaException: A different synchronous Kafka failure occurred.
         """
         self._create_topic(topic=event_name)
-        self.producer.produce(
-            topic=event_name,
-            value=payload,
-            key=partition_key.encode() if partition_key is not None else None,
-            headers=dict(headers),
-            callback=self._message_delivery_report,
-        )
+        try:
+            self.producer.produce(
+                topic=event_name,
+                value=payload,
+                key=partition_key.encode() if partition_key is not None else None,
+                headers=dict(headers),
+                callback=self._message_delivery_report,
+            )
+        except KafkaException as error:
+            rejected_records = [
+                reason
+                for reason in error.args
+                if isinstance(reason, KafkaError)
+                and reason.code() == KafkaError.MSG_SIZE_TOO_LARGE
+            ]
+            if not rejected_records:
+                raise
+            raise EventDeliveryRejectedError(
+                [str(reason) for reason in rejected_records]
+            ) from error
         self.producer.poll(0)
 
     @override
     def flush(self) -> None:
         """Block until the producer has sent every queued record.
 
-        Rejections collected by the delivery callback are raised here as
-        `EventDeliveryRejectedError`. Without this the caller would treat a
-        refused record as delivered — the outbox relay would mark it published
-        and the event would be lost with no trace beyond a log line.
+        A message-size rejection collected by the delivery callback is raised as
+        `EventDeliveryRejectedError`. Other callback errors remain transport-wide
+        `KafkaException` failures, so callers do not charge them to a record.
 
         Raises:
-            EventDeliveryRejectedError: The broker refused at least one record.
+            EventDeliveryRejectedError: The broker refused a record as too large.
+            KafkaException: Delivery failed for a transport-wide Kafka error.
         """
         self.producer.flush()
-        if not self._delivery_rejections:
+        if not self._delivery_errors:
             return
-        rejections = self._delivery_rejections
-        self._delivery_rejections = []
-        raise EventDeliveryRejectedError(rejections)
+        delivery_errors = self._delivery_errors
+        self._delivery_errors = []
+        transport_errors = [
+            error
+            for error in delivery_errors
+            if error.code() != KafkaError.MSG_SIZE_TOO_LARGE
+        ]
+        if transport_errors:
+            raise KafkaException(transport_errors[0])
+        raise EventDeliveryRejectedError([str(error) for error in delivery_errors])
 
 
 @immutable
@@ -275,25 +302,33 @@ class AsyncKafkaEventTransport(IAsyncEventTransport, IAsyncService):
         the record rather than to whoever happened to flush first.
 
         A failure of the flush itself propagates as it comes: the client could
-        not talk to the broker, which is no single record's fault. A failure
-        carried by a record's own delivery future is that record's verdict and
-        is raised as `EventDeliveryRejectedError`, so a caller can tell the two
-        apart and only spend a retry budget on the second.
+        not talk to the broker, which is no single record's fault. A delivery
+        future's `MessageSizeTooLargeError` is attributable to its record and is
+        raised as `EventDeliveryRejectedError`; every other future failure keeps
+        its original type as a transport-wide failure.
 
         Raises:
-            EventDeliveryRejectedError: The broker refused at least one record.
+            EventDeliveryRejectedError: The broker refused at least one record
+                as too large.
         """
         await producer.flush()
         outcomes = await gather(*deliveries, return_exceptions=True)
         # Every outcome is retrieved before raising, so a second rejected record
         # does not linger as an unretrieved exception.
-        refusals = [
+        failures = [
             outcome for outcome in outcomes if isinstance(outcome, BaseException)
         ]
-        if not refusals:
+        if not failures:
             return
-        raise EventDeliveryRejectedError([str(refusal) for refusal in refusals]) from (
-            refusals[0]
+        transport_failures = [
+            failure
+            for failure in failures
+            if not isinstance(failure, MessageSizeTooLargeError)
+        ]
+        if transport_failures:
+            raise transport_failures[0]
+        raise EventDeliveryRejectedError([str(failure) for failure in failures]) from (
+            failures[0]
         )
 
     @override
@@ -361,11 +396,15 @@ class AsyncKafkaEventTransport(IAsyncEventTransport, IAsyncService):
         Raises:
             EventTransportNotRunningError: When the application has not started
                 the transport's producer, or has already stopped it.
+            EventDeliveryRejectedError: The producer rejected this record as too
+                large.
+            aiokafka.errors.KafkaError: Any producer failure not attributable to
+                this record's size, propagated without conversion.
         """
         self._create_topic(topic=event_name)
         running = self._running_producer
-        self._record_delivery(
-            await self._on_producer_loop(
+        try:
+            delivery = await self._on_producer_loop(
                 running.producer.send(
                     topic=event_name,
                     value=payload,
@@ -374,7 +413,9 @@ class AsyncKafkaEventTransport(IAsyncEventTransport, IAsyncService):
                 ),
                 running.loop,
             )
-        )
+        except MessageSizeTooLargeError as error:
+            raise EventDeliveryRejectedError([str(error)]) from error
+        self._record_delivery(delivery)
 
     @override
     async def flush(self) -> None:
@@ -383,7 +424,9 @@ class AsyncKafkaEventTransport(IAsyncEventTransport, IAsyncService):
         Raises:
             EventTransportNotRunningError: When the application has not started
                 the transport's producer, or has already stopped it.
-            KafkaError: When the broker rejected one of this publisher's records.
+            EventDeliveryRejectedError: When the broker rejected one or more of
+                this publisher's records as too large. Any other delivery failure
+                keeps its original exception type.
         """
         running = self._running_producer
         await self._on_producer_loop(

--- a/plugins/spakky-kafka/tests/unit/test_transport.py
+++ b/plugins/spakky-kafka/tests/unit/test_transport.py
@@ -18,8 +18,13 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aiokafka.errors import (
+    KafkaConnectionError,
+    KafkaTimeoutError,
+    MessageSizeTooLargeError,
+)
 from aiokafka.structs import RecordMetadata, TopicPartition
-from confluent_kafka import KafkaError
+from confluent_kafka import KafkaError, KafkaException
 from spakky.event.error import (
     EventDeliveryRejectedError,
     EventTransportNotRunningError,
@@ -195,6 +200,69 @@ def test_sync_transport_send_expect_produce_without_flush(
 
 @patch("spakky.plugins.kafka.event.transport.Producer")
 @patch("spakky.plugins.kafka.event.transport.AdminClient")
+def test_sync_transport_send_message_too_large_expect_delivery_rejection(
+    mock_admin_cls: MagicMock,
+    mock_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """메시지 크기 거부는 해당 레코드의 EventDeliveryRejectedError로 변환한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    kafka_error = KafkaError(KafkaError.MSG_SIZE_TOO_LARGE)
+    mock_producer_cls.return_value.produce.side_effect = KafkaException(kafka_error)
+
+    transport = KafkaEventTransport(config)
+
+    with pytest.raises(EventDeliveryRejectedError) as rejection:
+        transport.send("TestEvent", b"{}", {})
+
+    assert rejection.value.reasons == [str(kafka_error)]
+
+
+@patch("spakky.plugins.kafka.event.transport.Producer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+def test_sync_transport_send_queue_full_expect_buffer_error_propagated(
+    mock_admin_cls: MagicMock,
+    mock_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """로컬 producer 큐 포화는 레코드 거부로 변환하지 않는다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    mock_producer_cls.return_value.produce.side_effect = BufferError("Queue full")
+
+    transport = KafkaEventTransport(config)
+
+    with pytest.raises(BufferError, match="Queue full"):
+        transport.send("TestEvent", b"{}", {})
+
+
+@patch("spakky.plugins.kafka.event.transport.Producer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+def test_sync_transport_send_kafka_transport_error_expect_original_error_propagated(
+    mock_admin_cls: MagicMock,
+    mock_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """레코드 크기와 무관한 Kafka 장애는 원래 transport 예외를 유지한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    kafka_exception = KafkaException(KafkaError(KafkaError.BROKER_NOT_AVAILABLE))
+    mock_producer_cls.return_value.produce.side_effect = kafka_exception
+
+    transport = KafkaEventTransport(config)
+
+    with pytest.raises(KafkaException) as raised:
+        transport.send("TestEvent", b"{}", {})
+
+    assert raised.value is kafka_exception
+
+
+@patch("spakky.plugins.kafka.event.transport.Producer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
 def test_sync_transport_batch_expect_single_flush_for_two_sends(
     mock_admin_cls: MagicMock,
     mock_producer_cls: MagicMock,
@@ -295,6 +363,65 @@ async def test_async_transport_send_expect_record_handed_to_started_producer(
 @pytest.mark.asyncio
 @patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
 @patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_send_message_too_large_expect_delivery_rejection(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """비동기 producer의 동기 레코드 크기 거부도 공통 예외로 변환한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    rejection = MessageSizeTooLargeError("Message exceeds max_request_size")
+    mock_producer = AsyncMock()
+    mock_producer.send.side_effect = rejection
+    mock_aio_producer_cls.return_value = mock_producer
+
+    transport = AsyncKafkaEventTransport(config)
+    await transport.start_async()
+
+    with pytest.raises(EventDeliveryRejectedError) as raised:
+        await transport.send("TestEvent", b"{}", {})
+
+    assert raised.value.reasons == [str(rejection)]
+    assert _claimed_deliveries() == []
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_send_transport_failures_expect_original_without_pending(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """연결·timeout send 장애는 원래 객체를 유지하고 delivery로 등록하지 않는다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    mock_producer = AsyncMock()
+    mock_aio_producer_cls.return_value = mock_producer
+
+    transport = AsyncKafkaEventTransport(config)
+    await transport.start_async()
+
+    transport_failures = (
+        KafkaConnectionError("Connection lost"),
+        KafkaTimeoutError("Request timed out"),
+    )
+    for transport_failure in transport_failures:
+        mock_producer.send.side_effect = transport_failure
+
+        with pytest.raises((KafkaConnectionError, KafkaTimeoutError)) as raised:
+            await transport.send("TestEvent", b"{}", {})
+
+        assert raised.value is transport_failure
+        assert _claimed_deliveries() == []
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
 async def test_async_transport_send_expect_no_broker_wait_before_flush(
     mock_admin_cls: MagicMock,
     mock_aio_producer_cls: MagicMock,
@@ -337,9 +464,10 @@ async def test_async_transport_flush_rejected_record_expect_broker_error_raised(
     mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
     mock_admin_cls.return_value = mock_admin
 
+    record_rejection = MessageSizeTooLargeError("Message exceeds max_request_size")
     mock_producer = AsyncMock()
     mock_producer.send.side_effect = [
-        _rejected_record(ConnectionError("Broker rejected the record")),
+        _rejected_record(record_rejection),
         _delivered_record(),
     ]
     mock_aio_producer_cls.return_value = mock_producer
@@ -352,7 +480,80 @@ async def test_async_transport_flush_rejected_record_expect_broker_error_raised(
     with pytest.raises(EventDeliveryRejectedError) as rejection:
         await transport.flush()
 
-    assert rejection.value.reasons == ["Broker rejected the record"]
+    assert rejection.value.reasons == [str(record_rejection)]
+
+
+@pytest.mark.asyncio
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_flush_transport_failure_expect_original_error_propagated(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """delivery future의 연결 장애는 레코드 거부로 변환하지 않는다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    transport_failure = KafkaConnectionError("Connection lost")
+
+    mock_producer = AsyncMock()
+    mock_producer.send.return_value = _rejected_record(transport_failure)
+    mock_aio_producer_cls.return_value = mock_producer
+
+    transport = AsyncKafkaEventTransport(config)
+    await transport.start_async()
+    await transport.send("TestEvent", b"{}", {})
+
+    with pytest.raises(KafkaConnectionError) as raised:
+        await transport.flush()
+
+    assert raised.value is transport_failure
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport_first", [False, True])
+@patch("spakky.plugins.kafka.event.transport.AIOKafkaProducer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+async def test_async_transport_flush_mixed_failures_expect_transport_failure_first(
+    mock_admin_cls: MagicMock,
+    mock_aio_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    *,
+    transport_first: bool,
+) -> None:
+    """혼합 delivery 실패는 순서와 무관하게 transport 장애를 우선 보존한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    record_rejection = MessageSizeTooLargeError("Message exceeds max_request_size")
+    transport_failure = KafkaConnectionError("Connection lost")
+    failures = (
+        (transport_failure, record_rejection)
+        if transport_first
+        else (record_rejection, transport_failure)
+    )
+
+    mock_producer = AsyncMock()
+    mock_producer.send.side_effect = [_rejected_record(failure) for failure in failures]
+    mock_aio_producer_cls.return_value = mock_producer
+
+    transport = AsyncKafkaEventTransport(config)
+    await transport.start_async()
+    await transport.send("TestEvent", b"{}", {})
+    await transport.send("TestEvent", b"{}", {})
+
+    with pytest.raises(KafkaConnectionError) as raised:
+        await transport.flush()
+
+    assert raised.value is transport_failure
+    assert _claimed_deliveries() == []
+
+    mock_producer.send.side_effect = None
+    mock_producer.send.return_value = _delivered_record()
+    await transport.send("TestEvent", b"{}", {})
+    await transport.flush()
+    assert _claimed_deliveries() == []
 
 
 @pytest.mark.asyncio
@@ -380,7 +581,7 @@ async def test_async_transport_concurrent_publishers_expect_rejection_to_its_own
     async def publish_rejected_record() -> None:
         """발행자 A: 거부될 레코드를 보내고, 동시 발행자가 flush를 마친 뒤 flush한다."""
         mock_producer.send.return_value = _rejected_record(
-            ConnectionError("Broker rejected the record")
+            MessageSizeTooLargeError("Message exceeds max_request_size")
         )
         await transport.send("TestEvent", b'{"sender": "rejected"}', {})
         rejected_publisher_started.set()
@@ -440,7 +641,7 @@ async def test_async_transport_stop_async_with_rejected_record_expect_producer_c
     mock_admin_cls.return_value = mock_admin
     mock_producer = AsyncMock()
     mock_producer.send.return_value = _rejected_record(
-        ConnectionError("Broker rejected the record")
+        MessageSizeTooLargeError("Message exceeds max_request_size")
     )
     mock_aio_producer_cls.return_value = mock_producer
 
@@ -658,10 +859,75 @@ def test_sync_transport_flush_rejected_record_expect_broker_error_raised(
 
     transport = KafkaEventTransport(config)
     transport.send("TestEvent", b"{}", {})
-    transport._message_delivery_report(MagicMock(spec=KafkaError), MagicMock())
+    transport._message_delivery_report(
+        KafkaError(KafkaError.MSG_SIZE_TOO_LARGE), MagicMock()
+    )
 
     with pytest.raises(EventDeliveryRejectedError):
         transport.flush()
+
+
+@patch("spakky.plugins.kafka.event.transport.Producer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+def test_sync_transport_flush_transport_failure_expect_kafka_error_propagated(
+    mock_admin_cls: MagicMock,
+    mock_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+) -> None:
+    """delivery callback의 transport 장애는 원래 KafkaError를 보존한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    mock_producer_cls.return_value = MagicMock()
+    transport_failure = KafkaError(KafkaError._TRANSPORT)
+
+    transport = KafkaEventTransport(config)
+    transport._message_delivery_report(transport_failure, MagicMock())
+
+    with pytest.raises(KafkaException) as raised:
+        transport.flush()
+
+    assert raised.value.args[0] is transport_failure
+
+    transport.flush()
+
+
+@pytest.mark.parametrize(
+    "error_codes",
+    [
+        (KafkaError.MSG_SIZE_TOO_LARGE, KafkaError._TRANSPORT),
+        (KafkaError._TRANSPORT, KafkaError.MSG_SIZE_TOO_LARGE),
+    ],
+)
+@patch("spakky.plugins.kafka.event.transport.Producer")
+@patch("spakky.plugins.kafka.event.transport.AdminClient")
+def test_sync_transport_flush_mixed_failures_expect_transport_failure_first(
+    mock_admin_cls: MagicMock,
+    mock_producer_cls: MagicMock,
+    config: KafkaConnectionConfig,
+    error_codes: tuple[int, int],
+) -> None:
+    """혼합 callback 실패는 순서와 무관하게 transport 장애를 우선 보존한다."""
+    mock_admin = MagicMock()
+    mock_admin.list_topics.return_value.topics.keys.return_value = {"TestEvent"}
+    mock_admin_cls.return_value = mock_admin
+    mock_producer_cls.return_value = MagicMock()
+    delivery_errors = [KafkaError(code) for code in error_codes]
+    transport_failure = next(
+        error for error in delivery_errors if error.code() == KafkaError._TRANSPORT
+    )
+
+    transport = KafkaEventTransport(config)
+    for delivery_error in delivery_errors:
+        transport._message_delivery_report(delivery_error, MagicMock())
+
+    with pytest.raises(KafkaException) as raised:
+        transport.flush()
+
+    assert raised.value.args[0] is transport_failure
+
+    transport.send("TestEvent", b"{}", {})
+    transport.flush()
 
 
 @patch("spakky.plugins.kafka.event.transport.Producer")
@@ -678,7 +944,9 @@ def test_sync_transport_flush_after_rejection_expect_next_batch_unaffected(
     mock_producer_cls.return_value = MagicMock()
 
     transport = KafkaEventTransport(config)
-    transport._message_delivery_report(MagicMock(spec=KafkaError), MagicMock())
+    transport._message_delivery_report(
+        KafkaError(KafkaError.MSG_SIZE_TOO_LARGE), MagicMock()
+    )
     with pytest.raises(EventDeliveryRejectedError):
         transport.flush()
 


### PR DESCRIPTION
## 요약

- Outbox 릴레이가 `EventDeliveryRejectedError`로 확정된 메시지 고유 거부에만 retry/abandon 예산을 쓰고, 연결·timeout·queue 등 transport-wide 장애에는 배치를 미발행으로 보존하도록 분리했습니다.
- Kafka 동기·비동기 `send()`와 `flush()`가 메시지 크기 초과만 공통 레코드 거부로 변환하고, 다른 Kafka 오류는 원래 transport 실패와 객체 정체성을 유지하도록 했습니다.
- 공개 Transport Port, 아키텍처·패키지 README·사용자 가이드·용어·에러 계층 문서를 같은 실패 taxonomy와 terminal abandon을 포함한 전달 보장으로 동기화했습니다.
- 즉시 send 장애, callback/future 혼합 실패 양 순서, transport 우선순위, 실패 후 정상 batch 상태 비누수를 실행형 회귀 테스트로 고정했습니다.

## 검증

- `spakky-event`: 66 passed, 12 skipped, line/branch coverage 100%
- `spakky-outbox`: 55 passed, line/branch coverage 100%
- `spakky-kafka`: 149 passed, 6 skipped, line/branch coverage 100%
- 변경 패키지 ruff format/lint, Python harness, pyrefly 통과
- `mkdocs build --strict`, `git diff --check`, pre-commit, pre-push 변경 프로젝트 검사 통과
- 독립 코드 리뷰 iteration 5: Critical 0, Warning 0
- fresh 사용자 문서 Reviewer: Critical 0, Warning 0

## Acceptance Criteria (자가 grep)

acceptance_check: missing

이슈 본문에 실행 가능한 수용 기준 grep 라인이 없습니다. 대신 동기·비동기 transport 분류와 relay retry 예산 경계를 실제 회귀 테스트로 검증했습니다.

## 후속 하네스 gap

- #517 — `process-ticket`의 canonical `issue: #N` 반환과 `autopilot` 검증 정규식 불일치를 별도 분해했습니다.

Closes #513
