### PR TITLE
docs(agui): replace action flow with Mermaid (#520)

### DIFF
--- a/plugins/spakky-agui/README.md
+++ b/plugins/spakky-agui/README.md
@@ -36,13 +36,22 @@ durable Agent 실행(state·signal·evidence repository)과 모델 어댑터(`IA
 
 ## 동작 구조
 
-```
-AgentRunner.run_events() → 중립 AgentEvent  (런너가 native로 방출)
-중립 AgentEvent  ──(AgUiProjector)──▶  AG-UI BaseEvent
-AG-UI BaseEvent  ──(EventEncoder)──▶  "data: {...}\n\n" SSE 프레임
-                                      또는 "{...}\n" HTTP streaming chunk
-                                      또는 WebSocket text message
-                                      또는 stdout "{...}\n" stdio payload
+```mermaid
+graph LR
+    runner["AgentRunner.run_events()"]:::core -->|"native 방출"| neutral["중립 AgentEvent"]:::core
+    neutral --> projector["AgUiProjector"]:::plugin
+    projector --> event["AG-UI BaseEvent"]:::external
+    event --> encoder["EventEncoder"]:::external
+    encoder --> frame["인코딩된 AG-UI 프레임"]:::plugin
+    frame --> sse["SSE data frame"]:::external
+    frame --> websocket["WebSocket text message"]:::external
+    frame --> payload["sse_frame_payload()"]:::plugin
+    payload --> http["HTTP streaming JSON-line chunk"]:::external
+    payload --> stdio["stdio JSON-line payload"]:::external
+
+    classDef core fill:#E8F5E9,stroke:#2E7D32,color:#1B5E20
+    classDef plugin fill:#FFF3E0,stroke:#EF6C00,color:#E65100
+    classDef external fill:#ECEFF1,stroke:#546E7A,color:#263238
 ```
 
 - **`AgentRunner.run_events()`**: 런너가 중립 `AgentEvent` taxonomy를 native로 방출하는


### PR DESCRIPTION
## 요약

- `spakky-agui` README의 기존 화살표 동작 구조를 Mermaid `graph LR`로 교체했습니다.
- 실제 코드 경계에 맞게 `AgentRunner.run_events()` → `AgUiProjector` → `EventEncoder` 흐름과 SSE/WebSocket, HTTP streaming/stdio 출력 분기를 표현했습니다.
- HTTP streaming과 stdio가 `sse_frame_payload()`로 JSON-line payload를 추출하는 변환 경계를 코드와 동일하게 반영했습니다.

## 검증

- 격리 코드 리뷰: Critical 0, Warning 0
- fresh `sync-dev-docs` 검증: PASS
- Mermaid 11.15 parser 및 `mkdocs build --strict`: PASS
- ruff format/lint, Python harness, pyrefly: PASS
- `spakky-agui`: 110 passed, 11 skipped, line/branch coverage 100%
- `git diff --check`: PASS

## Acceptance Criteria (자가 grep)

`acceptance_check: missing` — 이슈 본문에 실행 가능한 grep 라인은 없으며, 명시된 성공 기준은 위 격리 문서 검증으로 확인했습니다.

Closes #520
