### PR TITLE
fix(harness): align terminal return issue identifiers (#517)

### DIFF
--- a/.agents/skills/autopilot/phases/phase-3-wave-loop.md
+++ b/.agents/skills/autopilot/phases/phase-3-wave-loop.md
@@ -80,7 +80,7 @@ process-ticket SKILL.md "서브에이전트 반환 형식 (강제)" 정규형. 1
 ```
 ^status: (merged|awaiting-review|failed)$
 ^pr: (#\d+ \(https?://[^)]+\)|none)$
-^issue: [A-Z]+-\d+$
+^issue: #\d+$
 ```
 
 미준수 → §3-6 fallback. 파싱 직후 `status == merged`인 ID를 `merged_children`에 누적한다 (Phase 6 부모 자동 Done 입력).

--- a/.agents/skills/process-ticket/SKILL.md
+++ b/.agents/skills/process-ticket/SKILL.md
@@ -421,7 +421,7 @@ turn 종료 직전, sub-agent는 다음을 자가검사한다 — 본 검사는 
 ```
 ^status: (merged|awaiting-review|failed)$
 ^pr: (#\d+ \(https?://[^)]+\)|none)$
-^issue: [A-Z]+-\d+$
+^issue: #\d+$
 ^acceptance_check: (PASS|partial|missing)$
 ^issue_status: (Done|InReview|InProgress|Backlog|Cancelled)$
 ^spawned: ([A-Z]+-\d+(,[A-Z]+-\d+)*|none)$

--- a/.agents/skills/process-ticket/phases/phase-8-merge-cleanup.md
+++ b/.agents/skills/process-ticket/phases/phase-8-merge-cleanup.md
@@ -53,7 +53,7 @@ sub-agent로 실행 중이면(team_name 발급) **이 시점에 SKILL.md "서브
 
 근거 (순서): 반환은 cleanup 완료에 논리적으로 무관 (cleanup은 idempotent + sub-agent 경로에서 메인 소유) — 핸드오프 왕복 뒤에 두면 단일 실패점.
 
-- 반환 정규형의 `status` / `pr` / `ticket` / `acceptance_check` / `issue_status` / `spawned` / `gaps_detected` / `gaps_dispatched` 라인을 모두 포함한다. `issue_status`는 §3-bis에서 실제 조회한 statusType을 그대로 반영한다.
+- 반환 정규형의 `status` / `pr` / `issue` / `acceptance_check` / `issue_status` / `spawned` / `gaps_detected` / `gaps_dispatched` 라인을 모두 포함한다. `issue_status`는 §3-bis에서 실제 조회한 statusType을 그대로 반영한다.
 - terminal 반환 emit 후에도 turn을 종료하지 않는다 — §5~§8을 이어서 수행한다. §5 워크트리 정리 핸드오프의 메인 회신(`worktree-removed`) 수신까지 마친 뒤에 turn을 종료한다.
 - 사용자 직접 호출(메인이 곧 사용자 채널)에서는 별도 정규형 emit 대신 §8 최종 완료 보고가 동등 역할을 한다 — 본 §4를 건너뛰고 §5로 진행한다.
 

--- a/.agents/skills/process-ticket/scripts/check_terminal_return_issue_contract.py
+++ b/.agents/skills/process-ticket/scripts/check_terminal_return_issue_contract.py
@@ -1,0 +1,66 @@
+"""Exercise the canonical terminal-return issue validator in both consumers."""
+
+from pathlib import Path
+import re
+import sys
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+VALIDATOR_PATHS = (
+    REPOSITORY_ROOT / ".agents/skills/process-ticket/SKILL.md",
+    REPOSITORY_ROOT / ".agents/skills/autopilot/phases/phase-3-wave-loop.md",
+)
+CANONICAL_FIXTURES = (
+    "issue: #1",
+    "issue: #42",
+    "issue: #123456",
+)
+NON_CANONICAL_FIXTURES = (
+    "issue: ABC-42",
+    "issue: 42",
+    "issue: #42x",
+    "issue: #-42",
+)
+
+
+def extract_issue_validator(path: Path) -> str:
+    validators = [
+        line
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.startswith("^issue: ")
+    ]
+    if len(validators) != 1:
+        raise ValueError(
+            f"{path}: expected exactly one issue validator, found {len(validators)}"
+        )
+    return validators[0]
+
+
+def main() -> int:
+    failures: list[str] = []
+    validators = {path: extract_issue_validator(path) for path in VALIDATOR_PATHS}
+
+    if len(set(validators.values())) != 1:
+        failures.append("process-ticket and autopilot issue validators differ")
+
+    for path, validator in validators.items():
+        compiled = re.compile(validator)
+        for fixture in CANONICAL_FIXTURES:
+            if compiled.fullmatch(fixture) is None:
+                failures.append(f"{path}: rejected canonical fixture {fixture!r}")
+        for fixture in NON_CANONICAL_FIXTURES:
+            if compiled.fullmatch(fixture) is not None:
+                failures.append(f"{path}: accepted non-canonical fixture {fixture!r}")
+
+    if failures:
+        print("terminal-return issue contract failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("terminal-return issue contract checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,15 @@ repos:
         verbose: true
         stages: [pre-commit]
 
+      - id: terminal-return-issue-contract
+        name: Validate terminal-return issue contract
+        entry: uv run python .agents/skills/process-ticket/scripts/check_terminal_return_issue_contract.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
+        stages: [pre-commit]
+
       - id: monorepo-pre-commit
         name: Run pre-commit on changed sub-projects
         entry: uv run python scripts/run_subproject_precommit.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,7 @@ flowchart TD
     commit[git commit]
     commit --> pythonharness[python-harness-rules]
     commit --> reviewcontract[review-delegate-context-contract]
+    commit --> terminal[terminal-return-issue-contract]
     commit --> precommit[monorepo-pre-commit]
     commit --> commitizen[commitizen message validation]
     precommit --> changed[Each changed sub-project]
@@ -126,6 +127,7 @@ pre-commit 설정에는 다음 항목이 포함됩니다.
 
 - **Python harness hook**: Python 코드에서 하네스가 금지한 정적 패턴을 검증합니다.
 - **Review delegation contract hook**: `.agents/skills/review-code/SKILL.md`의 `review-persona-contract` marker 안에 선언된 다섯 persona를 정본으로 삼습니다. 14개 카테고리 행이 각각 정본 persona 하나만 참조하는지, 각 persona가 인용하는 `.agents/rules/*.md`가 존재하는지, autopilot의 `review-delegate-persona-source` marker가 이 정본을 중복 없이 참조하는지 검증합니다.
+- **Terminal-return issue contract**: terminal 반환의 GitHub 이슈 식별자를 `issue: #N`으로 고정하고, `process-ticket`과 `autopilot`의 정규식이 같은 정상·비정상 fixture를 판정하는지 검사합니다.
 - **Monorepo hook**: 변경 파일에 대해 하위 프로젝트별 검사를 실행합니다.
 - **Commitizen**: commit message가 Conventional Commits format을 따르는지 검증합니다.
 


### PR DESCRIPTION
## 요약

- `process-ticket`과 `autopilot`의 terminal-return 이슈 식별자 검증을 정본 `issue: #N` 형식으로 통일합니다.
- 두 문서에서 정규식을 추출해 정상·비정상 fixture를 실제 실행하는 contract test와 pre-commit hook을 추가합니다.
- Phase 8 반환 지침의 `ticket` 오타를 canonical 필드명인 `issue`로 바로잡고, 기여 문서에 새 hook을 반영합니다.

## 결정 근거

문구 존재만 검사하면 서로 다른 정규식이 같은 의미인지 보장할 수 없으므로, 두 소비자의 정규식을 각각 컴파일해 같은 fixture 집합으로 실행합니다. 기존 terminal-return 필드의 의미와 전달 채널은 변경하지 않습니다.

## Acceptance Criteria (자가 grep)

- [x] `rg -nF '^issue: [A-Z]+-\d+$' .agents/skills/process-ticket/SKILL.md .agents/skills/autopilot/phases/phase-3-wave-loop.md` → 0 hits (실제: 0)
- [x] `rg -nF '^issue: #\d+$' .agents/skills/process-ticket/SKILL.md .agents/skills/autopilot/phases/phase-3-wave-loop.md` → 2 hits (실제: 2)
- [x] 정상 `issue: #N` fixture를 양쪽 검증기가 수용하고 Jira형·비정본 fixture를 거부합니다.

## 검증

- `uv run python .agents/skills/process-ticket/scripts/check_terminal_return_issue_contract.py`
- `uv run pre-commit run --all-files`
- `uv run mkdocs build --strict`
- `/review-code` Critical 0, Warning 0
- `/evaluate-harness` PASS
- `/sync-docs dev` fresh Reviewer Critical 0, Warning 0

Closes #517
