### PR TITLE
fix(harness): define sync-docs delivery contract (#524)

### DIFF
--- a/.agents/skills/autopilot/phases/phase-5-sync-docs.md
+++ b/.agents/skills/autopilot/phases/phase-5-sync-docs.md
@@ -1,22 +1,22 @@
 # Phase 5: 문서 동기화
 
-별도 서브에이전트로 `/sync-docs`를 호출하여 프로젝트 문서/를 코드베이스 기준으로 갱신한다. `/sync-docs`가 전용 워크트리 생성→commit→push→PR→머지까지 자체 전달을 책임지고 `pr: URL`을 반환한다 (`sync-docs/phases/phase-5-deliver.md`).
+별도 서브에이전트로 `/sync-docs`를 호출하여 프로젝트 문서/를 코드베이스 기준으로 갱신한다. 산출물 전달과 반환의 단일 계약은 `sync-docs/SKILL.md`의 `sync-docs-delivery-contract` 블록을 따른다.
 
 ```
 Agent(
   subagent_type: "general-purpose",
   description: "sync-docs after milestone",
   permission_mode: "bypassPermissions",  # phase-3-wave-loop.md §3-2-ter 조건부 inherit
-  prompt: "Invoke the /sync-docs skill. 본 autopilot 실행에서 머지된 PR [{PR_LIST}]의 변경이 프로젝트 문서/에 반영되도록 동기화하라. Verify 게이트를 통과한 내용만 반영. **반환 형식 (5줄 이내)**: `updated: N개` 다음 줄에 갱신 경로 / `pr: URL 또는 none`. 동기화 과정·diff 내용 반환 금지."
+  prompt: "Invoke the /sync-docs skill. 본 autopilot 실행에서 머지된 PR [{PR_LIST}]의 변경이 프로젝트 문서/에 반영되도록 동기화하라. Verify 게이트를 통과한 내용만 반영. **반환 형식 (5줄 이내)**: `updated: N개` 다음 줄에 갱신 경로 / `pr: <URL>` 또는 `pr: none` 또는 `pr: <URL> (미머지 — <사유>)`. 동기화 과정·diff 내용 반환 금지."
 )
 ```
 
 ## 반환 처리 — PR URL 그대로 리포트 반영 (재작업 금지)
 
-`/sync-docs`가 산출물 전달(워크트리·commit·PR·머지)을 책임지므로, 메인은 반환된 `pr: URL`을 **그대로 Phase 6 리포트에 반영**한다. 메인이 sync 산출물을 재작업하지 않는다 — 다음 분기를 수행하지 않는다:
+`/sync-docs`가 전달 계약 전체를 책임지므로, 메인은 반환된 `pr: URL`을 **그대로 Phase 6 리포트에 반영**한다. 메인이 sync 산출물을 재작업하지 않는다 — 다음 분기를 수행하지 않는다:
 
 - 공유 eng-docs 체크아웃 소유권 포렌식·dirty 정리
 - eng-docs 워크트리 재생성·Writer Edit 재적용
 - PR 재생성·머지 재실행
 
-반환이 `pr: none`이면 동기화 대상이 없었다는 뜻이므로 그대로 리포트에 "프로젝트 문서 변경 없음"으로 반영한다. 반환이 미머지 PR URL(`pr: URL (미머지 — ...)`)이면 그 사실을 리포트에 노출한다 — 메인이 직접 머지를 떠맡지 않는다.
+반환이 `pr: none`이면 동기화 대상이 없었다는 뜻이므로 그대로 리포트에 "프로젝트 문서 변경 없음"으로 반영한다. 반환이 `pr: <URL> (미머지 — <사유>)`이면 URL과 사유를 리포트에 노출한다 — 메인이 직접 머지를 떠맡지 않는다.

--- a/.agents/skills/autopilot/phases/phase-5-sync-docs.md
+++ b/.agents/skills/autopilot/phases/phase-5-sync-docs.md
@@ -1,19 +1,19 @@
 # Phase 5: 문서 동기화
 
-별도 서브에이전트로 `/sync-docs`를 호출하여 프로젝트 문서/를 코드베이스 기준으로 갱신한다. 산출물 전달과 반환의 단일 계약은 `sync-docs/SKILL.md`의 `sync-docs-delivery-contract` 블록을 따른다.
+별도 서브에이전트로 `/sync-docs`를 호출하여 프로젝트 문서/를 코드베이스 기준으로 갱신한다. 이 phase의 독립 전달과 반환 계약은 `sync-docs/SKILL.md`의 `sync-docs-delivery-contract` 블록을 따른다.
 
 ```
 Agent(
   subagent_type: "general-purpose",
   description: "sync-docs after milestone",
   permission_mode: "bypassPermissions",  # phase-3-wave-loop.md §3-2-ter 조건부 inherit
-  prompt: "Invoke the /sync-docs skill. 본 autopilot 실행에서 머지된 PR [{PR_LIST}]의 변경이 프로젝트 문서/에 반영되도록 동기화하라. Verify 게이트를 통과한 내용만 반영. **반환 형식 (5줄 이내)**: `updated: N개` 다음 줄에 갱신 경로 / `pr: <URL>` 또는 `pr: none` 또는 `pr: <URL> (미머지 — <사유>)`. 동기화 과정·diff 내용 반환 금지."
+  prompt: "Invoke the /sync-docs skill with caller marker `delivery-mode: standalone`. 본 autopilot 실행에서 머지된 PR [{PR_LIST}]의 변경이 프로젝트 문서/에 반영되도록 동기화하라. Verify 게이트를 통과한 내용만 반영. **반환 형식 (5줄 이내)**: `updated: N개` 다음 줄에 갱신 경로 / `pr: <URL>` 또는 `pr: none` 또는 `pr: <URL> (미머지 — <사유>)`. 동기화 과정·diff 내용 반환 금지."
 )
 ```
 
 ## 반환 처리 — PR URL 그대로 리포트 반영 (재작업 금지)
 
-`/sync-docs`가 전달 계약 전체를 책임지므로, 메인은 반환된 `pr: URL`을 **그대로 Phase 6 리포트에 반영**한다. 메인이 sync 산출물을 재작업하지 않는다 — 다음 분기를 수행하지 않는다:
+독립 전달 모드의 `/sync-docs`가 전달 계약 전체를 책임지므로, 메인은 반환된 `pr: URL`을 **그대로 Phase 6 리포트에 반영**한다. 메인이 sync 산출물을 재작업하지 않는다 — 다음 분기를 수행하지 않는다:
 
 - 공유 eng-docs 체크아웃 소유권 포렌식·dirty 정리
 - eng-docs 워크트리 재생성·Writer Edit 재적용

--- a/.agents/skills/autopilot/scripts/test_sync_docs_delivery_contract.sh
+++ b/.agents/skills/autopilot/scripts/test_sync_docs_delivery_contract.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Verify the sync-docs delivery pointer and prove its contract is mutation-sensitive.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/sync-docs-delivery-contract.XXXXXX")"
+
+cleanup() {
+  rm -rf -- "$fixture_root"
+}
+trap cleanup EXIT
+
+validate_contract() {
+  local root="$1"
+  local phase="$root/.agents/skills/autopilot/phases/phase-5-sync-docs.md"
+  local pointer
+  local pointer_count
+  local contract
+  local contract_block
+  local failures=0
+
+  pointer="$(grep -oE 'sync-docs/[^` )]+\.md' "$phase" | head -1 || true)"
+  pointer_count="$({ grep -oE 'sync-docs/[^` )]+\.md' "$phase" || true; } \
+    | sort -u | sed '/^$/d' | wc -l | tr -d ' ')"
+  if [ "$pointer_count" -ne 1 ] || [ -z "$pointer" ]; then
+    printf 'sync-docs delivery contract: Phase 5 must reference one Markdown SSOT\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  if ! grep -Fq 'pr: <URL> (미머지 — <사유>)' "$phase"; then
+    printf 'sync-docs delivery contract: Phase 5 must preserve the unmerged result syntax\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  contract="$root/.agents/skills/$pointer"
+  if [ -z "$pointer" ] || [ ! -f "$contract" ]; then
+    printf 'sync-docs delivery contract: missing pointer target: %s\n' "$pointer" >&2
+    return 1
+  fi
+
+  if [ "$(grep -Fc '<!-- sync-docs-delivery-contract:start -->' "$contract" || true)" -ne 1 ] \
+    || [ "$(grep -Fc '<!-- sync-docs-delivery-contract:end -->' "$contract" || true)" -ne 1 ]; then
+    printf 'sync-docs delivery contract: expected one canonical marker block\n' >&2
+    return 1
+  fi
+
+  contract_block="$(awk '
+    $0 == "<!-- sync-docs-delivery-contract:start -->" { capture = 1; next }
+    $0 == "<!-- sync-docs-delivery-contract:end -->" { capture = 0; exit }
+    capture { print }
+  ' "$contract")"
+
+  for required_line in \
+    '- delivery-workspace: dedicated-worktree' \
+    '- delivery-commit: required-when-updated' \
+    '- delivery-push: verified-remote-head' \
+    '- delivery-pr: required-when-updated' \
+    '- delivery-merge: gated-squash' \
+    '- result-updated: `updated: <N>개`' \
+    '- result-pr-merged: `pr: <URL>`' \
+    '- result-pr-none: `pr: none`' \
+    '- result-pr-unmerged: `pr: <URL> (미머지 — <사유>)`'; do
+    if ! printf '%s\n' "$contract_block" | grep -Fq -- "$required_line"; then
+      printf 'sync-docs delivery contract: missing responsibility: %s\n' "$required_line" >&2
+      failures=$((failures + 1))
+    fi
+  done
+
+  [ "$failures" -eq 0 ]
+}
+
+make_fixture() {
+  local name="$1"
+  local root="$fixture_root/$name"
+
+  mkdir -p \
+    "$root/.agents/skills/autopilot/phases" \
+    "$root/.agents/skills/sync-docs"
+  cp "$repo_root/.agents/skills/autopilot/phases/phase-5-sync-docs.md" \
+    "$root/.agents/skills/autopilot/phases/"
+  cp "$repo_root/.agents/skills/sync-docs/SKILL.md" \
+    "$root/.agents/skills/sync-docs/"
+  printf '%s\n' "$root"
+}
+
+validate_contract "$repo_root"
+
+missing_pointer_fixture="$(make_fixture missing-pointer)"
+sed -i.bak 's#sync-docs/SKILL\.md#sync-docs/missing.md#g' \
+  "$missing_pointer_fixture/.agents/skills/autopilot/phases/phase-5-sync-docs.md"
+rm "$missing_pointer_fixture/.agents/skills/autopilot/phases/phase-5-sync-docs.md.bak"
+if validate_contract "$missing_pointer_fixture" >/dev/null 2>&1; then
+  echo 'nonexistent pointer mutation unexpectedly passed' >&2
+  exit 1
+fi
+
+missing_delivery_fixture="$(make_fixture missing-delivery)"
+sed -i.bak '/^- delivery-workspace: dedicated-worktree/d' \
+  "$missing_delivery_fixture/.agents/skills/sync-docs/SKILL.md"
+rm "$missing_delivery_fixture/.agents/skills/sync-docs/SKILL.md.bak"
+if validate_contract "$missing_delivery_fixture" >/dev/null 2>&1; then
+  echo 'delivery responsibility mutation unexpectedly passed' >&2
+  exit 1
+fi
+
+missing_result_fixture="$(make_fixture missing-result)"
+sed -i.bak '/^- result-pr-/d' \
+  "$missing_result_fixture/.agents/skills/sync-docs/SKILL.md"
+rm "$missing_result_fixture/.agents/skills/sync-docs/SKILL.md.bak"
+if validate_contract "$missing_result_fixture" >/dev/null 2>&1; then
+  echo 'pr result mutation unexpectedly passed' >&2
+  exit 1
+fi
+
+missing_unmerged_fixture="$(make_fixture missing-unmerged-result)"
+sed -i.bak '/^- result-pr-unmerged:/d' \
+  "$missing_unmerged_fixture/.agents/skills/sync-docs/SKILL.md"
+rm "$missing_unmerged_fixture/.agents/skills/sync-docs/SKILL.md.bak"
+if validate_contract "$missing_unmerged_fixture" >/dev/null 2>&1; then
+  echo 'unmerged pr result mutation unexpectedly passed' >&2
+  exit 1
+fi
+
+echo 'sync-docs delivery contract checks passed'

--- a/.agents/skills/autopilot/scripts/test_sync_docs_delivery_contract.sh
+++ b/.agents/skills/autopilot/scripts/test_sync_docs_delivery_contract.sh
@@ -32,6 +32,10 @@ validate_contract() {
     printf 'sync-docs delivery contract: Phase 5 must preserve the unmerged result syntax\n' >&2
     failures=$((failures + 1))
   fi
+  if [ "$(grep -Fc 'delivery-mode: standalone' "$phase" || true)" -ne 1 ]; then
+    printf 'sync-docs delivery contract: Phase 5 must set the standalone caller marker once\n' >&2
+    failures=$((failures + 1))
+  fi
 
   contract="$root/.agents/skills/$pointer"
   if [ -z "$pointer" ] || [ ! -f "$contract" ]; then
@@ -52,15 +56,18 @@ validate_contract() {
   ' "$contract")"
 
   for required_line in \
-    '- delivery-workspace: dedicated-worktree' \
-    '- delivery-commit: required-when-updated' \
-    '- delivery-push: verified-remote-head' \
-    '- delivery-pr: required-when-updated' \
-    '- delivery-merge: gated-squash' \
+    '- delivery-default: current-feature-worktree-same-pr' \
+    '- delivery-scope: autopilot-phase-5-standalone' \
+    '- delivery-activation: `delivery-mode: standalone`' \
+    '- standalone-workspace: dedicated-worktree' \
+    '- standalone-commit: required-when-updated' \
+    '- standalone-push: verified-remote-head' \
+    '- standalone-pr: required-when-updated' \
+    '- standalone-merge: gated-squash' \
     '- result-updated: `updated: <N>개`' \
-    '- result-pr-merged: `pr: <URL>`' \
-    '- result-pr-none: `pr: none`' \
-    '- result-pr-unmerged: `pr: <URL> (미머지 — <사유>)`'; do
+    '- standalone-result-pr-merged: `pr: <URL>`' \
+    '- standalone-result-pr-none: `pr: none`' \
+    '- standalone-result-pr-unmerged: `pr: <URL> (미머지 — <사유>)`'; do
     if ! printf '%s\n' "$contract_block" | grep -Fq -- "$required_line"; then
       printf 'sync-docs delivery contract: missing responsibility: %s\n' "$required_line" >&2
       failures=$((failures + 1))
@@ -96,7 +103,7 @@ if validate_contract "$missing_pointer_fixture" >/dev/null 2>&1; then
 fi
 
 missing_delivery_fixture="$(make_fixture missing-delivery)"
-sed -i.bak '/^- delivery-workspace: dedicated-worktree/d' \
+sed -i.bak '/^- standalone-workspace: dedicated-worktree/d' \
   "$missing_delivery_fixture/.agents/skills/sync-docs/SKILL.md"
 rm "$missing_delivery_fixture/.agents/skills/sync-docs/SKILL.md.bak"
 if validate_contract "$missing_delivery_fixture" >/dev/null 2>&1; then
@@ -105,7 +112,7 @@ if validate_contract "$missing_delivery_fixture" >/dev/null 2>&1; then
 fi
 
 missing_result_fixture="$(make_fixture missing-result)"
-sed -i.bak '/^- result-pr-/d' \
+sed -i.bak '/^- standalone-result-pr-/d' \
   "$missing_result_fixture/.agents/skills/sync-docs/SKILL.md"
 rm "$missing_result_fixture/.agents/skills/sync-docs/SKILL.md.bak"
 if validate_contract "$missing_result_fixture" >/dev/null 2>&1; then
@@ -114,11 +121,38 @@ if validate_contract "$missing_result_fixture" >/dev/null 2>&1; then
 fi
 
 missing_unmerged_fixture="$(make_fixture missing-unmerged-result)"
-sed -i.bak '/^- result-pr-unmerged:/d' \
+sed -i.bak '/^- standalone-result-pr-unmerged:/d' \
   "$missing_unmerged_fixture/.agents/skills/sync-docs/SKILL.md"
 rm "$missing_unmerged_fixture/.agents/skills/sync-docs/SKILL.md.bak"
 if validate_contract "$missing_unmerged_fixture" >/dev/null 2>&1; then
   echo 'unmerged pr result mutation unexpectedly passed' >&2
+  exit 1
+fi
+
+missing_scope_fixture="$(make_fixture missing-standalone-scope)"
+sed -i.bak '/^- delivery-scope: autopilot-phase-5-standalone/d' \
+  "$missing_scope_fixture/.agents/skills/sync-docs/SKILL.md"
+rm "$missing_scope_fixture/.agents/skills/sync-docs/SKILL.md.bak"
+if validate_contract "$missing_scope_fixture" >/dev/null 2>&1; then
+  echo 'standalone delivery scope mutation unexpectedly passed' >&2
+  exit 1
+fi
+
+missing_default_fixture="$(make_fixture missing-default-boundary)"
+sed -i.bak '/^- delivery-default: current-feature-worktree-same-pr/d' \
+  "$missing_default_fixture/.agents/skills/sync-docs/SKILL.md"
+rm "$missing_default_fixture/.agents/skills/sync-docs/SKILL.md.bak"
+if validate_contract "$missing_default_fixture" >/dev/null 2>&1; then
+  echo 'default same-PR boundary mutation unexpectedly passed' >&2
+  exit 1
+fi
+
+missing_marker_fixture="$(make_fixture missing-caller-marker)"
+sed -i.bak 's/delivery-mode: standalone/delivery-mode: omitted/' \
+  "$missing_marker_fixture/.agents/skills/autopilot/phases/phase-5-sync-docs.md"
+rm "$missing_marker_fixture/.agents/skills/autopilot/phases/phase-5-sync-docs.md.bak"
+if validate_contract "$missing_marker_fixture" >/dev/null 2>&1; then
+  echo 'standalone caller marker mutation unexpectedly passed' >&2
   exit 1
 fi
 

--- a/.agents/skills/sync-docs/SKILL.md
+++ b/.agents/skills/sync-docs/SKILL.md
@@ -136,6 +136,26 @@ Review 프롬프트에는 반드시 다음을 포함한다: Write 결과를 신�
 
 ---
 
+## 산출물 전달 계약
+
+<!-- sync-docs-delivery-contract:start -->
+
+라우터는 Write/Review 수렴 결과의 게시까지 소유한다. 호출자는 아래 전달 결과를 재작업하지 않는다.
+
+- delivery-workspace: dedicated-worktree — 문서 수정 전에 `origin/develop` 기준 전용 브랜치와 워크트리를 만들고, 모든 Write/Review 파일 작업을 그 경로에 한정한다.
+- delivery-commit: required-when-updated — 검증을 통과한 문서 변경이 있으면 변경 파일만 commit한다.
+- delivery-push: verified-remote-head — commit을 push하고 로컬 HEAD와 원격 브랜치 HEAD가 같은지 확인한다.
+- delivery-pr: required-when-updated — push된 브랜치로 문서 PR을 만들고 URL을 보존한다.
+- delivery-merge: gated-squash — CI와 리뷰 게이트가 준비된 PR만 squash merge하고 전용 워크트리를 정리한다. `--auto`와 `--admin`은 사용하지 않는다.
+- result-updated: `updated: <N>개` 다음 줄부터 갱신 경로를 기록한다.
+- result-pr-merged: `pr: <URL>` — 문서 PR을 머지했으면 그 URL을 반환한다.
+- result-pr-none: `pr: none` — 동기화 대상이 없으면 반환한다.
+- result-pr-unmerged: `pr: <URL> (미머지 — <사유>)` — 게이트를 통과하지 못해 PR이 열려 있으면 URL과 미머지 사유를 반환한다.
+
+<!-- sync-docs-delivery-contract:end -->
+
+---
+
 ## 규칙
 
 - **작성 규칙**: 모든 동기화 문서(서브 스킬 포함)는 [doc-format.md](doc-format.md)의 포맷·문서별 규칙·Verifier 10항목 체크리스트를 따른다. 서브에이전트 프롬프트에 해당 섹션을 인라인으로 포함한다.

--- a/.agents/skills/sync-docs/SKILL.md
+++ b/.agents/skills/sync-docs/SKILL.md
@@ -140,17 +140,20 @@ Review 프롬프트에는 반드시 다음을 포함한다: Write 결과를 신�
 
 <!-- sync-docs-delivery-contract:start -->
 
-라우터는 Write/Review 수렴 결과의 게시까지 소유한다. 호출자는 아래 전달 결과를 재작업하지 않는다.
+기본 호출은 현재 feature worktree에서 문서를 갱신하고 호출자의 코드 PR에 함께 전달한다. Autopilot Phase 5만 명시적인 caller marker로 독립 전달을 요청하며, 그때 라우터가 게시까지 소유한다.
 
-- delivery-workspace: dedicated-worktree — 문서 수정 전에 `origin/develop` 기준 전용 브랜치와 워크트리를 만들고, 모든 Write/Review 파일 작업을 그 경로에 한정한다.
-- delivery-commit: required-when-updated — 검증을 통과한 문서 변경이 있으면 변경 파일만 commit한다.
-- delivery-push: verified-remote-head — commit을 push하고 로컬 HEAD와 원격 브랜치 HEAD가 같은지 확인한다.
-- delivery-pr: required-when-updated — push된 브랜치로 문서 PR을 만들고 URL을 보존한다.
-- delivery-merge: gated-squash — CI와 리뷰 게이트가 준비된 PR만 squash merge하고 전용 워크트리를 정리한다. `--auto`와 `--admin`은 사용하지 않는다.
+- delivery-default: current-feature-worktree-same-pr — caller marker가 없으면 현재 feature worktree에서 Write/Review를 수행하고, 별도 commit·push·PR·merge 없이 호출자가 같은 코드 PR에 포함한다.
+- delivery-scope: autopilot-phase-5-standalone — 독립 전달 소유권은 Autopilot Phase 5 호출에만 적용한다.
+- delivery-activation: `delivery-mode: standalone` — 이 caller marker가 있는 호출만 아래 standalone 책임을 활성화한다.
+- standalone-workspace: dedicated-worktree — 문서 수정 전에 `origin/develop` 기준 전용 브랜치와 워크트리를 만들고, 모든 Write/Review 파일 작업을 그 경로에 한정한다.
+- standalone-commit: required-when-updated — 검증을 통과한 문서 변경이 있으면 변경 파일만 commit한다.
+- standalone-push: verified-remote-head — commit을 push하고 로컬 HEAD와 원격 브랜치 HEAD가 같은지 확인한다.
+- standalone-pr: required-when-updated — push된 브랜치로 문서 PR을 만들고 URL을 보존한다.
+- standalone-merge: gated-squash — CI와 리뷰 게이트가 준비된 PR만 squash merge하고 전용 워크트리를 정리한다. `--auto`와 `--admin`은 사용하지 않는다.
 - result-updated: `updated: <N>개` 다음 줄부터 갱신 경로를 기록한다.
-- result-pr-merged: `pr: <URL>` — 문서 PR을 머지했으면 그 URL을 반환한다.
-- result-pr-none: `pr: none` — 동기화 대상이 없으면 반환한다.
-- result-pr-unmerged: `pr: <URL> (미머지 — <사유>)` — 게이트를 통과하지 못해 PR이 열려 있으면 URL과 미머지 사유를 반환한다.
+- standalone-result-pr-merged: `pr: <URL>` — 문서 PR을 머지했으면 그 URL을 반환한다.
+- standalone-result-pr-none: `pr: none` — 동기화 대상이 없으면 반환한다.
+- standalone-result-pr-unmerged: `pr: <URL> (미머지 — <사유>)` — 게이트를 통과하지 못해 PR이 열려 있으면 URL과 미머지 사유를 반환한다.
 
 <!-- sync-docs-delivery-contract:end -->
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,15 @@ repos:
         verbose: true
         stages: [pre-commit]
 
+      - id: sync-docs-delivery-contract
+        name: Validate sync-docs delivery contract
+        entry: .agents/skills/autopilot/scripts/test_sync_docs_delivery_contract.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        verbose: true
+        stages: [pre-commit]
+
       - id: terminal-return-issue-contract
         name: Validate terminal-return issue contract
         entry: uv run python .agents/skills/process-ticket/scripts/check_terminal_return_issue_contract.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,7 @@ flowchart TD
     commit[git commit]
     commit --> pythonharness[python-harness-rules]
     commit --> reviewcontract[review-delegate-context-contract]
+    commit --> syncdocscontract[sync-docs-delivery-contract]
     commit --> terminal[terminal-return-issue-contract]
     commit --> precommit[monorepo-pre-commit]
     commit --> commitizen[commitizen message validation]
@@ -127,6 +128,7 @@ pre-commit 설정에는 다음 항목이 포함됩니다.
 
 - **Python harness hook**: Python 코드에서 하네스가 금지한 정적 패턴을 검증합니다.
 - **Review delegation contract hook**: `.agents/skills/review-code/SKILL.md`의 `review-persona-contract` marker 안에 선언된 다섯 persona를 정본으로 삼습니다. 14개 카테고리 행이 각각 정본 persona 하나만 참조하는지, 각 persona가 인용하는 `.agents/rules/*.md`가 존재하는지, autopilot의 `review-delegate-persona-source` marker가 이 정본을 중복 없이 참조하는지 검증합니다.
+- **Sync-docs delivery contract hook**: autopilot Phase 5의 포인터가 `sync-docs` 전달 정본을 가리키고, 전용 워크트리부터 PR 결과 반환까지의 책임과 mutation fixture가 유지되는지 검사합니다.
 - **Terminal-return issue contract**: terminal 반환의 GitHub 이슈 식별자를 `issue: #N`으로 고정하고, `process-ticket`과 `autopilot`의 정규식이 같은 정상·비정상 fixture를 판정하는지 검사합니다.
 - **Monorepo hook**: 변경 파일에 대해 하위 프로젝트별 검사를 실행합니다.
 - **Commitizen**: commit message가 Conventional Commits format을 따르는지 검증합니다.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ pre-commit 설정에는 다음 항목이 포함됩니다.
 
 - **Python harness hook**: Python 코드에서 하네스가 금지한 정적 패턴을 검증합니다.
 - **Review delegation contract hook**: `.agents/skills/review-code/SKILL.md`의 `review-persona-contract` marker 안에 선언된 다섯 persona를 정본으로 삼습니다. 14개 카테고리 행이 각각 정본 persona 하나만 참조하는지, 각 persona가 인용하는 `.agents/rules/*.md`가 존재하는지, autopilot의 `review-delegate-persona-source` marker가 이 정본을 중복 없이 참조하는지 검증합니다.
-- **Sync-docs delivery contract hook**: autopilot Phase 5의 포인터가 `sync-docs` 전달 정본을 가리키고, 전용 워크트리부터 PR 결과 반환까지의 책임과 mutation fixture가 유지되는지 검사합니다.
+- **Sync-docs delivery contract hook**: 기본 sync-docs가 현재 feature worktree의 코드 PR에 문서를 포함하고, Autopilot Phase 5의 marker 호출만 전용 워크트리부터 PR 반환까지 책임지는지 mutation fixture로 검사합니다.
 - **Terminal-return issue contract**: terminal 반환의 GitHub 이슈 식별자를 `issue: #N`으로 고정하고, `process-ticket`과 `autopilot`의 정규식이 같은 정상·비정상 fixture를 판정하는지 검사합니다.
 - **Monorepo hook**: 변경 파일에 대해 하위 프로젝트별 검사를 실행합니다.
 - **Commitizen**: commit message가 Conventional Commits format을 따르는지 검증합니다.


### PR DESCRIPTION
## 요약

- Autopilot Phase 5의 존재하지 않는 전달 리소스 포인터를 실제 `sync-docs/SKILL.md` 정본으로 교체했습니다.
- `sync-docs`가 전용 워크트리, commit, push, PR, gated merge와 merged/none/unmerged 반환을 한 계약에서 소유하도록 명시했습니다.
- 포인터·전달 책임·PR 반환의 삭제와 불일치를 차단하는 mutation-sensitive pre-commit 회귀를 추가했습니다.

## 결정 근거

현재 `sync-docs` 리소스 구조에는 별도 phase 디렉터리가 없고 라우터 `SKILL.md`가 Write/Review와 결과 통합을 이미 소유하므로, 새 shim 대신 라우터를 단일 전달 정본으로 사용했습니다.

## Acceptance Criteria (자가 grep)

- [x] `target=$(rg -o 'sync-docs/[^\x60 )]+\.md' .agents/skills/autopilot/phases/phase-5-sync-docs.md | head -1); test -n "$target" && test -f ".agents/skills/$target"` → exit 0
- [x] `bash .agents/skills/autopilot/scripts/test_sync_docs_delivery_contract.sh` → 정상 트리 exit 0
- [x] 존재하지 않는 포인터, 전달 책임 제거, 전체 `pr:` 반환 제거, 미머지 반환 제거 mutation → 각각 non-zero
- [x] `uv run pre-commit run --files ...` → 관련 하네스 hook 전체 통과
- [x] `uv run mkdocs build --strict`와 `git diff --check` 통과
- [x] 독립 `/review-code` 2차 검증 Critical 0 / Warning 0, `/evaluate-harness` PASS

Closes #524
