### PR TITLE
fix(harness): honor configured review bot logins (#516)

### DIFF
--- a/.agents/skills/monitor-pr/SKILL.md
+++ b/.agents/skills/monitor-pr/SKILL.md
@@ -29,7 +29,7 @@ PR 번호를 받아 고정 30초 polling으로 상태를 감시하고 분기 처
 - `reason=merged` → Phase 8 cleanup 1회 실행 후 turn 종료.
 - `reason=mergeable-clean` → Phase 7 머지 게이트로 전환. 호출자가 `process-ticket --auto-merge` 또는 autopilot 하위 실행이면 같은 turn 안에서 Phase 8 squash merge + cleanup까지 계속 수행하고, `phase7_ready`만 기록한 채 turn을 종료하지 않는다. 직접 호출 기본 모드에서만 merge 승인 질의로 멈춘다.
 - `reason=closed-without-merge` → 결과 보고 (`status: failed`, `failed_reason: PR closed without merge`) 후 turn 종료.
-- `reason=awaiting-human-review` → 결과 보고 (`status: awaiting-review`, `pending_human_comments: <configured bot CH2/CH3 평가 참조>`) 후 turn 종료. configured review bot 중 하나가 post-HEAD CH2 comment 또는 exact-head `APPROVED`/`COMMENTED`/`CHANGES_REQUESTED` CH3 review로 HEAD를 평가했지만 PR이 여전히 human review를 요구하는 상태이므로, 추가 polling은 봇 재평가 트리거 부재로 무의미하다 — 휴먼 리뷰어가 응답할 때까지 본 PR의 자동 진행은 정지한다.
+- `reason=awaiting-human-review` → 결과 보고 (`status: awaiting-review`, `pending_human_comments: <formal CHANGES_REQUESTED 또는 configured bot CH2/CH3 평가 참조>`) 후 turn 종료. formal `CHANGES_REQUESTED`가 남아 있거나 configured review bot 중 하나가 post-HEAD CH2 comment 또는 exact-head `APPROVED`/`COMMENTED`/`CHANGES_REQUESTED` CH3 review로 HEAD를 평가했지만 PR이 여전히 human review를 요구하는 상태다. 추가 polling만으로 해소되지 않으므로 변경 요청 또는 휴먼 리뷰 응답이 올 때까지 본 PR의 자동 진행은 정지한다.
 
 "안전을 위해 한 번 더 polling" / "mergeStateStatus 재검증" / "다음 cycle에 변화가 있는지" 류 추가 호출은 머지 후 dead time을 누적시키며 본 절이 명시적으로 차단한다 — 추가 cycle은 §"이벤트 분기"의 EVENT consumer 루프 안에서만 의미가 있다.
 
@@ -224,7 +224,7 @@ claude bot이 동일 review id `R1`의 본문을 새 푸시 시 in-place로 재�
 
 `watch.sh`는 기본적으로 `REQUIRE_REVIEW_BOT_HEAD_EVAL=1`로 동작한다. 즉 GitHub가 `mergeState in (CLEAN, UNSTABLE)`이고 CI가 green이어도, `REVIEW_BOT_LOGINS` 대상 봇이 현재 HEAD를 평가했다는 증거가 없으면 `DONE reason=mergeable-clean`을 emit하지 않고 계속 대기한다. Codex-gated auto merge를 끄고 싶을 때만 명시적으로 `REQUIRE_REVIEW_BOT_HEAD_EVAL=0`을 전달한다.
 
-`reviewDecision=CHANGES_REQUESTED`이면 평가 완료 증거가 있거나 `REQUIRE_REVIEW_BOT_HEAD_EVAL=0`이어도 `mergeable-clean`을 emit하지 않는다. GitHub가 일시적으로 `mergeState=CLEAN|UNSTABLE`을 함께 노출하더라도 `DONE reason=awaiting-human-review`로 종료하여 변경 요청이 Phase 7 자동 병합으로 넘어가지 않게 한다.
+`reviewDecision=CHANGES_REQUESTED`이면 configured bot 평가 증거의 유무나 `REQUIRE_REVIEW_BOT_HEAD_EVAL` 값과 관계없이 `mergeable-clean`을 emit하지 않는다. formal 변경 요청 자체를 사람 검토가 남았다는 충분한 증거로 사용한다. GitHub가 일시적으로 `mergeState=CLEAN|UNSTABLE`을 함께 노출하더라도 `DONE reason=awaiting-human-review`로 종료하여 변경 요청이 Phase 7 자동 병합으로 넘어가지 않게 한다.
 
 평가 완료 증거는 configured review bot 중 어느 하나가 남긴 다음 신호 중 하나다:
 
@@ -235,7 +235,7 @@ claude bot이 동일 review id `R1`의 본문을 새 푸시 시 in-place로 재�
 
 (a) 모든 CI check가 COMPLETED (PENDING/IN_PROGRESS 0건)
 (b) `mergeStateStatus != CLEAN`
-(c) `reviewDecision != APPROVED`
+(c) `reviewDecision`이 `APPROVED`도 `CHANGES_REQUESTED`도 아님
 (d) latest configured review bot review의 `commit_id != HEAD oid` (또는 configured review bot review 부재)
 (e) `bot_evaluated_head == 0`: configured review bot 누구도 post-HEAD CH2 issue comment를 남기지 않았고, configured review bot 누구에게도 exact-head `APPROVED`/`COMMENTED`/`CHANGES_REQUESTED` CH3 review가 없다
 (f) PR labels에 `auto-approvable`이 포함되어 있다
@@ -246,11 +246,13 @@ claude bot이 동일 review id `R1`의 본문을 새 푸시 시 in-place로 재�
 
 CH2 issue comment와 CH3 review의 작성자는 모두 GitHub login 전체 문자열이 대상 집합의 한 항목과 정확히 일치할 때만 review bot으로 신뢰한다. prefix·suffix·부분 문자열 일치는 허용하지 않는다. `bot_evaluated_head`는 대상 집합 중 어느 한 bot이라도 post-HEAD CH2 issue comment를 남겼거나, 현재 HEAD commit에 anchor된 state `APPROVED`, `COMMENTED`, `CHANGES_REQUESTED` 중 하나의 CH3 review를 남기면 true다.
 
-이 계약의 회귀 검증은 `.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh`가 담당한다. 기본 집합 보존, `REVIEW_BOT_LOGINS` 추가·공백 정규화, CH2/CH3 exact login 매칭, CH3 세 state의 분기를 함께 검증한다.
+이 계약의 회귀 검증은 `.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh`가 담당한다. 기본 집합 보존, `REVIEW_BOT_LOGINS` 추가·공백 정규화, CH2/CH3 exact login 매칭, CH3 세 state의 분기, bot gate 비활성 상태의 formal 변경 요청 차단, `auto-approvable` 라벨보다 formal 변경 요청 우선 처리, BLOCKED/BEHIND 무증거 대기를 함께 검증한다.
 
 **(e)의 의의 (회귀 차단)**: configured review bot은 자동 승인 비적격 판정을 post-HEAD CH2 issue comment 또는 exact-head CH3 review로 남길 수 있다. 여러 bot 중 하나라도 현재 HEAD를 평가했다면 휴먼 리뷰어 응답을 기다려야 한다. (d)의 latest review만으로 판정하면 다른 configured bot의 유효한 평가를 놓쳐 stuck으로 잘못 분류되고, 빈 커밋 retrigger가 동일 판정만 재발행하면서 polling·credit을 소진한다 — (e)가 모든 configured bot의 두 채널을 함께 검사해 이 회귀를 차단한다.
 
 **(f)의 의의 (회귀 차단)**: `auto-approvable` 라벨은 `/pr-review`가 `AUTO_APPROVE` 판정일 때만 부여하고 다른 verdict에서는 제거하는 복구 허용 신호다. 라벨이 없는 PR은 자동 승인 비적격 또는 사람 검토 대기가 정상 경로이므로 `bot-stuck` retrigger를 보내지 않는다. 이 라벨은 승인 트리거가 아니며, 승인 트리거는 `ai-review` commit status다.
+
+formal `CHANGES_REQUESTED`는 bot 평가 증거와 `auto-approvable` 라벨보다 우선하는 사람 검토 신호다. 따라서 라벨이 남아 있고 configured bot의 HEAD 평가 증거가 없어도 `bot-stuck`으로 재트리거하지 않고 `awaiting-human-review`로 종료한다.
 
 **핸들러**: 빈 커밋 + push로 새 commit hash 생성 → 봇 재리뷰 + CI 재실행 유도.
 
@@ -395,6 +397,6 @@ SendMessage(
 
 ## 종료 조건
 
-`mergeState in (CLEAN, UNSTABLE)` + `pendingChecks=0` + `failedChecks=0` + review bot HEAD 평가 완료 + `reviewDecision != CHANGES_REQUESTED` → Phase 7 전환. GitHub Copilot/Codex code review는 formal Approve를 남기지 않으므로 `reviewDecision=APPROVED`를 요구하지 않는다. 실제 branch protection상 human approval이 필수라면 GitHub가 `mergeState=BLOCKED`로 노출한다.
+`mergeState in (CLEAN, UNSTABLE)` + `pendingChecks=0` + `failedChecks=0` + (`REQUIRE_REVIEW_BOT_HEAD_EVAL=0` 또는 review bot HEAD 평가 완료) + `reviewDecision != CHANGES_REQUESTED` → Phase 7 전환. GitHub Copilot/Codex code review는 formal Approve를 남기지 않으므로 `reviewDecision=APPROVED`를 요구하지 않는다. 실제 branch protection상 human approval이 필수라면 GitHub가 `mergeState=BLOCKED`로 노출한다.
 
 $ARGUMENTS

--- a/.agents/skills/monitor-pr/SKILL.md
+++ b/.agents/skills/monitor-pr/SKILL.md
@@ -224,6 +224,8 @@ claude bot이 동일 review id `R1`의 본문을 새 푸시 시 in-place로 재�
 
 `watch.sh`는 기본적으로 `REQUIRE_REVIEW_BOT_HEAD_EVAL=1`로 동작한다. 즉 GitHub가 `mergeState in (CLEAN, UNSTABLE)`이고 CI가 green이어도, `REVIEW_BOT_LOGINS` 대상 봇이 현재 HEAD를 평가했다는 증거가 없으면 `DONE reason=mergeable-clean`을 emit하지 않고 계속 대기한다. Codex-gated auto merge를 끄고 싶을 때만 명시적으로 `REQUIRE_REVIEW_BOT_HEAD_EVAL=0`을 전달한다.
 
+`reviewDecision=CHANGES_REQUESTED`이면 평가 완료 증거가 있거나 `REQUIRE_REVIEW_BOT_HEAD_EVAL=0`이어도 `mergeable-clean`을 emit하지 않는다. GitHub가 일시적으로 `mergeState=CLEAN|UNSTABLE`을 함께 노출하더라도 `DONE reason=awaiting-human-review`로 종료하여 변경 요청이 Phase 7 자동 병합으로 넘어가지 않게 한다.
+
 평가 완료 증거는 configured review bot 중 어느 하나가 남긴 다음 신호 중 하나다:
 
 - CH2 issue comment가 HEAD commit 시점 이후에 작성됨
@@ -393,6 +395,6 @@ SendMessage(
 
 ## 종료 조건
 
-`mergeState in (CLEAN, UNSTABLE)` + `pendingChecks=0` + `failedChecks=0` + review bot HEAD 평가 완료 → Phase 7 전환. GitHub Copilot/Codex code review는 formal Approve를 남기지 않으므로 `reviewDecision=APPROVED`를 요구하지 않는다. 실제 branch protection상 human approval이 필수라면 GitHub가 `mergeState=BLOCKED`로 노출한다.
+`mergeState in (CLEAN, UNSTABLE)` + `pendingChecks=0` + `failedChecks=0` + review bot HEAD 평가 완료 + `reviewDecision != CHANGES_REQUESTED` → Phase 7 전환. GitHub Copilot/Codex code review는 formal Approve를 남기지 않으므로 `reviewDecision=APPROVED`를 요구하지 않는다. 실제 branch protection상 human approval이 필수라면 GitHub가 `mergeState=BLOCKED`로 노출한다.
 
 $ARGUMENTS

--- a/.agents/skills/monitor-pr/SKILL.md
+++ b/.agents/skills/monitor-pr/SKILL.md
@@ -29,7 +29,7 @@ PR 번호를 받아 고정 30초 polling으로 상태를 감시하고 분기 처
 - `reason=merged` → Phase 8 cleanup 1회 실행 후 turn 종료.
 - `reason=mergeable-clean` → Phase 7 머지 게이트로 전환. 호출자가 `process-ticket --auto-merge` 또는 autopilot 하위 실행이면 같은 turn 안에서 Phase 8 squash merge + cleanup까지 계속 수행하고, `phase7_ready`만 기록한 채 turn을 종료하지 않는다. 직접 호출 기본 모드에서만 merge 승인 질의로 멈춘다.
 - `reason=closed-without-merge` → 결과 보고 (`status: failed`, `failed_reason: PR closed without merge`) 후 turn 종료.
-- `reason=awaiting-human-review` → 결과 보고 (`status: awaiting-review`, `pending_human_comments: <bot CH2 코멘트 URL>`) 후 turn 종료. 봇이 HEAD 를 평가했고 의도적으로 review submission 대신 CH2 코멘트로 휴먼 리뷰 의견을 남긴 상태이므로, 추가 polling 은 봇 재평가 트리거 부재로 무의미하다 — 휴먼 리뷰어가 응답할 때까지 본 PR 의 자동 진행은 정지한다.
+- `reason=awaiting-human-review` → 결과 보고 (`status: awaiting-review`, `pending_human_comments: <configured bot CH2/CH3 평가 참조>`) 후 turn 종료. configured review bot 중 하나가 post-HEAD CH2 comment 또는 exact-head `APPROVED`/`COMMENTED`/`CHANGES_REQUESTED` CH3 review로 HEAD를 평가했지만 PR이 여전히 human review를 요구하는 상태이므로, 추가 polling은 봇 재평가 트리거 부재로 무의미하다 — 휴먼 리뷰어가 응답할 때까지 본 PR의 자동 진행은 정지한다.
 
 "안전을 위해 한 번 더 polling" / "mergeStateStatus 재검증" / "다음 cycle에 변화가 있는지" 류 추가 호출은 머지 후 dead time을 누적시키며 본 절이 명시적으로 차단한다 — 추가 cycle은 §"이벤트 분기"의 EVENT consumer 루프 안에서만 의미가 있다.
 
@@ -224,25 +224,29 @@ claude bot이 동일 review id `R1`의 본문을 새 푸시 시 in-place로 재�
 
 `watch.sh`는 기본적으로 `REQUIRE_REVIEW_BOT_HEAD_EVAL=1`로 동작한다. 즉 GitHub가 `mergeState in (CLEAN, UNSTABLE)`이고 CI가 green이어도, `REVIEW_BOT_LOGINS` 대상 봇이 현재 HEAD를 평가했다는 증거가 없으면 `DONE reason=mergeable-clean`을 emit하지 않고 계속 대기한다. Codex-gated auto merge를 끄고 싶을 때만 명시적으로 `REQUIRE_REVIEW_BOT_HEAD_EVAL=0`을 전달한다.
 
-평가 완료 증거는 다음 중 하나다:
+평가 완료 증거는 configured review bot 중 어느 하나가 남긴 다음 신호 중 하나다:
 
-- review bot의 CH2 issue comment가 HEAD commit 시점 이후에 작성됨
-- review bot의 CH3 review가 HEAD commit id에 anchor됨 (`COMMENTED`, `APPROVED`, `CHANGES_REQUESTED` 모두 평가 완료로 간주)
+- CH2 issue comment가 HEAD commit 시점 이후에 작성됨
+- CH3 review가 HEAD commit id에 anchor됨 (`COMMENTED`, `APPROVED`, `CHANGES_REQUESTED` 모두 평가 완료로 간주)
 
 `watch.sh`가 다음 6-조건을 모두 만족하면 `EVENT reason=bot-stuck`을 송신한다:
 
 (a) 모든 CI check가 COMPLETED (PENDING/IN_PROGRESS 0건)
 (b) `mergeStateStatus != CLEAN`
 (c) `reviewDecision != APPROVED`
-(d) latest external review bot review의 `commit_id != HEAD oid` (또는 review bot review 부재)
-(e) external review bot이 HEAD commit 시점 이후로 CH2 issue comment 도 남기지 않았다
+(d) latest configured review bot review의 `commit_id != HEAD oid` (또는 configured review bot review 부재)
+(e) `bot_evaluated_head == 0`: configured review bot 누구도 post-HEAD CH2 issue comment를 남기지 않았고, configured review bot 누구에게도 exact-head `APPROVED`/`COMMENTED`/`CHANGES_REQUESTED` CH3 review가 없다
 (f) PR labels에 `auto-approvable`이 포함되어 있다
 
 이 상태는 rebase 후 동일 트리·force-push 후 사실상 hash 미변경 등으로 봇이 신규 커밋으로 인식하지 않아 재리뷰 트리거가 누락된 정체다. CI는 끝났지만 GitHub가 아직 mergeable로 계산하지 않아 polling만 무한 반복된다.
 
-대상 봇은 기본적으로 `claude[bot]`, `codex[bot]`, `chatgpt-codex-connector[bot]`이며, GitHub App login이 다르면 `REVIEW_BOT_LOGINS` 환경변수에 콤마 구분으로 추가한다.
+대상 봇의 기본 login 집합은 `claude[bot]`, `codex[bot]`, `chatgpt-codex-connector[bot]`이다. GitHub App login이 다르면 `REVIEW_BOT_LOGINS` 환경변수에 콤마 구분으로 **추가**한다. 이 환경변수는 기본 집합을 대체하지 않는다. 각 항목의 바깥 공백과 빈 항목을 제거한 뒤 기본 집합과 합집합으로 사용한다.
 
-**(e)의 의의 (회귀 차단)**: 외부 리뷰 봇은 자동 승인 비적격 판정 시 formal review 대신 CH2 issue comment 로 "팀원 리뷰 필요" 의견을 남기는 경로를 가질 수 있다. 이 경우 봇은 현재 HEAD 를 평가했지만 의도적으로 review submission 을 하지 않은 것이며, 휴먼 리뷰어 승인을 대기해야 한다. (d) 만으로 판정하면 본 case 가 stuck 으로 잘못 분류되어 빈 커밋 retrigger 가 동일 판정만 재발행하면서 폴링·크레딧을 소진한다 — (e) 가 이 회귀를 차단한다.
+CH2 issue comment와 CH3 review의 작성자는 모두 GitHub login 전체 문자열이 대상 집합의 한 항목과 정확히 일치할 때만 review bot으로 신뢰한다. prefix·suffix·부분 문자열 일치는 허용하지 않는다. `bot_evaluated_head`는 대상 집합 중 어느 한 bot이라도 post-HEAD CH2 issue comment를 남겼거나, 현재 HEAD commit에 anchor된 state `APPROVED`, `COMMENTED`, `CHANGES_REQUESTED` 중 하나의 CH3 review를 남기면 true다.
+
+이 계약의 회귀 검증은 `.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh`가 담당한다. 기본 집합 보존, `REVIEW_BOT_LOGINS` 추가·공백 정규화, CH2/CH3 exact login 매칭, CH3 세 state의 분기를 함께 검증한다.
+
+**(e)의 의의 (회귀 차단)**: configured review bot은 자동 승인 비적격 판정을 post-HEAD CH2 issue comment 또는 exact-head CH3 review로 남길 수 있다. 여러 bot 중 하나라도 현재 HEAD를 평가했다면 휴먼 리뷰어 응답을 기다려야 한다. (d)의 latest review만으로 판정하면 다른 configured bot의 유효한 평가를 놓쳐 stuck으로 잘못 분류되고, 빈 커밋 retrigger가 동일 판정만 재발행하면서 polling·credit을 소진한다 — (e)가 모든 configured bot의 두 채널을 함께 검사해 이 회귀를 차단한다.
 
 **(f)의 의의 (회귀 차단)**: `auto-approvable` 라벨은 `/pr-review`가 `AUTO_APPROVE` 판정일 때만 부여하고 다른 verdict에서는 제거하는 복구 허용 신호다. 라벨이 없는 PR은 자동 승인 비적격 또는 사람 검토 대기가 정상 경로이므로 `bot-stuck` retrigger를 보내지 않는다. 이 라벨은 승인 트리거가 아니며, 승인 트리거는 `ai-review` commit status다.
 

--- a/.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh
+++ b/.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh
@@ -37,6 +37,10 @@ run_case() {
       ch3_json="[{\"id\":301,\"user\":{\"login\":\"$author_login\"},\"submitted_at\":\"$review_date\",\"commit_id\":\"$head_oid\",\"state\":\"$review_state\",\"body\":\"reviewed\"}]"
       prev_ch3="{\"301\":\"$review_date\"}"
       ;;
+    ch3_mixed_heads)
+      ch3_json="[{\"id\":301,\"user\":{\"login\":\"review-app-a[bot]\"},\"submitted_at\":\"2026-01-01T01:00:00Z\",\"commit_id\":\"$head_oid\",\"state\":\"COMMENTED\",\"body\":\"reviewed head\"},{\"id\":302,\"user\":{\"login\":\"review-app-b[bot]\"},\"submitted_at\":\"2026-01-01T02:00:00Z\",\"commit_id\":\"stale123\",\"state\":\"COMMENTED\",\"body\":\"reviewed stale head\"}]"
+      prev_ch3='{"301":"2026-01-01T01:00:00Z","302":"2026-01-01T02:00:00Z"}'
+      ;;
     none) ;;
   esac
 
@@ -125,7 +129,10 @@ EOF_STATE
 run_case "default-commented" "" "claude[bot]" ch3 COMMENTED CLEAN REVIEW_REQUIRED mergeable-clean
 run_case "configured-preserves-default" "review-app[bot]" "claude[bot]" ch3 COMMENTED CLEAN REVIEW_REQUIRED mergeable-clean
 run_case "configured-commented" "  review-app[bot]  " "review-app[bot]" ch3 COMMENTED CLEAN REVIEW_REQUIRED mergeable-clean
+run_case "configured-list-second-login" "review-app-a[bot],review-app-b[bot]" "review-app-b[bot]" ch3 COMMENTED CLEAN REVIEW_REQUIRED mergeable-clean
+run_case "configured-multiple-bots-any-exact-head" "review-app-a[bot],review-app-b[bot]" "" ch3_mixed_heads COMMENTED CLEAN REVIEW_REQUIRED mergeable-clean
 run_case "configured-approved" "review-app[bot]" "review-app[bot]" ch3 APPROVED CLEAN APPROVED mergeable-clean
+run_case "configured-changes-requested-state" "review-app[bot]" "review-app[bot]" ch3 CHANGES_REQUESTED CLEAN REVIEW_REQUIRED mergeable-clean
 run_case "configured-changes-requested" "review-app[bot]" "review-app[bot]" ch3 CHANGES_REQUESTED BLOCKED CHANGES_REQUESTED awaiting-human-review
 run_case "configured-changes-requested-clean" "review-app[bot]" "review-app[bot]" ch3 CHANGES_REQUESTED CLEAN CHANGES_REQUESTED awaiting-human-review
 run_case "disabled-bot-gate-changes-requested-clean" "" "" none CHANGES_REQUESTED CLEAN CHANGES_REQUESTED awaiting-human-review 0

--- a/.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh
+++ b/.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# REVIEW_BOT_LOGINS regression coverage for the CH2/CH3 exact-head gates.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+watch_sh="$script_dir/watch.sh"
+
+run_case() {
+  local case_name="$1" configured_logins="$2" author_login="$3" channel="$4"
+  local review_state="$5" merge_state="$6" review_decision="$7" expected_reason="$8"
+  local tmp_dir head_oid head_commit_date review_date ch2_json ch3_json prev_ch2 prev_ch3
+
+  tmp_dir="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmp_dir'" RETURN
+  head_oid="abc123def456"
+  head_commit_date="2026-01-01T00:00:00Z"
+  review_date="2026-01-01T01:00:00Z"
+  ch2_json='[]'
+  ch3_json='[]'
+  prev_ch2='{}'
+  prev_ch3='{}'
+
+  if [ "$channel" = "ch2" ]; then
+    ch2_json="[{\"id\":201,\"user\":{\"login\":\"$author_login\"},\"created_at\":\"$review_date\",\"updated_at\":\"$review_date\",\"body\":\"reviewed\"}]"
+    prev_ch2="{\"201\":\"$review_date\"}"
+  else
+    ch3_json="[{\"id\":301,\"user\":{\"login\":\"$author_login\"},\"submitted_at\":\"$review_date\",\"commit_id\":\"$head_oid\",\"state\":\"$review_state\",\"body\":\"reviewed\"}]"
+    prev_ch3="{\"301\":\"$review_date\"}"
+  fi
+
+  mkdir -p "$tmp_dir/bin"
+  cat > "$tmp_dir/bin/gh" <<EOF_GH
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmd="\$1"
+shift || true
+if [ "\$cmd" = "pr" ] && [ "\${1:-}" = "view" ]; then
+  cat <<'EOJSON'
+{
+  "mergeStateStatus": "$merge_state",
+  "reviewDecision": "$review_decision",
+  "statusCheckRollup": [
+    {"name":"ci","status":"COMPLETED","conclusion":"SUCCESS","workflowName":"ci"}
+  ],
+  "comments": [],
+  "state": "OPEN",
+  "headRefOid": "$head_oid",
+  "labels": []
+}
+EOJSON
+  exit 0
+fi
+
+if [ "\$cmd" = "api" ]; then
+  endpoint="\$1"
+  shift
+  jq_filter=""
+  while [ \$# -gt 0 ]; do
+    case "\$1" in
+      --jq) jq_filter="\$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  case "\$endpoint" in
+    *"/pulls/"*"/comments") echo '[]' ;;
+    *"/issues/"*"/comments") echo '$ch2_json' ;;
+    *"/pulls/"*"/reviews") echo '$ch3_json' ;;
+    *"/commits/"*)
+      if [ -n "\$jq_filter" ]; then
+        echo "$head_commit_date"
+      else
+        echo '{"commit":{"committer":{"date":"$head_commit_date"}}}'
+      fi
+      ;;
+    *) exit 1 ;;
+  esac
+  exit 0
+fi
+exit 1
+EOF_GH
+  chmod +x "$tmp_dir/bin/gh"
+
+  cat > "$tmp_dir/bin/sleep" <<'EOF_SLEEP'
+#!/usr/bin/env bash
+exit 0
+EOF_SLEEP
+  chmod +x "$tmp_dir/bin/sleep"
+
+  cat > "$tmp_dir/prev_state.json" <<EOF_STATE
+{"ch1":{},"ch2":$prev_ch2,"ch3":$prev_ch3,"reviewDecision":"$review_decision"}
+EOF_STATE
+
+  grep -v '^export PATH="/opt/homebrew/bin' "$watch_sh" > "$tmp_dir/watch_under_test.sh"
+  MONITOR_PR_SCRIPTS_DIR="$script_dir" \
+    PATH="$tmp_dir/bin:/usr/bin:/bin" \
+    REVIEW_BOT_LOGINS="$configured_logins" \
+    REPO=E5presso/spakky-framework \
+    PR_NUMBER=99999 \
+    PREV_STATE_FILE="$tmp_dir/prev_state.json" \
+    bash "$tmp_dir/watch_under_test.sh" > "$tmp_dir/stdout.log" 2> "$tmp_dir/stderr.log" || true
+
+  if ! grep -q "^reason=$expected_reason$" "$tmp_dir/stdout.log"; then
+    echo "FAIL [$case_name]: expected reason=$expected_reason" >&2
+    cat "$tmp_dir/stdout.log" >&2
+    cat "$tmp_dir/stderr.log" >&2
+    return 1
+  fi
+  echo "OK [$case_name]: reason=$expected_reason"
+}
+
+run_case "default-commented" "" "claude[bot]" ch3 COMMENTED CLEAN REVIEW_REQUIRED mergeable-clean
+run_case "configured-preserves-default" "review-app[bot]" "claude[bot]" ch3 COMMENTED CLEAN REVIEW_REQUIRED mergeable-clean
+run_case "configured-commented" "  review-app[bot]  " "review-app[bot]" ch3 COMMENTED CLEAN REVIEW_REQUIRED mergeable-clean
+run_case "configured-approved" "review-app[bot]" "review-app[bot]" ch3 APPROVED CLEAN APPROVED mergeable-clean
+run_case "configured-changes-requested" "review-app[bot]" "review-app[bot]" ch3 CHANGES_REQUESTED BLOCKED CHANGES_REQUESTED awaiting-human-review
+run_case "configured-ch2" "review-app[bot]" "review-app[bot]" ch2 COMMENTED BLOCKED REVIEW_REQUIRED awaiting-human-review
+run_case "ch3-exact-login-match" "review-app[bot]" "review-app[bot]-shadow" ch3 COMMENTED BLOCKED REVIEW_REQUIRED heartbeat
+run_case "ch2-exact-login-match" "review-app[bot]" "review-app[bot]-shadow" ch2 COMMENTED BLOCKED REVIEW_REQUIRED heartbeat
+
+echo "test_review_bot_logins.sh: OK"

--- a/.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh
+++ b/.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh
@@ -129,6 +129,7 @@ run_case "configured-approved" "review-app[bot]" "review-app[bot]" ch3 APPROVED 
 run_case "configured-changes-requested" "review-app[bot]" "review-app[bot]" ch3 CHANGES_REQUESTED BLOCKED CHANGES_REQUESTED awaiting-human-review
 run_case "configured-changes-requested-clean" "review-app[bot]" "review-app[bot]" ch3 CHANGES_REQUESTED CLEAN CHANGES_REQUESTED awaiting-human-review
 run_case "disabled-bot-gate-changes-requested-clean" "" "" none CHANGES_REQUESTED CLEAN CHANGES_REQUESTED awaiting-human-review 0
+run_case "disabled-bot-gate-changes-requested-unstable" "" "" none CHANGES_REQUESTED UNSTABLE CHANGES_REQUESTED awaiting-human-review 0
 run_case "labeled-changes-requested-blocked" "" "" none CHANGES_REQUESTED BLOCKED CHANGES_REQUESTED awaiting-human-review 1 1
 run_case "labeled-changes-requested-behind" "" "" none CHANGES_REQUESTED BEHIND CHANGES_REQUESTED awaiting-human-review 1 1
 run_case "blocked-review-required-needs-bot-evidence" "" "" none COMMENTED BLOCKED REVIEW_REQUIRED heartbeat

--- a/.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh
+++ b/.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh
@@ -115,6 +115,7 @@ run_case "configured-preserves-default" "review-app[bot]" "claude[bot]" ch3 COMM
 run_case "configured-commented" "  review-app[bot]  " "review-app[bot]" ch3 COMMENTED CLEAN REVIEW_REQUIRED mergeable-clean
 run_case "configured-approved" "review-app[bot]" "review-app[bot]" ch3 APPROVED CLEAN APPROVED mergeable-clean
 run_case "configured-changes-requested" "review-app[bot]" "review-app[bot]" ch3 CHANGES_REQUESTED BLOCKED CHANGES_REQUESTED awaiting-human-review
+run_case "configured-changes-requested-clean" "review-app[bot]" "review-app[bot]" ch3 CHANGES_REQUESTED CLEAN CHANGES_REQUESTED awaiting-human-review
 run_case "configured-ch2" "review-app[bot]" "review-app[bot]" ch2 COMMENTED BLOCKED REVIEW_REQUIRED awaiting-human-review
 run_case "ch3-exact-login-match" "review-app[bot]" "review-app[bot]-shadow" ch3 COMMENTED BLOCKED REVIEW_REQUIRED heartbeat
 run_case "ch2-exact-login-match" "review-app[bot]" "review-app[bot]-shadow" ch2 COMMENTED BLOCKED REVIEW_REQUIRED heartbeat

--- a/.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh
+++ b/.agents/skills/monitor-pr/scripts/test_review_bot_logins.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# REVIEW_BOT_LOGINS regression coverage for the CH2/CH3 exact-head gates.
+# REVIEW_BOT_LOGINS and negative-review regression coverage for the bot-head gates.
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -8,7 +8,9 @@ watch_sh="$script_dir/watch.sh"
 run_case() {
   local case_name="$1" configured_logins="$2" author_login="$3" channel="$4"
   local review_state="$5" merge_state="$6" review_decision="$7" expected_reason="$8"
-  local tmp_dir head_oid head_commit_date review_date ch2_json ch3_json prev_ch2 prev_ch3
+  local require_bot_head_eval="${9:-1}"
+  local has_auto_approvable="${10:-0}"
+  local tmp_dir head_oid head_commit_date review_date ch2_json ch3_json prev_ch2 prev_ch3 labels_json
 
   tmp_dir="$(mktemp -d)"
   # shellcheck disable=SC2064
@@ -20,14 +22,23 @@ run_case() {
   ch3_json='[]'
   prev_ch2='{}'
   prev_ch3='{}'
+  labels_json='[]'
 
-  if [ "$channel" = "ch2" ]; then
-    ch2_json="[{\"id\":201,\"user\":{\"login\":\"$author_login\"},\"created_at\":\"$review_date\",\"updated_at\":\"$review_date\",\"body\":\"reviewed\"}]"
-    prev_ch2="{\"201\":\"$review_date\"}"
-  else
-    ch3_json="[{\"id\":301,\"user\":{\"login\":\"$author_login\"},\"submitted_at\":\"$review_date\",\"commit_id\":\"$head_oid\",\"state\":\"$review_state\",\"body\":\"reviewed\"}]"
-    prev_ch3="{\"301\":\"$review_date\"}"
+  if [ "$has_auto_approvable" = "1" ]; then
+    labels_json='[{"name":"auto-approvable"}]'
   fi
+
+  case "$channel" in
+    ch2)
+      ch2_json="[{\"id\":201,\"user\":{\"login\":\"$author_login\"},\"created_at\":\"$review_date\",\"updated_at\":\"$review_date\",\"body\":\"reviewed\"}]"
+      prev_ch2="{\"201\":\"$review_date\"}"
+      ;;
+    ch3)
+      ch3_json="[{\"id\":301,\"user\":{\"login\":\"$author_login\"},\"submitted_at\":\"$review_date\",\"commit_id\":\"$head_oid\",\"state\":\"$review_state\",\"body\":\"reviewed\"}]"
+      prev_ch3="{\"301\":\"$review_date\"}"
+      ;;
+    none) ;;
+  esac
 
   mkdir -p "$tmp_dir/bin"
   cat > "$tmp_dir/bin/gh" <<EOF_GH
@@ -47,7 +58,7 @@ if [ "\$cmd" = "pr" ] && [ "\${1:-}" = "view" ]; then
   "comments": [],
   "state": "OPEN",
   "headRefOid": "$head_oid",
-  "labels": []
+  "labels": $labels_json
 }
 EOJSON
   exit 0
@@ -96,6 +107,7 @@ EOF_STATE
   MONITOR_PR_SCRIPTS_DIR="$script_dir" \
     PATH="$tmp_dir/bin:/usr/bin:/bin" \
     REVIEW_BOT_LOGINS="$configured_logins" \
+    REQUIRE_REVIEW_BOT_HEAD_EVAL="$require_bot_head_eval" \
     REPO=E5presso/spakky-framework \
     PR_NUMBER=99999 \
     PREV_STATE_FILE="$tmp_dir/prev_state.json" \
@@ -116,6 +128,11 @@ run_case "configured-commented" "  review-app[bot]  " "review-app[bot]" ch3 COMM
 run_case "configured-approved" "review-app[bot]" "review-app[bot]" ch3 APPROVED CLEAN APPROVED mergeable-clean
 run_case "configured-changes-requested" "review-app[bot]" "review-app[bot]" ch3 CHANGES_REQUESTED BLOCKED CHANGES_REQUESTED awaiting-human-review
 run_case "configured-changes-requested-clean" "review-app[bot]" "review-app[bot]" ch3 CHANGES_REQUESTED CLEAN CHANGES_REQUESTED awaiting-human-review
+run_case "disabled-bot-gate-changes-requested-clean" "" "" none CHANGES_REQUESTED CLEAN CHANGES_REQUESTED awaiting-human-review 0
+run_case "labeled-changes-requested-blocked" "" "" none CHANGES_REQUESTED BLOCKED CHANGES_REQUESTED awaiting-human-review 1 1
+run_case "labeled-changes-requested-behind" "" "" none CHANGES_REQUESTED BEHIND CHANGES_REQUESTED awaiting-human-review 1 1
+run_case "blocked-review-required-needs-bot-evidence" "" "" none COMMENTED BLOCKED REVIEW_REQUIRED heartbeat
+run_case "behind-review-required-needs-bot-evidence" "" "" none COMMENTED BEHIND REVIEW_REQUIRED heartbeat
 run_case "configured-ch2" "review-app[bot]" "review-app[bot]" ch2 COMMENTED BLOCKED REVIEW_REQUIRED awaiting-human-review
 run_case "ch3-exact-login-match" "review-app[bot]" "review-app[bot]-shadow" ch3 COMMENTED BLOCKED REVIEW_REQUIRED heartbeat
 run_case "ch2-exact-login-match" "review-app[bot]" "review-app[bot]-shadow" ch2 COMMENTED BLOCKED REVIEW_REQUIRED heartbeat

--- a/.agents/skills/monitor-pr/scripts/watch.sh
+++ b/.agents/skills/monitor-pr/scripts/watch.sh
@@ -80,7 +80,8 @@
 #   bot_evaluated_head 의 두 경로 (OR): (1) latest_bot_ch2_date > head_commit_date (CH2 issue comment),
 #   (2) configured bot의 review가 head_oid에 anchor되고 state가 APPROVED/COMMENTED/CHANGES_REQUESTED (CH3).
 #   AND 조건: (a) pending_checks == 0, (b) failed_checks == 0, (c) mergeState in {BLOCKED, BEHIND}
-#   (DIRTY 제외 — DIRTY 는 EVENT 로 별도 분기), (d) reviewDecision != APPROVED, (e) bot_evaluated_head == 1.
+#   또는 reviewDecision == CHANGES_REQUESTED인 CLEAN/UNSTABLE (DIRTY는 EVENT), (d) reviewDecision != APPROVED,
+#   (e) bot_evaluated_head == 1.
 #   분기 위치: 모든 EVENT 분기 이후 (변화 있으면 EVENT 우선) + heartbeat 직전 (변화 없음 path 에서 즉시 종료).
 #
 # 매 30초 cycle마다 stderr에 1줄 진행 로그를 출력한다 (살아있음 가시성):
@@ -309,12 +310,13 @@ while true; do
     exit 0
   fi
 
-  # 종료 조건 2: CLEAN/UNSTABLE + CI green + review bot HEAD 평가 완료
+  # 종료 조건 2: CLEAN/UNSTABLE + CI green + review bot HEAD 평가 완료 + 변경 요청 없음
   # Codex/Copilot review bots often submit COMMENTED reviews instead of formal APPROVED.
   if { [ "${REQUIRE_REVIEW_BOT_HEAD_EVAL:-1}" = "0" ] || [ "$bot_evaluated_head" = "1" ]; } \
      && { [ "$merge_state" = "CLEAN" ] || [ "$merge_state" = "UNSTABLE" ]; } \
      && [ "$pending_checks" = "0" ] \
-     && [ "$failed_checks" = "0" ]; then
+     && [ "$failed_checks" = "0" ] \
+     && [ "$review_decision" != "CHANGES_REQUESTED" ]; then
     persist_state
     snapshot_and_emit "DONE" "mergeable-clean"
     exit 0
@@ -369,8 +371,8 @@ while true; do
   # bot_evaluated_head 의 의의: review bot 은 자동 승인 비적격 판정 시 두 경로로 의견을 남길 수 있다 —
   # (1) CH2 issue comment 로 "팀원 리뷰 필요" 의견 (HEAD commit 이후 created_at),
   # (2) CH3 reviews API 로 APPROVED/COMMENTED/CHANGES_REQUESTED 리뷰 (commit_id == HEAD).
-  # 둘 중 어느 경로든 봇은 현재 HEAD 를 평가했지만 의도적으로 승인하지 않은 것이므로 stuck 이 아니다 —
-  # 빈 커밋 retrigger 는 동일 판정을 재발행할 뿐이며 폴링/크레딧만 소진한다.
+  # 둘 중 어느 경로든 봇은 현재 HEAD를 평가했으므로 stuck이 아니다. human review가 남았거나 변경 요청이
+  # 있으면 빈 커밋 retrigger는 동일 판정만 재발행하고 polling/credit만 소진한다.
   #
   # (f) auto-approvable 태그의 의의: pr-review SKILL.md 가 AE6/AE7 또는 전 파일 AE1–AE5 매칭 시
   # `gh pr edit --add-label "auto-approvable"` 로 자동 부여한다. 태그가 없으면 봇 자동 승인 비적격이며
@@ -393,7 +395,10 @@ while true; do
   # 본 DONE 이 송신된다 (heartbeat 누적 직전).
   if [ "$pending_checks" = "0" ] \
      && [ "$failed_checks" = "0" ] \
-     && { [ "$merge_state" = "BLOCKED" ] || [ "$merge_state" = "BEHIND" ]; } \
+     && { [ "$merge_state" = "BLOCKED" ] \
+       || [ "$merge_state" = "BEHIND" ] \
+       || { { [ "$merge_state" = "CLEAN" ] || [ "$merge_state" = "UNSTABLE" ]; } \
+         && [ "$review_decision" = "CHANGES_REQUESTED" ]; }; } \
      && [ "$review_decision" != "APPROVED" ] \
      && [ "$bot_evaluated_head" = "1" ]; then
     persist_state

--- a/.agents/skills/monitor-pr/scripts/watch.sh
+++ b/.agents/skills/monitor-pr/scripts/watch.sh
@@ -64,7 +64,8 @@
 #
 # bot-stuck: review bot이 마지막 리뷰 이후 신규 커밋이 없어 재리뷰를 트리거하지 않는 정체 상태.
 #   AND 조건: (a) 모든 CI check가 COMPLETED (PENDING/IN_PROGRESS 0건), (b) mergeState != CLEAN,
-#   (c) reviewDecision != APPROVED, (d) latest configured review bot review.commit.oid != HEAD oid (또는 review 부재),
+#   (c) reviewDecision not in {APPROVED, CHANGES_REQUESTED},
+#   (d) latest configured review bot review.commit.oid != HEAD oid (또는 review 부재),
 #   (e) bot_evaluated_head == 0 (봇이 HEAD 를 평가하지 않았다), (f) PR labels 에 "auto-approvable" 포함.
 #   호출자는 빈 커밋 push로 새 commit hash를 만들어 봇 재리뷰 + CI 재실행을 유도한다 (SKILL.md 참조).
 #   상한 1회는 호출자가 .process-state.json으로 누적·검사한다 (스크립트는 무상태).
@@ -74,14 +75,15 @@
 #   의미한다. 태그가 없는 PR 은 휴먼 리뷰가 정상 경로이므로 stuck 으로 간주하지 않는다 (retrigger 시도가
 #   휴먼 리뷰 대기 PR 에서 무의미한 빈 커밋만 누적시키는 회귀 차단).
 #
-# awaiting-human-review (terminal DONE): configured review bot이 HEAD를 평가했지만 human review/approval이 남은 상태.
-#   봇 재평가 트리거가 부재하므로 polling 누적이 무의미하다 — DONE 으로 종료하여 호출자(서브에이전트)가
+# awaiting-human-review (terminal DONE): formal CHANGES_REQUESTED가 있거나 configured review bot이 HEAD를
+#   평가했지만 human review/approval이 남은 상태. polling만으로 해소되지 않으므로 DONE으로 종료하여 호출자가
 #   status=awaiting-review 로 보고 후 turn 종료.
 #   bot_evaluated_head 의 두 경로 (OR): (1) latest_bot_ch2_date > head_commit_date (CH2 issue comment),
 #   (2) configured bot의 review가 head_oid에 anchor되고 state가 APPROVED/COMMENTED/CHANGES_REQUESTED (CH3).
-#   AND 조건: (a) pending_checks == 0, (b) failed_checks == 0, (c) mergeState in {BLOCKED, BEHIND}
-#   또는 reviewDecision == CHANGES_REQUESTED인 CLEAN/UNSTABLE (DIRTY는 EVENT), (d) reviewDecision != APPROVED,
-#   (e) bot_evaluated_head == 1.
+#   공통 조건: pending_checks == 0, failed_checks == 0. 이후 두 경로 중 하나면 종료한다.
+#   (1) reviewDecision == CHANGES_REQUESTED이고 mergeState in {CLEAN, UNSTABLE, BLOCKED, BEHIND}.
+#       formal 변경 요청 자체가 증거이므로 bot_evaluated_head와 무관하다.
+#   (2) mergeState in {BLOCKED, BEHIND}, reviewDecision != APPROVED, bot_evaluated_head == 1.
 #   분기 위치: 모든 EVENT 분기 이후 (변화 있으면 EVENT 우선) + heartbeat 직전 (변화 없음 path 에서 즉시 종료).
 #
 # 매 30초 cycle마다 stderr에 1줄 진행 로그를 출력한다 (살아있음 가시성):
@@ -363,7 +365,8 @@ while true; do
   fi
 
   # 이벤트 5: bot-stuck — review bot이 신규 커밋을 인식하지 않아 재리뷰 트리거가 누락된 정체 상태.
-  # (a) CI 전부 COMPLETED, (b) mergeState != CLEAN, (c) reviewDecision != APPROVED,
+  # (a) CI 전부 COMPLETED, (b) mergeState != CLEAN,
+  # (c) reviewDecision not in {APPROVED, CHANGES_REQUESTED},
   # (d) latest configured review bot review.commit_id != HEAD oid (또는 review 부재),
   # (e) 동시에 봇이 HEAD 를 평가하지 않았다 (bot_evaluated_head=0),
   # (f) PR labels 에 "auto-approvable" 포함 (휴먼 리뷰 대기 PR 회복 시도 차단).
@@ -380,6 +383,7 @@ while true; do
   if [ "$pending_checks" = "0" ] \
      && [ "$merge_state" != "CLEAN" ] \
      && [ "$review_decision" != "APPROVED" ] \
+     && [ "$review_decision" != "CHANGES_REQUESTED" ] \
      && [ "$latest_bot_review_oid" != "$head_oid" ] \
      && [ "$bot_evaluated_head" = "0" ] \
      && [ "$has_auto_approvable" = "true" ]; then
@@ -387,20 +391,24 @@ while true; do
     exit 0
   fi
 
-  # 종료 조건 3: awaiting-human-review — configured review bot 중 하나가 post-HEAD CH2 comment 또는
-  # exact-head APPROVED/COMMENTED/CHANGES_REQUESTED CH3 review로 HEAD를 평가했지만, PR에는 human review가
-  # 남은 상태. bot_evaluated_head=1 가드로 bot-stuck EVENT가 의도적으로 미송신되는 케이스에서,
-  # 추가 polling은 봇 재평가 트리거 부재 + human review만 남음 = 무의미 — DONE으로 종료한다.
+  # 종료 조건 3: awaiting-human-review — formal CHANGES_REQUESTED가 있거나, configured review bot이 HEAD를
+  # 평가했지만 PR에는 human review가 남은 상태. 변경 요청은 bot gate 설정과 무관한 차단 증거이며,
+  # 나머지 경로는 bot_evaluated_head=1로 bot-stuck EVENT가 의도적으로 미송신된 경우다.
+  # 추가 polling만으로 formal 변경 요청이나 human review가 해소되지 않으므로 DONE으로 종료한다.
   # 본 분기는 모든 EVENT 분기 이후에 위치하므로 변화가 있으면 EVENT 가 먼저 종료, 변화 없음 path 에서만
   # 본 DONE 이 송신된다 (heartbeat 누적 직전).
   if [ "$pending_checks" = "0" ] \
      && [ "$failed_checks" = "0" ] \
-     && { [ "$merge_state" = "BLOCKED" ] \
-       || [ "$merge_state" = "BEHIND" ] \
-       || { { [ "$merge_state" = "CLEAN" ] || [ "$merge_state" = "UNSTABLE" ]; } \
-         && [ "$review_decision" = "CHANGES_REQUESTED" ]; }; } \
-     && [ "$review_decision" != "APPROVED" ] \
-     && [ "$bot_evaluated_head" = "1" ]; then
+     && { \
+       { [ "$review_decision" = "CHANGES_REQUESTED" ] \
+         && { [ "$merge_state" = "CLEAN" ] \
+           || [ "$merge_state" = "UNSTABLE" ] \
+           || [ "$merge_state" = "BLOCKED" ] \
+           || [ "$merge_state" = "BEHIND" ]; }; } \
+       || { { [ "$merge_state" = "BLOCKED" ] || [ "$merge_state" = "BEHIND" ]; } \
+         && [ "$review_decision" != "APPROVED" ] \
+         && [ "$bot_evaluated_head" = "1" ]; }; \
+     }; then
     persist_state
     snapshot_and_emit "DONE" "awaiting-human-review"
     exit 0

--- a/.agents/skills/monitor-pr/scripts/watch.sh
+++ b/.agents/skills/monitor-pr/scripts/watch.sh
@@ -21,6 +21,9 @@
 #     — 메인 세션이 모니터링 중 호출자에게 SendMessage 로 지시를 보낼 때 그 직후 쓰는 sentinel 파일 경로
 #       (관례상 워크트리 루트의 .monitor-interrupt). 매 cycle sleep 직후 존재를 확인하여, 있으면 삭제 후
 #       EVENT reason=interrupt 로 즉시 종료한다. 미지정 시 본 경로 비활성. 상세는 아래 "interrupt:" 주석.
+#   REVIEW_BOT_LOGINS
+#     — 기본 review bot login 목록에 추가할 GitHub login의 콤마 구분 목록. 공백·빈 항목은 제거하며
+#       CH2/CH3 작성자의 login 전체 문자열이 목록 항목과 정확히 일치할 때만 신뢰한다.
 #
 # 출력 형식 (마지막 1회만 출력 후 종료):
 #   - 종료 조건 도달:
@@ -59,9 +62,9 @@
 # 호출자(에이전트)는 이 값을 `collect_comments.sh`의 `STALE_HANDLED_IDS` 환경변수로 그대로 전달하여
 # 해당 id의 기존 reply 마커를 무효화하고 변경된 본문을 재수집·재triage한다.
 #
-# bot-stuck: claude bot이 마지막 리뷰 이후 신규 커밋이 없어 재리뷰를 트리거하지 않는 정체 상태.
+# bot-stuck: review bot이 마지막 리뷰 이후 신규 커밋이 없어 재리뷰를 트리거하지 않는 정체 상태.
 #   AND 조건: (a) 모든 CI check가 COMPLETED (PENDING/IN_PROGRESS 0건), (b) mergeState != CLEAN,
-#   (c) reviewDecision != APPROVED, (d) latest claude[bot] review.commit.oid != HEAD oid (또는 review 부재),
+#   (c) reviewDecision != APPROVED, (d) latest configured review bot review.commit.oid != HEAD oid (또는 review 부재),
 #   (e) bot_evaluated_head == 0 (봇이 HEAD 를 평가하지 않았다), (f) PR labels 에 "auto-approvable" 포함.
 #   호출자는 빈 커밋 push로 새 commit hash를 만들어 봇 재리뷰 + CI 재실행을 유도한다 (SKILL.md 참조).
 #   상한 1회는 호출자가 .process-state.json으로 누적·검사한다 (스크립트는 무상태).
@@ -71,11 +74,11 @@
 #   의미한다. 태그가 없는 PR 은 휴먼 리뷰가 정상 경로이므로 stuck 으로 간주하지 않는다 (retrigger 시도가
 #   휴먼 리뷰 대기 PR 에서 무의미한 빈 커밋만 누적시키는 회귀 차단).
 #
-# awaiting-human-review (terminal DONE): claude bot 이 HEAD 를 평가했고 의도적으로 승인하지 않은 상태.
+# awaiting-human-review (terminal DONE): configured review bot이 HEAD를 평가했지만 human review/approval이 남은 상태.
 #   봇 재평가 트리거가 부재하므로 polling 누적이 무의미하다 — DONE 으로 종료하여 호출자(서브에이전트)가
 #   status=awaiting-review 로 보고 후 turn 종료.
 #   bot_evaluated_head 의 두 경로 (OR): (1) latest_bot_ch2_date > head_commit_date (CH2 issue comment),
-#   (2) latest_bot_review_oid == head_oid AND latest_bot_review_state == "COMMENTED" (CH3 reviews API).
+#   (2) configured bot의 review가 head_oid에 anchor되고 state가 APPROVED/COMMENTED/CHANGES_REQUESTED (CH3).
 #   AND 조건: (a) pending_checks == 0, (b) failed_checks == 0, (c) mergeState in {BLOCKED, BEHIND}
 #   (DIRTY 제외 — DIRTY 는 EVENT 로 별도 분기), (d) reviewDecision != APPROVED, (e) bot_evaluated_head == 1.
 #   분기 위치: 모든 EVENT 분기 이후 (변화 있으면 EVENT 우선) + heartbeat 직전 (변화 없음 path 에서 즉시 종료).
@@ -104,6 +107,13 @@ fi
 monitor_pr_scripts_dir="${MONITOR_PR_SCRIPTS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 # shellcheck source=comment_filters.sh
 source "$monitor_pr_scripts_dir/comment_filters.sh"
+
+# Keep the documented defaults and extend them with exact GitHub login names.
+review_bot_logins=$(jq -cn --arg configured "${REVIEW_BOT_LOGINS:-}" '
+  (["claude[bot]", "codex[bot]", "chatgpt-codex-connector[bot]"]
+    + ($configured | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))))
+  | unique
+')
 
 prev_state_file="${PREV_STATE_FILE:-}"
 interrupt_file="${INTERRUPT_FILE:-}"
@@ -223,34 +233,39 @@ while true; do
   pending_checks=$(echo "$latest_checks" | jq '[.[] | select(.status != "COMPLETED" and .status != null)] | length')
   has_auto_approvable=$(echo "$snapshot" | jq '[.labels // [] | .[] | select(.name == "auto-approvable")] | length > 0')
 
-  # latest claude[bot] review의 commit.oid / state (없으면 빈 문자열)
-  latest_bot_review_oid=$(echo "$ch3_raw" \
-    | jq -r '[.[] | select(.user.login == "claude[bot]")] | sort_by(.submitted_at) | last | .commit_id // ""' 2>/dev/null || echo "")
-  latest_bot_review_state=$(echo "$ch3_raw" \
-    | jq -r '[.[] | select(.user.login == "claude[bot]")] | sort_by(.submitted_at) | last | .state // ""' 2>/dev/null || echo "")
+  # latest configured review bot review의 commit.oid / state (없으면 빈 문자열)
+  bot_reviews=$(echo "$ch3_raw" \
+    | jq -c --argjson logins "$review_bot_logins" \
+      '[.[] | select(.user.login as $login | $logins | index($login))]' 2>/dev/null || echo '[]')
+  latest_bot_review_oid=$(echo "$bot_reviews" \
+    | jq -r 'sort_by(.submitted_at) | last | .commit_id // ""' 2>/dev/null || echo "")
+  bot_review_evaluated_head=$(echo "$bot_reviews" \
+    | jq -r --arg head_oid "$head_oid" \
+      '[.[] | select(.commit_id == $head_oid and (.state == "APPROVED" or .state == "COMMENTED" or .state == "CHANGES_REQUESTED"))] | length > 0' \
+      2>/dev/null || echo "false")
 
-  # HEAD commit의 committedDate (없으면 빈 문자열) — claude[bot] 평가 시점 비교용
+  # HEAD commit의 committedDate (없으면 빈 문자열) — review bot 평가 시점 비교용
   head_commit_date=$(gh api "repos/$REPO/commits/$head_oid" \
     --jq '.commit.committer.date // ""' 2>/dev/null || echo "")
 
-  # latest claude[bot] CH2 issue comment의 created_at (없으면 빈 문자열).
-  # claude[bot]이 자동 승인 비적격 판정 시 formal review 대신 issue comment 로 의견을 남기는 경로 —
+  # latest configured review bot CH2 issue comment의 created_at (없으면 빈 문자열).
+  # review bot이 자동 승인 비적격 판정 시 formal review 대신 issue comment 로 의견을 남기는 경로 —
   # 이 코멘트가 HEAD 이후에 작성되었다면 봇은 현재 HEAD를 평가한 것으로 간주.
-  # claude[bot] edits its CH2 summary comment in-place on re-review: created_at stays at first-post time
+  # A review bot can edit its CH2 summary comment in-place on re-review: created_at stays at first-post time
   # while updated_at advances. Use max(created_at, updated_at) so an in-place re-review counts as the
   # bot having evaluated the current HEAD — otherwise condition (e) misclassifies awaiting-human-review
   # as bot-stuck and can trigger a credit-burning empty-commit retrigger.
   latest_bot_ch2_date=$(echo "$ch2_raw" \
-    | jq -r '[.[] | select(.user.login == "claude[bot]") | (if (.updated_at // "") > (.created_at // "") then .updated_at else .created_at end)] | sort | last // ""' 2>/dev/null || echo "")
+    | jq -r --argjson logins "$review_bot_logins" \
+      '[.[] | select(.user.login as $login | $logins | index($login)) | (if (.updated_at // "") > (.created_at // "") then .updated_at else .created_at end)] | sort | last // ""' \
+      2>/dev/null || echo "")
 
   bot_evaluated_head=0
   if [ -n "$latest_bot_ch2_date" ] && [ -n "$head_commit_date" ] \
      && [ "$latest_bot_ch2_date" \> "$head_commit_date" ]; then
     bot_evaluated_head=1
   fi
-  if [ -n "$latest_bot_review_oid" ] \
-     && [ "$latest_bot_review_oid" = "$head_oid" ] \
-     && [ "$latest_bot_review_state" = "COMMENTED" ]; then
+  if [ "$bot_review_evaluated_head" = "true" ]; then
     bot_evaluated_head=1
   fi
 
@@ -345,15 +360,15 @@ while true; do
     exit 0
   fi
 
-  # 이벤트 5: bot-stuck — claude bot이 신규 커밋을 인식하지 않아 재리뷰 트리거가 누락된 정체 상태.
+  # 이벤트 5: bot-stuck — review bot이 신규 커밋을 인식하지 않아 재리뷰 트리거가 누락된 정체 상태.
   # (a) CI 전부 COMPLETED, (b) mergeState != CLEAN, (c) reviewDecision != APPROVED,
-  # (d) latest claude[bot] review.commit_id != HEAD oid (또는 review 부재),
+  # (d) latest configured review bot review.commit_id != HEAD oid (또는 review 부재),
   # (e) 동시에 봇이 HEAD 를 평가하지 않았다 (bot_evaluated_head=0),
   # (f) PR labels 에 "auto-approvable" 포함 (휴먼 리뷰 대기 PR 회복 시도 차단).
   #
-  # bot_evaluated_head 의 의의: claude bot 은 자동 승인 비적격 판정 시 두 경로로 의견을 남길 수 있다 —
+  # bot_evaluated_head 의 의의: review bot 은 자동 승인 비적격 판정 시 두 경로로 의견을 남길 수 있다 —
   # (1) CH2 issue comment 로 "팀원 리뷰 필요" 의견 (HEAD commit 이후 created_at),
-  # (2) CH3 reviews API 로 state=COMMENTED 리뷰 (commit_id == HEAD, APPROVED 아님).
+  # (2) CH3 reviews API 로 APPROVED/COMMENTED/CHANGES_REQUESTED 리뷰 (commit_id == HEAD).
   # 둘 중 어느 경로든 봇은 현재 HEAD 를 평가했지만 의도적으로 승인하지 않은 것이므로 stuck 이 아니다 —
   # 빈 커밋 retrigger 는 동일 판정을 재발행할 뿐이며 폴링/크레딧만 소진한다.
   #
@@ -370,9 +385,10 @@ while true; do
     exit 0
   fi
 
-  # 종료 조건 3: awaiting-human-review — 봇이 HEAD 를 평가했으나 review submission 대신 CH2 코멘트로
-  # 휴먼 리뷰 의견을 남긴 상태. bot_evaluated_head=1 가드로 bot-stuck EVENT 가 의도적으로 미송신되는
-  # 케이스에서, 추가 polling 은 봇 재평가 트리거 부재 + 휴먼 리뷰만 남음 = 무의미 — DONE 으로 종료한다.
+  # 종료 조건 3: awaiting-human-review — configured review bot 중 하나가 post-HEAD CH2 comment 또는
+  # exact-head APPROVED/COMMENTED/CHANGES_REQUESTED CH3 review로 HEAD를 평가했지만, PR에는 human review가
+  # 남은 상태. bot_evaluated_head=1 가드로 bot-stuck EVENT가 의도적으로 미송신되는 케이스에서,
+  # 추가 polling은 봇 재평가 트리거 부재 + human review만 남음 = 무의미 — DONE으로 종료한다.
   # 본 분기는 모든 EVENT 분기 이후에 위치하므로 변화가 있으면 EVENT 가 먼저 종료, 변화 없음 path 에서만
   # 본 DONE 이 송신된다 (heartbeat 누적 직전).
   if [ "$pending_checks" = "0" ] \


### PR DESCRIPTION
## 요약

- `monitor-pr`가 문서화된 기본 review bot login을 유지하면서 `REVIEW_BOT_LOGINS` 값을 합집합으로 사용하도록 수정했습니다.
- CH2와 CH3 모두 login 전체 문자열의 정확 일치를 사용하고, exact-head `APPROVED`·`COMMENTED`·`CHANGES_REQUESTED`를 평가 완료 증거로 인정합니다.
- 기본값 보존, custom CH2/CH3, review state, 유사 login 거부를 실행형 셸 회귀 테스트로 고정했습니다.

## 결정 근거

`REVIEW_BOT_LOGINS`는 기존 기본 bot을 대체하지 않고 확장하는 문서 계약입니다. CH2와 CH3가 동일한 login 집합과 exact-match 규칙을 공유해야 `mergeable-clean`, `awaiting-human-review`, `bot-stuck` 분기가 같은 신뢰 경계를 사용합니다.

## 검증

- monitor-pr `test_*.sh` 8개와 `check_filters.sh` 통과
- `bash -n` 통과
- `uv run pre-commit run --all-files` 통과
- `/review-code` Critical 0, Warning 0
- `/evaluate-harness` PASS
- `/sync-docs dev` Writer → fresh Reviewer 최종 PASS

## Acceptance Criteria (자가 grep)

acceptance_check: missing

이슈 본문에 실행 가능한 grep 라인은 없으며, 기대 동작은 신규 회귀 테스트 8개 사례로 검증했습니다.

## 후속 작업

- #520: 기존 `spakky-agui` README의 비-Mermaid 시각화 교정

Closes #516
